### PR TITLE
fix(support): admin / user notification skeleton on empty table

### DIFF
--- a/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
+++ b/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
@@ -177,7 +177,7 @@
 				{/each}
 			</Table.Header>
 			<Table.Body>
-				{#if isLoading}
+				{#if isLoading && skeletonCount > 0}
 					<!-- Skeleton loading rows matching real row structure exactly -->
 					{#each Array(skeletonCount) as _, i (i)}
 						<Table.Row data-testid="recipients-loading">
@@ -223,8 +223,8 @@
 							</Table.Cell>
 						</Table.Row>
 					{/each}
-				{:else if table.getRowModel().rows.length === 0}
-					<!-- No results -->
+				{:else if table.getRowModel().rows.length === 0 || (isLoading && skeletonCount === 0)}
+					<!-- No results (shown immediately when cache=0, or after load completes with 0 items) -->
 					<Table.Row data-testid="recipients-empty">
 						<Table.Cell
 							colspan={columns.length}

--- a/src/routes/[[lang]]/admin/users/+page.svelte
+++ b/src/routes/[[lang]]/admin/users/+page.svelte
@@ -642,7 +642,7 @@
 				{/each}
 			</Table.Header>
 			<Table.Body>
-				{#if currentPageData === undefined}
+				{#if currentPageData === undefined && skeletonCount > 0}
 					<!-- Skeleton loading rows matching real row structure -->
 					{#each Array(skeletonCount) as _, i (i)}
 						<Table.Row>
@@ -686,8 +686,8 @@
 							</Table.Cell>
 						</Table.Row>
 					{/each}
-				{:else if table.getRowModel().rows.length === 0}
-					<!-- No results -->
+				{:else if table.getRowModel().rows.length === 0 || (currentPageData === undefined && skeletonCount === 0)}
+					<!-- No results (shown immediately when cache=0, or after load completes with 0 items) -->
 					<Table.Row>
 						<Table.Cell
 							colspan={columns.length}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed skeleton loader displaying unnecessarily when cached count is 0 in admin tables.

**Changes:**
- Modified skeleton row rendering condition from `isLoading` to `isLoading && skeletonCount > 0` in notification recipients table
- Updated empty state condition to handle `isLoading && skeletonCount === 0` case explicitly
- Applied identical fix to admin users table for consistency
- Enhanced comments to clarify when empty state is shown (immediately when cache=0, or after load completes with 0 items)

**Impact:**
When users have no items cached (count = 0), the empty state message now displays immediately instead of showing skeleton rows. This provides better UX by avoiding unnecessary loading UI when the system already knows the table is empty.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- Simple, focused UI fix with clear logic. Changes are minimal and well-tested through the conditional rendering pattern. The fix prevents an edge case where skeleton rows display when cached count is 0. No breaking changes, no security concerns, and consistent implementation across both affected files.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte | Added conditional check to prevent skeleton display when cached count is 0, showing empty state immediately instead |
| src/routes/[[lang]]/admin/users/+page.svelte | Applied same skeleton count fix to prevent skeleton display when cached count is 0, ensuring consistent behavior |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Component as Admin Table Component
    participant Cache as adminCache (localStorage)
    participant Query as Convex Query
    
    User->>Component: Load admin page
    Component->>Cache: Read cached count
    
    alt Cache has count (e.g., 5)
        Cache-->>Component: Return count (5)
        Component->>Component: skeletonCount = 5
        Component->>User: Show 5 skeleton rows
        Component->>Query: Fetch data
        Query-->>Component: Return data
        Component->>Cache: Update cached count
        Component->>User: Show actual data rows
    else Cache is empty (null)
        Cache-->>Component: Return null
        Component->>Component: skeletonCount = 1
        Component->>User: Show 1 skeleton row
        Component->>Query: Fetch data
        Query-->>Component: Return data (0 items)
        Component->>Cache: Update cached count = 0
        Component->>User: Show empty state message
    else Cache has 0 count (PR fix)
        Cache-->>Component: Return 0
        Component->>Component: skeletonCount = 0
        Note over Component: OLD: Show skeleton rows<br/>NEW: Show empty state immediately
        Component->>User: Show empty state message
        Component->>Query: Fetch data
        Query-->>Component: Return data (0 items)
        Component->>User: Keep showing empty state
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->