### PR TITLE
refactor(spacing): reduce section padding and layout top spacing

### DIFF
--- a/src/blocks/hero/hero-five.svelte
+++ b/src/blocks/hero/hero-five.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <main class="overflow-hidden">
-	<section class="pt-16 md:pt-32">
+	<section class="pt-16 md:pt-24">
 		<div class="mx-auto max-w-6xl px-6 lg:px-12">
 			<div class="border-t">
 				<span class="text-caption -mt-3.5 -ml-6 block w-max bg-background px-6">

--- a/src/blocks/pricing/pricing-three.svelte
+++ b/src/blocks/pricing/pricing-three.svelte
@@ -92,7 +92,7 @@
 	});
 </script>
 
-<section class="py-16 md:py-32">
+<section class="py-16 md:py-24">
 	<div class="mx-auto max-w-6xl px-6 lg:px-12">
 		<div class="border-t">
 			<span class="text-caption -mt-3.5 -ml-6 block w-max bg-background px-6">

--- a/src/blocks/team/team-two.svelte
+++ b/src/blocks/team/team-two.svelte
@@ -47,7 +47,7 @@
 	];
 </script>
 
-<section class="py-16 md:py-32">
+<section class="py-16 md:py-24">
 	<div class="mx-auto max-w-6xl px-6 lg:px-12">
 		<div class="border-t">
 			<span class="text-caption -mt-3.5 -ml-6 block w-max bg-background px-6">

--- a/src/routes/[[lang]]/(marketing)/+layout.svelte
+++ b/src/routes/[[lang]]/(marketing)/+layout.svelte
@@ -10,6 +10,6 @@
 </script>
 
 <MarketingHeader />
-<div class="pt-16 sm:pt-20">
+<div class="pt-4 sm:pt-0">
 	{@render children?.()}
 </div>


### PR DESCRIPTION
- Reduce section padding from md:py-32 to md:py-24 across hero, pricing, and team blocks
- Reduce layout top padding from pt-16/sm:pt-20 to pt-4/sm:pt-0 for tighter spacing