### PR TITLE
refactor(animations): migrate all components from svelte-motion to motion-sv

### DIFF
--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -16,7 +16,7 @@
 	import { Bot, ChevronLeft, MessagesSquare } from '@lucide/svelte';
 
 	// Animation imports
-	import { Motion, AnimatePresence } from 'svelte-motion';
+	import { motion, AnimatePresence } from 'motion-sv';
 	import { Button } from '$lib/components/ui/button';
 
 	let {
@@ -120,39 +120,35 @@
 		<div class="relative flex size-10 items-center justify-center">
 			<!-- Messages icon (visible in overview) -->
 			<AnimatePresence show={threadContext.currentView === 'overview'}>
-				<Motion
-					let:motion
+				<motion.div
 					initial={hasMounted ? { opacity: 0, x: 20, scale: 0.5 } : { opacity: 1, x: 0, scale: 1 }}
 					animate={{ opacity: 1, x: 0, scale: 1 }}
 					exit={{ opacity: 0, x: -20, scale: 0.5 }}
 					transition={{ type: 'spring', duration: 0.2, bounce: 0 }}
+					class="absolute inset-0 flex items-center justify-center"
 				>
-					<div use:motion class="absolute inset-0 flex items-center justify-center">
-						<MessagesSquare class="size-5 text-muted-foreground" />
-					</div>
-				</Motion>
+					<MessagesSquare class="size-5 text-muted-foreground" />
+				</motion.div>
 			</AnimatePresence>
 
 			<!-- Back icon (visible in chat) -->
 			<AnimatePresence show={threadContext.currentView !== 'overview'}>
-				<Motion
-					let:motion
+				<motion.div
 					initial={hasMounted ? { opacity: 0, x: 20, scale: 0.5 } : { opacity: 1, x: 0, scale: 1 }}
 					animate={{ opacity: 1, x: 0, scale: 1 }}
 					exit={{ opacity: 0, x: -20, scale: 0.5 }}
 					transition={{ type: 'spring', duration: 0.2, bounce: 0 }}
+					class="absolute inset-0 flex items-center justify-center"
 				>
-					<div use:motion class="absolute inset-0 flex items-center justify-center">
-						<Button
-							variant="ghost"
-							size="icon"
-							class="h-10 w-10 rounded-full hover:!bg-muted-foreground/10"
-							onclick={() => threadContext.goBack()}
-						>
-							<ChevronLeft class="size-5" />
-						</Button>
-					</div>
-				</Motion>
+					<Button
+						variant="ghost"
+						size="icon"
+						class="h-10 w-10 rounded-full hover:!bg-muted-foreground/10"
+						onclick={() => threadContext.goBack()}
+					>
+						<ChevronLeft class="size-5" />
+					</Button>
+				</motion.div>
 			</AnimatePresence>
 		</div>
 
@@ -163,32 +159,28 @@
 		>
 			<!-- Overview title -->
 			<AnimatePresence show={threadContext.currentView === 'overview'}>
-				<Motion
-					let:motion
+				<motion.div
 					initial={hasMounted ? { y: -40, opacity: 0.8 } : { y: 0, opacity: 1 }}
 					animate={{ y: 0, opacity: 1 }}
 					exit={{ y: 40, opacity: 0.8 }}
 					transition={{ type: 'spring', duration: 0.5, bounce: 0.3 }}
+					class="col-start-1 row-start-1 flex h-10 items-center"
 				>
-					<div use:motion class="col-start-1 row-start-1 flex h-10 items-center">
-						<h2 class="text-xl leading-none font-semibold">Messages</h2>
-					</div>
-				</Motion>
+					<h2 class="text-xl leading-none font-semibold">Messages</h2>
+				</motion.div>
 			</AnimatePresence>
 
 			<!-- Chat title -->
 			<AnimatePresence show={threadContext.currentView !== 'overview'}>
-				<Motion
-					let:motion
+				<motion.div
 					initial={hasMounted ? { y: -40, opacity: 0.8 } : { y: 0, opacity: 1 }}
 					animate={{ y: 0, opacity: 1 }}
 					exit={{ y: 40, opacity: 0.8 }}
 					transition={{ type: 'spring', duration: 0.5, bounce: 0.3 }}
+					class="col-start-1 row-start-1 flex h-10 items-center"
 				>
-					<div use:motion class="col-start-1 row-start-1 flex h-10 items-center">
-						<AvatarHeading icon={Bot} title={agentName} subtitle="Our bot will reply instantly" />
-					</div>
-				</Motion>
+					<AvatarHeading icon={Bot} title={agentName} subtitle="Our bot will reply instantly" />
+				</motion.div>
 			</AnimatePresence>
 		</div>
 

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -10,12 +10,7 @@
 	import memberFour from '$blocks/team/avatars/member-four.webp';
 	import memberTwo from '$blocks/team/avatars/member-two.webp';
 	import memberFive from '$blocks/team/avatars/member-five.webp';
-	import { Motion } from 'svelte-motion';
-
-	const blurFadeVariants = {
-		hidden: { opacity: 0, y: 6, filter: 'blur(6px)' },
-		visible: { opacity: 1, y: 0, filter: 'blur(0px)' }
-	};
+	import { motion } from 'motion-sv';
 
 	const ctx = supportThreadContext.get();
 
@@ -89,26 +84,24 @@
 					</div>
 
 					<!-- Greeting -->
-					<Motion
-						variants={blurFadeVariants}
-						initial="hidden"
-						animate="visible"
+					<motion.h2
+						initial={{ opacity: 0, y: 6, filter: 'blur(6px)' }}
+						animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
 						transition={{ duration: 0.4, delay: 0.25, ease: 'easeOut' }}
-						let:motion
+						class="mb-4 text-5xl font-semibold text-muted-foreground"
 					>
-						<h2 use:motion class="mb-4 text-5xl font-semibold text-muted-foreground">Hi 👋</h2>
-					</Motion>
+						Hi 👋
+					</motion.h2>
 
 					<!-- Main heading -->
-					<Motion
-						variants={blurFadeVariants}
-						initial="hidden"
-						animate="visible"
+					<motion.h3
+						initial={{ opacity: 0, y: 6, filter: 'blur(6px)' }}
+						animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
 						transition={{ duration: 0.4, delay: 0.5, ease: 'easeOut' }}
-						let:motion
+						class="text-3xl font-bold"
 					>
-						<h3 use:motion class="text-3xl font-bold">How can we help you today?</h3>
-					</Motion>
+						How can we help you today?
+					</motion.h3>
 				</div>
 			</div>
 		{:else}

--- a/src/lib/components/ui/metric-card.svelte
+++ b/src/lib/components/ui/metric-card.svelte
@@ -5,12 +5,7 @@
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { cn } from '$lib/utils.js';
 	import type { Component } from 'svelte';
-	import { Motion } from 'svelte-motion';
-
-	const blurFadeVariants = {
-		hidden: { opacity: 0, y: 6, filter: 'blur(6px)' },
-		visible: { opacity: 1, y: 0, filter: 'blur(0px)' }
-	};
+	import { motion } from 'motion-sv';
 
 	interface Props {
 		label: string;
@@ -63,17 +58,14 @@
 				<span class="invisible">{value}</span>
 				<!-- Animated value positioned on top -->
 				{#if !loading}
-					<Motion
-						variants={blurFadeVariants}
-						initial="hidden"
-						animate="visible"
+					<motion.span
+						initial={{ opacity: 0, y: 6, filter: 'blur(6px)' }}
+						animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
 						transition={{ duration: 0.4, delay: 0.04, ease: 'easeOut' }}
-						let:motion
+						class="absolute inset-0"
 					>
-						<span use:motion class="absolute inset-0">
-							{value}
-						</span>
-					</Motion>
+						{value}
+					</motion.span>
 				{/if}
 			</span>
 		</Card.Title>


### PR DESCRIPTION
Migrate metric-card, feedback-widget, and threads-overview to motion-sv.
Motion-sv provides better Svelte 5 compatibility and GPU-accelerated animations.

- metric-card: blur-fade entrance animation
- feedback-widget: spring-based icon and title transitions
- threads-overview: staggered blur-fade greeting animations

All use <motion.*> syntax instead of <Motion let:motion> for cleaner code.