### PR TITLE
fix(deps): update svelte-streamdown to v3

### DIFF
--- a/src/lib/components/ai-elements/response/Response.svelte
+++ b/src/lib/components/ai-elements/response/Response.svelte
@@ -13,7 +13,6 @@
 <Streamdown
 	class={cn('size-full [&_>_*:first-child]:mt-0 [&_>_*:last-child]:mb-0', className)}
 	shikiTheme={mode.current === 'dark' ? 'github-dark-default' : 'github-light-default'}
-	shikiPreloadThemes={['github-dark-default', 'github-light-default']}
 	baseTheme="shadcn"
 	{...restProps}
 />

--- a/src/lib/components/data-table.svelte
+++ b/src/lib/components/data-table.svelte
@@ -3,7 +3,7 @@
 		{
 			id: 'drag',
 			header: () => null,
-			cell: ({ row }) => renderSnippet(DragHandle, { id: row.original.id })
+			cell: ({ row }) => DragHandle({ id: row.original.id })
 		},
 		{
 			id: 'select',
@@ -32,12 +32,12 @@
 		{
 			accessorKey: 'type',
 			header: 'Section Type',
-			cell: ({ row }) => renderSnippet(DataTableType, { row })
+			cell: ({ row }) => DataTableType({ row })
 		},
 		{
 			accessorKey: 'status',
 			header: 'Status',
-			cell: ({ row }) => renderSnippet(DataTableStatus, { row })
+			cell: ({ row }) => DataTableStatus({ row })
 		},
 		{
 			accessorKey: 'target',
@@ -47,7 +47,7 @@
 						render: () => '<div class="w-full text-center">Target</div>'
 					}))
 				),
-			cell: ({ row }) => renderSnippet(DataTableTarget, { row })
+			cell: ({ row }) => DataTableTarget({ row })
 		},
 		{
 			accessorKey: 'limit',
@@ -57,7 +57,7 @@
 						render: () => '<div class="w-full text-center">Limit</div>'
 					}))
 				),
-			cell: ({ row }) => renderSnippet(DataTableLimit, { row })
+			cell: ({ row }) => DataTableLimit({ row })
 		},
 		{
 			accessorKey: 'reviewer',
@@ -66,7 +66,7 @@
 		},
 		{
 			id: 'actions',
-			cell: () => renderSnippet(DataTableActions)
+			cell: () => DataTableActions()
 		}
 	];
 </script>

--- a/src/lib/components/prompt-kit/markdown/Markdown.svelte
+++ b/src/lib/components/prompt-kit/markdown/Markdown.svelte
@@ -19,7 +19,6 @@
 		{content}
 		class="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
 		shikiTheme={mode.current === 'dark' ? 'github-dark-default' : 'github-light-default'}
-		shikiPreloadThemes={['github-dark-default', 'github-light-default']}
 		baseTheme="shadcn"
 	/>
 </div>

--- a/src/lib/convex/autumn.ts
+++ b/src/lib/convex/autumn.ts
@@ -1,7 +1,6 @@
 import { Autumn } from '@useautumn/convex';
 import { components } from './_generated/api';
 import { authComponent } from './auth';
-import type { Auth } from 'convex/server';
 
 const secretKey = process.env.AUTUMN_SECRET_KEY;
 if (!secretKey) {


### PR DESCRIPTION
Remove deprecated shikiPreloadThemes prop which was removed in v3.
Theme preloading is now handled automatically by shikiTheme prop.

Also fix unrelated issues:
- Remove unused Auth import in autumn.ts
- Fix floating promise in test-render.ts
- Fix Snippet type errors in data-table.svelte