### PR TITLE
fix(e2e): skip sending emails to test users

### DIFF
--- a/src/lib/convex/emails/send.ts
+++ b/src/lib/convex/emails/send.ts
@@ -13,6 +13,12 @@ import { getAuthEmail, getSiteUrl } from '../env';
 import type { NotificationMessage } from '../../emails/templates/types';
 
 /**
+ * Check if an email address belongs to an E2E test user.
+ * Test emails are skipped to prevent sending real emails during automated testing.
+ */
+const isTestEmail = (email: string): boolean => email.endsWith('@e2e.example.com');
+
+/**
  * Send verification email with verification link
  *
  * Uses pre-rendered HTML templates with template placeholders for dynamic content.
@@ -25,6 +31,13 @@ export const sendVerificationEmail = internalMutation({
 	},
 	handler: async (ctx, args) => {
 		const { email, verificationUrl, expiryMinutes = 20 } = args;
+
+		// Skip sending emails to E2E test users
+		if (isTestEmail(email)) {
+			console.log(`[sendVerificationEmail] Skipping test email: ${email}`);
+			return;
+		}
+
 		const { html, text } = renderVerificationEmail(verificationUrl, expiryMinutes);
 
 		await resend.sendEmail(ctx, {
@@ -55,6 +68,13 @@ export const sendResetPasswordEmail = internalMutation({
 	},
 	handler: async (ctx, args) => {
 		const { email, resetUrl, userName } = args;
+
+		// Skip sending emails to E2E test users
+		if (isTestEmail(email)) {
+			console.log(`[sendResetPasswordEmail] Skipping test email: ${email}`);
+			return;
+		}
+
 		const { html, text } = renderPasswordResetEmail(resetUrl, userName);
 
 		await resend.sendEmail(ctx, {
@@ -88,6 +108,13 @@ export const sendAdminReplyNotification = internalMutation({
 	},
 	handler: async (ctx, args) => {
 		const { email, adminName, messagePreview, threadId, pageUrl } = args;
+
+		// Skip sending emails to E2E test users
+		if (isTestEmail(email)) {
+			console.log(`[sendAdminReplyNotification] Skipping test email: ${email}`);
+			return;
+		}
+
 		const siteUrl = getSiteUrl();
 
 		// Build deep link that opens the support widget to this thread
@@ -189,6 +216,13 @@ export const sendNewUserSignupNotification = internalMutation({
 	},
 	handler: async (ctx, args) => {
 		const { userName, userEmail, signupMethod, signupTime } = args;
+
+		// Skip sending notifications for E2E test users
+		if (isTestEmail(userEmail)) {
+			console.log(`[sendNewUserSignupNotification] Skipping test user: ${userEmail}`);
+			return;
+		}
+
 		const siteUrl = getSiteUrl();
 
 		// Get recipients who have new signup notifications enabled


### PR DESCRIPTION
Prevent verification and signup notification emails from being sent
to @e2e.example.com addresses during E2E test user creation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Prevents verification and signup emails from being sent to E2E test users.

- Added `isTestEmail()` helper that checks for test email domain pattern
- Modified `sendVerificationEmail` to skip sending for test users
- Modified `sendNewUserSignupNotification` to skip sending for test users
- Both functions log when test emails are skipped for debugging

The implementation is clean and focused. Consider also applying this pattern to `sendResetPasswordEmail` and `sendAdminReplyNotification` since test users may trigger password resets or support interactions during E2E tests.

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor considerations for comprehensive test email handling
- The implementation correctly prevents test emails for the two primary flows (verification and signup), with clear logging and simple logic. Score is 4/5 because password reset and support emails may also be triggered by test users during E2E tests, though these are less critical flows.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/convex/emails/send.ts | Added `isTestEmail` helper and checks to skip verification and signup emails for `@e2e.example.com` test users |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Auth as Better Auth
    participant Email as Email Service
    participant Filter as isTestEmail
    participant Provider as Resend

    User->>Auth: Sign up
    Auth->>Email: sendVerificationEmail
    Email->>Filter: Check domain
    alt Test user
        Filter-->>Email: Skip sending
        Email-->>Auth: Return early
    else Production user
        Filter-->>Email: Proceed
        Email->>Provider: Send email
        Provider-->>User: Deliver
    end

    User->>Auth: Signup complete
    Auth->>Email: sendNewUserSignup
    Email->>Filter: Check domain
    alt Test user
        Filter-->>Email: Skip sending
        Email-->>Auth: Return early
    else Production user
        Filter-->>Email: Proceed
        Email->>Provider: Send to admins
        Provider-->>User: Deliver
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->