### PR TITLE
fix: use single worker for E2E tests to prevent dev server overload

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"static-checks": "bun scripts/static-checks.ts",
 		"static-checks:staged": "bun scripts/static-checks.ts --staged",
 		"test:e2e": "playwright test",
+		"test:e2e:headed": "playwright test --headed",
 		"test": "bun run test:e2e && bun run test:unit",
 		"test:unit": "vitest --run --reporter=verbose --passWithNoTests",
 		"i18n:pull": "dotenv -e .env.local -- tolgee pull",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,10 +26,10 @@ export default defineConfig({
 	forbidOnly: isCI,
 	/* Retry on CI only */
 	retries: isCI ? 2 : 0,
-	/* Opt out of parallel tests on CI */
-	workers: isCI ? 1 : undefined,
-	/* Reporter to use */
-	reporter: 'html',
+	/* Single worker prevents dev server overload in headed mode */
+	workers: 1,
+	/* Reporter to use - auto-open after tests complete */
+	reporter: [['html', { open: 'always' }]],
 	/* Shared settings for all the projects below */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')` */


### PR DESCRIPTION
- Change workers from 'isCI ? 1 : undefined' to '1'
- Auto-open HTML report after tests with reporter config
- Add test:e2e:headed script to package.json

Fixes issue where 5 parallel headed browsers overwhelmed dev server with concurrent SSR requests causing 500 errors. Single worker runs tests sequentially preventing server overload while maintaining fast execution.