### PR TITLE
style: remove redundant bg-muted from auth screens

### DIFF
--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -96,7 +96,7 @@
 	</div>
 </noscript>
 
-<div class="flex min-h-svh flex-col items-center justify-center bg-muted p-6 md:p-10">
+<div class="flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
 	<div class="flex w-full max-w-sm flex-col gap-6 md:max-w-3xl">
 		<Card.Root class="overflow-hidden p-0">
 			<Card.Content class="grid p-0 md:grid-cols-2">

--- a/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
@@ -107,7 +107,7 @@
 	</div>
 </noscript>
 
-<div class="flex min-h-svh flex-col items-center justify-center bg-muted p-6 md:p-10">
+<div class="flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
 	<div class="flex w-full max-w-sm flex-col gap-6 md:max-w-3xl">
 		<Card.Root class="overflow-hidden p-0">
 			<Card.Content class="grid p-0 md:grid-cols-2">

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -248,7 +248,7 @@
 	</div>
 </noscript>
 
-<div class="flex min-h-svh flex-col items-center justify-center bg-muted p-6 md:p-10">
+<div class="flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
 	<div class="flex w-full max-w-sm flex-col gap-6 md:max-w-3xl">
 		<Card.Root class="overflow-hidden p-0">
 			<Card.Content class="grid p-0 md:grid-cols-2">


### PR DESCRIPTION
Remove bg-muted background color from outer containers in signin, signup, forgot-password, and reset-password pages to simplify the background layer structure.