### PR TITLE
chore(ci,tooling): use npm scripts and optimize workflow triggers

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -1,6 +1,10 @@
 name: Quality Checks
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main] # Only run on pushes to main branch
+  pull_request:
+    types: [opened, synchronize, reopened] # Run on PR creation and subsequent pushes
 
 jobs:
   quality_checks:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-./quality-check.sh --staged
+bun run quality-check:staged

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,9 +18,10 @@
 			}
 		},
 		{
-			"label": "quality-check.sh",
+			"label": "bun run quality-check",
 			"type": "shell",
-			"command": "./quality-check.sh",
+			"command": "bun",
+			"args": ["run", "quality-check"],
 			"group": {
 				"kind": "test",
 				"isDefault": true
@@ -32,10 +33,10 @@
 			}
 		},
 		{
-			"label": "quality-check.sh --staged",
+			"label": "bun run quality-check:staged",
 			"type": "shell",
-			"command": "./quality-check.sh",
-			"args": ["--staged"],
+			"command": "bun",
+			"args": ["run", "quality-check:staged"],
 			"group": "test",
 			"problemMatcher": ["$eslint-compact", "$tsc"],
 			"detail": "Run pre-commit checks on staged files only",
@@ -78,6 +79,37 @@
 			"presentation": {
 				"clear": true
 			}
+		},
+		{
+			"label": "bun run worktree --open-editor",
+			"type": "shell",
+			"command": "bun",
+			"args": ["run", "worktree", "${input:branchName}", "--open-editor", "${input:editorChoice}"],
+			"group": "none",
+			"problemMatcher": [],
+			"detail": "Create a new git worktree with Graphite tracking and environment setup",
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": true,
+				"panel": "shared",
+				"clear": true
+			}
+		}
+	],
+	"inputs": [
+		{
+			"id": "branchName",
+			"type": "promptString",
+			"description": "Branch name for new worktree (e.g., feature-auth)",
+			"default": "feature/"
+		},
+		{
+			"id": "editorChoice",
+			"type": "pickString",
+			"description": "Open worktree in which editor?",
+			"options": ["cursor", "code"],
+			"default": "cursor"
 		}
 	]
 }


### PR DESCRIPTION
Improve CI configuration and developer tooling to use npm scripts consistently:

CI Improvements:
- Run quality checks only on main branch pushes and PR events
- Reduces unnecessary workflow runs

Developer Tooling:
- Update pre-commit hook to use 'bun run quality-check:staged'
- Update VSCode tasks to use npm scripts instead of direct script calls
- Add VSCode task for creating git worktrees with Graphite integration