### PR TITLE
ci(graphite): add write permissions for gt submit

### DIFF
--- a/.github/workflows/graphite-bot-tracking.yml
+++ b/.github/workflows/graphite-bot-tracking.yml
@@ -10,8 +10,8 @@ jobs:
     if: endsWith(github.actor, '[bot]') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout PR branch


### PR DESCRIPTION
gt submit requires write access to push branches and update PRs.
Changed permissions from read to write for contents and pull-requests.