### PR TITLE
fix(e2e): fix e2e admin notification test to correctly test sveltekit remote function

### DIFF
--- a/src/routes/[[lang]]/admin/settings/add-email-dialog.svelte
+++ b/src/routes/[[lang]]/admin/settings/add-email-dialog.svelte
@@ -42,6 +42,12 @@
 			{...addEmailForm.preflight(emailSchema).enhance(async ({ submit, form: formEl }) => {
 				try {
 					await submit();
+					// Check if server returned validation errors (e.g., duplicate email)
+					const issues = addEmailForm.fields.email.issues() ?? [];
+					if (issues.length > 0) {
+						// Don't close dialog - let error be displayed
+						return;
+					}
 					formEl.reset();
 					toast.success($t('admin.settings.email_added'));
 					open = false;

--- a/src/routes/[[lang]]/admin/settings/data.remote.ts
+++ b/src/routes/[[lang]]/admin/settings/data.remote.ts
@@ -23,7 +23,8 @@ export const addEmailForm = form(emailSchema, async ({ email }, issue) => {
 		return { success: true };
 	} catch (err) {
 		if (err instanceof Error && err.message.includes('already exists')) {
-			invalid(issue.email('This email already exists'));
+			// Return validation error - don't re-throw
+			return invalid(issue.email('This email already exists'));
 		}
 		throw err;
 	}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed duplicate email validation in admin notification settings by adding missing `return` statement in server-side error handler and preventing premature dialog closure on validation errors.

## Changes Made

- **Server-side fix**: Added `return` keyword before `invalid()` call in `data.remote.ts:27` to properly return validation errors instead of falling through and throwing
- **Client-side fix**: Added error checking in form submission handler to prevent dialog from closing when server returns validation errors
- **Test impact**: E2E test for duplicate email detection now works correctly (test at `e2e/admin-settings.spec.ts:86-115`)

## Technical Context

The bug occurred because SvelteKit's remote form `invalid()` helper requires an explicit `return` statement. Without it, the error was re-thrown (caught by the `catch` block), causing the dialog to close with a generic error toast instead of displaying the specific validation message in the form field.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are focused bug fixes that correct the error handling flow for duplicate email validation. Both changes work together to implement the proper pattern for SvelteKit remote forms: server returns validation errors via `invalid()`, client checks for issues before closing dialog. The fix aligns with the E2E test expectations and follows SvelteKit's documented patterns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/[[lang]]/admin/settings/data.remote.ts | Added missing `return` statement for `invalid()` to properly handle duplicate email validation errors |
| src/routes/[[lang]]/admin/settings/add-email-dialog.svelte | Added validation error check after form submission to prevent dialog from closing when server returns errors |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Dialog as add-email-dialog.svelte
    participant Form as addEmailForm (SvelteKit Remote)
    participant Backend as data.remote.ts
    participant Convex as Convex API

    User->>Dialog: Click "Add Email"
    Dialog->>User: Show dialog with input
    User->>Dialog: Enter duplicate email
    User->>Dialog: Click submit
    Dialog->>Form: submit()
    Form->>Backend: Execute form handler
    Backend->>Backend: Normalize email
    Backend->>Convex: mutation(addCustomEmail)
    Convex-->>Backend: Error: "already exists"
    Backend->>Backend: Catch error
    Backend->>Form: return invalid(issue.email(...))
    Form-->>Dialog: Form updated with validation errors
    Dialog->>Dialog: Check addEmailForm.fields.email.issues()
    Dialog->>Dialog: Find issues.length > 0
    Dialog->>Dialog: return (don't close dialog)
    Dialog->>User: Display error message
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->