### PR TITLE
debug: add logging for viewer data loss

### DIFF
--- a/src/lib/components/authenticated/authenticated-layout.svelte
+++ b/src/lib/components/authenticated/authenticated-layout.svelte
@@ -15,6 +15,12 @@
 	}
 
 	let { children, sidebarConfig, user, routePrefix, rootLabel }: Props = $props();
+
+	// DEBUG: Log when user prop changes
+	$effect(() => {
+		console.log('[AuthenticatedLayout] user changed:', user);
+		console.log('[AuthenticatedLayout] rendering:', !!user);
+	});
 </script>
 
 {#if user}

--- a/src/routes/[[lang]]/app/+layout.svelte
+++ b/src/routes/[[lang]]/app/+layout.svelte
@@ -18,6 +18,12 @@
 	const sidebarConfig = $derived(
 		getAppSidebarConfig({ pathname: page.url.pathname, lang: page.params.lang }, viewer?.role)
 	);
+
+	// DEBUG: Log when viewer changes
+	$effect(() => {
+		console.log('[App Layout] viewer changed:', viewer);
+		console.log('[App Layout] data.viewer:', data.viewer);
+	});
 </script>
 
 <AuthenticatedLayout


### PR DESCRIPTION
Re-add debug console.log statements to diagnose recurring data.viewer
null issue during navigation (originally fixed in commit 95fdc57).