### PR TITLE
feat(admin): add admin email notification table; enhance skeleton loading with cached numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Library/
 react-reference
 
 *.local*
+
+.opencode/plans

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ See [official docs](https://docs.convex.dev/scheduling/scheduled-functions) for 
 
 **Components with Built-in Durability:**
 
-- `@convex-dev/resend`: Idempotency keys guarantee exactly-once email delivery, durable execution via workpools. See [component docs](https://www.convex.dev/components/resend).
+- `@convex-dev/resend`: Idempotency keys guarantee exactly-once email delivery, durable execution via workpools (default: 5 retries, 30s initial backoff). Catching errors from `resend.sendEmail()` is valid - they indicate permanent failures (invalid config), not transient network issues. See [component docs](https://www.convex.dev/components/resend).
 - `@convex-dev/workpool`: Configurable retry with backoff/jitter, `onComplete` callbacks, parallelism control.
 
 Note: Other components (`@convex-dev/better-auth`, `@convex-dev/rate-limiter`, `@convex-dev/agent`) do NOT have automatic retry for external API calls - standard error handling applies.
@@ -269,4 +269,4 @@ A customizable Svelte component for building node-based editors and interactive 
 ## Plan Mode
 
 - Make the plan extremely concise. Sacrifice grammar for the sake of concision.
-- At the end of each plan, give me a list of unresolved questions to answer, if any.
+- At the end of each plan, give me a list of unresolved questions to answer, if any, using the question tool.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,36 @@ bun run dev
 
 Visit `http://localhost:5173` to see your app!
 
+### 7. Set Up First Admin (Required for Admin Panel)
+
+The admin panel requires at least one admin user. To promote your first admin:
+
+1. **Sign up** with the email you want to be admin
+2. **Run the seed command:**
+
+   ```bash
+   bunx convex run admin/mutations:seedFirstAdmin '{"email":"your-email@example.com"}'
+   ```
+
+This is a one-time setup. The command will:
+
+- Verify the user exists
+- Check that no admins exist yet (prevents accidental re-runs)
+- Promote the user to admin role
+- Enable notification preferences for admin alerts
+
+**Note:** After the first admin is set up, additional admins can be promoted via the Admin Panel → Users page.
+
+### 8. Sync Existing Admins (Migration)
+
+If you had admin users before the notification preferences feature was added, run this one-time migration to sync them:
+
+```bash
+bunx convex run admin/notificationPreferences/mutations:syncAllAdminPreferences
+```
+
+This ensures all existing admins appear in the Admin Settings → Notification Recipients page. Safe to run multiple times.
+
 ## Available Scripts
 
 - `bun run dev` - Start development server
@@ -356,6 +386,19 @@ bunx convex env set RESEND_API_KEY your_resend_api_key --prod
 bunx convex env set AUTH_EMAIL "noreply@yourdomain.com" --prod
 bunx convex env set RESEND_WEBHOOK_SECRET your_webhook_secret --prod
 ```
+
+### Set Up Production Admin
+
+After deploying to production, set up your first admin:
+
+1. **Sign up** on your production site with your admin email
+2. **Run the seed command** against production:
+
+   ```bash
+   bunx convex run admin/mutations:seedFirstAdmin '{"email":"admin@yourdomain.com"}' --prod
+   ```
+
+This enables access to the Admin Panel at `/admin`.
 
 ## Customization
 

--- a/antigravity.json
+++ b/antigravity.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://raw.githubusercontent.com/NoeFabris/opencode-antigravity-auth/main/assets/antigravity.schema.json",
+	"web_search": {
+		"default_mode": "auto"
+	}
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "saas-starter",
@@ -16,6 +15,7 @@
         "@stickerdaniel/convex-autumn-svelte": "^0.1.3",
         "@svelte-put/lockscroll": "^2.0.1",
         "@tolgee/cli": "^2.14.0",
+        "@tolgee/format-icu": "^6.2.7",
         "@tolgee/svelte": "^6.2.7",
         "@zumer/snapdom": "^2.0.0",
         "ai": "^5.0.93",
@@ -616,6 +616,8 @@
     "@tolgee/cli": ["@tolgee/cli@2.14.0", "", { "dependencies": { "ajv": "^8.17.1", "ansi-colors": "^4.1.3", "base32-decode": "^1.0.0", "commander": "^12.1.0", "cosmiconfig": "^9.0.0", "json5": "^2.2.3", "jsonschema": "^1.5.0", "openapi-fetch": "0.13.1", "tinyglobby": "^0.2.12", "unescape-js": "^1.1.4", "vscode-oniguruma": "^2.0.1", "vscode-textmate": "^9.1.0", "yauzl": "^3.2.0" }, "peerDependencies": { "jiti": ">= 2" }, "optionalPeers": ["jiti"], "bin": { "tolgee": "dist/cli.js" } }, "sha512-M5/VfZBaZ19lvZULdQswFVWwrn4bfaIsmyNzuM/WDpo5jFsAP7K/lyrg8H7ps4xLAWMmwy6gdy0ET0A5IYDFQg=="],
 
     "@tolgee/core": ["@tolgee/core@6.2.7", "", {}, "sha512-0Au+m9R23/gmeaLJY0X6lKcR2LSy9dW7hEFrpFvPdJoGvxc8XCNZpKlgnm1N534CwmtIBJ4rzOK6vOrSKbl45w=="],
+
+    "@tolgee/format-icu": ["@tolgee/format-icu@6.2.7", "", {}, "sha512-rLa8EZZVX3pDYC3I6HLnLvTgwLr2PAyOw+7SanS7d7SXp9cvcxbX8O6nqHubv6K7YDqVblcj9FoFbvGBQ22PgQ=="],
 
     "@tolgee/svelte": ["@tolgee/svelte@6.2.7", "", { "dependencies": { "@tolgee/web": "6.2.7" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0" } }, "sha512-R7J3XO3g5BtUnXwvzljajRAnJeFIPB0qmisEl896L4IJUMHfsddDytaFRP90hlQzEgwRICMtbr43T6XFgSNJrQ=="],
 

--- a/e2e/admin-settings.spec.ts
+++ b/e2e/admin-settings.spec.ts
@@ -1,0 +1,221 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for Admin Settings page - Notification Recipients
+ *
+ * Prerequisites:
+ * - Test user must be an admin (promote via Convex dashboard if needed)
+ * - Dev server running with Convex backend
+ */
+test.describe('Admin Settings Page', () => {
+	test.beforeEach(async ({ page }) => {
+		// Navigate to admin settings page
+		await page.goto('/admin/settings');
+		await page.waitForLoadState('networkidle');
+
+		// Debug: log current URL and page title
+		console.log('Current URL:', page.url());
+		console.log('Page title:', await page.title());
+	});
+
+	test('displays recipients table', async ({ page }) => {
+		// Debug: take screenshot
+		await page.screenshot({ path: 'test-results/admin-settings-debug.png' });
+		console.log('Page HTML:', await page.content());
+
+		// Verify page loads
+		await expect(page.getByTestId('admin-settings-page')).toBeVisible();
+		await expect(page.getByTestId('recipients-table')).toBeVisible();
+
+		// Wait for data to load (no more loading skeletons)
+		await expect(page.getByTestId('recipients-loading')).not.toBeVisible({ timeout: 10000 });
+
+		// Should have at least one recipient row (the admin user)
+		const rows = page.locator('[data-testid^="recipient-row-"]');
+		await expect(rows.first()).toBeVisible();
+	});
+
+	test('adds custom email recipient', async ({ page }) => {
+		// Wait for table to load
+		await expect(page.getByTestId('recipients-loading')).not.toBeVisible({ timeout: 10000 });
+
+		// Generate unique email to avoid conflicts
+		const testEmail = `test-e2e-${Date.now()}@example.com`;
+
+		// Open add email dialog
+		await page.getByTestId('add-email-button').click();
+
+		// Fill in email
+		await page.getByTestId('add-email-input').fill(testEmail);
+
+		// Submit
+		await page.getByTestId('add-email-submit').click();
+
+		// Wait for dialog to close and verify email appears in table
+		await expect(page.getByTestId('add-email-input')).not.toBeVisible({ timeout: 5000 });
+
+		// Verify the new email appears in the table
+		await expect(page.getByTestId(`recipient-row-${testEmail}`)).toBeVisible({ timeout: 5000 });
+	});
+
+	test('shows error for invalid email', async ({ page }) => {
+		// Wait for table to load
+		await expect(page.getByTestId('recipients-loading')).not.toBeVisible({ timeout: 10000 });
+
+		// Open add email dialog
+		await page.getByTestId('add-email-button').click();
+
+		// Wait for dialog to open
+		await expect(page.getByTestId('add-email-input')).toBeVisible();
+
+		// Fill in invalid email (missing @ symbol triggers validation error)
+		const invalidEmail = 'not-an-email';
+		await page.getByTestId('add-email-input').fill(invalidEmail);
+
+		// Verify submit button is enabled (not empty)
+		await expect(page.getByTestId('add-email-submit')).toBeEnabled();
+
+		// Submit the form
+		await page.getByTestId('add-email-submit').click();
+
+		// Verify error message appears (client-side validation catches missing @)
+		// The regex /^[^\s@]+@[^\s@]+\.[^\s@]+$/ requires @ symbol
+		await expect(page.getByTestId('add-email-error')).toBeVisible({ timeout: 5000 });
+	});
+
+	test('shows error for duplicate email', async ({ page }) => {
+		// Wait for table to load
+		await expect(page.getByTestId('recipients-loading')).not.toBeVisible({ timeout: 10000 });
+
+		// First, add a custom email
+		const testEmail = `test-dup-${Date.now()}@example.com`;
+
+		await page.getByTestId('add-email-button').click();
+		await page.getByTestId('add-email-input').fill(testEmail);
+		await page.getByTestId('add-email-submit').click();
+
+		// Wait for email to appear in table
+		await expect(page.getByTestId(`recipient-row-${testEmail}`)).toBeVisible({ timeout: 5000 });
+
+		// Try to add the same email again
+		await page.getByTestId('add-email-button').click();
+		await page.getByTestId('add-email-input').fill(testEmail);
+		await page.getByTestId('add-email-submit').click();
+
+		// Verify error message appears for duplicate email
+		await expect(page.getByTestId('add-email-error')).toBeVisible({ timeout: 5000 });
+
+		// Close dialog
+		await page.keyboard.press('Escape');
+
+		// Cleanup: remove the test email
+		await page.getByTestId(`delete-email-${testEmail}`).click();
+		await page.getByTestId('confirm-delete-button').click();
+		await expect(page.getByTestId(`recipient-row-${testEmail}`)).not.toBeVisible({ timeout: 5000 });
+	});
+
+	test('filters recipients by type', async ({ page }) => {
+		// Wait for table to load
+		await expect(page.getByTestId('recipients-loading')).not.toBeVisible({ timeout: 10000 });
+
+		// Get initial row count
+		const allRows = page.locator('[data-testid^="recipient-row-"]');
+		const initialCount = await allRows.count();
+
+		// Skip if not enough data to test filtering
+		if (initialCount < 1) {
+			test.skip();
+			return;
+		}
+
+		// Open filter dropdown
+		await page.getByTestId('filter-type-trigger').click();
+
+		// Select admin filter
+		await page.getByTestId('filter-admin').click();
+
+		// Verify filter is applied (clear button appears)
+		await expect(page.getByTestId('filter-clear')).toBeVisible();
+
+		// Clear filter
+		await page.getByTestId('filter-clear').click();
+
+		// Verify filter is cleared (clear button disappears)
+		await expect(page.getByTestId('filter-clear')).not.toBeVisible();
+	});
+
+	test('toggles notification preference', async ({ page }) => {
+		// Wait for table to load
+		await expect(page.getByTestId('recipients-loading')).not.toBeVisible({ timeout: 10000 });
+
+		// Find the first recipient row
+		const firstRow = page.locator('[data-testid^="recipient-row-"]').first();
+		await expect(firstRow).toBeVisible();
+
+		// Get the email from the row's data-testid
+		const rowTestId = await firstRow.getAttribute('data-testid');
+		const email = rowTestId?.replace('recipient-row-', '');
+
+		if (!email) {
+			test.skip();
+			return;
+		}
+
+		// Find a toggle checkbox for this recipient
+		const toggle = page.getByTestId(`toggle-notifyNewSupportTickets-${email}`);
+
+		if (!(await toggle.isVisible())) {
+			test.skip();
+			return;
+		}
+
+		// Get initial state
+		const initialChecked = await toggle.isChecked();
+
+		// Click to toggle
+		await toggle.click();
+
+		// Wait for state to change (more reliable than waitForTimeout)
+		if (initialChecked) {
+			await expect(toggle).not.toBeChecked({ timeout: 5000 });
+		} else {
+			await expect(toggle).toBeChecked({ timeout: 5000 });
+		}
+
+		// Toggle back to original state
+		await toggle.click();
+
+		// Wait for state to be restored
+		if (initialChecked) {
+			await expect(toggle).toBeChecked({ timeout: 5000 });
+		} else {
+			await expect(toggle).not.toBeChecked({ timeout: 5000 });
+		}
+	});
+
+	test('removes custom email recipient', async ({ page }) => {
+		// Wait for table to load
+		await expect(page.getByTestId('recipients-loading')).not.toBeVisible({ timeout: 10000 });
+
+		// First, add a custom email to remove
+		const testEmail = `test-remove-${Date.now()}@example.com`;
+
+		await page.getByTestId('add-email-button').click();
+		await page.getByTestId('add-email-input').fill(testEmail);
+		await page.getByTestId('add-email-submit').click();
+
+		// Wait for email to appear
+		await expect(page.getByTestId(`recipient-row-${testEmail}`)).toBeVisible({ timeout: 5000 });
+
+		// Click delete button
+		await page.getByTestId(`delete-email-${testEmail}`).click();
+
+		// Confirm deletion in dialog - use specific testid
+		await page.getByTestId('confirm-delete-button').click();
+
+		// Wait for removal
+		await expect(page.getByTestId(`recipient-row-${testEmail}`)).not.toBeVisible({
+			timeout: 5000
+		});
+	});
+});

--- a/e2e/admin.setup.ts
+++ b/e2e/admin.setup.ts
@@ -1,0 +1,68 @@
+import { test as setup } from '@playwright/test';
+import { ConvexHttpClient } from 'convex/browser';
+import { api } from '../src/lib/convex/_generated/api';
+
+const adminAuthFile = 'e2e/.auth/admin.json';
+
+/**
+ * This setup test promotes the test user to admin and saves a fresh auth state.
+ * Admin tests will use this authenticated state.
+ *
+ * Prerequisites:
+ * 1. Set TEST_USER_EMAIL, TEST_USER_PASSWORD, and AUTH_E2E_TEST_SECRET in .env.test
+ * 2. Run: bun run setup:test-user (with dev server running)
+ * 3. Set CONVEX_URL in .env.test (e.g., from `bunx convex dev`)
+ */
+setup('promote test user to admin', async ({ page }) => {
+	const email = process.env.TEST_USER_EMAIL;
+	const password = process.env.TEST_USER_PASSWORD;
+	const testSecret = process.env.AUTH_E2E_TEST_SECRET;
+	const convexUrl = process.env.PUBLIC_CONVEX_URL || process.env.VITE_CONVEX_URL;
+
+	if (!email || !password) {
+		throw new Error(
+			'TEST_USER_EMAIL and TEST_USER_PASSWORD must be set. ' +
+				'Update .env.test with test credentials, ' +
+				'then run: bun run setup:test-user'
+		);
+	}
+
+	if (!testSecret) {
+		throw new Error('AUTH_E2E_TEST_SECRET must be set in .env.test');
+	}
+
+	if (!convexUrl) {
+		throw new Error('PUBLIC_CONVEX_URL or VITE_CONVEX_URL must be set in .env.test');
+	}
+
+	// Promote test user to admin via Convex mutation
+	const client = new ConvexHttpClient(convexUrl);
+	const result = await client.mutation(api.tests.promoteTestUserToAdmin, {
+		email,
+		secret: testSecret
+	});
+
+	if (!result.success) {
+		throw new Error(`Failed to promote test user to admin: ${result.error}`);
+	}
+
+	console.log(
+		result.alreadyAdmin
+			? `Test user ${email} is already an admin`
+			: `Promoted test user ${email} to admin`
+	);
+
+	// Sign in to get fresh auth state with admin role in JWT
+	await page.goto('/signin');
+	await page.waitForLoadState('networkidle');
+
+	await page.fill('[data-testid="email-input"]', email);
+	await page.fill('[data-testid="password-input"]', password);
+	await page.click('[data-testid="signin-button"]');
+
+	// Wait for redirect to app
+	await page.waitForURL(/\/[a-z]{2}\/app/, { timeout: 15000 });
+
+	// Save authenticated state with admin role
+	await page.context().storageState({ path: adminAuthFile });
+});

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -4,10 +4,7 @@
 	"model": "anthropic/claude-opus-4-5",
 	// "model": "google/antigravity-claude-opus-4-5",
 	// "model": "github-copilot/claude-opus-4-5",
-	"plugin": [
-		"@nick-vi/opencode-type-inject",
-		"opencode-antigravity-auth@beta"
-	],
+	"plugin": ["@nick-vi/opencode-type-inject", "opencode-antigravity-auth@1.3.0"],
 	"mcp": {
 		"svelte": {
 			"type": "remote",
@@ -15,22 +12,11 @@
 		},
 		"convex": {
 			"type": "local",
-			"command": [
-				"bunx",
-				"-y",
-				"convex@latest",
-				"mcp",
-				"start"
-			]
+			"command": ["bunx", "-y", "convex@latest", "mcp", "start"]
 		},
 		"jsrepo": {
 			"type": "local",
-			"command": [
-				"bunx",
-				"-y",
-				"jsrepo",
-				"mcp"
-			],
+			"command": ["bunx", "-y", "jsrepo", "mcp"],
 			"enabled": false
 		},
 		"konva-documentation": {
@@ -45,11 +31,7 @@
 		},
 		"lighthouse": {
 			"type": "local",
-			"command": [
-				"bunx",
-				"-y",
-				"@danielsogl/lighthouse-mcp@latest"
-			],
+			"command": ["bunx", "-y", "@danielsogl/lighthouse-mcp@latest"],
 			"enabled": true
 		}
 	},
@@ -63,14 +45,8 @@
 						"output": 65535
 					},
 					"modalities": {
-						"input": [
-							"text",
-							"image",
-							"pdf"
-						],
-						"output": [
-							"text"
-						]
+						"input": ["text", "image", "pdf"],
+						"output": ["text"]
 					},
 					"variants": {
 						"low": {
@@ -88,14 +64,8 @@
 						"output": 65536
 					},
 					"modalities": {
-						"input": [
-							"text",
-							"image",
-							"pdf"
-						],
-						"output": [
-							"text"
-						]
+						"input": ["text", "image", "pdf"],
+						"output": ["text"]
 					},
 					"variants": {
 						"minimal": {
@@ -119,14 +89,8 @@
 						"output": 64000
 					},
 					"modalities": {
-						"input": [
-							"text",
-							"image",
-							"pdf"
-						],
-						"output": [
-							"text"
-						]
+						"input": ["text", "image", "pdf"],
+						"output": ["text"]
 					}
 				},
 				"antigravity-claude-sonnet-4-5-thinking": {
@@ -136,14 +100,8 @@
 						"output": 64000
 					},
 					"modalities": {
-						"input": [
-							"text",
-							"image",
-							"pdf"
-						],
-						"output": [
-							"text"
-						]
+						"input": ["text", "image", "pdf"],
+						"output": ["text"]
 					},
 					"variants": {
 						"low": {
@@ -165,14 +123,8 @@
 						"output": 64000
 					},
 					"modalities": {
-						"input": [
-							"text",
-							"image",
-							"pdf"
-						],
-						"output": [
-							"text"
-						]
+						"input": ["text", "image", "pdf"],
+						"output": ["text"]
 					},
 					"variants": {
 						"low": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,12 +28,17 @@ export default defineConfig({
 
 	/* Configure projects */
 	projects: [
-		// Setup project - authenticates and saves state
+		// Setup project - authenticates regular user and saves state
 		{
 			name: 'setup',
-			testMatch: /.*\.setup\.ts/
+			testMatch: /signin\.setup\.ts/
 		},
-		// Tests that need authentication (most tests)
+		// Admin setup - promotes test user to admin and saves admin auth state
+		{
+			name: 'admin-setup',
+			testMatch: /admin\.setup\.ts/
+		},
+		// Tests that need regular user authentication
 		{
 			name: 'chromium',
 			use: {
@@ -42,8 +47,19 @@ export default defineConfig({
 				storageState: 'e2e/.auth/user.json'
 			},
 			dependencies: ['setup'],
-			// Don't run invalid-auth tests - those need unauthenticated state
-			testIgnore: /invalid-auth\.spec\.ts/
+			// Don't run invalid-auth or admin tests
+			testIgnore: [/invalid-auth\.spec\.ts/, /admin-.*\.spec\.ts/]
+		},
+		// Admin tests - require admin role
+		{
+			name: 'chromium-admin',
+			use: {
+				...devices['Desktop Chrome'],
+				// Use stored admin auth state
+				storageState: 'e2e/.auth/admin.json'
+			},
+			dependencies: ['admin-setup'],
+			testMatch: /admin-.*\.spec\.ts/
 		},
 		// Tests that specifically test unauthenticated behavior
 		{

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -51,19 +51,60 @@
 			"website": "Webseite"
 		},
 		"settings": {
+			"add_email": "E-Mail hinzufügen",
+			"add_email_dialog_desc": "E-Mail-Adresse für Admin-Benachrichtigungen hinzufügen",
+			"add_email_dialog_title": "Benutzerdefinierte E-Mail hinzufügen",
+			"add_email_placeholder": "email@example.com",
+			"column_email": "E-Mail",
+			"column_name": "Name",
+			"column_new_signups": "Neue Anmeldungen",
+			"column_new_tickets": "Neue Tickets",
+			"column_type": "Typ",
+			"column_user_replies": "Benutzerantworten",
 			"default_support_email": "Standard-Support-E-Mail",
 			"default_support_email_help": "Leer lassen, um Benachrichtigungen an alle Admin-Benutzer zu senden.",
 			"default_support_email_placeholder": "support@example.com",
+			"delete_email": "Entfernen",
+			"delete_email_confirm": "{email} aus den Benachrichtigungsempfängern entfernen?",
+			"delete_email_description": "{email} aus den Benachrichtigungsempfängern entfernen?",
+			"delete_email_title": "E-Mail entfernen",
 			"description": "Admin-Panel-Einstellungen und Benachrichtigungen konfigurieren.",
+			"email_added": "E-Mail hinzugefügt",
+			"email_add_failed": "E-Mail konnte nicht hinzugefügt werden",
+			"email_exists": "Diese E-Mail existiert bereits",
+			"email_removed": "E-Mail entfernt",
+			"field_new_signups": "Benachrichtigungen für neue Anmeldungen",
+			"field_new_tickets": "Benachrichtigungen für neue Tickets",
+			"field_user_replies": "Benachrichtigungen für Benutzerantworten",
+			"filter": {
+				"admin_only": "Nur Admins",
+				"all_types": "Alle Typen",
+				"clear": "Löschen",
+				"custom_only": "Nur Benutzerdefiniert"
+			},
+			"invalid_email": "Ungültige E-Mail-Adresse",
+			"no_recipients": "Keine Benachrichtigungsempfänger konfiguriert",
+			"notification_recipients": "Benachrichtigungsempfänger",
+			"notification_recipients_desc": "Konfigurieren Sie, wer Admin-Benachrichtigungen erhält. Admin-Benutzer werden automatisch einbezogen.",
+			"preference_disabled": "{field} deaktiviert",
+			"preference_disabling": "{field} wird deaktiviert...",
+			"preference_enabled": "{field} aktiviert",
+			"preference_enabling": "{field} wird aktiviert...",
+			"preference_update_failed": "Einstellung konnte nicht aktualisiert werden",
+			"recipient_count": "{count, plural, other {# Empfänger} }",
 			"save": "Einstellungen speichern",
 			"saved": "Einstellungen gespeichert",
 			"saving": "Speichern...",
+			"selected": "{selected} von {total} ausgewählt",
 			"support_notifications": "Support-Benachrichtigungen",
 			"support_notifications_desc": "E-Mail-Benachrichtigungen für neue und nicht zugewiesene wiedereröffnete Support-Tickets konfigurieren.",
 			"tabs": {
-				"notifications": "Benachrichtigungen"
+				"notifications": "Benachrichtigungen",
+				"recipients": "Empfänger"
 			},
-			"title": "Admin-Einstellungen"
+			"title": "Admin-Einstellungen",
+			"type_admin": "Admin",
+			"type_custom": "Benutzerdefiniert"
 		},
 		"sidebar": {
 			"back_to_app": "Zurück zur App",
@@ -277,6 +318,7 @@
 		"title": "Community Chat"
 	},
 	"common": {
+		"adding": "Wird hinzugefügt...",
 		"cancel": "Abbrechen",
 		"confirm": "Bestätigen"
 	},

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -51,19 +51,60 @@
 			"website": "Website"
 		},
 		"settings": {
+			"add_email": "Add Email",
+			"add_email_dialog_desc": "Add an email address to receive admin notifications",
+			"add_email_dialog_title": "Add Custom Email",
+			"add_email_placeholder": "email@example.com",
+			"column_email": "Email",
+			"column_name": "Name",
+			"column_new_signups": "New Signups",
+			"column_new_tickets": "New Tickets",
+			"column_type": "Type",
+			"column_user_replies": "User Replies",
 			"default_support_email": "Default Support Email",
 			"default_support_email_help": "Leave empty to send notifications to all admin users.",
 			"default_support_email_placeholder": "support@example.com",
+			"delete_email": "Remove",
+			"delete_email_confirm": "Remove {email} from notification recipients?",
+			"delete_email_description": "Remove {email} from notification recipients?",
+			"delete_email_title": "Remove Email",
 			"description": "Configure admin panel settings and notifications.",
+			"email_added": "Email added",
+			"email_add_failed": "Failed to add email",
+			"email_exists": "This email already exists",
+			"email_removed": "Email removed",
+			"field_new_signups": "New signup notifications",
+			"field_new_tickets": "New ticket notifications",
+			"field_user_replies": "User reply notifications",
+			"filter": {
+				"admin_only": "Admin Only",
+				"all_types": "All Types",
+				"clear": "Clear",
+				"custom_only": "Custom Only"
+			},
+			"invalid_email": "Invalid email address",
+			"no_recipients": "No notification recipients configured",
+			"notification_recipients": "Notification Recipients",
+			"notification_recipients_desc": "Configure who receives admin notifications. Admin users are automatically included.",
+			"preference_disabled": "{field} disabled",
+			"preference_disabling": "Disabling {field}...",
+			"preference_enabled": "{field} enabled",
+			"preference_enabling": "Enabling {field}...",
+			"preference_update_failed": "Failed to update preference",
+			"recipient_count": "{count, plural, one {# recipient} other {# recipients}}",
 			"save": "Save Settings",
 			"saved": "Settings saved",
 			"saving": "Saving...",
+			"selected": "{selected} of {total} selected",
 			"support_notifications": "Support Notifications",
 			"support_notifications_desc": "Configure email notifications for new and unassigned reopened support tickets.",
 			"tabs": {
-				"notifications": "Notifications"
+				"notifications": "Notifications",
+				"recipients": "Recipients"
 			},
-			"title": "Admin Settings"
+			"title": "Admin Settings",
+			"type_admin": "Admin",
+			"type_custom": "Custom"
 		},
 		"sidebar": {
 			"back_to_app": "Back to App",
@@ -279,6 +320,7 @@
 		"title": "Community Chat"
 	},
 	"common": {
+		"adding": "Adding...",
 		"cancel": "Cancel",
 		"confirm": "Confirm"
 	},

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -51,19 +51,60 @@
 			"website": "Sitio Web"
 		},
 		"settings": {
+			"add_email": "Agregar Email",
+			"add_email_dialog_desc": "Agregar una dirección de email para recibir notificaciones de administrador",
+			"add_email_dialog_title": "Agregar Email Personalizado",
+			"add_email_placeholder": "email@example.com",
+			"column_email": "Email",
+			"column_name": "Nombre",
+			"column_new_signups": "Nuevos Registros",
+			"column_new_tickets": "Nuevos Tickets",
+			"column_type": "Tipo",
+			"column_user_replies": "Respuestas de Usuario",
 			"default_support_email": "Email de Soporte Predeterminado",
 			"default_support_email_help": "Dejar vacío para enviar notificaciones a todos los administradores.",
 			"default_support_email_placeholder": "soporte@example.com",
+			"delete_email": "Eliminar",
+			"delete_email_confirm": "¿Eliminar {email} de los destinatarios de notificaciones?",
+			"delete_email_description": "¿Eliminar {email} de los destinatarios de notificaciones?",
+			"delete_email_title": "Eliminar Email",
 			"description": "Configura los ajustes del panel de administración y las notificaciones.",
+			"email_added": "Email agregado",
+			"email_add_failed": "No se pudo agregar el email",
+			"email_exists": "Este email ya existe",
+			"email_removed": "Email eliminado",
+			"field_new_signups": "Notificaciones de nuevos registros",
+			"field_new_tickets": "Notificaciones de nuevos tickets",
+			"field_user_replies": "Notificaciones de respuestas de usuario",
+			"filter": {
+				"admin_only": "Solo Admins",
+				"all_types": "Todos los Tipos",
+				"clear": "Limpiar",
+				"custom_only": "Solo Personalizados"
+			},
+			"invalid_email": "Dirección de email inválida",
+			"no_recipients": "No hay destinatarios de notificaciones configurados",
+			"notification_recipients": "Destinatarios de Notificaciones",
+			"notification_recipients_desc": "Configura quién recibe notificaciones de administrador. Los usuarios administradores se incluyen automáticamente.",
+			"preference_disabled": "{field} desactivadas",
+			"preference_disabling": "Desactivando {field}...",
+			"preference_enabled": "{field} activadas",
+			"preference_enabling": "Activando {field}...",
+			"preference_update_failed": "Error al actualizar preferencia",
+			"recipient_count": "{count, plural, one {# destinatario} other {# destinatarios}}",
 			"save": "Guardar Configuración",
 			"saved": "Configuración guardada",
 			"saving": "Guardando...",
+			"selected": "{selected} de {total} seleccionados",
 			"support_notifications": "Notificaciones de Soporte",
 			"support_notifications_desc": "Configura las notificaciones por email para tickets de soporte nuevos y reabiertos no asignados.",
 			"tabs": {
-				"notifications": "Notificaciones"
+				"notifications": "Notificaciones",
+				"recipients": "Destinatarios"
 			},
-			"title": "Configuración de Admin"
+			"title": "Configuración de Admin",
+			"type_admin": "Admin",
+			"type_custom": "Personalizado"
 		},
 		"sidebar": {
 			"back_to_app": "Volver a la App",
@@ -277,6 +318,7 @@
 		"title": "Chat Comunitario"
 	},
 	"common": {
+		"adding": "Agregando...",
 		"cancel": "Cancelar",
 		"confirm": "Confirmar"
 	},

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -51,19 +51,60 @@
 			"website": "Site Web"
 		},
 		"settings": {
+			"add_email": "Ajouter un Email",
+			"add_email_dialog_desc": "Ajouter une adresse email pour recevoir les notifications admin",
+			"add_email_dialog_title": "Ajouter un Email Personnalisé",
+			"add_email_placeholder": "email@example.com",
+			"column_email": "Email",
+			"column_name": "Nom",
+			"column_new_signups": "Nouvelles Inscriptions",
+			"column_new_tickets": "Nouveaux Tickets",
+			"column_type": "Type",
+			"column_user_replies": "Réponses Utilisateur",
 			"default_support_email": "Email de Support par Défaut",
 			"default_support_email_help": "Laisser vide pour envoyer les notifications à tous les administrateurs.",
 			"default_support_email_placeholder": "support@example.com",
+			"delete_email": "Supprimer",
+			"delete_email_confirm": "Supprimer {email} des destinataires de notifications ?",
+			"delete_email_description": "Supprimer {email} des destinataires de notifications ?",
+			"delete_email_title": "Supprimer l'Email",
 			"description": "Configurez les paramètres du panneau d'administration et les notifications.",
+			"email_added": "Email ajouté",
+			"email_add_failed": "Impossible d'ajouter l'email",
+			"email_exists": "Cet email existe déjà",
+			"email_removed": "Email supprimé",
+			"field_new_signups": "Notifications de nouvelles inscriptions",
+			"field_new_tickets": "Notifications de nouveaux tickets",
+			"field_user_replies": "Notifications de réponses utilisateur",
+			"filter": {
+				"admin_only": "Admins Uniquement",
+				"all_types": "Tous les Types",
+				"clear": "Effacer",
+				"custom_only": "Personnalisés Uniquement"
+			},
+			"invalid_email": "Adresse email invalide",
+			"no_recipients": "Aucun destinataire de notifications configuré",
+			"notification_recipients": "Destinataires des Notifications",
+			"notification_recipients_desc": "Configurez qui reçoit les notifications admin. Les utilisateurs admin sont automatiquement inclus.",
+			"preference_disabled": "{field} désactivées",
+			"preference_disabling": "Désactivation de {field}...",
+			"preference_enabled": "{field} activées",
+			"preference_enabling": "Activation de {field}...",
+			"preference_update_failed": "Échec de la mise à jour de la préférence",
+			"recipient_count": "{count, plural, one {# destinataire} other {# destinataires}}",
 			"save": "Enregistrer les Paramètres",
 			"saved": "Paramètres enregistrés",
 			"saving": "Enregistrement...",
+			"selected": "{selected} sur {total} sélectionnés",
 			"support_notifications": "Notifications de Support",
 			"support_notifications_desc": "Configurez les notifications par email pour les tickets de support nouveaux et rouverts non assignés.",
 			"tabs": {
-				"notifications": "Notifications"
+				"notifications": "Notifications",
+				"recipients": "Destinataires"
 			},
-			"title": "Paramètres Admin"
+			"title": "Paramètres Admin",
+			"type_admin": "Admin",
+			"type_custom": "Personnalisé"
 		},
 		"sidebar": {
 			"back_to_app": "Retour à l'App",
@@ -277,6 +318,7 @@
 		"title": "Chat Communautaire"
 	},
 	"common": {
+		"adding": "Ajout en cours...",
 		"cancel": "Annuler",
 		"confirm": "Confirmer"
 	},

--- a/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import { Button, buttonVariants, type ButtonProps } from '$lib/components/ui/button/index.js';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		variant = 'default',
+		class: className,
+		children,
+		loading = false,
+		disabled = false,
+		...restProps
+	}: AlertDialogPrimitive.ActionProps & {
+		variant?: ButtonProps['variant'];
+		loading?: boolean;
+		disabled?: boolean;
+	} = $props();
+</script>
+
+<AlertDialogPrimitive.Action
+	bind:ref
+	data-slot="alert-dialog-action"
+	class={cn(buttonVariants({ variant }), className)}
+	{...restProps}
+>
+	{#snippet child({ props })}
+		<Button {...props} {loading} disabled={disabled || loading}>
+			{@render children?.()}
+		</Button>
+	{/snippet}
+</AlertDialogPrimitive.Action>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import { buttonVariants } from '$lib/components/ui/button/index.js';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.CancelProps = $props();
+</script>
+
+<AlertDialogPrimitive.Cancel
+	bind:ref
+	data-slot="alert-dialog-cancel"
+	class={cn(buttonVariants({ variant: 'outline' }), className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import AlertDialogPortal from './alert-dialog-portal.svelte';
+	import AlertDialogOverlay from './alert-dialog-overlay.svelte';
+	import { cn, type WithoutChild, type WithoutChildrenOrChild } from '$lib/utils.js';
+	import type { ComponentProps } from 'svelte';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		portalProps,
+		...restProps
+	}: WithoutChild<AlertDialogPrimitive.ContentProps> & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof AlertDialogPortal>>;
+	} = $props();
+</script>
+
+<AlertDialogPortal {...portalProps}>
+	<AlertDialogOverlay />
+	<AlertDialogPrimitive.Content
+		bind:ref
+		data-slot="alert-dialog-content"
+		class={cn(
+			'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+			className
+		)}
+		{...restProps}
+	/>
+</AlertDialogPortal>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.DescriptionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Description
+	bind:ref
+	data-slot="alert-dialog-description"
+	class={cn('text-sm text-muted-foreground', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-footer"
+	class={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-header"
+	class={cn('flex flex-col gap-2 text-center sm:text-start', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.OverlayProps = $props();
+</script>
+
+<AlertDialogPrimitive.Overlay
+	bind:ref
+	data-slot="alert-dialog-overlay"
+	class={cn(
+		'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+
+	let { ...restProps }: AlertDialogPrimitive.PortalProps = $props();
+</script>
+
+<AlertDialogPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.TitleProps = $props();
+</script>
+
+<AlertDialogPrimitive.Title
+	bind:ref
+	data-slot="alert-dialog-title"
+	class={cn('text-lg font-semibold', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-trigger.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: AlertDialogPrimitive.TriggerProps = $props();
+</script>
+
+<AlertDialogPrimitive.Trigger bind:ref data-slot="alert-dialog-trigger" {...restProps} />

--- a/src/lib/components/ui/alert-dialog/alert-dialog.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+
+	let { open = $bindable(false), ...restProps }: AlertDialogPrimitive.RootProps = $props();
+</script>
+
+<AlertDialogPrimitive.Root bind:open {...restProps} />

--- a/src/lib/components/ui/alert-dialog/index.ts
+++ b/src/lib/components/ui/alert-dialog/index.ts
@@ -1,0 +1,37 @@
+import Root from './alert-dialog.svelte';
+import Portal from './alert-dialog-portal.svelte';
+import Trigger from './alert-dialog-trigger.svelte';
+import Title from './alert-dialog-title.svelte';
+import Action from './alert-dialog-action.svelte';
+import Cancel from './alert-dialog-cancel.svelte';
+import Footer from './alert-dialog-footer.svelte';
+import Header from './alert-dialog-header.svelte';
+import Overlay from './alert-dialog-overlay.svelte';
+import Content from './alert-dialog-content.svelte';
+import Description from './alert-dialog-description.svelte';
+
+export {
+	Root,
+	Title,
+	Action,
+	Cancel,
+	Portal,
+	Footer,
+	Header,
+	Trigger,
+	Overlay,
+	Content,
+	Description,
+	//
+	Root as AlertDialog,
+	Title as AlertDialogTitle,
+	Action as AlertDialogAction,
+	Cancel as AlertDialogCancel,
+	Portal as AlertDialogPortal,
+	Footer as AlertDialogFooter,
+	Header as AlertDialogHeader,
+	Trigger as AlertDialogTrigger,
+	Overlay as AlertDialogOverlay,
+	Content as AlertDialogContent,
+	Description as AlertDialogDescription
+};

--- a/src/lib/components/ui/confirm-delete-dialog/confirm-delete-dialog.svelte
+++ b/src/lib/components/ui/confirm-delete-dialog/confirm-delete-dialog.svelte
@@ -1,0 +1,135 @@
+<script lang="ts" module>
+	class ConfirmDeleteDialogState {
+		open = $state(false);
+		inputText = $state('');
+		options = $state<ConfirmDeleteOptions | null>(null);
+		loading = $state(false);
+
+		constructor() {
+			this.confirm = this.confirm.bind(this);
+			this.cancel = this.cancel.bind(this);
+		}
+
+		newConfirmation(options: ConfirmDeleteOptions) {
+			this.reset();
+			this.options = options;
+			this.open = true;
+		}
+
+		reset() {
+			this.open = false;
+			this.inputText = '';
+			this.options = null;
+		}
+
+		confirm() {
+			if (this.options?.input) {
+				if (this.inputText !== this.options.input.confirmationText) {
+					return;
+				}
+			}
+
+			this.loading = true;
+			this.options
+				?.onConfirm()
+				.then(() => {
+					this.open = false;
+				})
+				.finally(() => {
+					this.loading = false;
+				});
+		}
+
+		cancel() {
+			this.options?.onCancel?.();
+			this.open = false;
+		}
+	}
+
+	const dialogState = new ConfirmDeleteDialogState();
+
+	export type ConfirmDeleteOptions = {
+		title: string;
+		description: string;
+		skipConfirmation?: boolean;
+		input?: {
+			confirmationText: string;
+		};
+		confirm?: {
+			text?: string;
+		};
+		cancel?: {
+			text?: string;
+		};
+		onConfirm: () => Promise<unknown>;
+		onCancel?: () => void;
+	};
+
+	export function confirmDelete(options: ConfirmDeleteOptions) {
+		if (options.skipConfirmation) {
+			options.onConfirm();
+			return;
+		}
+
+		dialogState.newConfirmation(options);
+	}
+</script>
+
+<script lang="ts">
+	import * as AlertDialog from '$lib/components/ui/alert-dialog';
+	import { Input } from '$lib/components/ui/input';
+</script>
+
+<AlertDialog.Root bind:open={dialogState.open}>
+	<AlertDialog.Content>
+		<form
+			method="POST"
+			onsubmit={(e) => {
+				e.preventDefault();
+				dialogState.confirm();
+			}}
+			class="flex flex-col gap-4"
+		>
+			<AlertDialog.Header>
+				<AlertDialog.Title>
+					{dialogState.options?.title}
+				</AlertDialog.Title>
+				<AlertDialog.Description>
+					{dialogState.options?.description}
+				</AlertDialog.Description>
+			</AlertDialog.Header>
+			{#if dialogState.options?.input}
+				<Input
+					bind:value={dialogState.inputText}
+					placeholder={`Enter "${dialogState.options.input.confirmationText}" to confirm.`}
+					onkeydown={(e) => {
+						if (e.key === 'Enter') {
+							// for some reason without this the form will submit and the dialog will close immediately
+							e.preventDefault();
+							dialogState.confirm();
+						}
+					}}
+				/>
+			{/if}
+			<AlertDialog.Footer>
+				<AlertDialog.Cancel
+					type="button"
+					onclick={dialogState.cancel}
+					data-testid="confirm-delete-cancel"
+				>
+					{dialogState.options?.cancel?.text ?? 'Cancel'}
+				</AlertDialog.Cancel>
+				<AlertDialog.Action
+					type="submit"
+					variant="destructive"
+					loading={dialogState.loading}
+					disabled={dialogState.options?.input &&
+						dialogState.inputText !== dialogState.options.input.confirmationText}
+					data-testid="confirm-delete-button"
+				>
+					{dialogState.options?.confirm?.text ?? 'Delete'}
+				</AlertDialog.Action>
+			</AlertDialog.Footer>
+		</form>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/lib/components/ui/confirm-delete-dialog/index.ts
+++ b/src/lib/components/ui/confirm-delete-dialog/index.ts
@@ -1,0 +1,6 @@
+import ConfirmDeleteDialog, {
+	confirmDelete,
+	type ConfirmDeleteOptions
+} from './confirm-delete-dialog.svelte';
+
+export { ConfirmDeleteDialog, confirmDelete, type ConfirmDeleteOptions };

--- a/src/lib/components/ui/field/field-content.svelte
+++ b/src/lib/components/ui/field/field-content.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="field-content"
+	class={cn('group/field-content flex flex-1 flex-col gap-1.5 leading-snug', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/field/field-description.svelte
+++ b/src/lib/components/ui/field/field-description.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLParagraphElement>> = $props();
+</script>
+
+<p
+	bind:this={ref}
+	data-slot="field-description"
+	class={cn(
+		'text-sm leading-normal font-normal text-muted-foreground group-has-[[data-orientation=horizontal]]/field:text-balance',
+		'last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5',
+		'[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary',
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</p>

--- a/src/lib/components/ui/field/field-error.svelte
+++ b/src/lib/components/ui/field/field-error.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		errors,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		children?: Snippet;
+		errors?: { message?: string }[];
+	} = $props();
+
+	const hasContent = $derived.by(() => {
+		// has slotted error
+		if (children) return true;
+
+		// no errors
+		if (!errors) return false;
+
+		// has an error but no message
+		if (errors.length === 1 && !errors[0]?.message) {
+			return false;
+		}
+
+		return true;
+	});
+
+	const isMultipleErrors = $derived(errors && errors.length > 1);
+	const singleErrorMessage = $derived(errors && errors.length === 1 && errors[0]?.message);
+</script>
+
+{#if hasContent}
+	<div
+		bind:this={ref}
+		role="alert"
+		data-slot="field-error"
+		class={cn('text-sm font-normal text-destructive', className)}
+		{...restProps}
+	>
+		{#if children}
+			{@render children()}
+		{:else if singleErrorMessage}
+			{singleErrorMessage}
+		{:else if isMultipleErrors}
+			<ul class="ms-4 flex list-disc flex-col gap-1">
+				{#each errors ?? [] as error, index (index)}
+					{#if error?.message}
+						<li>{error.message}</li>
+					{/if}
+				{/each}
+			</ul>
+		{/if}
+	</div>
+{/if}

--- a/src/lib/components/ui/field/field-group.svelte
+++ b/src/lib/components/ui/field/field-group.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="field-group"
+	class={cn(
+		'group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4',
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/field/field-label.svelte
+++ b/src/lib/components/ui/field/field-label.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { cn } from '$lib/utils.js';
+	import type { ComponentProps } from 'svelte';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: ComponentProps<typeof Label> = $props();
+</script>
+
+<Label
+	bind:ref
+	data-slot="field-label"
+	class={cn(
+		'group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50',
+		'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4',
+		'has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5 dark:has-data-[state=checked]:bg-primary/10',
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</Label>

--- a/src/lib/components/ui/field/field-legend.svelte
+++ b/src/lib/components/ui/field/field-legend.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = 'legend',
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLLegendElement>> & {
+		variant?: 'legend' | 'label';
+	} = $props();
+</script>
+
+<legend
+	bind:this={ref}
+	data-slot="field-legend"
+	data-variant={variant}
+	class={cn(
+		'mb-3 font-medium',
+		'data-[variant=legend]:text-base',
+		'data-[variant=label]:text-sm',
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</legend>

--- a/src/lib/components/ui/field/field-separator.svelte
+++ b/src/lib/components/ui/field/field-separator.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		children?: Snippet;
+	} = $props();
+
+	const hasContent = $derived(!!children);
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="field-separator"
+	data-content={hasContent}
+	class={cn('relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2', className)}
+	{...restProps}
+>
+	<Separator class="absolute inset-0 top-1/2" />
+	{#if children}
+		<span
+			class="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+			data-slot="field-separator-content"
+		>
+			{@render children()}
+		</span>
+	{/if}
+</div>

--- a/src/lib/components/ui/field/field-set.svelte
+++ b/src/lib/components/ui/field/field-set.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLFieldsetAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLFieldsetAttributes> = $props();
+</script>
+
+<fieldset
+	bind:this={ref}
+	data-slot="field-set"
+	class={cn(
+		'flex flex-col gap-6',
+		'has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3',
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</fieldset>

--- a/src/lib/components/ui/field/field-title.svelte
+++ b/src/lib/components/ui/field/field-title.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="field-title"
+	class={cn(
+		'flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50',
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/field/field.svelte
+++ b/src/lib/components/ui/field/field.svelte
@@ -1,0 +1,53 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from 'tailwind-variants';
+
+	export const fieldVariants = tv({
+		base: 'group/field data-[invalid=true]:text-destructive flex w-full gap-3',
+		variants: {
+			orientation: {
+				vertical: 'flex-col [&>*]:w-full [&>.sr-only]:w-auto',
+				horizontal: [
+					'flex-row items-center',
+					'[&>[data-slot=field-label]]:flex-auto',
+					'has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px'
+				],
+				responsive: [
+					'flex-col @md/field-group:flex-row @md/field-group:items-center [&>*]:w-full @md/field-group:[&>*]:w-auto [&>.sr-only]:w-auto',
+					'@md/field-group:[&>[data-slot=field-label]]:flex-auto',
+					'@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px'
+				]
+			}
+		},
+		defaultVariants: {
+			orientation: 'vertical'
+		}
+	});
+
+	export type FieldOrientation = VariantProps<typeof fieldVariants>['orientation'];
+</script>
+
+<script lang="ts">
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		orientation = 'vertical',
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		orientation?: FieldOrientation;
+	} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	role="group"
+	data-slot="field"
+	data-orientation={orientation}
+	class={cn(fieldVariants({ orientation }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/field/index.ts
+++ b/src/lib/components/ui/field/index.ts
@@ -1,0 +1,33 @@
+import Field from './field.svelte';
+import Set from './field-set.svelte';
+import Legend from './field-legend.svelte';
+import Group from './field-group.svelte';
+import Content from './field-content.svelte';
+import Label from './field-label.svelte';
+import Title from './field-title.svelte';
+import Description from './field-description.svelte';
+import Separator from './field-separator.svelte';
+import Error from './field-error.svelte';
+
+export {
+	Field,
+	Set,
+	Legend,
+	Group,
+	Content,
+	Label,
+	Title,
+	Description,
+	Separator,
+	Error,
+	//
+	Set as FieldSet,
+	Legend as FieldLegend,
+	Group as FieldGroup,
+	Content as FieldContent,
+	Label as FieldLabel,
+	Title as FieldTitle,
+	Description as FieldDescription,
+	Separator as FieldSeparator,
+	Error as FieldError
+};

--- a/src/lib/components/ui/separator/separator.svelte
+++ b/src/lib/components/ui/separator/separator.svelte
@@ -14,7 +14,7 @@
 	bind:ref
 	data-slot={dataSlot}
 	class={cn(
-		'shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+		'shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:min-h-full data-[orientation=vertical]:w-px',
 		className
 	)}
 	{...restProps}

--- a/src/lib/convex/_generated/api.d.ts
+++ b/src/lib/convex/_generated/api.d.ts
@@ -9,6 +9,9 @@
  */
 
 import type * as admin_mutations from "../admin/mutations.js";
+import type * as admin_notificationPreferences_index from "../admin/notificationPreferences/index.js";
+import type * as admin_notificationPreferences_mutations from "../admin/notificationPreferences/mutations.js";
+import type * as admin_notificationPreferences_queries from "../admin/notificationPreferences/queries.js";
 import type * as admin_queries from "../admin/queries.js";
 import type * as admin_settings_mutations from "../admin/settings/mutations.js";
 import type * as admin_settings_queries from "../admin/settings/queries.js";
@@ -24,6 +27,7 @@ import type * as crons from "../crons.js";
 import type * as emails__generated_adminReplyNotification from "../emails/_generated/adminReplyNotification.js";
 import type * as emails__generated_index from "../emails/_generated/index.js";
 import type * as emails__generated_newTicketAdminNotification from "../emails/_generated/newTicketAdminNotification.js";
+import type * as emails__generated_newUserSignupNotification from "../emails/_generated/newUserSignupNotification.js";
 import type * as emails__generated_passwordReset from "../emails/_generated/passwordReset.js";
 import type * as emails__generated_verification from "../emails/_generated/verification.js";
 import type * as emails__generated_verificationCode from "../emails/_generated/verificationCode.js";
@@ -56,6 +60,9 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   "admin/mutations": typeof admin_mutations;
+  "admin/notificationPreferences/index": typeof admin_notificationPreferences_index;
+  "admin/notificationPreferences/mutations": typeof admin_notificationPreferences_mutations;
+  "admin/notificationPreferences/queries": typeof admin_notificationPreferences_queries;
   "admin/queries": typeof admin_queries;
   "admin/settings/mutations": typeof admin_settings_mutations;
   "admin/settings/queries": typeof admin_settings_queries;
@@ -71,6 +78,7 @@ declare const fullApi: ApiFromModules<{
   "emails/_generated/adminReplyNotification": typeof emails__generated_adminReplyNotification;
   "emails/_generated/index": typeof emails__generated_index;
   "emails/_generated/newTicketAdminNotification": typeof emails__generated_newTicketAdminNotification;
+  "emails/_generated/newUserSignupNotification": typeof emails__generated_newUserSignupNotification;
   "emails/_generated/passwordReset": typeof emails__generated_passwordReset;
   "emails/_generated/verification": typeof emails__generated_verification;
   "emails/_generated/verificationCode": typeof emails__generated_verificationCode;

--- a/src/lib/convex/admin/notificationPreferences/index.ts
+++ b/src/lib/convex/admin/notificationPreferences/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Admin Notification Preferences Module
+ *
+ * Manages per-recipient notification preferences for admin users and custom emails.
+ */
+
+export * from './queries';
+export * from './mutations';

--- a/src/lib/convex/admin/notificationPreferences/mutations.ts
+++ b/src/lib/convex/admin/notificationPreferences/mutations.ts
@@ -1,0 +1,291 @@
+/**
+ * Admin Notification Preferences Mutations
+ *
+ * Mutations for managing notification recipient preferences.
+ * Includes both admin-facing mutations and internal mutations for auth triggers.
+ */
+
+import { v, ConvexError } from 'convex/values';
+import { adminMutation } from '../../functions';
+import { internalMutation } from '../../_generated/server';
+import { components, internal } from '../../_generated/api';
+
+/**
+ * Update a notification preference toggle
+ *
+ * @security Requires admin role
+ */
+export const updatePreference = adminMutation({
+	args: {
+		email: v.string(),
+		field: v.union(
+			v.literal('notifyNewSupportTickets'),
+			v.literal('notifyUserReplies'),
+			v.literal('notifyNewSignups')
+		),
+		value: v.boolean()
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		// Find the preference by email
+		const pref = await ctx.db
+			.query('adminNotificationPreferences')
+			.withIndex('by_email', (q) => q.eq('email', args.email))
+			.first();
+
+		if (!pref) {
+			throw new ConvexError('Notification preference not found');
+		}
+
+		// Verify it's an active recipient (admin or custom email)
+		if (!pref.isAdminUser && pref.userId !== undefined) {
+			throw new ConvexError('Cannot update dormant preference');
+		}
+
+		// Update the specific field
+		await ctx.db.patch(pref._id, {
+			[args.field]: args.value,
+			updatedAt: Date.now()
+		});
+
+		return null;
+	}
+});
+
+/**
+ * Add a custom email address for notifications
+ *
+ * Creates a new preference with isAdminUser=false and all toggles ON.
+ *
+ * @security Requires admin role
+ */
+export const addCustomEmail = adminMutation({
+	args: {
+		email: v.string()
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const email = args.email.toLowerCase().trim();
+
+		// Validate email format (basic check)
+		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+		if (!emailRegex.test(email)) {
+			throw new ConvexError('Invalid email address');
+		}
+
+		// Check for duplicates
+		const existing = await ctx.db
+			.query('adminNotificationPreferences')
+			.withIndex('by_email', (q) => q.eq('email', email))
+			.first();
+
+		if (existing) {
+			throw new ConvexError('This email already exists');
+		}
+
+		// Create new preference with all notifications enabled
+		const now = Date.now();
+		await ctx.db.insert('adminNotificationPreferences', {
+			email,
+			userId: undefined,
+			isAdminUser: false,
+			notifyNewSupportTickets: true,
+			notifyUserReplies: true,
+			notifyNewSignups: true,
+			createdAt: now,
+			updatedAt: now
+		});
+
+		return null;
+	}
+});
+
+/**
+ * Remove a custom email address
+ *
+ * Only allows removing custom emails (where userId is undefined).
+ * Admin users cannot be removed, only their toggles disabled.
+ *
+ * @security Requires admin role
+ */
+export const removeCustomEmail = adminMutation({
+	args: {
+		email: v.string()
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const email = args.email.toLowerCase().trim();
+
+		const pref = await ctx.db
+			.query('adminNotificationPreferences')
+			.withIndex('by_email', (q) => q.eq('email', email))
+			.first();
+
+		if (!pref) {
+			throw new ConvexError('Email not found');
+		}
+
+		// Only allow removing custom emails (no userId)
+		if (pref.userId !== undefined) {
+			throw new ConvexError('Cannot remove admin user. Disable their notifications instead.');
+		}
+
+		await ctx.db.delete(pref._id);
+		return null;
+	}
+});
+
+/**
+ * Upsert admin notification preferences
+ *
+ * Called by auth triggers and admin role management utilities when:
+ * - User is promoted to admin (setUserRole, seedFirstAdmin)
+ * - Admin's email changes
+ * - User signs up as admin (rare)
+ *
+ * If preference exists: updates isAdminUser=true and email
+ * If not exists: creates with all toggles ON
+ *
+ * @internal Called by auth triggers and admin role management
+ */
+export const upsertAdminPreferences = internalMutation({
+	args: {
+		userId: v.string(),
+		email: v.string()
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const now = Date.now();
+
+		// Check if preference already exists for this user
+		const existing = await ctx.db
+			.query('adminNotificationPreferences')
+			.withIndex('by_user', (q) => q.eq('userId', args.userId))
+			.first();
+
+		if (existing) {
+			// Reactivate and update email if changed
+			await ctx.db.patch(existing._id, {
+				email: args.email.toLowerCase().trim(),
+				isAdminUser: true,
+				updatedAt: now
+			});
+		} else {
+			// Check if there's a custom email entry with same email
+			const existingByEmail = await ctx.db
+				.query('adminNotificationPreferences')
+				.withIndex('by_email', (q) => q.eq('email', args.email.toLowerCase().trim()))
+				.first();
+
+			if (existingByEmail && existingByEmail.userId === undefined) {
+				// Convert custom email to admin user preference
+				await ctx.db.patch(existingByEmail._id, {
+					userId: args.userId,
+					isAdminUser: true,
+					updatedAt: now
+				});
+			} else if (!existingByEmail) {
+				// Create new preference with all notifications enabled
+				await ctx.db.insert('adminNotificationPreferences', {
+					email: args.email.toLowerCase().trim(),
+					userId: args.userId,
+					isAdminUser: true,
+					notifyNewSupportTickets: true,
+					notifyUserReplies: true,
+					notifyNewSignups: true,
+					createdAt: now,
+					updatedAt: now
+				});
+			} else {
+				// existingByEmail exists with a different userId - data integrity issue
+				// Log warning but don't throw to avoid blocking auth flow
+				console.warn(
+					`[upsertAdminPreferences] Email collision detected: ` +
+						`email=${args.email} already belongs to userId=${existingByEmail.userId} ` +
+						`but attempting to assign to userId=${args.userId}. Skipping update.`
+				);
+			}
+		}
+
+		return null;
+	}
+});
+
+/**
+ * Deactivate admin notification preferences
+ *
+ * Called by auth trigger when admin is demoted.
+ * Sets isAdminUser=false but keeps the record for potential re-promotion.
+ *
+ * @internal Called by auth triggers only
+ */
+export const deactivateAdminPreferences = internalMutation({
+	args: {
+		userId: v.string()
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const existing = await ctx.db
+			.query('adminNotificationPreferences')
+			.withIndex('by_user', (q) => q.eq('userId', args.userId))
+			.first();
+
+		if (existing) {
+			await ctx.db.patch(existing._id, {
+				isAdminUser: false,
+				updatedAt: Date.now()
+			});
+		}
+
+		return null;
+	}
+});
+
+/**
+ * Sync all existing admin users to notification preferences
+ *
+ * One-time migration for existing admins created before the auth trigger.
+ * Safe to run multiple times - upsertAdminPreferences handles duplicates.
+ *
+ * @internal Run via: bunx convex run admin/notificationPreferences/mutations:syncAllAdminPreferences
+ */
+export const syncAllAdminPreferences = internalMutation({
+	args: {},
+	returns: v.object({ synced: v.number(), skipped: v.number() }),
+	handler: async (ctx) => {
+		const result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+			model: 'user',
+			paginationOpts: { cursor: null, numItems: 1000 }
+		});
+
+		const users = result.page as Array<{ _id: string; email: string; role?: string | null }>;
+		const admins = users.filter((u) => u.role === 'admin');
+
+		let synced = 0;
+		let skipped = 0;
+
+		for (const admin of admins) {
+			const existing = await ctx.db
+				.query('adminNotificationPreferences')
+				.withIndex('by_user', (q) => q.eq('userId', admin._id))
+				.first();
+
+			if (existing) {
+				skipped++;
+				continue;
+			}
+
+			await ctx.runMutation(
+				internal.admin.notificationPreferences.mutations.upsertAdminPreferences,
+				{
+					userId: admin._id,
+					email: admin.email
+				}
+			);
+			synced++;
+		}
+
+		console.log(`Synced ${synced} admins, skipped ${skipped} (already existed)`);
+		return { synced, skipped };
+	}
+});

--- a/src/lib/convex/admin/notificationPreferences/queries.ts
+++ b/src/lib/convex/admin/notificationPreferences/queries.ts
@@ -1,0 +1,176 @@
+/**
+ * Admin Notification Preferences Queries
+ *
+ * Queries for retrieving notification recipient preferences.
+ * Used by the admin settings UI and notification send logic.
+ */
+
+import { v } from 'convex/values';
+import { adminQuery } from '../../functions';
+import { internalQuery } from '../../_generated/server';
+import { components } from '../../_generated/api';
+import { parseBetterAuthUsers } from '../types';
+
+/**
+ * Notification type validator for internal queries
+ */
+export const notificationTypeValidator = v.union(
+	v.literal('newTickets'),
+	v.literal('userReplies'),
+	v.literal('newSignups')
+);
+
+export type NotificationType = 'newTickets' | 'userReplies' | 'newSignups';
+
+/**
+ * Notification recipient data for UI display
+ */
+export interface NotificationRecipient {
+	email: string;
+	name?: string;
+	userId?: string;
+	isAdminUser: boolean;
+	notifyNewSupportTickets: boolean;
+	notifyUserReplies: boolean;
+	notifyNewSignups: boolean;
+	createdAt: number;
+	updatedAt: number;
+}
+
+/**
+ * List all notification recipients for the admin settings UI
+ *
+ * Returns preferences where:
+ * - isAdminUser=true (active admins)
+ * - OR userId is undefined (custom email addresses)
+ *
+ * Dormant preferences (demoted admins with isAdminUser=false and userId set) are excluded.
+ *
+ * @security Requires admin role
+ */
+export const listNotificationRecipients = adminQuery({
+	args: {},
+	returns: v.array(
+		v.object({
+			email: v.string(),
+			name: v.optional(v.string()),
+			userId: v.optional(v.string()),
+			isAdminUser: v.boolean(),
+			notifyNewSupportTickets: v.boolean(),
+			notifyUserReplies: v.boolean(),
+			notifyNewSignups: v.boolean(),
+			createdAt: v.number(),
+			updatedAt: v.number()
+		})
+	),
+	handler: async (ctx): Promise<NotificationRecipient[]> => {
+		// Get all preferences
+		const allPrefs = await ctx.db.query('adminNotificationPreferences').collect();
+
+		// Filter to active recipients (admins or custom emails)
+		const activePrefs = allPrefs.filter((p) => p.isAdminUser || p.userId === undefined);
+
+		// Get admin user IDs to fetch names
+		const adminUserIds = activePrefs.filter((p) => p.userId).map((p) => p.userId as string);
+
+		// Fetch admin user data for names
+		const userMap = new Map<string, string>();
+		if (adminUserIds.length > 0) {
+			const usersResult = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+				model: 'user',
+				paginationOpts: { cursor: null, numItems: 100 },
+				where: [{ field: 'role', operator: 'eq', value: 'admin' }]
+			});
+			const users = parseBetterAuthUsers(usersResult.page);
+			for (const user of users) {
+				userMap.set(user._id, user.name || user.email);
+			}
+		}
+
+		// Map to response format with names
+		return activePrefs.map((p) => ({
+			email: p.email,
+			name: p.userId ? userMap.get(p.userId) : undefined,
+			userId: p.userId,
+			isAdminUser: p.isAdminUser,
+			notifyNewSupportTickets: p.notifyNewSupportTickets,
+			notifyUserReplies: p.notifyUserReplies,
+			notifyNewSignups: p.notifyNewSignups,
+			createdAt: p.createdAt,
+			updatedAt: p.updatedAt
+		}));
+	}
+});
+
+/**
+ * Get email addresses for a specific notification type
+ *
+ * Used by notification send logic to determine recipients.
+ * Only returns emails where:
+ * - The specific notification toggle is enabled
+ * - AND (isAdminUser=true OR userId is undefined for custom emails)
+ *
+ * @internal Used by email send mutations
+ */
+export const getRecipientsForNotificationType = internalQuery({
+	args: {
+		type: notificationTypeValidator
+	},
+	returns: v.array(v.string()),
+	handler: async (ctx, args): Promise<string[]> => {
+		const allPrefs = await ctx.db.query('adminNotificationPreferences').collect();
+
+		// Map notification type to field name
+		const toggleField =
+			args.type === 'newTickets'
+				? 'notifyNewSupportTickets'
+				: args.type === 'userReplies'
+					? 'notifyUserReplies'
+					: 'notifyNewSignups';
+
+		// Filter to active recipients with this notification enabled
+		const activePrefs = allPrefs.filter(
+			(p) => (p.isAdminUser || p.userId === undefined) && p[toggleField]
+		);
+
+		return activePrefs.map((p) => p.email);
+	}
+});
+
+/**
+ * Get recipients for support notifications with assigned admin priority
+ *
+ * If assigned admin has the notification enabled, returns only their email.
+ * Otherwise, returns all recipients with the notification enabled.
+ *
+ * @internal Used by support notification logic
+ */
+export const getSupportNotificationRecipients = internalQuery({
+	args: {
+		assignedTo: v.optional(v.string()),
+		notificationType: v.union(v.literal('newTickets'), v.literal('userReplies'))
+	},
+	returns: v.array(v.string()),
+	handler: async (ctx, args): Promise<string[]> => {
+		const allPrefs = await ctx.db.query('adminNotificationPreferences').collect();
+
+		// Map notification type to field name
+		const toggleField =
+			args.notificationType === 'newTickets' ? 'notifyNewSupportTickets' : 'notifyUserReplies';
+
+		// Filter to active recipients with this notification enabled
+		const activePrefs = allPrefs.filter(
+			(p) => (p.isAdminUser || p.userId === undefined) && p[toggleField]
+		);
+
+		// If assigned admin has this notification enabled, prioritize them
+		if (args.assignedTo) {
+			const assignedPref = activePrefs.find((p) => p.userId === args.assignedTo);
+			if (assignedPref) {
+				return [assignedPref.email];
+			}
+		}
+
+		return activePrefs.map((p) => p.email);
+	}
+});

--- a/src/lib/convex/admin/settings/queries.ts
+++ b/src/lib/convex/admin/settings/queries.ts
@@ -2,22 +2,6 @@ import { v } from 'convex/values';
 import { adminQuery } from '../../functions';
 
 /**
- * Admin Settings Keys
- *
- * Use these constants to ensure type-safe setting keys throughout the codebase.
- */
-export const ADMIN_SETTING_KEYS = {
-	DEFAULT_SUPPORT_EMAIL: 'defaultSupportEmail'
-} as const;
-
-/**
- * Type-safe admin setting key union
- *
- * Use this type to ensure only valid setting keys are passed to functions.
- */
-export type AdminSettingKey = (typeof ADMIN_SETTING_KEYS)[keyof typeof ADMIN_SETTING_KEYS];
-
-/**
  * Get a single admin setting by key
  *
  * @param args.key - The setting key to retrieve
@@ -65,25 +49,5 @@ export const getAllSettings = adminQuery({
 			updatedAt: s.updatedAt,
 			updatedBy: s.updatedBy
 		}));
-	}
-});
-
-/**
- * Get the default support notification email
- *
- * Convenience wrapper for the common use case of getting the default email.
- *
- * @returns The default email or null if not configured
- */
-export const getDefaultSupportEmail = adminQuery({
-	args: {},
-	returns: v.union(v.string(), v.null()),
-	handler: async (ctx) => {
-		const setting = await ctx.db
-			.query('adminSettings')
-			.withIndex('by_key', (q) => q.eq('key', ADMIN_SETTING_KEYS.DEFAULT_SUPPORT_EMAIL))
-			.first();
-
-		return setting?.value ?? null;
 	}
 });

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -1,4 +1,4 @@
-import { createClient, type GenericCtx } from '@convex-dev/better-auth';
+import { createClient, type GenericCtx, type AuthFunctions } from '@convex-dev/better-auth';
 import { requireRunMutationCtx } from '@convex-dev/better-auth/utils';
 import { convex } from '@convex-dev/better-auth/plugins';
 import { components, internal } from './_generated/api';
@@ -11,14 +11,126 @@ import authSchema from './betterAuth/schema';
 import authConfig from './auth.config';
 import { getBetterAuthSecret, getSiteUrl, googleOAuth, githubOAuth } from './env';
 
+// Required for triggers to work - references internal auth functions
+const authFunctions: AuthFunctions = internal.auth;
+
 // The component client has methods needed for integrating Convex with Better Auth,
 // as well as helper methods for general use.
 // Using local schema to include admin plugin fields (role, banned, etc.)
 export const authComponent = createClient<DataModel, typeof authSchema>(components.betterAuth, {
 	local: {
 		schema: authSchema
+	},
+	authFunctions,
+	triggers: {
+		user: {
+			/**
+			 * Called when a new user signs up
+			 * - Sends new user signup notification email to admins
+			 * - Creates notification preferences if user is admin (rare)
+			 *
+			 * Non-critical operations are wrapped in try/catch to prevent
+			 * blocking user signup if notifications or preferences fail.
+			 */
+			onCreate: async (ctx, user) => {
+				// Detect signup method from account using Better Auth adapter
+				let signupMethod: 'Email' | 'Google' | 'GitHub' = 'Email';
+				try {
+					const accountResult = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+						model: 'account',
+						paginationOpts: { cursor: null, numItems: 1 },
+						where: [{ field: 'userId', operator: 'eq', value: user._id }]
+					});
+
+					const account = accountResult.page[0] as { providerId?: string } | undefined;
+
+					signupMethod =
+						account?.providerId === 'google'
+							? 'Google'
+							: account?.providerId === 'github'
+								? 'GitHub'
+								: 'Email';
+				} catch (error) {
+					console.error('Failed to detect signup method:', error);
+				}
+
+				const signupTime = new Date().toLocaleString('en-US', {
+					month: 'short',
+					day: 'numeric',
+					year: 'numeric',
+					hour: 'numeric',
+					minute: '2-digit',
+					hour12: true
+				});
+
+				// Schedule signup notification email (runs after transaction commits)
+				// Non-critical: don't block signup if notification scheduling fails
+				try {
+					await ctx.scheduler.runAfter(0, internal.emails.send.sendNewUserSignupNotification, {
+						userName: user.name,
+						userEmail: user.email,
+						signupMethod,
+						signupTime
+					});
+				} catch (error) {
+					console.error('Failed to schedule signup notification:', error);
+				}
+
+				// If new user is admin (rare but possible via seeding), create preferences
+				// Non-critical: don't block signup if preference creation fails
+				if (user.role === 'admin') {
+					try {
+						await ctx.runMutation(
+							internal.admin.notificationPreferences.mutations.upsertAdminPreferences,
+							{ userId: user._id, email: user.email }
+						);
+					} catch (error) {
+						console.error('Failed to create admin preferences:', error);
+					}
+				}
+			},
+
+			/**
+			 * Called when a user is updated
+			 * - Detects admin role changes and syncs notification preferences
+			 *
+			 * Non-critical operations are wrapped in try/catch to prevent
+			 * blocking user updates if preference sync fails.
+			 */
+			onUpdate: async (ctx, newUser, oldUser) => {
+				const wasAdmin = oldUser.role === 'admin';
+				const isAdmin = newUser.role === 'admin';
+
+				try {
+					if (!wasAdmin && isAdmin) {
+						// Promoted to admin → activate/create preferences
+						await ctx.runMutation(
+							internal.admin.notificationPreferences.mutations.upsertAdminPreferences,
+							{ userId: newUser._id, email: newUser.email }
+						);
+					} else if (wasAdmin && !isAdmin) {
+						// Demoted from admin → deactivate preferences (keep dormant)
+						await ctx.runMutation(
+							internal.admin.notificationPreferences.mutations.deactivateAdminPreferences,
+							{ userId: newUser._id }
+						);
+					} else if (isAdmin && oldUser.email !== newUser.email) {
+						// Admin changed email → update preferences
+						await ctx.runMutation(
+							internal.admin.notificationPreferences.mutations.upsertAdminPreferences,
+							{ userId: newUser._id, email: newUser.email }
+						);
+					}
+				} catch (error) {
+					console.error('Failed to sync admin preferences on user update:', error);
+				}
+			}
+		}
 	}
 });
+
+// Export trigger handlers (required for triggers to be registered)
+export const { onCreate, onUpdate, onDelete } = authComponent.triggersApi();
 
 // Creates Better Auth options object (used by adapter and betterAuth CLI)
 export const createAuthOptions = (ctx: GenericCtx<DataModel>): BetterAuthOptions => {

--- a/src/lib/convex/emails/send.ts
+++ b/src/lib/convex/emails/send.ts
@@ -1,11 +1,13 @@
 import { internalMutation } from '../_generated/server';
 import { v } from 'convex/values';
+import { internal } from '../_generated/api';
 import { resend } from './resend';
 import {
 	renderVerificationEmail,
 	renderPasswordResetEmail,
 	renderAdminReplyNotificationEmail,
-	renderNewTicketAdminNotificationEmail
+	renderNewTicketAdminNotificationEmail,
+	renderNewUserSignupNotificationEmail
 } from './templates';
 import { getAuthEmail, getSiteUrl } from '../env';
 import type { NotificationMessage } from '../../emails/templates/types';
@@ -167,5 +169,87 @@ export const sendNewTicketAdminNotification = internalMutation({
 				{ name: 'X-Thread-ID', value: threadId }
 			]
 		});
+	}
+});
+
+/**
+ * Send notification email to recipients when a new user signs up
+ *
+ * Called by auth trigger when a new user is created.
+ * Sends to all recipients with new signup notifications enabled (admins + custom emails).
+ *
+ * Uses pre-rendered HTML templates with template placeholders for dynamic content.
+ */
+export const sendNewUserSignupNotification = internalMutation({
+	args: {
+		userName: v.optional(v.string()),
+		userEmail: v.string(),
+		signupMethod: v.union(v.literal('Email'), v.literal('Google'), v.literal('GitHub')),
+		signupTime: v.string()
+	},
+	handler: async (ctx, args) => {
+		const { userName, userEmail, signupMethod, signupTime } = args;
+		const siteUrl = getSiteUrl();
+
+		// Get recipients who have new signup notifications enabled
+		const recipients = await ctx.runQuery(
+			internal.admin.notificationPreferences.queries.getRecipientsForNotificationType,
+			{ type: 'newSignups' }
+		);
+
+		if (recipients.length === 0) {
+			console.log('[sendNewUserSignupNotification] No recipients configured, skipping');
+			return;
+		}
+
+		// Build admin dashboard link with search for this user
+		const adminDashboardLink = `${siteUrl}/admin/users?search=${encodeURIComponent(userEmail)}`;
+
+		const { html, text } = renderNewUserSignupNotificationEmail({
+			userName: userName || 'New User',
+			userEmail,
+			signupMethod,
+			signupTime,
+			adminDashboardLink
+		});
+
+		// Send to each recipient
+		// Note: The Resend component handles retries internally via workpool (5 retries, 30s backoff)
+		// and uses idempotency keys for exactly-once delivery
+		let sentCount = 0;
+		for (const email of recipients) {
+			try {
+				await resend.sendEmail(ctx, {
+					from: getAuthEmail(),
+					to: email,
+					subject: `New user signup: ${userEmail}`,
+					html,
+					text,
+					headers: [
+						{ name: 'X-Email-Category', value: 'stats' },
+						{ name: 'X-Email-Template', value: 'new-user-signup' }
+					]
+				});
+				sentCount++;
+			} catch (error) {
+				// Log permanent errors (invalid config, API key issues)
+				// The Resend component handles transient errors internally
+				console.error(
+					`[sendNewUserSignupNotification] Failed to enqueue email to ${email}:`,
+					error instanceof Error ? error.message : error
+				);
+			}
+		}
+
+		if (sentCount > 0) {
+			console.log(
+				`[sendNewUserSignupNotification] Enqueued notification for ${userEmail} to ${sentCount}/${recipients.length} recipient(s)`
+			);
+		} else if (recipients.length > 0) {
+			// All sends failed - log aggregated error for observability
+			console.error(
+				`[sendNewUserSignupNotification] All ${recipients.length} email sends failed for new user ${userEmail}`
+			);
+		}
 	}
 });

--- a/src/lib/convex/emails/templates.ts
+++ b/src/lib/convex/emails/templates.ts
@@ -11,6 +11,7 @@ import type {
 	PasswordResetEmailData,
 	AdminReplyNotificationEmailData,
 	NewTicketAdminNotificationEmailData,
+	NewUserSignupNotificationEmailData,
 	RenderedEmail
 } from '../../emails/templates/types';
 import {
@@ -23,7 +24,9 @@ import {
 	ADMINREPLYNOTIFICATION_HTML,
 	ADMINREPLYNOTIFICATION_TEXT,
 	NEWTICKETADMINNOTIFICATION_HTML,
-	NEWTICKETADMINNOTIFICATION_TEXT
+	NEWTICKETADMINNOTIFICATION_TEXT,
+	NEWUSERSIGNUPNOTIFICATION_HTML,
+	NEWUSERSIGNUPNOTIFICATION_TEXT
 } from './_generated/index.js';
 import { getEmailAssetUrl } from '../env';
 
@@ -236,5 +239,42 @@ export function renderNewTicketAdminNotificationEmail(
 	return {
 		html: renderTemplate(NEWTICKETADMINNOTIFICATION_HTML, templateData),
 		text: renderTemplate(NEWTICKETADMINNOTIFICATION_TEXT, textData)
+	};
+}
+
+/**
+ * Render new user signup notification email
+ *
+ * Sent to admins when a new user registers on the platform.
+ *
+ * @param data - Email data including user info and admin dashboard link
+ * @returns Rendered HTML and plain text email
+ */
+export function renderNewUserSignupNotificationEmail(
+	data: NewUserSignupNotificationEmailData
+): RenderedEmail {
+	const baseUrl = getBaseUrl();
+
+	const templateData = {
+		userName: escapeHtml(data.userName || 'New User'),
+		userEmail: escapeHtml(data.userEmail),
+		signupMethod: escapeHtml(data.signupMethod),
+		signupTime: escapeHtml(data.signupTime),
+		adminDashboardLink: escapeHtml(data.adminDashboardLink),
+		baseUrl: escapeHtml(baseUrl)
+	};
+
+	const textData = {
+		userName: data.userName || 'New User',
+		userEmail: data.userEmail,
+		signupMethod: data.signupMethod,
+		signupTime: data.signupTime,
+		adminDashboardLink: data.adminDashboardLink,
+		baseUrl
+	};
+
+	return {
+		html: renderTemplate(NEWUSERSIGNUPNOTIFICATION_HTML, templateData),
+		text: renderTemplate(NEWUSERSIGNUPNOTIFICATION_TEXT, textData)
 	};
 }

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -116,11 +116,31 @@ export default defineSchema({
 	pendingAdminNotifications: defineTable({
 		threadId: v.string(), // Support thread ID
 		isReopen: v.boolean(), // true = reopened ticket, false = new/handoff ticket
+		notificationType: v.union(v.literal('newTickets'), v.literal('userReplies')), // Which preference toggle to use
 		scheduledFor: v.number(), // Timestamp when notification should send
 		messageIds: v.array(v.string()), // Accumulated message IDs to include
 		scheduledFnId: v.optional(v.id('_scheduled_functions')), // For cancellation
 		createdAt: v.number()
-	}).index('by_thread', ['threadId'])
+	}).index('by_thread', ['threadId']),
+
+	// Admin notification preferences - per-recipient toggles for notification types
+	// Admin users are auto-synced via auth triggers; custom emails can be added manually.
+	// When admin is demoted, isAdminUser is set to false but record is kept dormant.
+	adminNotificationPreferences: defineTable({
+		email: v.string(), // Email address to send notifications to
+		userId: v.optional(v.string()), // Better Auth user ID (undefined for custom emails)
+		isAdminUser: v.boolean(), // true = currently has admin role, false = demoted or custom email
+
+		// Notification type toggles
+		notifyNewSupportTickets: v.boolean(), // New support tickets (handoff from AI)
+		notifyUserReplies: v.boolean(), // User replied, admin didn't respond within 2 min
+		notifyNewSignups: v.boolean(), // New user registrations
+
+		createdAt: v.number(),
+		updatedAt: v.number()
+	})
+		.index('by_email', ['email'])
+		.index('by_user', ['userId'])
 
 	// Note: The agent component automatically creates the following tables:
 	// - agent:threads - Conversation threads for customer support

--- a/src/lib/convex/support/messages.ts
+++ b/src/lib/convex/support/messages.ts
@@ -112,7 +112,9 @@ export const sendMessage = mutation({
 					{
 						threadId: args.threadId,
 						messageIds: [messageId],
-						isReopen: wasClosedBeforeThisMessage
+						isReopen: wasClosedBeforeThisMessage,
+						// Reopened tickets use 'newTickets' preference; follow-up messages use 'userReplies'
+						notificationType: wasClosedBeforeThisMessage ? 'newTickets' : 'userReplies'
 					}
 				);
 			}

--- a/src/lib/convex/support/threads.ts
+++ b/src/lib/convex/support/threads.ts
@@ -440,7 +440,8 @@ export const updateThreadHandoff = mutation({
 				{
 					threadId: args.threadId,
 					messageIds: recentMessageIds,
-					isReopen: false
+					isReopen: false,
+					notificationType: 'newTickets' // Handoff from AI to human
 				}
 			);
 		}

--- a/src/lib/convex/tests.ts
+++ b/src/lib/convex/tests.ts
@@ -52,3 +52,43 @@ export const verifyTestUserEmail = mutation({
 		return { success: true };
 	}
 });
+
+// Promote test user to admin role
+// Note: This mutation requires AUTH_E2E_TEST_SECRET for security
+// Only use for test accounts - it bypasses the normal admin promotion flow
+export const promoteTestUserToAdmin = mutation({
+	args: { email: v.string(), secret: v.string() },
+	handler: async (ctx, { email, secret }) => {
+		// Verify test secret to prevent unauthorized access
+		const expectedSecret = process.env.AUTH_E2E_TEST_SECRET;
+		if (!expectedSecret || secret !== expectedSecret) {
+			throw new Error('Unauthorized: Invalid test secret');
+		}
+
+		// Find user by email using Better Auth adapter
+		const user = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+			model: 'user',
+			where: [{ field: 'email', value: email }]
+		});
+
+		if (!user) {
+			return { success: false, error: 'User not found' };
+		}
+
+		// Check if already admin
+		if (user.role === 'admin') {
+			return { success: true, alreadyAdmin: true };
+		}
+
+		// Promote to admin using Better Auth adapter's updateOne method
+		await ctx.runMutation(components.betterAuth.adapter.updateOne, {
+			input: {
+				model: 'user',
+				where: [{ field: 'email', value: email }],
+				update: { role: 'admin' }
+			}
+		});
+
+		return { success: true };
+	}
+});

--- a/src/lib/emails/templates/NewUserSignupNotificationEmail.svelte
+++ b/src/lib/emails/templates/NewUserSignupNotificationEmail.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import { Html, Head, Body, Preview, Container } from 'better-svelte-email/components';
+	import { Badge, Button, Card } from '$lib/emails/components/ui/index.js';
+	import { EmailHeader, EmailFooter } from '$lib/emails/components/layout/index.js';
+
+	let {
+		userName = 'New User',
+		userEmail = 'user@example.com',
+		signupMethod = 'Email',
+		signupTime = 'Jan 15, 2026 at 3:45 PM',
+		adminDashboardLink = 'https://example.com/admin/users'
+	}: {
+		userName?: string;
+		userEmail?: string;
+		signupMethod?: string;
+		signupTime?: string;
+		adminDashboardLink?: string;
+	} = $props();
+</script>
+
+<Html>
+	<Head />
+	<Body class="mx-auto my-auto bg-white px-2 font-sans">
+		<Preview preview="New user: {userEmail}" />
+		<Container class="mx-auto my-10 max-w-md p-5">
+			<Card.Root>
+				<EmailHeader />
+				<Card.Header>
+					<Badge class="mb-2 border-transparent bg-blue-600 text-white">Stats</Badge>
+					<Card.Title>New user signed up</Card.Title>
+					<Card.Description>A new user has registered on your platform</Card.Description>
+				</Card.Header>
+
+				<Card.Content>
+					<div
+						style="background-color: #f4f4f5; border-radius: 6px; padding: 16px; margin-bottom: 16px;"
+					>
+						<p style="margin: 0 0 8px 0; font-size: 14px;">
+							<strong>Name:</strong>
+							{userName}
+						</p>
+						<p style="margin: 0 0 8px 0; font-size: 14px;">
+							<strong>Email:</strong>
+							{userEmail}
+						</p>
+						<p style="margin: 0 0 8px 0; font-size: 14px;">
+							<strong>Method:</strong>
+							{signupMethod}
+						</p>
+						<p style="margin: 0; font-size: 14px;">
+							<strong>Time:</strong>
+							{signupTime}
+						</p>
+					</div>
+
+					<Button class="mb-4" href={adminDashboardLink}>View in Admin Dashboard</Button>
+
+					<p class="text-xs text-muted-foreground">
+						You're receiving this email because you have new signup notifications enabled.
+					</p>
+				</Card.Content>
+
+				<Card.Footer>
+					<EmailFooter />
+				</Card.Footer>
+			</Card.Root>
+		</Container>
+	</Body>
+</Html>

--- a/src/lib/emails/templates/registry.ts
+++ b/src/lib/emails/templates/registry.ts
@@ -63,6 +63,16 @@ export const EMAIL_TEMPLATES: Record<string, TemplateConfig> = {
 			messagesHtml: '__ETA_messagesHtml__',
 			adminDashboardLink: '__ETA_adminDashboardLink__'
 		}
+	},
+	NewUserSignupNotificationEmail: {
+		outputName: 'newUserSignupNotification',
+		props: {
+			userName: '__ETA_userName__',
+			userEmail: '__ETA_userEmail__',
+			signupMethod: '__ETA_signupMethod__',
+			signupTime: '__ETA_signupTime__',
+			adminDashboardLink: '__ETA_adminDashboardLink__'
+		}
 	}
 };
 

--- a/src/lib/emails/templates/types.ts
+++ b/src/lib/emails/templates/types.ts
@@ -4,6 +4,7 @@ import type VerificationCodeEmail from './VerificationCodeEmail.svelte';
 import type PasswordResetEmail from './PasswordResetEmail.svelte';
 import type AdminReplyNotificationEmail from './AdminReplyNotificationEmail.svelte';
 import type NewTicketAdminNotificationEmail from './NewTicketAdminNotificationEmail.svelte';
+import type NewUserSignupNotificationEmail from './NewUserSignupNotificationEmail.svelte';
 
 // Extract component prop types
 export type VerificationEmailProps = ComponentProps<typeof VerificationEmail>;
@@ -12,6 +13,9 @@ export type PasswordResetEmailProps = ComponentProps<typeof PasswordResetEmail>;
 export type AdminReplyNotificationEmailProps = ComponentProps<typeof AdminReplyNotificationEmail>;
 export type NewTicketAdminNotificationEmailProps = ComponentProps<
 	typeof NewTicketAdminNotificationEmail
+>;
+export type NewUserSignupNotificationEmailProps = ComponentProps<
+	typeof NewUserSignupNotificationEmail
 >;
 
 // Helper to make all props required (removes optional defaults)
@@ -94,6 +98,25 @@ export type NewTicketAdminNotificationEmailData = {
 	isReopen: boolean;
 	userName: string;
 	messages: NotificationMessage[];
+	adminDashboardLink: string;
+};
+
+/**
+ * Data required to render a new user signup notification email
+ *
+ * Sent to admins when a new user registers on the platform.
+ *
+ * @property userName - User's display name or "New User" if not provided
+ * @property userEmail - User's email address
+ * @property signupMethod - How the user signed up ('Email', 'Google', 'GitHub')
+ * @property signupTime - Formatted timestamp of when the user signed up
+ * @property adminDashboardLink - Link to the admin users page filtered by this user
+ */
+export type NewUserSignupNotificationEmailData = {
+	userName: string;
+	userEmail: string;
+	signupMethod: 'Email' | 'Google' | 'GitHub';
+	signupTime: string;
 	adminDashboardLink: string;
 };
 

--- a/src/lib/hooks/admin-cache.svelte.ts
+++ b/src/lib/hooks/admin-cache.svelte.ts
@@ -1,5 +1,10 @@
-class AdminCacheManager {
-	userCount = $state<number | null>(null);
-}
+import { PersistedState } from 'runed';
 
-export const adminCache = new AdminCacheManager();
+export const adminCache = {
+	userCount: new PersistedState<number | null>('admin-cache:userCount', null),
+	recipientCount: new PersistedState<number | null>('admin-cache:recipientCount', null),
+	supportThreadCounts: new PersistedState<Record<string, number>>(
+		'admin-cache:supportThreadCounts',
+		{}
+	)
+};

--- a/src/routes/[[lang]]/+layout.svelte
+++ b/src/routes/[[lang]]/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { Tolgee, DevTools, FormatSimple, TolgeeProvider } from '@tolgee/svelte';
+	import { Tolgee, DevTools, TolgeeProvider } from '@tolgee/svelte';
+	import { FormatIcu } from '@tolgee/format-icu';
 	import { browser } from '$app/environment';
 	import type { LayoutData } from './$types';
 	import { watch } from 'runed';
@@ -13,7 +14,7 @@
 
 	const tolgee = Tolgee()
 		.use(DevTools())
-		.use(FormatSimple())
+		.use(FormatIcu())
 		.init({
 			language: data.lang,
 

--- a/src/routes/[[lang]]/admin/settings/+page.server.ts
+++ b/src/routes/[[lang]]/admin/settings/+page.server.ts
@@ -1,12 +1,6 @@
 import type { PageServerLoad } from './$types';
-import { api } from '$lib/convex/_generated/api.js';
-import { createConvexHttpClient } from '@mmailaender/convex-better-auth-svelte/sveltekit';
 
-export const load = (async (event) => {
-	const client = createConvexHttpClient({ token: event.locals.token });
-	const defaultSupportEmail = await client.query(
-		api.admin.settings.queries.getDefaultSupportEmail,
-		{}
-	);
-	return { defaultSupportEmail };
+export const load = (async () => {
+	// Notification recipients are loaded client-side via useQuery for real-time updates
+	return {};
 }) satisfies PageServerLoad;

--- a/src/routes/[[lang]]/admin/settings/+page.svelte
+++ b/src/routes/[[lang]]/admin/settings/+page.svelte
@@ -1,120 +1,14 @@
 <script lang="ts">
-	import type { PageData } from './$types';
-	import { Button } from '$lib/components/ui/button/index.js';
-	import { Input } from '$lib/components/ui/input/index.js';
-	import * as Card from '$lib/components/ui/card/index.js';
-	import { Label } from '$lib/components/ui/label/index.js';
-	import { Separator } from '$lib/components/ui/separator/index.js';
-	import * as Tabs from '$lib/components/ui/tabs/index.js';
-	import { T, getTranslate } from '@tolgee/svelte';
-	import { useConvexClient } from 'convex-svelte';
-	import { api } from '$lib/convex/_generated/api.js';
-	import { toast } from 'svelte-sonner';
-
-	interface Props {
-		data: PageData;
-	}
-
-	let { data }: Props = $props();
-
-	const { t } = getTranslate();
-
-	// Get Convex client for mutations
-	const client = useConvexClient();
-
-	// Form state - track both input and last saved value
-	let savedEmail = $state(data.defaultSupportEmail ?? '');
-	let emailInput = $state(data.defaultSupportEmail ?? '');
-	let isSaving = $state(false);
-	let saveError = $state<string | null>(null);
-
-	// Check if value has changed from last saved value
-	let hasChanges = $derived(emailInput !== savedEmail);
-
-	async function handleSave() {
-		isSaving = true;
-		saveError = null;
-
-		try {
-			await client.mutation(api.admin.settings.mutations.updateDefaultSupportEmail, {
-				email: emailInput
-			});
-			savedEmail = emailInput; // Update saved value to match current input
-			toast.success($t('admin.settings.saved'));
-		} catch (error) {
-			saveError = error instanceof Error ? error.message : 'Failed to save settings';
-		} finally {
-			isSaving = false;
-		}
-	}
+	import { T } from '@tolgee/svelte';
+	import NotificationRecipientsTable from './notification-recipients-table.svelte';
 </script>
 
-<div class="flex flex-1 flex-col px-4 lg:px-6">
-	<div class="flex-1 space-y-6">
-		<div>
-			<h2 class="text-2xl font-bold tracking-tight">
-				<T keyName="admin.settings.title" />
-			</h2>
-			<p class="text-muted-foreground">
-				<T keyName="admin.settings.description" />
-			</p>
-		</div>
-
-		<Separator />
-
-		<Tabs.Root value="notifications" class="space-y-6">
-			<Tabs.List>
-				<Tabs.Trigger value="notifications">
-					<T keyName="admin.settings.tabs.notifications" />
-				</Tabs.Trigger>
-			</Tabs.List>
-
-			<Tabs.Content value="notifications" class="space-y-6">
-				<Card.Root>
-					<Card.Header>
-						<Card.Title>
-							<T keyName="admin.settings.support_notifications" />
-						</Card.Title>
-						<Card.Description>
-							<T keyName="admin.settings.support_notifications_desc" />
-						</Card.Description>
-					</Card.Header>
-
-					<Card.Content>
-						<div class="flex flex-col gap-4">
-							<div class="flex flex-col gap-2">
-								<Label for="default-email">
-									<T keyName="admin.settings.default_support_email" />
-								</Label>
-								<Input
-									id="default-email"
-									type="email"
-									placeholder={$t('admin.settings.default_support_email_placeholder')}
-									bind:value={emailInput}
-									disabled={isSaving}
-								/>
-								<p class="text-sm text-muted-foreground">
-									<T keyName="admin.settings.default_support_email_help" />
-								</p>
-							</div>
-
-							{#if saveError}
-								<p class="text-sm text-destructive">{saveError}</p>
-							{/if}
-						</div>
-					</Card.Content>
-
-					<Card.Footer>
-						<Button onclick={handleSave} disabled={isSaving || !hasChanges}>
-							{#if isSaving}
-								<T keyName="admin.settings.saving" />
-							{:else}
-								<T keyName="admin.settings.save" />
-							{/if}
-						</Button>
-					</Card.Footer>
-				</Card.Root>
-			</Tabs.Content>
-		</Tabs.Root>
+<div class="flex flex-col gap-6 px-4 lg:px-6 xl:px-8 2xl:px-16" data-testid="admin-settings-page">
+	<!-- Header -->
+	<div class="flex items-center justify-between">
+		<h1 class="text-2xl font-bold"><T keyName="admin.settings.title" /></h1>
 	</div>
+
+	<!-- Notification Recipients Table -->
+	<NotificationRecipientsTable />
 </div>

--- a/src/routes/[[lang]]/admin/settings/add-email-dialog.svelte
+++ b/src/routes/[[lang]]/admin/settings/add-email-dialog.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import * as Field from '$lib/components/ui/field/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import PlusIcon from '@tabler/icons-svelte/icons/plus';
+	import { T, getTranslate } from '@tolgee/svelte';
+	import { toast } from 'svelte-sonner';
+	import { addEmailForm } from './data.remote';
+	import { emailSchema } from './email-schema';
+
+	const { t } = getTranslate();
+
+	interface Props {
+		open?: boolean;
+	}
+
+	let { open = $bindable(false) }: Props = $props();
+
+	function handleOpenChange(isOpen: boolean) {
+		open = isOpen;
+	}
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Trigger>
+		{#snippet child({ props })}
+			<Button {...props} variant="outline" size="sm" data-testid="add-email-button">
+				<PlusIcon class="mr-2 h-4 w-4" />
+				<T keyName="admin.settings.add_email" />
+			</Button>
+		{/snippet}
+	</Dialog.Trigger>
+	<Dialog.Content class="sm:max-w-[425px]">
+		<Dialog.Header>
+			<Dialog.Title><T keyName="admin.settings.add_email_dialog_title" /></Dialog.Title>
+			<Dialog.Description>
+				<T keyName="admin.settings.add_email_dialog_desc" />
+			</Dialog.Description>
+		</Dialog.Header>
+		<form
+			{...addEmailForm.preflight(emailSchema).enhance(async ({ submit, form: formEl }) => {
+				try {
+					await submit();
+					formEl.reset();
+					toast.success($t('admin.settings.email_added'));
+					open = false;
+				} catch {
+					toast.error($t('admin.settings.email_add_failed'));
+				}
+			})}
+			class="grid gap-4"
+		>
+			<Field.Field>
+				<Field.Label for="email"><T keyName="admin.settings.column_email" /></Field.Label>
+				<Input
+					{...addEmailForm.fields.email.as('text')}
+					inputmode="email"
+					autocomplete="email"
+					placeholder={$t('admin.settings.add_email_placeholder')}
+					data-testid="add-email-input"
+				/>
+				<Field.Error errors={addEmailForm.fields.email.issues()} data-testid="add-email-error" />
+			</Field.Field>
+			<Dialog.Footer>
+				<Button
+					type="button"
+					variant="outline"
+					onclick={() => (open = false)}
+					disabled={!!addEmailForm.pending}
+				>
+					<T keyName="common.cancel" />
+				</Button>
+				<Button
+					type="submit"
+					disabled={!!addEmailForm.pending || !addEmailForm.fields.email.value()?.trim()}
+					data-testid="add-email-submit"
+				>
+					{#if addEmailForm.pending}
+						<T keyName="common.adding" />
+					{:else}
+						<T keyName="admin.settings.add_email" />
+					{/if}
+				</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/routes/[[lang]]/admin/settings/columns.ts
+++ b/src/routes/[[lang]]/admin/settings/columns.ts
@@ -1,0 +1,151 @@
+import type { ColumnDef } from '@tanstack/table-core';
+import { createRawSnippet } from 'svelte';
+import { renderComponent, renderSnippet } from '$lib/components/ui/data-table/index.js';
+import type { NotificationRecipient } from '$lib/convex/admin/notificationPreferences/queries';
+import DataTableCheckbox from '$lib/components/data-table-checkbox.svelte';
+import DataTableColumnHeader from './data-table-column-header.svelte';
+import RecipientsActions from './recipients-actions.svelte';
+import RecipientsToggle from './recipients-toggle.svelte';
+import TypeBadge from './type-badge.svelte';
+
+export const columns: ColumnDef<NotificationRecipient>[] = [
+	// Temporary checkbox column for layout testing
+	{
+		id: 'select',
+		size: 40,
+		minSize: 40,
+		maxSize: 40,
+		header: ({ table }) =>
+			renderComponent(DataTableCheckbox, {
+				checked: table.getIsAllPageRowsSelected(),
+				indeterminate: table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
+				onCheckedChange: (value: boolean) => table.toggleAllPageRowsSelected(!!value),
+				'aria-label-key': 'admin.users.select_all'
+			}),
+		cell: ({ row }) =>
+			renderComponent(DataTableCheckbox, {
+				checked: row.getIsSelected(),
+				onCheckedChange: (value: boolean) => row.toggleSelected(!!value),
+				'aria-label-key': 'admin.users.select_row'
+			}),
+		enableSorting: false,
+		enableHiding: false
+	},
+	{
+		accessorKey: 'email',
+		size: 250,
+		minSize: 200,
+		header: () =>
+			renderComponent(DataTableColumnHeader, {
+				titleKey: 'admin.settings.column_email'
+			}),
+		cell: ({ row }) => {
+			const emailSnippet = createRawSnippet<[{ email: string }]>((getData) => {
+				const { email } = getData();
+				return {
+					render: () => `<div class="font-medium">${email}</div>`
+				};
+			});
+			return renderSnippet(emailSnippet, { email: row.original.email });
+		}
+	},
+	{
+		accessorKey: 'name',
+		accessorFn: (row) => row.name ?? '',
+		size: 150,
+		minSize: 120,
+		header: () =>
+			renderComponent(DataTableColumnHeader, {
+				titleKey: 'admin.settings.column_name'
+			}),
+		cell: ({ row }) => {
+			const nameSnippet = createRawSnippet<[{ name?: string }]>((getData) => {
+				const { name } = getData();
+				return {
+					render: () =>
+						`<div class="text-muted-foreground">${name || '<span class="text-muted-foreground/50">-</span>'}</div>`
+				};
+			});
+			return renderSnippet(nameSnippet, { name: row.original.name });
+		}
+	},
+	{
+		id: 'type',
+		size: 100,
+		minSize: 80,
+		header: () =>
+			renderComponent(DataTableColumnHeader, {
+				titleKey: 'admin.settings.column_type'
+			}),
+		cell: ({ row }) =>
+			renderComponent(TypeBadge, {
+				isAdmin: row.original.isAdminUser
+			})
+	},
+	{
+		id: 'notifyNewSupportTickets',
+		size: 100,
+		minSize: 100,
+		header: () =>
+			renderComponent(DataTableColumnHeader, {
+				titleKey: 'admin.settings.column_new_tickets',
+				class: 'text-center'
+			}),
+		cell: ({ row }) =>
+			renderComponent(RecipientsToggle, {
+				email: row.original.email,
+				field: 'notifyNewSupportTickets',
+				checked: row.original.notifyNewSupportTickets
+			})
+	},
+	{
+		id: 'notifyUserReplies',
+		size: 100,
+		minSize: 100,
+		header: () =>
+			renderComponent(DataTableColumnHeader, {
+				titleKey: 'admin.settings.column_user_replies',
+				class: 'text-center'
+			}),
+		cell: ({ row }) =>
+			renderComponent(RecipientsToggle, {
+				email: row.original.email,
+				field: 'notifyUserReplies',
+				checked: row.original.notifyUserReplies
+			})
+	},
+	{
+		id: 'notifyNewSignups',
+		size: 100,
+		minSize: 100,
+		header: () =>
+			renderComponent(DataTableColumnHeader, {
+				titleKey: 'admin.settings.column_new_signups',
+				class: 'text-center'
+			}),
+		cell: ({ row }) =>
+			renderComponent(RecipientsToggle, {
+				email: row.original.email,
+				field: 'notifyNewSignups',
+				checked: row.original.notifyNewSignups
+			})
+	},
+	{
+		id: 'actions',
+		size: 50,
+		minSize: 50,
+		maxSize: 50,
+		enableHiding: false,
+		header: () => {
+			const headerSnippet = createRawSnippet(() => ({
+				render: () => `<span class="sr-only">Actions</span>`
+			}));
+			return renderSnippet(headerSnippet, {});
+		},
+		cell: ({ row }) =>
+			renderComponent(RecipientsActions, {
+				email: row.original.email,
+				isAdminUser: row.original.isAdminUser
+			})
+	}
+];

--- a/src/routes/[[lang]]/admin/settings/data-table-column-header.svelte
+++ b/src/routes/[[lang]]/admin/settings/data-table-column-header.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { T } from '@tolgee/svelte';
+
+	type Props = {
+		titleKey: string;
+		class?: string;
+	};
+
+	let { titleKey, class: className = '' }: Props = $props();
+</script>
+
+<div class={className}>
+	<T keyName={titleKey} />
+</div>

--- a/src/routes/[[lang]]/admin/settings/data-table-filters.svelte
+++ b/src/routes/[[lang]]/admin/settings/data-table-filters.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import * as Select from '$lib/components/ui/select/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import XIcon from '@tabler/icons-svelte/icons/x';
+	import { T, getTranslate } from '@tolgee/svelte';
+
+	const { t } = getTranslate();
+
+	type Props = {
+		typeFilter: 'all' | 'admin' | 'custom';
+		onFilterChange: (filter: 'all' | 'admin' | 'custom') => void;
+	};
+
+	let { typeFilter, onFilterChange }: Props = $props();
+
+	// Check if filter is active
+	const hasActiveFilter = $derived(typeFilter !== 'all');
+
+	function handleTypeChange(value: string) {
+		onFilterChange(value as 'all' | 'admin' | 'custom');
+	}
+
+	function clearFilter() {
+		onFilterChange('all');
+	}
+
+	type TypeOption = { value: 'all' | 'admin' | 'custom'; label: string };
+	const typeOptions: TypeOption[] = $derived([
+		{ value: 'all', label: $t('admin.settings.filter.all_types') },
+		{ value: 'admin', label: $t('admin.settings.filter.admin_only') },
+		{ value: 'custom', label: $t('admin.settings.filter.custom_only') }
+	]);
+</script>
+
+<div class="flex items-center gap-2">
+	<!-- Type Filter -->
+	<Select.Root type="single" value={typeFilter} onValueChange={handleTypeChange}>
+		<Select.Trigger class="h-8 w-[130px]" data-testid="filter-type-trigger">
+			{typeOptions.find((opt) => opt.value === typeFilter)?.label ??
+				$t('admin.settings.filter.all_types')}
+		</Select.Trigger>
+		<Select.Content>
+			{#each typeOptions as option (option.value)}
+				<Select.Item value={option.value} data-testid="filter-{option.value}"
+					>{option.label}</Select.Item
+				>
+			{/each}
+		</Select.Content>
+	</Select.Root>
+
+	<!-- Clear Filter Button -->
+	{#if hasActiveFilter}
+		<Button
+			variant="ghost"
+			size="sm"
+			class="h-8 px-2"
+			onclick={clearFilter}
+			data-testid="filter-clear"
+		>
+			<XIcon class="mr-1 size-4" />
+			<T keyName="admin.settings.filter.clear" />
+		</Button>
+	{/if}
+</div>

--- a/src/routes/[[lang]]/admin/settings/data.remote.ts
+++ b/src/routes/[[lang]]/admin/settings/data.remote.ts
@@ -1,0 +1,30 @@
+import { form, getRequestEvent } from '$app/server';
+import { invalid } from '@sveltejs/kit';
+import { createConvexHttpClient } from '@mmailaender/convex-better-auth-svelte/sveltekit';
+import { api } from '$lib/convex/_generated/api';
+import { emailSchema } from './email-schema';
+
+/**
+ * Remote form for adding a custom email recipient
+ *
+ * Uses SvelteKit remote functions with Zod validation.
+ * Calls Convex mutation server-side with proper authentication.
+ */
+export const addEmailForm = form(emailSchema, async ({ email }, issue) => {
+	const event = getRequestEvent();
+	const client = createConvexHttpClient({ token: event.locals.token });
+
+	const normalizedEmail = email.trim().toLowerCase();
+
+	try {
+		await client.mutation(api.admin.notificationPreferences.mutations.addCustomEmail, {
+			email: normalizedEmail
+		});
+		return { success: true };
+	} catch (err) {
+		if (err instanceof Error && err.message.includes('already exists')) {
+			invalid(issue.email('This email already exists'));
+		}
+		throw err;
+	}
+});

--- a/src/routes/[[lang]]/admin/settings/email-schema.ts
+++ b/src/routes/[[lang]]/admin/settings/email-schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+/**
+ * Zod schema for email validation
+ * Used for both server-side validation in data.remote.ts and
+ * client-side preflight validation in add-email-dialog.svelte
+ */
+export const emailSchema = z.object({
+	email: z.string().email('Please enter a valid email address')
+});

--- a/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
+++ b/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
@@ -1,0 +1,266 @@
+<script lang="ts">
+	import { getCoreRowModel, type RowSelectionState } from '@tanstack/table-core';
+	import * as Table from '$lib/components/ui/table/index.js';
+	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+
+	import { T, getTranslate } from '@tolgee/svelte';
+	import { useQuery, useConvexClient } from 'convex-svelte';
+	import { api } from '$lib/convex/_generated/api.js';
+	import { setContext } from 'svelte';
+	import { createSvelteTable, FlexRender } from '$lib/components/ui/data-table/index.js';
+	import { columns } from './columns.js';
+	import type { NotificationRecipient } from '$lib/convex/admin/notificationPreferences/queries';
+	import { adminCache } from '$lib/hooks/admin-cache.svelte';
+	import AddEmailDialog from './add-email-dialog.svelte';
+	import DataTableFilters from './data-table-filters.svelte';
+	import { ConfirmDeleteDialog } from '$lib/components/ui/confirm-delete-dialog';
+
+	const { t } = getTranslate();
+	const client = useConvexClient();
+
+	// Query for notification recipients
+	const recipientsQuery = useQuery(
+		api.admin.notificationPreferences.queries.listNotificationRecipients,
+		{}
+	);
+
+	// Track pending updates for optimistic UI
+	let pendingUpdates = $state<Map<string, Record<string, boolean>>>(new Map());
+
+	// Filter state
+	let typeFilter = $state<'all' | 'admin' | 'custom'>('all');
+
+	// Row selection state (for temp checkbox column)
+	let rowSelection = $state<RowSelectionState>({});
+
+	// Derive recipients with pending updates applied
+	const recipientsWithUpdates: NotificationRecipient[] = $derived.by(() => {
+		if (!recipientsQuery.data) return [];
+		return recipientsQuery.data.map((r: NotificationRecipient) => {
+			const pending = pendingUpdates.get(r.email);
+			if (pending) {
+				return { ...r, ...pending };
+			}
+			return r;
+		});
+	});
+
+	// Apply client-side type filter
+	const recipients: NotificationRecipient[] = $derived.by(() => {
+		if (typeFilter === 'all') return recipientsWithUpdates;
+		if (typeFilter === 'admin') return recipientsWithUpdates.filter((r) => r.isAdminUser);
+		return recipientsWithUpdates.filter((r) => !r.isAdminUser);
+	});
+
+	// Total count (unfiltered) for footer - falls back to cache during loading
+	const totalCount = $derived(
+		recipientsQuery.data?.length ?? adminCache.recipientCount.current ?? 0
+	);
+
+	const isLoading = $derived(recipientsQuery.isLoading);
+
+	async function togglePreference(
+		email: string,
+		field: 'notifyNewSupportTickets' | 'notifyUserReplies' | 'notifyNewSignups',
+		currentValue: boolean
+	) {
+		const newValue = !currentValue;
+
+		// Optimistic update
+		const existing = pendingUpdates.get(email) ?? {};
+		pendingUpdates.set(email, { ...existing, [field]: newValue });
+		pendingUpdates = new Map(pendingUpdates);
+
+		try {
+			await client.mutation(api.admin.notificationPreferences.mutations.updatePreference, {
+				email,
+				field,
+				value: newValue
+			});
+		} catch (error) {
+			// Revert optimistic update
+			const current = pendingUpdates.get(email);
+			if (current) {
+				delete current[field];
+				if (Object.keys(current).length === 0) {
+					pendingUpdates.delete(email);
+				}
+			}
+			pendingUpdates = new Map(pendingUpdates);
+			throw error;
+		}
+	}
+
+	// Remove a custom email - returns promise for confirmDelete
+	async function removeEmail(email: string) {
+		await client.mutation(api.admin.notificationPreferences.mutations.removeCustomEmail, {
+			email
+		});
+	}
+
+	// Provide context for cell components
+	setContext('onTogglePreference', togglePreference);
+	setContext('onRemoveEmail', removeEmail);
+	// Provide selection state and recipients for bulk operations
+	setContext('getRowSelection', () => rowSelection);
+	setContext('getRecipients', () => recipientsWithUpdates);
+
+	// Add email dialog state
+	let addEmailDialogOpen = $state(false);
+
+	// Handle filter change
+	function handleFilterChange(filter: 'all' | 'admin' | 'custom') {
+		typeFilter = filter;
+	}
+
+	// Create the table
+	const table = createSvelteTable({
+		get data() {
+			return recipients;
+		},
+		columns,
+		state: {
+			get rowSelection() {
+				return rowSelection;
+			}
+		},
+		getRowId: (row) => row.email,
+		getCoreRowModel: getCoreRowModel(),
+		onRowSelectionChange: (updater) => {
+			if (typeof updater === 'function') {
+				rowSelection = updater(rowSelection);
+			} else {
+				rowSelection = updater;
+			}
+		}
+	});
+
+	// Smart skeleton count: use cached count or default to 1
+	const skeletonCount = $derived(adminCache.recipientCount.current ?? 1);
+
+	// Cache recipient count when data loads
+	$effect(() => {
+		if (recipientsQuery.data) {
+			adminCache.recipientCount.current = recipientsQuery.data.length;
+		}
+	});
+</script>
+
+<div class="flex flex-col gap-6" data-testid="recipients-table">
+	<!-- Controls: Filters + Add Email Button -->
+	<div class="flex flex-wrap items-center justify-between gap-4">
+		<DataTableFilters {typeFilter} onFilterChange={handleFilterChange} />
+		<AddEmailDialog bind:open={addEmailDialogOpen} />
+	</div>
+
+	<!-- Data Table -->
+	<div class="overflow-hidden rounded-md border">
+		<Table.Root class="table-fixed">
+			<Table.Header class="sticky top-0 z-10 bg-muted">
+				{#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
+					<Table.Row class="hover:[&>th]:bg-muted">
+						{#each headerGroup.headers as header (header.id)}
+							<Table.Head
+								class="[&:has([role=checkbox])]:ps-3"
+								style="width: {header.getSize()}px; min-width: {header.column.columnDef.minSize}px;"
+							>
+								{#if !header.isPlaceholder}
+									<FlexRender
+										content={header.column.columnDef.header}
+										context={header.getContext()}
+									/>
+								{/if}
+							</Table.Head>
+						{/each}
+					</Table.Row>
+				{/each}
+			</Table.Header>
+			<Table.Body>
+				{#if isLoading}
+					<!-- Skeleton loading rows matching real row structure exactly -->
+					{#each Array(skeletonCount) as _, i (i)}
+						<Table.Row data-testid="recipients-loading">
+							<!-- Checkbox: matches DataTableCheckbox -->
+							<Table.Cell class="[&:has([role=checkbox])]:ps-3">
+								<div class="flex items-center justify-center">
+									<Checkbox disabled aria-label="Loading" />
+								</div>
+							</Table.Cell>
+							<!-- Email -->
+							<Table.Cell>
+								<Skeleton class="h-4 w-40" />
+							</Table.Cell>
+							<!-- Name: show dash like actual empty state -->
+							<Table.Cell>
+								<span class="text-muted-foreground/50">-</span>
+							</Table.Cell>
+							<!-- Type: badge skeleton -->
+							<Table.Cell>
+								<Skeleton class="h-[22px] w-14 rounded-md" />
+							</Table.Cell>
+							<!-- New Tickets -->
+							<Table.Cell class="[&:has([role=checkbox])]:ps-3">
+								<div class="flex items-center justify-center">
+									<Checkbox disabled aria-label="Loading" />
+								</div>
+							</Table.Cell>
+							<!-- User Replies -->
+							<Table.Cell class="[&:has([role=checkbox])]:ps-3">
+								<div class="flex items-center justify-center">
+									<Checkbox disabled aria-label="Loading" />
+								</div>
+							</Table.Cell>
+							<!-- New Signups -->
+							<Table.Cell class="[&:has([role=checkbox])]:ps-3">
+								<div class="flex items-center justify-center">
+									<Checkbox disabled aria-label="Loading" />
+								</div>
+							</Table.Cell>
+							<!-- Actions: invisible placeholder for consistent row height -->
+							<Table.Cell>
+								<div class="h-8 w-8" aria-hidden="true"></div>
+							</Table.Cell>
+						</Table.Row>
+					{/each}
+				{:else if table.getRowModel().rows.length === 0}
+					<!-- No results -->
+					<Table.Row data-testid="recipients-empty">
+						<Table.Cell
+							colspan={columns.length}
+							class="h-24 text-center text-muted-foreground hover:!bg-transparent"
+						>
+							<T keyName="admin.settings.no_recipients" />
+						</Table.Cell>
+					</Table.Row>
+				{:else}
+					{#each table.getRowModel().rows as row (row.id)}
+						<Table.Row
+							data-state={row.getIsSelected() && 'selected'}
+							data-testid="recipient-row-{row.id}"
+						>
+							{#each row.getVisibleCells() as cell (cell.id)}
+								<Table.Cell class="[&:has([role=checkbox])]:ps-3">
+									<FlexRender content={cell.column.columnDef.cell} context={cell.getContext()} />
+								</Table.Cell>
+							{/each}
+						</Table.Row>
+					{/each}
+				{/if}
+			</Table.Body>
+		</Table.Root>
+	</div>
+
+	<!-- Footer: Selection Count -->
+	<div class="flex items-center px-2">
+		<div class="text-sm text-muted-foreground">
+			<T
+				keyName="admin.settings.selected"
+				params={{ selected: Object.keys(rowSelection).length, total: totalCount }}
+			/>
+		</div>
+	</div>
+</div>
+
+<!-- Global Confirm Delete Dialog -->
+<ConfirmDeleteDialog />

--- a/src/routes/[[lang]]/admin/settings/recipients-actions.svelte
+++ b/src/routes/[[lang]]/admin/settings/recipients-actions.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import TrashIcon from '@tabler/icons-svelte/icons/trash';
+	import { T, getTranslate } from '@tolgee/svelte';
+	import { getContext } from 'svelte';
+	import { confirmDelete } from '$lib/components/ui/confirm-delete-dialog';
+	import { toast } from 'svelte-sonner';
+
+	interface Props {
+		email: string;
+		isAdminUser: boolean;
+	}
+
+	let { email, isAdminUser }: Props = $props();
+
+	const { t } = getTranslate();
+
+	// Get the remove handler from context (provided by the table)
+	const onRemove = getContext<(email: string) => Promise<void>>('onRemoveEmail');
+
+	function handleRemove() {
+		confirmDelete({
+			title: $t('admin.settings.delete_email_title'),
+			description: $t('admin.settings.delete_email_description', { email }),
+			confirm: {
+				text: $t('admin.settings.delete_email')
+			},
+			cancel: {
+				text: $t('common.cancel')
+			},
+			onConfirm: async () => {
+				try {
+					await onRemove(email);
+					toast.success($t('admin.settings.email_removed'));
+				} catch (error) {
+					console.error('[recipients-actions] Failed to remove email:', error);
+					toast.error(
+						error instanceof Error ? error.message : $t('admin.settings.preference_update_failed')
+					);
+					throw error; // Re-throw so confirmDelete knows it failed
+				}
+			}
+		});
+	}
+</script>
+
+{#if !isAdminUser}
+	<Button
+		variant="ghost"
+		size="icon"
+		class="h-8 w-8 text-muted-foreground hover:text-destructive"
+		onclick={handleRemove}
+		data-testid="delete-email-{email}"
+	>
+		<TrashIcon class="h-4 w-4" />
+		<span class="sr-only"><T keyName="admin.settings.delete_email" /></span>
+	</Button>
+{:else}
+	<!-- Invisible placeholder to maintain consistent row height -->
+	<div class="h-8 w-8" aria-hidden="true"></div>
+{/if}

--- a/src/routes/[[lang]]/admin/settings/recipients-toggle.svelte
+++ b/src/routes/[[lang]]/admin/settings/recipients-toggle.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import { getContext } from 'svelte';
+	import { toast } from 'svelte-sonner';
+	import { getTranslate } from '@tolgee/svelte';
+	import type { RowSelectionState } from '@tanstack/table-core';
+	import type { NotificationRecipient } from '$lib/convex/admin/notificationPreferences/queries';
+
+	type ToggleField = 'notifyNewSupportTickets' | 'notifyUserReplies' | 'notifyNewSignups';
+
+	interface Props {
+		email: string;
+		field: ToggleField;
+		checked: boolean;
+	}
+
+	let { email, field, checked }: Props = $props();
+
+	const { t } = getTranslate();
+
+	// Get the toggle handler from context (provided by the table)
+	const onToggle =
+		getContext<(email: string, field: ToggleField, currentValue: boolean) => Promise<void>>(
+			'onTogglePreference'
+		);
+
+	// Get selection state and recipients for bulk operations
+	const getRowSelection = getContext<() => RowSelectionState>('getRowSelection');
+	const getRecipients = getContext<() => NotificationRecipient[]>('getRecipients');
+
+	// Map field to translation key
+	const fieldTranslationKeys: Record<ToggleField, string> = {
+		notifyNewSupportTickets: 'admin.settings.field_new_tickets',
+		notifyUserReplies: 'admin.settings.field_user_replies',
+		notifyNewSignups: 'admin.settings.field_new_signups'
+	};
+
+	function handleToggle() {
+		const newValue = !checked;
+		const fieldName = $t(fieldTranslationKeys[field]);
+		const rowSelection = getRowSelection();
+		const selectedEmails = Object.keys(rowSelection).filter((key) => rowSelection[key]);
+
+		// Bulk toggle if 2+ rows selected and this row is one of them
+		if (selectedEmails.length >= 2 && selectedEmails.includes(email)) {
+			const recipients = getRecipients();
+
+			// Build promises for all selected rows, setting them to the new value
+			const promises = selectedEmails.map((selectedEmail) => {
+				const recipient = recipients.find((r) => r.email === selectedEmail);
+				if (recipient) {
+					// Only toggle if current value differs from target
+					const currentValue = recipient[field];
+					if (currentValue !== newValue) {
+						return onToggle(selectedEmail, field, currentValue);
+					}
+				}
+				return Promise.resolve();
+			});
+
+			toast.promise(Promise.all(promises), {
+				loading: newValue
+					? $t('admin.settings.preference_enabling', { field: fieldName })
+					: $t('admin.settings.preference_disabling', { field: fieldName }),
+				success: newValue
+					? $t('admin.settings.preference_enabled', { field: fieldName })
+					: $t('admin.settings.preference_disabled', { field: fieldName }),
+				error: $t('admin.settings.preference_update_failed')
+			});
+		} else {
+			// Single row toggle
+			toast.promise(onToggle(email, field, checked), {
+				loading: newValue
+					? $t('admin.settings.preference_enabling', { field: fieldName })
+					: $t('admin.settings.preference_disabling', { field: fieldName }),
+				success: newValue
+					? $t('admin.settings.preference_enabled', { field: fieldName })
+					: $t('admin.settings.preference_disabled', { field: fieldName }),
+				error: $t('admin.settings.preference_update_failed')
+			});
+		}
+	}
+</script>
+
+<div class="flex items-center justify-center">
+	<Checkbox
+		{checked}
+		onCheckedChange={handleToggle}
+		aria-label="{field} for {email}"
+		data-testid="toggle-{field}-{email}"
+	/>
+</div>

--- a/src/routes/[[lang]]/admin/settings/type-badge.svelte
+++ b/src/routes/[[lang]]/admin/settings/type-badge.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { T } from '@tolgee/svelte';
+
+	interface Props {
+		isAdmin: boolean;
+	}
+
+	let { isAdmin }: Props = $props();
+</script>
+
+{#if isAdmin}
+	<span
+		class="inline-flex items-center rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground ring-1 ring-primary/20 ring-inset"
+	>
+		<T keyName="admin.settings.type_admin" />
+	</span>
+{:else}
+	<span
+		class="inline-flex items-center rounded-md bg-secondary px-2 py-1 text-xs font-medium text-secondary-foreground ring-1 ring-secondary/20 ring-inset"
+	>
+		<T keyName="admin.settings.type_custom" />
+	</span>
+{/if}

--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { fade } from 'svelte/transition';
 	import { Input } from '$lib/components/ui/input';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import { Button } from '$lib/components/ui/button';
@@ -50,6 +49,7 @@
 		selectedThreadId,
 		isLoading = false,
 		isDone = false,
+		cachedCount,
 		onFilterChange,
 		onStatusChange,
 		onSearchChange,
@@ -63,12 +63,16 @@
 		selectedThreadId: string | null | undefined;
 		isLoading?: boolean;
 		isDone?: boolean;
+		cachedCount?: number;
 		onFilterChange: (mode: 'all' | 'unassigned' | 'my-inbox') => void;
 		onStatusChange: (status: 'open' | 'done') => void;
 		onSearchChange: (query: string) => void;
 		onThreadSelect: (id: string) => void;
 		onLoadMore: (numItems: number) => boolean;
 	} = $props();
+
+	// Skeleton count: use cached count or default to 6
+	const skeletonCount = $derived(cachedCount ?? 6);
 
 	// Create loader state instance for svelte-infinite
 	const loaderState = new LoaderState();
@@ -158,8 +162,8 @@
 	<div class="relative flex-1">
 		{#if isLoading}
 			<!-- Loading skeletons -->
-			<div class=" scrollbar-thin absolute inset-0 overflow-y-auto" out:fade={{ duration: 150 }}>
-				{#each Array(6) as _, i (i)}
+			<div class="scrollbar-thin absolute inset-0 overflow-y-auto">
+				{#each Array(skeletonCount) as _, i (i)}
 					<div class="border-b p-4">
 						<div class="flex items-start gap-3">
 							<!-- Avatar -->
@@ -186,10 +190,7 @@
 				{/each}
 			</div>
 		{:else if threads && threads.length > 0}
-			<div
-				class="scrollbar-thin absolute inset-0 overflow-x-hidden overflow-y-auto"
-				in:fade={{ duration: 150 }}
-			>
+			<div class="scrollbar-thin absolute inset-0 overflow-x-hidden overflow-y-auto">
 				<InfiniteLoader
 					{loaderState}
 					{triggerLoad}
@@ -280,7 +281,6 @@
 			</div>
 		{:else}
 			<div
-				in:fade={{ duration: 150 }}
 				class="absolute inset-0 flex items-center justify-center p-8 text-center text-muted-foreground"
 			>
 				<T keyName={showingOpen ? 'admin.support.no_open_chats' : 'admin.support.no_done_chats'} />

--- a/src/routes/[[lang]]/admin/users/+page.svelte
+++ b/src/routes/[[lang]]/admin/users/+page.svelte
@@ -220,8 +220,8 @@
 
 	// Calculate skeleton rows: min(knownCount - offset, pageSize) or pageSize if unknown
 	const skeletonCount = $derived.by(() => {
-		if (adminCache.userCount !== null) {
-			const remaining = adminCache.userCount - pageIndex * pageSize;
+		if (adminCache.userCount.current !== null) {
+			const remaining = adminCache.userCount.current - pageIndex * pageSize;
 			return Math.min(Math.max(remaining, 0), pageSize);
 		}
 		return pageSize;
@@ -233,8 +233,8 @@
 			return Math.ceil(countQuery.data / pageSize);
 		}
 		// Fallback to cached count
-		if (adminCache.userCount !== null) {
-			return Math.ceil(adminCache.userCount / pageSize);
+		if (adminCache.userCount.current !== null) {
+			return Math.ceil(adminCache.userCount.current / pageSize);
 		}
 		return 1;
 	});
@@ -242,7 +242,7 @@
 	// Update user count cache when count data loads
 	$effect(() => {
 		if (countQuery.data !== undefined) {
-			adminCache.userCount = countQuery.data;
+			adminCache.userCount.current = countQuery.data;
 		}
 	});
 
@@ -569,7 +569,7 @@
 	}
 </script>
 
-<div class="flex flex-col gap-6 px-4 lg:px-6">
+<div class="flex flex-col gap-6 px-4 lg:px-6 xl:px-8 2xl:px-16">
 	<!-- Header -->
 	<div class="flex items-center justify-between">
 		<h1 class="text-2xl font-bold"><T keyName="admin.users.title" /></h1>
@@ -620,11 +620,11 @@
 	</div>
 
 	<!-- Data Table -->
-	<div class="rounded-md border">
+	<div class="overflow-hidden rounded-md border">
 		<Table.Root class="table-fixed">
-			<Table.Header>
+			<Table.Header class="sticky top-0 z-10 bg-muted">
 				{#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
-					<Table.Row>
+					<Table.Row class="hover:[&>th]:bg-muted">
 						{#each headerGroup.headers as header (header.id)}
 							<Table.Head
 								class="[&:has([role=checkbox])]:ps-3"
@@ -689,7 +689,10 @@
 				{:else if table.getRowModel().rows.length === 0}
 					<!-- No results -->
 					<Table.Row>
-						<Table.Cell colspan={columns.length} class="h-24 text-center text-muted-foreground">
+						<Table.Cell
+							colspan={columns.length}
+							class="h-24 text-center text-muted-foreground hover:!bg-transparent"
+						>
 							<T keyName="admin.users.no_results" />
 						</Table.Cell>
 					</Table.Row>
@@ -715,7 +718,7 @@
 				keyName="admin.users.selected"
 				params={{
 					selected: Object.keys(rowSelection).length,
-					total: countQuery.data ?? 0
+					total: countQuery.data ?? adminCache.userCount.current ?? 0
 				}}
 			/>
 		</div>

--- a/src/routes/[[lang]]/admin/users/columns.ts
+++ b/src/routes/[[lang]]/admin/users/columns.ts
@@ -5,6 +5,8 @@ import DataTableCheckbox from '$lib/components/data-table-checkbox.svelte';
 import DataTableColumnHeader from './data-table-column-header.svelte';
 import DataTableActions from './data-table-actions.svelte';
 import type { AdminUserData } from '$lib/convex/admin/types';
+import StatusBadge from './status-badge.svelte';
+import RoleBadge from './role-badge.svelte';
 
 /**
  * Derive a sortable status value from user data.
@@ -26,13 +28,13 @@ export const columns: ColumnDef<AdminUserData>[] = [
 			renderComponent(DataTableCheckbox, {
 				checked: table.getIsAllPageRowsSelected(),
 				indeterminate: table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
-				onCheckedChange: (value) => table.toggleAllPageRowsSelected(!!value),
+				onCheckedChange: (value: boolean) => table.toggleAllPageRowsSelected(!!value),
 				'aria-label-key': 'admin.users.select_all'
 			}),
 		cell: ({ row }) =>
 			renderComponent(DataTableCheckbox, {
 				checked: row.getIsSelected(),
-				onCheckedChange: (value) => row.toggleSelected(!!value),
+				onCheckedChange: (value: boolean) => row.toggleSelected(!!value),
 				'aria-label-key': 'admin.users.select_row'
 			}),
 		enableSorting: false,
@@ -104,22 +106,11 @@ export const columns: ColumnDef<AdminUserData>[] = [
 				column,
 				titleKey: 'admin.users.role'
 			}),
-		cell: ({ row }) => {
-			const roleSnippet = createRawSnippet<[{ role: string }]>((getData) => {
-				const { role } = getData();
-				const variant = role === 'admin' ? 'default' : 'secondary';
-				return {
-					render: () =>
-						`<span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${
-							variant === 'default'
-								? 'bg-primary text-primary-foreground ring-primary/20'
-								: 'bg-secondary text-secondary-foreground ring-secondary/20'
-						}">${role}</span>`
-				};
-			});
-			return renderSnippet(roleSnippet, { role: row.original.role });
-		},
-		filterFn: (row, _columnId, filterValue) => {
+		cell: ({ row }) =>
+			renderComponent(RoleBadge, {
+				role: row.original.role
+			}),
+		filterFn: (row, _columnId, filterValue: string) => {
 			if (!filterValue || filterValue === 'all') return true;
 			return row.original.role === filterValue;
 		}
@@ -134,34 +125,12 @@ export const columns: ColumnDef<AdminUserData>[] = [
 				column,
 				titleKey: 'admin.users.status'
 			}),
-		cell: ({ row }) => {
-			const statusSnippet = createRawSnippet<[{ banned: boolean; emailVerified?: boolean }]>(
-				(getData) => {
-					const { banned, emailVerified } = getData();
-					if (banned) {
-						return {
-							render: () =>
-								`<span class="inline-flex items-center rounded-md bg-destructive px-2 py-1 text-xs font-medium text-destructive-foreground ring-1 ring-inset ring-destructive/20">Banned</span>`
-						};
-					}
-					if (emailVerified) {
-						return {
-							render: () =>
-								`<span class="inline-flex items-center rounded-md border border-green-600 px-2 py-1 text-xs font-medium text-green-600 ring-1 ring-inset ring-green-600/20">Verified</span>`
-						};
-					}
-					return {
-						render: () =>
-							`<span class="inline-flex items-center rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground ring-1 ring-inset ring-border">Unverified</span>`
-					};
-				}
-			);
-			return renderSnippet(statusSnippet, {
+		cell: ({ row }) =>
+			renderComponent(StatusBadge, {
 				banned: row.original.banned,
 				emailVerified: row.original.emailVerified
-			});
-		},
-		filterFn: (row, _columnId, filterValue) => {
+			}),
+		filterFn: (row, _columnId, filterValue: string) => {
 			if (!filterValue || filterValue === 'all') return true;
 			const user = row.original;
 			if (filterValue === 'banned') return user.banned;

--- a/src/routes/[[lang]]/admin/users/data-table-filters.svelte
+++ b/src/routes/[[lang]]/admin/users/data-table-filters.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import FilterIcon from '@tabler/icons-svelte/icons/filter';
 	import XIcon from '@tabler/icons-svelte/icons/x';
 	import { T, getTranslate } from '@tolgee/svelte';
 
@@ -61,8 +60,6 @@
 </script>
 
 <div class="flex items-center gap-2">
-	<FilterIcon class="size-4 text-muted-foreground" />
-
 	<!-- Role Filter -->
 	<Select.Root type="single" value={roleValue} onValueChange={handleRoleChange}>
 		<Select.Trigger class="h-8 w-[130px]">

--- a/src/routes/[[lang]]/admin/users/role-badge.svelte
+++ b/src/routes/[[lang]]/admin/users/role-badge.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { T } from '@tolgee/svelte';
+
+	interface Props {
+		role: string;
+	}
+
+	let { role }: Props = $props();
+
+	const isAdmin = role === 'admin';
+</script>
+
+<span
+	class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset {isAdmin
+		? 'bg-primary text-primary-foreground ring-primary/20'
+		: 'bg-secondary text-secondary-foreground ring-secondary/20'}"
+>
+	{#if isAdmin}
+		<T keyName="admin.users.filter.role_admin" />
+	{:else}
+		<T keyName="admin.users.filter.role_user" />
+	{/if}
+</span>

--- a/src/routes/[[lang]]/admin/users/status-badge.svelte
+++ b/src/routes/[[lang]]/admin/users/status-badge.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import { T } from '@tolgee/svelte';
+
+	interface Props {
+		banned: boolean;
+		emailVerified?: boolean;
+	}
+
+	let { banned, emailVerified }: Props = $props();
+</script>
+
+{#if banned}
+	<span
+		class="text-destructive-foreground inline-flex items-center rounded-md bg-destructive px-2 py-1 text-xs font-medium ring-1 ring-destructive/20 ring-inset"
+	>
+		<T keyName="admin.users.banned" />
+	</span>
+{:else if emailVerified}
+	<span
+		class="inline-flex items-center rounded-md border border-green-600 px-2 py-1 text-xs font-medium text-green-600 ring-1 ring-green-600/20 ring-inset"
+	>
+		<T keyName="admin.users.verified" />
+	</span>
+{:else}
+	<span
+		class="inline-flex items-center rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground ring-1 ring-border ring-inset"
+	>
+		<T keyName="admin.users.unverified" />
+	</span>
+{/if}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -11,6 +11,9 @@ const config = {
 		adapter: adapter(),
 		alias: {
 			$blocks: 'src/blocks'
+		},
+		experimental: {
+			remoteFunctions: true
 		}
 	}
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR implements a comprehensive admin email notification system with a granular preference management UI. The implementation adds an `adminNotificationPreferences` table to track per-recipient notification toggles for three event types (new tickets, user replies, new signups), with automatic sync via Better Auth triggers when admins are promoted/demoted.

**Major changes:**
- New database table with three toggle fields (`notifyNewSupportTickets`, `notifyUserReplies`, `notifyNewSignups`)
- Auth lifecycle triggers automatically create/update/deactivate preferences when admin role changes
- Support notification system now filters recipients by notification type preferences
- Admin settings UI with data table for managing recipients (admins + custom emails)
- Enhanced skeleton loading with cached counts from `PersistedState`
- Bulk toggle operations for updating multiple recipients simultaneously
- New user signup notifications sent to configured recipients
- E2E tests for recipient management workflows

**Implementation highlights:**
- Uses atomic "claim-then-act" pattern in notification sending to prevent race conditions
- Proper error handling with retry logic for failed email sends
- Optimistic UI updates for instant feedback on toggle changes
- Comprehensive validation (email format, duplicates, dormant preference checks)
- Migration utility (`syncAllAdminPreferences`) for existing admin users

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is well-architected with proper error handling, atomic operations for race condition prevention, comprehensive validation, and E2E test coverage. Code follows established patterns from the custom guides (Svelte 5 runes, Convex best practices). No security vulnerabilities, logic errors, or breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/convex/schema.ts | Added adminNotificationPreferences table for managing email notification recipients with per-type toggles; extended pendingAdminNotifications with notificationType field |
| src/lib/convex/admin/notificationPreferences/mutations.ts | Implements CRUD operations for notification preferences with proper validation, duplicate checking, and auth trigger integration |
| src/lib/convex/admin/notificationPreferences/queries.ts | Provides queries for listing recipients and filtering by notification type, with proper admin assignment priority logic |
| src/lib/convex/auth.ts | Added user lifecycle triggers (onCreate, onUpdate) to sync admin notification preferences and send signup notifications |
| src/lib/convex/admin/support/notifications.ts | Enhanced notification system with claim-then-act pattern for race condition safety, retry logic, and preference-based recipient filtering |
| src/lib/convex/emails/send.ts | Added sendNewUserSignupNotification mutation with proper recipient filtering and error handling |
| src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte | Implements data table for managing notification recipients with optimistic updates, filtering, and cached count fallbacks |
| src/lib/hooks/admin-cache.svelte.ts | Added recipientCount cache for skeleton loading optimization |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Auth
    participant AuthTrigger
    participant NotifPrefs as Notification<br/>Preferences
    participant Support
    participant Scheduler
    participant Email as Email Service
    
    Note over User,Email: User Signup Flow
    User->>Auth: Sign up (email/OAuth)
    Auth->>AuthTrigger: onCreate trigger
    AuthTrigger->>Email: Schedule signup notification
    AuthTrigger->>NotifPrefs: Create preferences (if admin)
    
    Note over User,Email: Admin Role Management
    User->>Auth: Update user role → admin
    Auth->>AuthTrigger: onUpdate trigger
    AuthTrigger->>NotifPrefs: upsertAdminPreferences()
    Note right of NotifPrefs: Creates entry with<br/>all toggles ON
    
    Note over User,Email: Support Ticket Flow
    User->>Support: Click "Talk to human"
    Support->>Scheduler: scheduleAdminNotification()<br/>(notificationType: newTickets)
    Note right of Scheduler: 2-minute debounce
    User->>Support: Send more messages
    Support->>Scheduler: Update pending notification<br/>(cancel old, reschedule)
    
    Scheduler->>Support: After 2 min: sendPendingAdminNotification()
    Support->>Support: claimNotificationForSending()<br/>(atomic claim)
    Support->>NotifPrefs: getNotificationTargetEmails()<br/>(filter by notificationType)
    NotifPrefs-->>Support: [assignedAdmin] or [all enabled]
    Support->>Email: Send to each recipient
    Support->>Support: deletePendingNotification()
    
    Note over User,Email: Admin Settings Management
    User->>NotifPrefs: Toggle notification preference
    NotifPrefs->>NotifPrefs: updatePreference()
    Note right of NotifPrefs: Updates specific<br/>toggle field
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=973fa3fa-32dc-443b-96ad-cbc9377e5b13))

<!-- /greptile_comment -->