### PR TITLE
fix(ci): use GRAPHITE_TOKEN for bot PR tracking

### DIFF
--- a/.github/workflows/graphite-bot-tracking.yml
+++ b/.github/workflows/graphite-bot-tracking.yml
@@ -28,9 +28,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Authenticate with Graphite
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gt auth --token ${{ secrets.GITHUB_TOKEN }}
+        run: gt auth --token ${{ secrets.GRAPHITE_TOKEN }}
 
       - name: Track branch in Graphite
         run: gt track --parent main --force


### PR DESCRIPTION
Replace GITHUB_TOKEN with GRAPHITE_TOKEN for proper Graphite CLI authentication.
Requires adding GRAPHITE_TOKEN secret from https://app.graphite.com/activate