### PR TITLE
fix(signin): update authentication redirect logic to exclude verification step

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -213,6 +213,7 @@
 		"signup": "Registrieren",
 		"verification": {
 			"button_cancel": "Abbrechen",
+			"check_email": "Bitte überprüfen Sie Ihre E-Mail und klicken Sie auf den Verifizierungslink, um Ihre Registrierung abzuschließen.",
 			"description": "Wir haben Ihnen einen Verifizierungslink gesendet",
 			"sent_to": "Wir haben eine Verifizierungs-E-Mail an",
 			"title": "E-Mail-Verifizierung"

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -213,12 +213,8 @@
 		"signup": "Registrieren",
 		"verification": {
 			"button_cancel": "Abbrechen",
-			"button_verify": "E-Mail verifizieren",
-			"button_verify_loading": "Wird verifiziert...",
-			"code_label": "Verifizierungscode",
-			"code_placeholder": "12345678",
-			"description": "Bitte überprüfen Sie Ihre E-Mail für einen Verifizierungscode",
-			"sent_to": "Wir haben einen 8-stelligen Verifizierungscode an",
+			"description": "Wir haben Ihnen einen Verifizierungslink gesendet",
+			"sent_to": "Wir haben eine Verifizierungs-E-Mail an",
 			"title": "E-Mail-Verifizierung"
 		}
 	},

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -215,12 +215,8 @@
 		"signup": "Sign Up",
 		"verification": {
 			"button_cancel": "Cancel",
-			"button_verify": "Verify Email",
-			"button_verify_loading": "Verifying...",
-			"code_label": "Verification Code",
-			"code_placeholder": "12345678",
-			"description": "Please check your email for a verification code",
-			"sent_to": "We've sent an 8-digit verification code to",
+			"description": "We've sent you a verification link",
+			"sent_to": "We've sent a verification email to",
 			"title": "Email Verification"
 		}
 	},

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -215,6 +215,7 @@
 		"signup": "Sign Up",
 		"verification": {
 			"button_cancel": "Cancel",
+			"check_email": "Please check your email and click the verification link to complete your registration.",
 			"description": "We've sent you a verification link",
 			"sent_to": "We've sent a verification email to",
 			"title": "Email Verification"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -213,6 +213,7 @@
 		"signup": "Registrarse",
 		"verification": {
 			"button_cancel": "Cancelar",
+			"check_email": "Por favor revisa tu correo electrónico y haz clic en el enlace de verificación para completar tu registro.",
 			"description": "Te hemos enviado un enlace de verificación",
 			"sent_to": "Hemos enviado un correo de verificación a",
 			"title": "Verificación de correo electrónico"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -213,12 +213,8 @@
 		"signup": "Registrarse",
 		"verification": {
 			"button_cancel": "Cancelar",
-			"button_verify": "Verificar correo",
-			"button_verify_loading": "Verificando...",
-			"code_label": "Código de verificación",
-			"code_placeholder": "12345678",
-			"description": "Por favor revisa tu correo electrónico para obtener un código de verificación",
-			"sent_to": "Hemos enviado un código de verificación de 8 dígitos a",
+			"description": "Te hemos enviado un enlace de verificación",
+			"sent_to": "Hemos enviado un correo de verificación a",
 			"title": "Verificación de correo electrónico"
 		}
 	},

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -213,6 +213,7 @@
 		"signup": "S'inscrire",
 		"verification": {
 			"button_cancel": "Annuler",
+			"check_email": "Veuillez vérifier votre e-mail et cliquer sur le lien de vérification pour finaliser votre inscription.",
 			"description": "Nous vous avons envoyé un lien de vérification",
 			"sent_to": "Nous avons envoyé un e-mail de vérification à",
 			"title": "Vérification de l'e-mail"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -53,8 +53,8 @@
 		"sidebar": {
 			"back_to_app": "Retour à l'App",
 			"dashboard": "Tableau de bord",
-			"users": "Utilisateurs",
-			"support": "Support"
+			"support": "Support",
+			"users": "Utilisateurs"
 		},
 		"support": {
 			"all_statuses": "Tous les statuts",
@@ -213,12 +213,8 @@
 		"signup": "S'inscrire",
 		"verification": {
 			"button_cancel": "Annuler",
-			"button_verify": "Vérifier l'e-mail",
-			"button_verify_loading": "Vérification en cours...",
-			"code_label": "Code de vérification",
-			"code_placeholder": "12345678",
-			"description": "Veuillez vérifier votre e-mail pour un code de vérification",
-			"sent_to": "Nous avons envoyé un code de vérification à 8 chiffres à",
+			"description": "Nous vous avons envoyé un lien de vérification",
+			"sent_to": "Nous avons envoyé un e-mail de vérification à",
 			"title": "Vérification de l'e-mail"
 		}
 	},

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -184,10 +184,7 @@
 							<span class="font-medium">{verificationStep.email}</span>
 						</p>
 						<p class="text-sm text-muted-foreground">
-							<T
-								keyName="auth.verification.check_email"
-								defaultValue="Please check your email and click the verification link to complete your registration."
-							/>
+							<T keyName="auth.verification.check_email" />
 						</p>
 						{#if formError}
 							<p class="text-sm text-red-500">{formError}</p>

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -119,9 +119,9 @@
 		}
 	});
 
-	// Redirect when authenticated on signin page
+	// Redirect when authenticated on signin page (but not during verification step)
 	$effect(() => {
-		if (auth.isAuthenticated) {
+		if (auth.isAuthenticated && !verificationStep) {
 			const destination = params.redirectTo || localizedHref('/app');
 			window.location.href = destination;
 		}

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -429,13 +429,13 @@
 							<T keyName="auth.signin.oauth_google" />
 						</Button>
 					</div>
-				{/if}
 
-				<div class="mt-6 text-center">
-					<a class="text-sm text-muted-foreground hover:underline" href={localizedHref('/')}>
-						<T keyName="auth.signin.cancel" />
-					</a>
-				</div>
+					<div class="mt-6 text-center">
+						<a class="text-sm text-muted-foreground hover:underline" href={localizedHref('/')}>
+							<T keyName="auth.signin.cancel" />
+						</a>
+					</div>
+				{/if}
 			</CardContent>
 		</Card>
 	</main>


### PR DESCRIPTION
fix(signin): update authentication redirect logic to exclude verification step

- Modified the redirect behavior on the signin page to prevent redirection during the verification step, ensuring a smoother user experience for users in the authentication process.

fix(signin): improve email verification screen UX

- Move cancel link inside conditional to prevent duplicate buttons
- Update translations to reflect magic link verification instead of
  8-digit code
- Remove unused verification code input translations