### PR TITLE
fix: use linear easing for progress bar animation

### DIFF
--- a/docs/animation-rules.md
+++ b/docs/animation-rules.md
@@ -72,7 +72,7 @@ Is the element entering or exiting the viewport?
     ├── Is it moving or morphing on screen?
     │   └── Yes → ease-in-out
     └── Is it a hover change?
-        ├── Yes → ease
+        ├── Yes → ease or cubic-bezier (0.19, 1, 0.22, 1) or cubic-bezier(0.785, 0.135, 0.15, 0.86) (don't forget to support focus-visible!)
         └── Is it constant motion?
             ├── Yes → linear
             └── Default → ease-out

--- a/src/lib/components/ui/FollowingPointer/FollowingPointer.svelte
+++ b/src/lib/components/ui/FollowingPointer/FollowingPointer.svelte
@@ -25,7 +25,6 @@
 	let animationFrameId: number | null = null;
 
 	const HOLD_DURATION = 3000; // 3 seconds
-	const QUICK_PHASE_DURATION = 100; // 100ms quick start to 5%
 	const RIVE_URL = 'https://rive.app/marketplace/3293-6929-spring-demo/';
 
 	const handleMouseMove = (e: MouseEvent) => {
@@ -60,17 +59,8 @@
 		if (!isHolding) return;
 
 		const elapsed = timestamp - holdStartTime;
-
-		if (elapsed < QUICK_PHASE_DURATION) {
-			// Phase 1: Quick linear animation to 5% (0-100ms)
-			holdProgress = (elapsed / QUICK_PHASE_DURATION) * 5;
-		} else {
-			// Phase 2: Linear animation from 5% to 100% (100-3000ms)
-			const remainingElapsed = elapsed - QUICK_PHASE_DURATION;
-			const remainingDuration = HOLD_DURATION - QUICK_PHASE_DURATION;
-			const linearProgress = Math.min(remainingElapsed / remainingDuration, 1);
-			holdProgress = 5 + linearProgress * 95;
-		}
+		const progress = Math.min((elapsed / HOLD_DURATION) * 100, 100);
+		holdProgress = progress;
 
 		if (holdProgress >= 100) {
 			// Open link in new tab
@@ -156,8 +146,10 @@
 				>
 					<!-- Progress bar background -->
 					<div
-						class="absolute inset-0 bg-primary opacity-20"
-						style="width: {holdProgress}%; transform-origin: left;"
+						class="absolute inset-0 bg-primary opacity-20 transition-[width]"
+						style="width: {holdProgress}%; transform-origin: left; transition-duration: {isHolding
+							? '0ms'
+							: '150ms'}; transition-timing-function: {isHolding ? 'linear' : 'ease-out'};"
 					></div>
 
 					<!-- Text content -->

--- a/src/lib/components/ui/FollowingPointer/FollowingPointer.svelte
+++ b/src/lib/components/ui/FollowingPointer/FollowingPointer.svelte
@@ -56,11 +56,6 @@
 		isInside = true;
 	};
 
-	// Easing function for smooth progress animation (ease-in-out cubic)
-	const easeInOutCubic = (t: number): number => {
-		return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
-	};
-
 	const updateHoldProgress = (timestamp: number) => {
 		if (!isHolding) return;
 
@@ -70,12 +65,11 @@
 			// Phase 1: Quick linear animation to 5% (0-100ms)
 			holdProgress = (elapsed / QUICK_PHASE_DURATION) * 5;
 		} else {
-			// Phase 2: Eased animation from 5% to 100% (100-3000ms)
+			// Phase 2: Linear animation from 5% to 100% (100-3000ms)
 			const remainingElapsed = elapsed - QUICK_PHASE_DURATION;
 			const remainingDuration = HOLD_DURATION - QUICK_PHASE_DURATION;
 			const linearProgress = Math.min(remainingElapsed / remainingDuration, 1);
-			const easedProgress = easeInOutCubic(linearProgress);
-			holdProgress = 5 + easedProgress * 95;
+			holdProgress = 5 + linearProgress * 95;
 		}
 
 		if (holdProgress >= 100) {


### PR DESCRIPTION
Change progress bar from eased to linear animation to accurately represent the 3-second hold timer, following animation rules