### PR TITLE
fix(load): preserve parent data in app/admin layout server loads

### DIFF
--- a/src/routes/[[lang]]/admin/+layout.server.ts
+++ b/src/routes/[[lang]]/admin/+layout.server.ts
@@ -1,6 +1,9 @@
 import type { LayoutServerLoad } from './$types';
 
-// Role check now happens in hooks.server.ts - no await needed here
-export const load = (async () => {
-	return {};
+// Role check now happens in hooks.server.ts - must spread parent to preserve viewer data
+export const load = (async ({ parent }) => {
+	const parentData = await parent();
+	return {
+		...parentData
+	};
 }) satisfies LayoutServerLoad;

--- a/src/routes/[[lang]]/app/+layout.server.ts
+++ b/src/routes/[[lang]]/app/+layout.server.ts
@@ -1,6 +1,9 @@
 import type { LayoutServerLoad } from './$types';
 
-// Viewer data is inherited from root layout - no fetch needed here
-export const load = (async () => {
-	return {};
+// Viewer data is inherited from root layout - must spread parent to preserve it
+export const load = (async ({ parent }) => {
+	const parentData = await parent();
+	return {
+		...parentData
+	};
 }) satisfies LayoutServerLoad;


### PR DESCRIPTION
Server load functions must spread parent data to preserve it during
client-side navigation. Without this, data.viewer becomes null when
navigating to /app or /admin routes.

This completes the fix started in commit 95fdc57, which only fixed
the universal load at [[lang]]/+layout.ts but missed the server loads
at app/+layout.server.ts and admin/+layout.server.ts.

Resolves viewer data loss issue during navigation.