### PR TITLE
fix(mobile): align header with content and add top spacing

### DIFF
--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -28,7 +28,7 @@
 </script>
 
 <header>
-	<nav class="fixed z-40 w-full px-2">
+	<nav class="fixed z-40 w-full">
 		<div
 			class="mx-auto max-w-6xl rounded-3xl bg-background/50 px-6 shadow-2xl/10 backdrop-blur-2xl lg:px-12 lg:shadow-none"
 		>

--- a/src/routes/[[lang]]/(marketing)/+layout.svelte
+++ b/src/routes/[[lang]]/(marketing)/+layout.svelte
@@ -10,4 +10,6 @@
 </script>
 
 <MarketingHeader />
-{@render children?.()}
+<div class="pt-16 sm:pt-20">
+	{@render children?.()}
+</div>


### PR DESCRIPTION
- Remove px-2 padding from nav to align logo with page content padding
- Add pt-16/sm:pt-20 wrapper to marketing layout to prevent overlap with fixed header