### PR TITLE
refactor(ci): expand Graphite workflow to track all PRs

### DIFF
--- a/.github/workflows/graphite-pr-sync.yml
+++ b/.github/workflows/graphite-pr-sync.yml
@@ -1,4 +1,4 @@
-name: Track Bot PRs in Graphite
+name: Sync PRs to Graphite
 
 on:
   pull_request:
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  track-in-graphite:
-    if: endsWith(github.actor, '[bot]') || github.event_name == 'workflow_dispatch'
+  sync-pr-to-graphite:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -40,5 +39,5 @@ jobs:
       - name: Track branch in Graphite
         run: gt track --parent main --force
 
-      - name: Submit PR to Graphite
+      - name: Sync PR to Graphite
         run: gt submit --no-edit


### PR DESCRIPTION
Rename workflow from 'Track Bot PRs in Graphite' to 'Sync PRs to Graphite' and
remove bot-only restriction to ensure 100% PR coverage in Graphite dashboard.

Changes:
- Rename file: graphite-bot-tracking.yml → graphite-pr-sync.yml
- Remove endsWith(github.actor, '[bot]') condition
- Update workflow and job names to reflect broader scope
- Rename step 'Submit PR to Graphite' → 'Sync PR to Graphite'

This ensures all PRs (not just bots) are tracked in Graphite, providing a
safety net for developers who forget to use 'gt create' and supporting
external contributors who don't have Graphite CLI.