### PR TITLE
feat(logo): replace lucide icon with masked logo svg

### DIFF
--- a/src/lib/components/authenticated/configs/app-sidebar-config.ts
+++ b/src/lib/components/authenticated/configs/app-sidebar-config.ts
@@ -3,8 +3,8 @@ import LayoutDashboardIcon from '@lucide/svelte/icons/layout-dashboard';
 import MessageCircleIcon from '@lucide/svelte/icons/message-circle';
 import BookOpenIcon from '@lucide/svelte/icons/book-open';
 import HomeIcon from '@lucide/svelte/icons/home';
-import CommandIcon from '@lucide/svelte/icons/command';
 import ServerCogIcon from '@lucide/svelte/icons/server-cog';
+import Logo from '$lib/components/icons/logo.svelte';
 import type { SidebarConfig } from '../types';
 
 interface PageState {
@@ -17,7 +17,7 @@ export function getAppSidebarConfig(pageState: PageState, userRole?: string): Si
 
 	return {
 		header: {
-			icon: CommandIcon,
+			icon: Logo,
 			titleKey: 'app.name',
 			href: localizedHref('/')
 		},

--- a/src/lib/components/icons/logo.svelte
+++ b/src/lib/components/icons/logo.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import type { IconProps } from '@lucide/svelte';
+	import { cn } from '$lib/utils';
+
+	// Accept IconProps for compatibility with LucideIcon type, but only use class
+	let { class: className }: IconProps = $props();
+</script>
+
+<span
+	class={cn(
+		'inline-block bg-[var(--logo-color,currentColor)] [mask-image:url(/logo.svg)] [mask-size:contain] [mask-position:center] [mask-repeat:no-repeat]',
+		className
+	)}
+></span>

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -7,8 +7,8 @@
 	import Menu from '@lucide/svelte/icons/menu';
 	import X from '@lucide/svelte/icons/x';
 	import LogOut from '@lucide/svelte/icons/log-out';
-	import Command from '@lucide/svelte/icons/command';
 	import Github from '@lucide/svelte/icons/github';
+	import Logo from '$lib/components/icons/logo.svelte';
 	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 	import { authClient } from '$lib/auth-client';
 	import { T } from '@tolgee/svelte';
@@ -33,7 +33,7 @@
 			>
 				<!-- Logo -->
 				<a href={localizedHref('/')} aria-label="home" class="flex items-center space-x-2">
-					<Command class="size-5" />
+					<Logo class="size-5" />
 					<span class="font-semibold">SaaS Starter</span>
 				</a>
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Replaced hardcoded Lucide Command icon with a custom Logo component that uses CSS masking to render `/logo.svg`. The new component accepts `IconProps` for compatibility with the existing `LucideIcon` type used in sidebar and header configurations.

**Key changes:**
- Created new `logo.svelte` component using CSS mask technique for SVG rendering
- Replaced `CommandIcon` with `Logo` in app sidebar header configuration
- Replaced `Command` with `Logo` in marketing header

**Issues found:**
- Self-closing `<span>` in logo component won't render properly because CSS masks need the element to have dimensions

<h3>Confidence Score: 3/5</h3>


- This PR has a critical rendering issue that will prevent the logo from displaying correctly
- The implementation approach is sound (CSS masking for custom logo), but the self-closing span element won't render with proper dimensions. This will cause the logo to be invisible or incorrectly sized in both the sidebar and marketing header.
- `src/lib/components/icons/logo.svelte` requires fixing the self-closing span tag

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/components/icons/logo.svelte | New component created using CSS mask for SVG logo rendering - potential sizing issue with self-closing span |
| src/lib/components/authenticated/configs/app-sidebar-config.ts | Replaced CommandIcon import with Logo component for sidebar header |
| src/lib/components/marketing/marketing-header.svelte | Replaced Command icon import with Logo component in marketing header |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Header as Marketing Header
    participant Sidebar as App Sidebar
    participant Logo as Logo Component
    participant SVG as /logo.svg

    User->>Header: Navigate to marketing page
    Header->>Logo: Render <Logo class="size-5" />
    Logo->>SVG: Apply CSS mask from /logo.svg
    SVG-->>Logo: SVG mask applied
    Logo-->>Header: Render masked span element
    
    User->>Sidebar: Navigate to app
    Sidebar->>Logo: Render <config.header.icon class="!size-5" />
    Logo->>SVG: Apply CSS mask from /logo.svg
    SVG-->>Logo: SVG mask applied
    Logo-->>Sidebar: Render masked span element
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->