### PR TITLE
chore(deps): remove svelte-motion library

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,6 @@
         "resend": "^6.5.2",
         "runed": "^0.37.0",
         "svelte-konva": "^1.0.1",
-        "svelte-motion": "^0.12.2",
         "svelte-streamdown": "^3.0.0",
         "vercel": "^50.0.0",
       },
@@ -709,10 +708,6 @@
 
     "@types/prettier": ["@types/prettier@3.0.0", "", { "dependencies": { "prettier": "*" } }, "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA=="],
 
-    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
-
-    "@types/react": ["@types/react@18.3.27", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w=="],
-
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -1281,8 +1276,6 @@
 
     "framer-motion": ["framer-motion@12.23.26", "", { "dependencies": { "motion-dom": "^12.23.23", "motion-utils": "^12.23.6", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-cPcIhgR42xBn1Uj+PzOyheMtZ73H927+uWPDVhUMqxy8UHt6Okavb6xIz9J/phFUHUj0OncR6UvMfJTXoc/LKA=="],
 
-    "framesync": ["framesync@6.1.2", "", { "dependencies": { "tslib": "2.4.0" } }, "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g=="],
-
     "fs-extra": ["fs-extra@11.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw=="],
 
     "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
@@ -1651,8 +1644,6 @@
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
-    "popmotion": ["popmotion@11.0.5", "", { "dependencies": { "framesync": "6.1.2", "hey-listen": "^1.0.8", "style-value-types": "5.1.2", "tslib": "2.4.0" } }, "sha512-la8gPM1WYeFznb/JqF4GiTkRRPZsfaj2+kCxqQgr2MJylMmIKUwBfWW8Wa5fml/8gmtlD5yI01MP1QCZPWmppA=="],
-
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "postcss-load-config": ["postcss-load-config@3.1.4", "", { "dependencies": { "lilconfig": "^2.0.5", "yaml": "^1.10.2" }, "peerDependencies": { "postcss": ">=8.0.9", "ts-node": ">=9.0.0" }, "optionalPeers": ["postcss", "ts-node"] }, "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg=="],
@@ -1833,8 +1824,6 @@
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
-    "style-value-types": ["style-value-types@5.1.2", "", { "dependencies": { "hey-listen": "^1.0.8", "tslib": "2.4.0" } }, "sha512-Vs9fNreYF9j6W2VvuDTP7kepALi7sk0xtk2Tu8Yxi9UoajJdEVpNpCov0HsLTqXvNGKX+Uv09pkozVITi1jf3Q=="],
-
     "stylis": ["stylis@4.3.6", "", {}, "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="],
 
     "superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
@@ -1848,8 +1837,6 @@
     "svelte-eslint-parser": ["svelte-eslint-parser@1.4.1", "", { "dependencies": { "eslint-scope": "^8.2.0", "eslint-visitor-keys": "^4.0.0", "espree": "^10.0.0", "postcss": "^8.4.49", "postcss-scss": "^4.0.9", "postcss-selector-parser": "^7.0.0" }, "peerDependencies": { "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-1eqkfQ93goAhjAXxZiu1SaKI9+0/sxp4JIWQwUpsz7ybehRE5L8dNuz7Iry7K22R47p5/+s9EM+38nHV2OlgXA=="],
 
     "svelte-konva": ["svelte-konva@1.0.1", "", { "peerDependencies": { "konva": "8 - 10", "svelte": "^5.0.0" } }, "sha512-XfiSF9+J9phRupYGzMfbp46dnqsgZfN3Fwqei4YVAy0/9dr7k/qGtEucOqEcwgL1GEI2rxwSFXH0S5zbZqyMJQ=="],
-
-    "svelte-motion": ["svelte-motion@0.12.2", "", { "dependencies": { "@types/react": "^18.2.42", "framesync": "^6.1.2", "popmotion": "^11.0.5", "style-value-types": "5.1.2", "tslib": "^2.6.2" }, "peerDependencies": { "svelte": ">=3.35.0 || ^4.0.0 || ^5.0.0 || ^5.0.0-next.0" } }, "sha512-7RrdRz9iVP55B9HT/C0hYW3pyrKlF61kAby/AkDtOAP0uHFQDrfd0qQetDC81cEsK9b40jt+jfcqSAXcA7LPEw=="],
 
     "svelte-sonner": ["svelte-sonner@1.0.7", "", { "dependencies": { "runed": "^0.28.0" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-1EUFYmd7q/xfs2qCHwJzGPh9n5VJ3X6QjBN10fof2vxgy8fYE7kVfZ7uGnd7i6fQaWIr5KvXcwYXE/cmTEjk5A=="],
 
@@ -2223,8 +2210,6 @@
 
     "formsnap/svelte-toolbelt": ["svelte-toolbelt@0.5.0", "", { "dependencies": { "clsx": "^2.1.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.0.0-next.126" } }, "sha512-t3tenZcnfQoIeRuQf/jBU7bvTeT3TGkcEE+1EUr5orp0lR7NEpprflpuie3x9Dn0W9nOKqs3HwKGJeeN5Ok1sQ=="],
 
-    "framesync/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
-
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "glob/minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
@@ -2255,8 +2240,6 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "popmotion/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
-
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "raw-body/http-errors": ["http-errors@1.7.3", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.1.1", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.0" } }, "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw=="],
@@ -2264,8 +2247,6 @@
     "raw-body/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
-    "style-value-types/tslib": ["tslib@2.4.0", "", {}, "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="],
 
     "svelte-check/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
 		"resend": "^6.5.2",
 		"runed": "^0.37.0",
 		"svelte-konva": "^1.0.1",
-		"svelte-motion": "^0.12.2",
 		"svelte-streamdown": "^3.0.0",
 		"vercel": "^50.0.0"
 	},

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -119,36 +119,44 @@
 		<!-- Left: Animated icon swap (based on view state only) -->
 		<div class="relative flex size-10 items-center justify-center">
 			<!-- Messages icon (visible in overview) -->
-			<AnimatePresence show={threadContext.currentView === 'overview'}>
-				<motion.div
-					initial={hasMounted ? { opacity: 0, x: 20, scale: 0.5 } : { opacity: 1, x: 0, scale: 1 }}
-					animate={{ opacity: 1, x: 0, scale: 1 }}
-					exit={{ opacity: 0, x: -20, scale: 0.5 }}
-					transition={{ type: 'spring', duration: 0.2, bounce: 0 }}
-					class="absolute inset-0 flex items-center justify-center"
-				>
-					<MessagesSquare class="size-5 text-muted-foreground" />
-				</motion.div>
+			<AnimatePresence>
+				{#if threadContext.currentView === 'overview'}
+					<motion.div
+						initial={hasMounted
+							? { opacity: 0, x: 20, scale: 0.5 }
+							: { opacity: 1, x: 0, scale: 1 }}
+						animate={{ opacity: 1, x: 0, scale: 1 }}
+						exit={{ opacity: 0, x: -20, scale: 0.5 }}
+						transition={{ type: 'spring', duration: 0.2, bounce: 0 }}
+						class="absolute inset-0 flex items-center justify-center"
+					>
+						<MessagesSquare class="size-5 text-muted-foreground" />
+					</motion.div>
+				{/if}
 			</AnimatePresence>
 
 			<!-- Back icon (visible in chat) -->
-			<AnimatePresence show={threadContext.currentView !== 'overview'}>
-				<motion.div
-					initial={hasMounted ? { opacity: 0, x: 20, scale: 0.5 } : { opacity: 1, x: 0, scale: 1 }}
-					animate={{ opacity: 1, x: 0, scale: 1 }}
-					exit={{ opacity: 0, x: -20, scale: 0.5 }}
-					transition={{ type: 'spring', duration: 0.2, bounce: 0 }}
-					class="absolute inset-0 flex items-center justify-center"
-				>
-					<Button
-						variant="ghost"
-						size="icon"
-						class="h-10 w-10 rounded-full hover:!bg-muted-foreground/10"
-						onclick={() => threadContext.goBack()}
+			<AnimatePresence>
+				{#if threadContext.currentView !== 'overview'}
+					<motion.div
+						initial={hasMounted
+							? { opacity: 0, x: 20, scale: 0.5 }
+							: { opacity: 1, x: 0, scale: 1 }}
+						animate={{ opacity: 1, x: 0, scale: 1 }}
+						exit={{ opacity: 0, x: -20, scale: 0.5 }}
+						transition={{ type: 'spring', duration: 0.2, bounce: 0 }}
+						class="absolute inset-0 flex items-center justify-center"
 					>
-						<ChevronLeft class="size-5" />
-					</Button>
-				</motion.div>
+						<Button
+							variant="ghost"
+							size="icon"
+							class="h-10 w-10 rounded-full hover:!bg-muted-foreground/10"
+							onclick={() => threadContext.goBack()}
+						>
+							<ChevronLeft class="size-5" />
+						</Button>
+					</motion.div>
+				{/if}
 			</AnimatePresence>
 		</div>
 
@@ -158,29 +166,33 @@
 			style="mask-image: linear-gradient(to bottom, transparent 0%, black 4px, black calc(100% - 4px), transparent 100%);"
 		>
 			<!-- Overview title -->
-			<AnimatePresence show={threadContext.currentView === 'overview'}>
-				<motion.div
-					initial={hasMounted ? { y: -40, opacity: 0.8 } : { y: 0, opacity: 1 }}
-					animate={{ y: 0, opacity: 1 }}
-					exit={{ y: 40, opacity: 0.8 }}
-					transition={{ type: 'spring', duration: 0.5, bounce: 0.3 }}
-					class="col-start-1 row-start-1 flex h-10 items-center"
-				>
-					<h2 class="text-xl leading-none font-semibold">Messages</h2>
-				</motion.div>
+			<AnimatePresence>
+				{#if threadContext.currentView === 'overview'}
+					<motion.div
+						initial={hasMounted ? { y: -40, opacity: 0.8 } : { y: 0, opacity: 1 }}
+						animate={{ y: 0, opacity: 1 }}
+						exit={{ y: 40, opacity: 0.8 }}
+						transition={{ type: 'spring', duration: 0.5, bounce: 0.3 }}
+						class="col-start-1 row-start-1 flex h-10 items-center"
+					>
+						<h2 class="text-xl leading-none font-semibold">Messages</h2>
+					</motion.div>
+				{/if}
 			</AnimatePresence>
 
 			<!-- Chat title -->
-			<AnimatePresence show={threadContext.currentView !== 'overview'}>
-				<motion.div
-					initial={hasMounted ? { y: -40, opacity: 0.8 } : { y: 0, opacity: 1 }}
-					animate={{ y: 0, opacity: 1 }}
-					exit={{ y: 40, opacity: 0.8 }}
-					transition={{ type: 'spring', duration: 0.5, bounce: 0.3 }}
-					class="col-start-1 row-start-1 flex h-10 items-center"
-				>
-					<AvatarHeading icon={Bot} title={agentName} subtitle="Our bot will reply instantly" />
-				</motion.div>
+			<AnimatePresence>
+				{#if threadContext.currentView !== 'overview'}
+					<motion.div
+						initial={hasMounted ? { y: -40, opacity: 0.8 } : { y: 0, opacity: 1 }}
+						animate={{ y: 0, opacity: 1 }}
+						exit={{ y: 40, opacity: 0.8 }}
+						transition={{ type: 'spring', duration: 0.5, bounce: 0.3 }}
+						class="col-start-1 row-start-1 flex h-10 items-center"
+					>
+						<AvatarHeading icon={Bot} title={agentName} subtitle="Our bot will reply instantly" />
+					</motion.div>
+				{/if}
 			</AnimatePresence>
 		</div>
 


### PR DESCRIPTION
Remove svelte-motion after migrating all components to motion-sv.
Svelte-motion is unmaintained and incompatible with Svelte 5 runes.

All animations now use motion-sv:
- metric-card.svelte (blur-fade)
- feedback-widget.svelte (spring transitions)
- threads-overview.svelte (blur-fade)

Savings: ~1.4MB raw, ~350KB gzipped
Bundle now uses single, modern animation library