### PR TITLE
fix(load): preserve parent data in language layout load function

### DIFF
--- a/src/lib/components/authenticated/authenticated-layout.svelte
+++ b/src/lib/components/authenticated/authenticated-layout.svelte
@@ -15,12 +15,6 @@
 	}
 
 	let { children, sidebarConfig, user, routePrefix, rootLabel }: Props = $props();
-
-	// DEBUG: Log when user prop changes
-	$effect(() => {
-		console.log('[AuthenticatedLayout] user changed:', user);
-		console.log('[AuthenticatedLayout] rendering:', !!user);
-	});
 </script>
 
 {#if user}

--- a/src/routes/[[lang]]/+layout.ts
+++ b/src/routes/[[lang]]/+layout.ts
@@ -2,12 +2,14 @@ import { error } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
 import { isSupportedLanguage, DEFAULT_LANGUAGE } from '$lib/i18n/languages';
 
-export const load: LayoutLoad = async ({ params }) => {
+export const load: LayoutLoad = async ({ params, parent }) => {
+	const parentData = await parent();
 	const lang = params.lang;
 
 	// If no language parameter, use default
 	if (!lang) {
 		return {
+			...parentData,
 			lang: DEFAULT_LANGUAGE
 		};
 	}
@@ -20,6 +22,7 @@ export const load: LayoutLoad = async ({ params }) => {
 	}
 
 	return {
+		...parentData,
 		lang
 	};
 };

--- a/src/routes/[[lang]]/app/+layout.svelte
+++ b/src/routes/[[lang]]/app/+layout.svelte
@@ -18,12 +18,6 @@
 	const sidebarConfig = $derived(
 		getAppSidebarConfig({ pathname: page.url.pathname, lang: page.params.lang }, viewer?.role)
 	);
-
-	// DEBUG: Log when viewer changes
-	$effect(() => {
-		console.log('[App Layout] viewer changed:', viewer);
-		console.log('[App Layout] data.viewer:', data.viewer);
-	});
 </script>
 
 <AuthenticatedLayout


### PR DESCRIPTION
Universal load functions must explicitly call await parent() and
spread parent data to preserve it during client-side navigation.

Without this, data.viewer becomes null when navigating from landing
page to dashboard, breaking PostHog analytics, community chat initial
data, and admin role detection.

Also removes debug console.log statements added during investigation.