### PR TITLE
ci(graphite): initialize Graphite CLI before tracking branches

### DIFF
--- a/.github/workflows/graphite-bot-tracking.yml
+++ b/.github/workflows/graphite-bot-tracking.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Authenticate with Graphite
         run: gt auth --token ${{ secrets.GRAPHITE_TOKEN }}
 
+      - name: Initialize Graphite
+        run: gt init --trunk main
+
       - name: Track branch in Graphite
         run: gt track --parent main --force


### PR DESCRIPTION
Fix error where gt track fails with 'Could not infer trunk branch' by adding
gt init --trunk main step. This ensures Graphite is properly initialized with
the trunk branch before attempting to track bot PRs.