### PR TITLE
refactor(auth): replace ctx.auth.getUserIdentity with Better Auth

### DIFF
--- a/src/lib/convex/storage.ts
+++ b/src/lib/convex/storage.ts
@@ -1,13 +1,14 @@
 import { mutation } from './_generated/server';
 import { v } from 'convex/values';
 import { PROFILE_IMAGE_ALLOWED_TYPES, PROFILE_IMAGE_MAX_SIZE } from './constants';
+import { authComponent } from './auth';
 
 // Generate an upload URL for file uploads (authenticated)
 export const generateUploadUrl = mutation({
 	args: {},
 	handler: async (ctx) => {
-		const identity = await ctx.auth.getUserIdentity();
-		if (!identity) {
+		const user = await authComponent.getAuthUser(ctx);
+		if (!user) {
 			throw new Error('Unauthorized');
 		}
 		return await ctx.storage.generateUploadUrl();
@@ -18,8 +19,8 @@ export const generateUploadUrl = mutation({
 export const saveProfileImage = mutation({
 	args: { storageId: v.id('_storage') },
 	handler: async (ctx, args) => {
-		const identity = await ctx.auth.getUserIdentity();
-		if (!identity) {
+		const user = await authComponent.getAuthUser(ctx);
+		if (!user) {
 			throw new Error('Unauthorized');
 		}
 

--- a/src/lib/convex/support/ticketHelpers.ts
+++ b/src/lib/convex/support/ticketHelpers.ts
@@ -337,9 +337,9 @@ export const getEmailForThread = query({
 	args: { threadId: v.string() },
 	handler: async (ctx, args): Promise<string | null> => {
 		// Check authenticated user first
-		const identity = await ctx.auth.getUserIdentity();
-		if (identity?.email) {
-			return identity.email;
+		const user = await authComponent.getAuthUser(ctx);
+		if (user?.email) {
+			return user.email;
 		}
 
 		// Check previous tickets in this thread
@@ -456,8 +456,8 @@ export const submitTicketToolResult = mutation({
 		includeAttachments: v.optional(v.boolean())
 	},
 	handler: async (ctx, args) => {
-		const identity = await ctx.auth.getUserIdentity();
-		const userId = identity?.subject;
+		const user = await authComponent.getAuthUser(ctx);
+		const userId = user?._id;
 
 		if (args.action === 'submitted') {
 			// Validate required fields


### PR DESCRIPTION
Replace deprecated Convex auth pattern with Better Auth component:
- storage.ts: Use authComponent.getAuthUser for upload mutations
- ticketHelpers.ts: Use authComponent.getAuthUser for ticket queries/mutations
- Access user._id instead of identity.subject for consistent user IDs

This ensures proper integration with Better Auth and provides access to full user objects with custom fields (role, banned status, etc.)