### PR TITLE
ci: add e2e-preview workflow for repository_dispatch

### DIFF
--- a/.github/workflows/e2e-preview.yml
+++ b/.github/workflows/e2e-preview.yml
@@ -1,0 +1,46 @@
+name: E2E Tests (Preview)
+
+on:
+  repository_dispatch:
+    types: [convex.deployed]
+
+jobs:
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+      PUBLIC_CONVEX_URL: ${{ github.event.client_payload.convex_url }}
+      PUBLIC_CONVEX_SITE_URL: ${{ github.event.client_payload.convex_site_url }}
+      AUTH_E2E_TEST_SECRET: ${{ secrets.AUTH_E2E_TEST_SECRET }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.git_sha }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install Playwright
+        run: bunx playwright install chromium --with-deps
+
+      - name: Log Convex URLs
+        run: |
+          echo "Testing against preview deployment:"
+          echo "  PUBLIC_CONVEX_URL: $PUBLIC_CONVEX_URL"
+          echo "  PUBLIC_CONVEX_SITE_URL: $PUBLIC_CONVEX_SITE_URL"
+
+      - name: Run E2E tests
+        run: bun run test:e2e
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/


### PR DESCRIPTION
## Summary

Adds the `e2e-preview.yml` workflow to main so that `repository_dispatch` events can trigger E2E tests.

**Why this is needed:**
- GitHub's `repository_dispatch` only triggers workflows that exist on the default branch
- Once merged, PRs can trigger E2E tests via webhook when Convex deploys on preview builds

**This is a prerequisite for PR #115** which refactors CI to run E2E tests against correct preview Convex deployments.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds new workflow file to enable E2E test execution via `repository_dispatch` webhook events. Since GitHub's `repository_dispatch` only triggers workflows on the default branch, this file must exist on main before PR #115's refactored CI can work correctly.

The workflow:
- Triggers on `convex.deployed` webhook events from Convex preview deployments
- Checks out the specific commit SHA from the webhook payload
- Passes Convex deployment URLs (`PUBLIC_CONVEX_URL`, `PUBLIC_CONVEX_SITE_URL`) as environment variables
- Runs E2E tests against the correct preview environment
- Uploads Playwright reports on test failures

This is a prerequisite infrastructure change with no functional code changes.

<h3>Confidence Score: 4/5</h3>


- Safe to merge - infrastructure-only change to enable webhook-triggered E2E tests
- Straightforward workflow addition with correct `repository_dispatch` configuration. Uses standard GitHub Actions patterns (checkout with specific ref, Bun setup, Playwright installation). Only minor concern is the hardcoded baseURL in playwright.config.ts which might conflict with preview testing, but that's outside this PR's scope.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/e2e-preview.yml | New workflow to run E2E tests via `repository_dispatch` when Convex deploys; correctly checks out specific commit SHA and passes Convex URLs via environment variables |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Convex as Convex Platform
    participant GitHub as GitHub Actions
    participant Workflow as e2e-preview.yml
    participant Repo as Repository
    participant Bun as Bun Runtime
    participant Playwright as Playwright Tests

    Note over Convex: Preview deployment completes
    Convex->>GitHub: repository_dispatch webhook<br/>(type: convex.deployed)
    Note over Convex,GitHub: Payload includes:<br/>- convex_url<br/>- convex_site_url<br/>- git_sha

    GitHub->>Workflow: Trigger workflow on main branch
    Note over Workflow: Check if e2e-preview.yml exists<br/>(must be on default branch)
    
    Workflow->>Repo: Checkout code
    Note over Workflow,Repo: ref: client_payload.git_sha
    Repo-->>Workflow: Code at specific commit
    
    Workflow->>Bun: Setup Bun runtime
    Workflow->>Bun: Install dependencies
    Bun-->>Workflow: Dependencies installed
    
    Workflow->>Playwright: Install Chromium with deps
    Playwright-->>Workflow: Browser ready
    
    Workflow->>Workflow: Set environment variables:<br/>PUBLIC_CONVEX_URL<br/>PUBLIC_CONVEX_SITE_URL<br/>AUTH_E2E_TEST_SECRET
    
    Workflow->>Playwright: Run E2E tests (bun run test:e2e)
    Note over Playwright: Tests run against preview URLs<br/>from webhook payload
    
    alt Tests Pass
        Playwright-->>Workflow: Success
        Workflow-->>GitHub: Workflow complete ✓
    else Tests Fail
        Playwright-->>Workflow: Failure
        Workflow->>GitHub: Upload playwright-report artifact
        Workflow-->>GitHub: Workflow failed ✗
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->