### PR TITLE
fix/opencode-config

### DIFF
--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -2,8 +2,8 @@
 name: code-reviewer
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-# "model": "github-copilot/gpt-5.2-codex"
+# model: 'openai/gpt-5.2-codex'
+model: 'github-copilot/gpt-5.2-codex'
 color: '#22c55e'
 description: |
   Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. This agent should be used proactively after writing or modifying code, especially before committing changes or creating pull requests. It will check for style violations, potential issues, and ensure code follows the established patterns in CLAUDE.md. Also the agent needs to know which files to focus on for the review. In most cases this will recently completed work which is unstaged in git (can be retrieved by doing a git diff). However there can be cases where this is different, make sure to specify this as the agent input when calling the agent. 

--- a/.opencode/agents/code-simplifier.md
+++ b/.opencode/agents/code-simplifier.md
@@ -2,8 +2,8 @@
 name: code-simplifier
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-# "model": "github-copilot/gpt-5.2-codex"
+# model: 'openai/gpt-5.2-codex'
+model: 'github-copilot/gpt-5.2-codex'
 color: '#3b82f6'
 description: |
   Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.

--- a/.opencode/agents/comment-analyzer.md
+++ b/.opencode/agents/comment-analyzer.md
@@ -2,8 +2,8 @@
 name: comment-analyzer
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-# "model": "github-copilot/gpt-5.2-codex"
+# model: 'openai/gpt-5.2-codex'
+model: 'github-copilot/gpt-5.2-codex'
 color: '#10b981'
 description: |
   Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.

--- a/.opencode/agents/pr-test-analyzer.md
+++ b/.opencode/agents/pr-test-analyzer.md
@@ -2,8 +2,8 @@
 name: pr-test-analyzer
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-# "model": "github-copilot/gpt-5.2-codex"
+# model: 'openai/gpt-5.2-codex'
+model: 'github-copilot/gpt-5.2-codex'
 color: '#06b6d4'
 description: |
   Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases. Examples:

--- a/.opencode/agents/silent-failure-hunter.md
+++ b/.opencode/agents/silent-failure-hunter.md
@@ -2,8 +2,8 @@
 name: silent-failure-hunter
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-# "model": "github-copilot/gpt-5.2-codex"
+# model: 'openai/gpt-5.2-codex'
+model: 'github-copilot/gpt-5.2-codex'
 color: '#eab308'
 description: |
   Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors. Examples:

--- a/.opencode/agents/type-design-analyzer.md
+++ b/.opencode/agents/type-design-analyzer.md
@@ -2,8 +2,8 @@
 name: type-design-analyzer
 mode: subagent
 # https://models.dev/
-model: 'openai/gpt-5.2-codex'
-# "model": "github-copilot/gpt-5.2-codex"
+# model: 'openai/gpt-5.2-codex'
+model: 'github-copilot/gpt-5.2-codex'
 color: '#ec4899'
 description: |
   Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,23 @@ This project is a saas template built with SvelteKit, Convex, Typescript and mod
 - `bunx convex env set KEY value` - Set Convex environment variables
 - `bunx convex env set KEY value --prod` - Set production environment variables
 
+### Convex Platform Guarantees
+
+When reviewing Convex backend code, be aware of these platform guarantees:
+
+**Scheduler Guarantees:**
+
+- Scheduling from mutations is atomic - if `ctx.scheduler.runAfter()` is called within a mutation, it's part of the transaction. Either the whole mutation succeeds (including the schedule), or it all rolls back. There is NO "silent scheduler failure" in mutations.
+- Scheduled mutations are guaranteed exactly-once execution. Convex automatically retries internal errors.
+- Actions are different - scheduling from actions is NOT atomic.
+
+**Components with Built-in Durability:**
+
+- `@convex-dev/resend`: Built-in idempotency keys, retry logic (5 attempts default), durable execution. Duplicate `sendEmail` calls return the same EmailId, not duplicate sends.
+- `@convex-dev/workpool`: Configurable retry with backoff/jitter, `onComplete` callbacks, parallelism control.
+
+Note: Other components (`@convex-dev/better-auth`, `@convex-dev/rate-limiter`, `@convex-dev/agent`) do NOT have automatic retry for external API calls - standard error handling applies.
+
 ### Tolgee CLI
 
 These commands use `dotenv` to load the local TOLGEE_API_KEY from `.env.local`:
@@ -146,11 +163,11 @@ Props: Use $props() instead of export let.
 Events: Use HTML attributes (e.g., onclick) instead of on:.
 Content: Use {#snippet} and {@render} instead of slots.
 Quick Examples:
-State & Events: <script lang="ts">let count = $state(0); </script> <button onclick={() => count += 1}>{count}</button>
+State & Events: `<script lang="ts">let count = $state(0); </script> <button onclick={() => count += 1}>{count}</button>`
 Derived: let doubled = $derived(count \* 2);
-Props: <script lang="ts">let { name = 'World' } = $props(); </script> <p>Hello, {name}!</p>
-Binding: <script lang="ts">let { value = $bindable() } = $props(); </script> <input bind:value={value} />
-Snippets: <div>{@render header()}</div> with <Child>{#snippet header()}<h1>Header</h1>{/snippet}</Child>
+Props: <script lang="ts">let { name = 'World' } = $props(); </script> `<p>Hello, {name}!</p>`
+Binding: `<script lang="ts">let { value = $bindable() } = $props(); </script> <input bind:value={value} />`
+Snippets: `<div>{@render header()}</div> with <Child>{#snippet header()}<h1>Header</h1>{/snippet}</Child>`
 Class Store: class Counter { count = $state(0); increment() { this.count += 1; } } export const counter = new Counter();
 Notes:
 Type $derived explicitly (e.g., let items: Item[] = $derived(...)) for arrays in TypeScript.

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -46,6 +46,11 @@
     },
     "provider": {
         "google": {
+            "options": {
+                "websearch_cited": {
+                    "model": "gemini-3-flash-preview"
+                }
+            },
             "models": {
                 "antigravity-gemini-3-pro": {
                     "name": "Gemini 3 Pro (Antigravity)",


### PR DESCRIPTION
# Switch to GitHub Copilot model and update documentation

### TL;DR

Switch all OpenCode agents to use the GitHub Copilot model and enhance documentation with Convex platform guarantees and Svelte syntax examples.

### What changed?

- Updated all agent configuration files to use `github-copilot/gpt-5.2-codex` instead of `openai/gpt-5.2-codex`
- Added detailed Convex platform guarantees section to AGENTS.md, explaining:
  - Scheduler guarantees for mutations and actions
  - Components with built-in durability (@convex-dev/resend, @convex-dev/workpool)
  - Components without automatic retry
- Improved Svelte syntax examples in AGENTS.md with proper code formatting
- Added Gemini model configuration in opencode.jsonc for websearch_cited option

### How to test?

1. Verify that all agents now use the GitHub Copilot model
2. Review the new Convex platform guarantees section in AGENTS.md for accuracy
3. Check that the Svelte syntax examples are properly formatted with backticks
4. Confirm the Gemini model configuration is correctly set in opencode.jsonc

### Why make this change?

This change standardizes our model usage across all agents to use GitHub Copilot's model for consistency. The enhanced documentation provides developers with clearer guidance on Convex platform guarantees, which is crucial for building reliable backend code. The improved Svelte syntax examples with proper code formatting make them more readable and easier to understand.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR standardizes agent model configuration and enhances documentation with critical platform guarantees and improved formatting.

**Key Changes:**
- Switched all 6 OpenCode agents from `openai/gpt-5.2-codex` to `github-copilot/gpt-5.2-codex` for consistency
- Added comprehensive Convex Platform Guarantees section documenting scheduler atomicity, exactly-once execution guarantees, and component durability behavior
- Improved Svelte 5 syntax examples by wrapping code snippets in backticks for better markdown formatting
- Configured Gemini websearch_cited option to use `gemini-3-flash-preview` model

**Impact:**
The documentation improvements are particularly valuable - the Convex platform guarantees clarify important transaction semantics (scheduler calls in mutations are atomic) and retry behavior (built-in for `@convex-dev/resend` and `@convex-dev/workpool`, but not for other components). This information helps prevent common misunderstandings about error handling requirements.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues detected
- All changes are configuration and documentation updates with no functional code changes. The model switch is a straightforward configuration change applied consistently across all 6 agent files. The documentation additions are accurate, well-structured, and provide valuable clarification about platform guarantees. The Svelte syntax improvements enhance readability. No logic changes, no breaking changes, and all modifications align with the stated PR objectives.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .opencode/agents/code-reviewer.md | Switched model from `openai/gpt-5.2-codex` to `github-copilot/gpt-5.2-codex` |
| .opencode/agents/code-simplifier.md | Switched model from `openai/gpt-5.2-codex` to `github-copilot/gpt-5.2-codex` |
| .opencode/agents/comment-analyzer.md | Switched model from `openai/gpt-5.2-codex` to `github-copilot/gpt-5.2-codex` |
| .opencode/agents/pr-test-analyzer.md | Switched model from `openai/gpt-5.2-codex` to `github-copilot/gpt-5.2-codex` |
| AGENTS.md | Added Convex platform guarantees section and improved Svelte syntax examples with backticks |
| opencode.jsonc | Added Gemini websearch_cited model configuration option |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant OC as OpenCode
    participant Agents as Agent Files
    participant Docs as AGENTS.md
    participant Config as opencode.jsonc

    Dev->>Agents: Update model configuration
    Agents->>Agents: Change openai/gpt-5.2-codex to github-copilot/gpt-5.2-codex
    Note over Agents: 6 agent files updated:<br/>code-reviewer, code-simplifier,<br/>comment-analyzer, pr-test-analyzer,<br/>silent-failure-hunter, type-design-analyzer
    
    Dev->>Docs: Add Convex Platform Guarantees
    Docs->>Docs: Document scheduler guarantees
    Docs->>Docs: Document component durability
    Note over Docs: Clarifies atomic transactions<br/>and retry behavior
    
    Dev->>Docs: Improve Svelte syntax examples
    Docs->>Docs: Wrap code snippets in backticks
    Note over Docs: Better formatting for<br/>State & Events, Props,<br/>Binding, Snippets
    
    Dev->>Config: Add Gemini websearch config
    Config->>Config: Configure gemini-3-flash-preview<br/>for websearch_cited option
    
    OC->>Agents: Load agent configurations
    Agents-->>OC: Return github-copilot model settings
    OC->>Config: Load provider options
    Config-->>OC: Return Gemini websearch settings
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->