### PR TITLE
refactor(marketing): remove section labels from pages

### DIFF
--- a/src/blocks/hero/hero-five.svelte
+++ b/src/blocks/hero/hero-five.svelte
@@ -16,15 +16,6 @@
 </script>
 
 <main class="overflow-hidden">
-	<section class="pt-16 md:pt-24">
-		<div class="mx-auto max-w-6xl px-6 lg:px-12">
-			<div class="border-t">
-				<span class="text-caption -mt-3.5 -ml-6 block w-max bg-background px-6">
-					<T keyName="hero.section_label" />
-				</span>
-			</div>
-		</div>
-	</section>
 	<section class="relative flex items-center justify-center">
 		<RiveBackground
 			src="/animations/spring-demo.riv"

--- a/src/blocks/pricing/pricing-three.svelte
+++ b/src/blocks/pricing/pricing-three.svelte
@@ -94,21 +94,16 @@
 
 <section class="py-16 md:py-24">
 	<div class="mx-auto max-w-6xl px-6 lg:px-12">
-		<div class="border-t">
-			<span class="text-caption -mt-3.5 -ml-6 block w-max bg-background px-6">
-				<T keyName="pricing.section_label" />
-			</span>
-			<div class="mt-12 gap-4 sm:grid sm:grid-cols-2 md:mt-24">
-				<div class="sm:w-3/5">
-					<h1 class="text-3xl font-bold sm:text-4xl">
-						<T keyName="pricing.title" />
-					</h1>
-				</div>
-				<div class="mt-6 sm:mt-0">
-					<p>
-						<T keyName="pricing.description" />
-					</p>
-				</div>
+		<div class="mt-12 gap-4 sm:grid sm:grid-cols-2 md:mt-24">
+			<div class="sm:w-3/5">
+				<h1 class="text-3xl font-bold sm:text-4xl">
+					<T keyName="pricing.title" />
+				</h1>
+			</div>
+			<div class="mt-6 sm:mt-0">
+				<p>
+					<T keyName="pricing.description" />
+				</p>
 			</div>
 		</div>
 

--- a/src/blocks/team/team-two.svelte
+++ b/src/blocks/team/team-two.svelte
@@ -49,59 +49,54 @@
 
 <section class="py-16 md:py-24">
 	<div class="mx-auto max-w-6xl px-6 lg:px-12">
-		<div class="border-t">
-			<span class="text-caption -mt-3.5 -ml-6 block w-max bg-background px-6">
-				<T keyName="team.section_label" />
-			</span>
-			<div class="mt-12 gap-4 sm:grid sm:grid-cols-2 md:mt-24">
-				<div class="sm:w-2/5">
-					<h2 class="text-3xl font-bold sm:text-4xl">
-						<T keyName="team.title" />
-					</h2>
-				</div>
-				<div class="mt-6 sm:mt-0">
-					<p>
-						<T keyName="team.description" />
-					</p>
-				</div>
+		<div class="mt-12 gap-4 sm:grid sm:grid-cols-2 md:mt-24">
+			<div class="sm:w-2/5">
+				<h2 class="text-3xl font-bold sm:text-4xl">
+					<T keyName="team.title" />
+				</h2>
 			</div>
-			<div class="mt-12 md:mt-24">
-				<div class="grid gap-x-6 gap-y-12 sm:grid-cols-2 lg:grid-cols-3">
-					{#each members as member, index}
-						<div class="group overflow-hidden">
-							<img
-								class="h-96 w-full rounded-md object-cover object-top grayscale transition-all duration-500 group-hover:h-[22.5rem] group-hover:rounded-xl hover:grayscale-0"
-								src={member.avatar}
-								alt="team member"
-								width="826"
-								height="1239"
-							/>
-							<div class="px-2 pt-2 sm:pt-4 sm:pb-0">
-								<div class="flex justify-between">
-									<h3
-										class="text-title text-base font-medium transition-all duration-500 group-hover:tracking-wider"
-									>
-										{member.name}
-									</h3>
-									<span class="text-xs">_0{index + 1}</span>
-								</div>
-								<div class="mt-1 flex items-center justify-between">
-									<span
-										class="inline-block translate-y-6 text-sm text-muted-foreground opacity-0 transition duration-300 group-hover:translate-y-0 group-hover:opacity-100"
-									>
-										<T keyName={member.roleKey} />
-									</span>
-									<a
-										href={member.link}
-										class="group-hover:text-primary-600 dark:group-hover:text-primary-400 inline-block translate-y-8 text-sm tracking-wide opacity-0 transition-all duration-500 group-hover:translate-y-0 group-hover:opacity-100 hover:underline"
-									>
-										<T keyName="team.linktree" />
-									</a>
-								</div>
+			<div class="mt-6 sm:mt-0">
+				<p>
+					<T keyName="team.description" />
+				</p>
+			</div>
+		</div>
+		<div class="mt-12 md:mt-24">
+			<div class="grid gap-x-6 gap-y-12 sm:grid-cols-2 lg:grid-cols-3">
+				{#each members as member, index}
+					<div class="group overflow-hidden">
+						<img
+							class="h-96 w-full rounded-md object-cover object-top grayscale transition-all duration-500 group-hover:h-[22.5rem] group-hover:rounded-xl hover:grayscale-0"
+							src={member.avatar}
+							alt="team member"
+							width="826"
+							height="1239"
+						/>
+						<div class="px-2 pt-2 sm:pt-4 sm:pb-0">
+							<div class="flex justify-between">
+								<h3
+									class="text-title text-base font-medium transition-all duration-500 group-hover:tracking-wider"
+								>
+									{member.name}
+								</h3>
+								<span class="text-xs">_0{index + 1}</span>
+							</div>
+							<div class="mt-1 flex items-center justify-between">
+								<span
+									class="inline-block translate-y-6 text-sm text-muted-foreground opacity-0 transition duration-300 group-hover:translate-y-0 group-hover:opacity-100"
+								>
+									<T keyName={member.roleKey} />
+								</span>
+								<a
+									href={member.link}
+									class="group-hover:text-primary-600 dark:group-hover:text-primary-400 inline-block translate-y-8 text-sm tracking-wide opacity-0 transition-all duration-500 group-hover:translate-y-0 group-hover:opacity-100 hover:underline"
+								>
+									<T keyName="team.linktree" />
+								</a>
 							</div>
 						</div>
-					{/each}
-				</div>
+					</div>
+				{/each}
 			</div>
 		</div>
 	</div>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -231,7 +231,6 @@
 		"cta": "Jetzt starten",
 		"cta_demo": "Demo anfordern",
 		"description": "Erwecke dein SaaS zum Leben in Minuten, nicht in Monaten. Open-Source Template mit einem Tech-Stack, der dich schnell shippen lässt.",
-		"section_label": "Start",
 		"tagline": "Mit Produktfokus schneller zum Ziel",
 		"title": "SaaS-Starter-Vorlage"
 	},
@@ -353,7 +352,6 @@
 			"pro[3]": "Priority-Support"
 		},
 		"popular_badge": "Beliebt",
-		"section_label": "Preise",
 		"tiers": {
 			"enterprise": {
 				"button": "Vertrieb kontaktieren",
@@ -462,7 +460,6 @@
 			"ux_engineer": "UX Engineer",
 			"visual_designer": "Visual Designer"
 		},
-		"section_label": "Team",
 		"title": "Unser Traumteam"
 	}
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -231,7 +231,6 @@
 		"cta": "Start Building",
 		"cta_demo": "Request a demo",
 		"description": "Bring your SaaS to life in minutes, not months. Open-source template loaded with the tech that gets you shipping.",
-		"section_label": "Home",
 		"tagline": "Focus on your product and ship faster.",
 		"title": "SaaS Starter Template"
 	},
@@ -353,7 +352,6 @@
 			"pro[3]": "Priority support"
 		},
 		"popular_badge": "Popular",
-		"section_label": "Pricing",
 		"tiers": {
 			"enterprise": {
 				"button": "Contact Sales",
@@ -462,7 +460,6 @@
 			"ux_engineer": "UX Engineer",
 			"visual_designer": "Visual Designer"
 		},
-		"section_label": "Team",
 		"title": "Our dream team"
 	}
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -231,7 +231,6 @@
 		"cta": "Comenzar ahora",
 		"cta_demo": "Solicitar una demo",
 		"description": "Dale vida a tu SaaS en minutos, no en meses. Plantilla open-source cargada con la tecnología que te hace lanzar rápido.",
-		"section_label": "Inicio",
 		"tagline": "Foco en tu producto. Lanzamiento más rápido.",
 		"title": "Plantilla SaaS Starter"
 	},
@@ -353,7 +352,6 @@
 			"pro[3]": "Soporte prioritario"
 		},
 		"popular_badge": "Popular",
-		"section_label": "Precios",
 		"tiers": {
 			"enterprise": {
 				"button": "Contactar Ventas",
@@ -462,7 +460,6 @@
 			"ux_engineer": "Ingeniero UX",
 			"visual_designer": "Diseñador Visual"
 		},
-		"section_label": "Equipo",
 		"title": "Nuestro equipo soñado"
 	}
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -231,7 +231,6 @@
 		"cta": "Commencer maintenant",
 		"cta_demo": "Demander une démo",
 		"description": "Donne vie à ton SaaS en quelques minutes, pas en mois. Template open-source bourré de tech qui te fait shipper direct.",
-		"section_label": "Accueil",
 		"tagline": "Focus sur ton produit. Lancement plus rapide.",
 		"title": "Modèle SaaS Starter"
 	},
@@ -353,7 +352,6 @@
 			"pro[3]": "Support prioritaire"
 		},
 		"popular_badge": "Populaire",
-		"section_label": "Tarifs",
 		"tiers": {
 			"enterprise": {
 				"button": "Contacter les Ventes",
@@ -462,7 +460,6 @@
 			"ux_engineer": "Ingénieur UX",
 			"visual_designer": "Designer Visuel"
 		},
-		"section_label": "Équipe",
 		"title": "Notre équipe de rêve"
 	}
 }


### PR DESCRIPTION
Remove decorative border-top line with overlaid text labels from hero, pricing, and team pages. Also clean up unused translation keys (section_label) from all i18n files.