### PR TITLE
ci(graphite): allow manual workflow triggers to bypass bot check

### DIFF
--- a/.github/workflows/graphite-bot-tracking.yml
+++ b/.github/workflows/graphite-bot-tracking.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   track-in-graphite:
-    if: endsWith(github.actor, '[bot]')
+    if: endsWith(github.actor, '[bot]') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Update condition to run workflow on manual dispatch events in addition to bot PRs.
This enables testing the workflow on any branch via workflow_dispatch.