### PR TITLE
fix(i18n): update translations for verification process back button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,3 +246,8 @@ A customizable Svelte component for building node-based editors and interactive 
 - `vercel env rm KEY environment` - Remove environment variable
 - `vercel logs` - View deployment logs
 - `vercel domains` - Manage custom domains
+
+## Plan Mode
+
+- Make the plan extremely concise. Sacrifice grammar for the sake of concision.
+- At the end of each plan, give me a list of unresolved questions to answer, if any.

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -212,8 +212,12 @@
 		},
 		"signup": "Registrieren",
 		"verification": {
-			"button_cancel": "Abbrechen",
+			"button_back": "Zurück zur Anmeldung",
+			"button_verify": "E-Mail verifizieren",
+			"button_verify_loading": "Wird verifiziert...",
 			"check_email": "Bitte überprüfen Sie Ihre E-Mail und klicken Sie auf den Verifizierungslink, um Ihre Registrierung abzuschließen.",
+			"code_label": "Verifizierungscode",
+			"code_placeholder": "12345678",
 			"description": "Wir haben Ihnen einen Verifizierungslink gesendet",
 			"sent_to": "Wir haben eine Verifizierungs-E-Mail an",
 			"title": "E-Mail-Verifizierung"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -214,8 +214,12 @@
 		},
 		"signup": "Sign Up",
 		"verification": {
-			"button_cancel": "Cancel",
+			"button_back": "Back to login",
+			"button_verify": "Verify Email",
+			"button_verify_loading": "Verifying...",
 			"check_email": "Please check your email and click the verification link to complete your registration.",
+			"code_label": "Verification Code",
+			"code_placeholder": "12345678",
 			"description": "We've sent you a verification link",
 			"sent_to": "We've sent a verification email to",
 			"title": "Email Verification"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -212,8 +212,12 @@
 		},
 		"signup": "Registrarse",
 		"verification": {
-			"button_cancel": "Cancelar",
+			"button_back": "Volver al inicio de sesión",
+			"button_verify": "Verificar correo",
+			"button_verify_loading": "Verificando...",
 			"check_email": "Por favor revisa tu correo electrónico y haz clic en el enlace de verificación para completar tu registro.",
+			"code_label": "Código de verificación",
+			"code_placeholder": "12345678",
 			"description": "Te hemos enviado un enlace de verificación",
 			"sent_to": "Hemos enviado un correo de verificación a",
 			"title": "Verificación de correo electrónico"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -212,8 +212,12 @@
 		},
 		"signup": "S'inscrire",
 		"verification": {
-			"button_cancel": "Annuler",
+			"button_back": "Retour à la connexion",
+			"button_verify": "Vérifier l'e-mail",
+			"button_verify_loading": "Vérification en cours...",
 			"check_email": "Veuillez vérifier votre e-mail et cliquer sur le lien de vérification pour finaliser votre inscription.",
+			"code_label": "Code de vérification",
+			"code_placeholder": "12345678",
 			"description": "Nous vous avons envoyé un lien de vérification",
 			"sent_to": "Nous avons envoyé un e-mail de vérification à",
 			"title": "Vérification de l'e-mail"

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -56,7 +56,7 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>): BetterAuthOptions
 				});
 			},
 			sendOnSignUp: true,
-			autoSignInAfterVerification: false
+			autoSignInAfterVerification: true
 		},
 		socialProviders: {
 			google: {

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -86,8 +86,15 @@
 				formError = '';
 
 				try {
+					// After email verification, user will be auto-logged in and redirected to /app
+					const callbackURL = params.redirectTo || localizedHref('/app');
 					await authClient.signUp.email(
-						{ email: f.data.email, password: f.data.password, name: f.data.name },
+						{
+							email: f.data.email,
+							password: f.data.password,
+							name: f.data.name,
+							callbackURL
+						},
 						{
 							onSuccess: () => {
 								verificationStep = { email: f.data.email };

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -202,7 +202,7 @@
 							<p class="text-sm text-red-500">{formError}</p>
 						{/if}
 						<Button type="button" variant="ghost" class="w-full" onclick={cancelVerification}>
-							<T keyName="auth.verification.button_cancel" />
+							<T keyName="auth.verification.button_back" />
 						</Button>
 					</div>
 				{:else}


### PR DESCRIPTION
fix(i18n): update translations for verification process back button

- Changed button text for cancel action to "Zurück zur Anmeldung" and added new translations for email verification buttons and messages, enhancing user experience during the signup process.

docs(AGENTS): add Plan Mode section with guidelines for conciseness and unresolved questions

- Introduced a new section outlining the Plan Mode, emphasizing the need for concise plans and the inclusion of unresolved questions at the end of each plan.

fix(auth): enable auto sign-in after email verification

- Updated the authentication options to allow automatic sign-in after email verification, enhancing user experience during the signup process.
- Modified the sign-up function to include a callback URL for redirection to the app post-verification.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR improves the email verification user experience by enabling auto sign-in after verification and adding a callback URL for proper post-verification redirection.

**Key Changes:**
- Enabled `autoSignInAfterVerification: true` in `src/lib/convex/auth.ts:59` to automatically sign users in after email verification
- Added `callbackURL` parameter to `authClient.signUp.email()` in `src/routes/[[lang]]/(auth)/signin/+page.svelte:90-96` to redirect users to the app after verification
- Updated verification button translation key from `button_cancel` to `button_back` across all languages (de, en, es, fr) for better clarity
- Added new translation keys (`button_verify`, `button_verify_loading`, `code_label`, `code_placeholder`) that appear to be preparation for a future code-based verification feature
- Added Plan Mode documentation in `AGENTS.md` for AI assistant guidelines

**Impact:**
Users will now be automatically signed in after clicking the email verification link and redirected to `/app` (or their intended destination), eliminating the need for manual login after verification. The verification screen button now says "Back to login" instead of "Cancel" which is more descriptive.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with low risk
- The changes are straightforward and improve UX. Auth config change is a simple boolean flag flip, callbackURL addition follows existing patterns (already used in OAuth flow), and i18n updates are consistent across all languages. Minor concern: unused translation keys suggest incomplete feature work, but don't impact functionality.
- Check that `bun run i18n:push` was run to sync translations to Tolgee Cloud (per AGENTS.md workflow)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/i18n/en.json | Updated English translations for verification flow, renamed button_cancel to button_back, added new verification keys |
| src/lib/convex/auth.ts | Enabled auto sign-in after email verification (autoSignInAfterVerification: true) |
| src/routes/[[lang]]/(auth)/signin/+page.svelte | Added callbackURL to signUp.email call, updated button translation key from button_cancel to button_back |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant F as Frontend (signin page)
    participant AC as Auth Client
    participant BA as Better Auth
    participant E as Email Service
    participant CB as Convex Backend

    U->>F: Fill signup form (name, email, password)
    U->>F: Submit signup form
    F->>F: Calculate callbackURL (redirectTo or /app)
    F->>AC: signUp.email(email, password, name, callbackURL)
    AC->>BA: Create user account
    BA->>CB: Store user in database
    BA->>E: Send verification email with link
    E-->>U: Verification email sent
    BA-->>AC: Success
    AC->>F: onSuccess callback
    F->>F: Set verificationStep with email
    F->>U: Display verification screen

    Note over U,F: User clicks verification link in email

    U->>BA: GET verify-email endpoint with token and callbackURL
    BA->>CB: Verify email token
    BA->>CB: Mark email as verified
    
    alt autoSignInAfterVerification enabled
        BA->>BA: Auto sign-in user
        BA->>BA: Create session
        BA-->>U: Redirect to callbackURL
        U->>F: Load app (authenticated)
    else autoSignInAfterVerification disabled
        BA-->>U: Redirect to login page
        U->>F: Manual login required
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=973fa3fa-32dc-443b-96ad-cbc9377e5b13))

<!-- /greptile_comment -->