### PR TITLE
ci(graphite): add gt submit to push PR metadata to Graphite

### DIFF
--- a/.github/workflows/graphite-bot-tracking.yml
+++ b/.github/workflows/graphite-bot-tracking.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Track branch in Graphite
         run: gt track --parent main --force
+
+      - name: Submit PR to Graphite
+        run: gt submit --no-edit


### PR DESCRIPTION
gt track only creates local metadata which is lost in CI. Adding gt submit
ensures the PR is registered with Graphite's servers and visible in the dashboard.