### PR TITLE
refactor: migrate from Zod to Valibot for validation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "svelte-infinite": "^0.5.1",
         "svelte-konva": "^1.0.1",
         "svelte-streamdown": "^3.0.0",
+        "valibot": "^1.2.0",
         "vercel": "^50.0.0",
       },
       "devDependencies": {
@@ -96,7 +97,6 @@
         "vaul-svelte": "1.0.0-next.7",
         "vite": "7.3.1",
         "vitest": "4.0.17",
-        "zod": "4.3.5",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"svelte-infinite": "^0.5.1",
 		"svelte-konva": "^1.0.1",
 		"svelte-streamdown": "^3.0.0",
+		"valibot": "^1.2.0",
 		"vercel": "^50.0.0"
 	},
 	"devDependencies": {
@@ -123,7 +124,6 @@
 		"typescript": "5.9.3",
 		"vaul-svelte": "1.0.0-next.7",
 		"vite": "7.3.1",
-		"vitest": "4.0.17",
-		"zod": "4.3.5"
+		"vitest": "4.0.17"
 	}
 }

--- a/src/lib/chat/ui/InlineEmailPrompt.svelte
+++ b/src/lib/chat/ui/InlineEmailPrompt.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import * as v from 'valibot';
 	import { toast } from 'svelte-sonner';
 	import * as InputGroup from '$lib/components/ui/input-group';
 	import { Button } from '$lib/components/ui/button';
@@ -35,7 +36,7 @@
 		}
 	});
 
-	const isValidEmail = $derived(emailSchema.safeParse(email.trim()).success);
+	const isValidEmail = $derived(v.safeParse(emailSchema, email.trim()).success);
 
 	// Check if email has changed from the saved value
 	const hasChanges = $derived(email.trim() !== (currentEmail || ''));

--- a/src/lib/components/customer-support/use-support-url-state.svelte.ts
+++ b/src/lib/components/customer-support/use-support-url-state.svelte.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 import { useSearchParams } from 'runed/kit';
 
 /**
@@ -6,9 +6,9 @@ import { useSearchParams } from 'runed/kit';
  * - support: 'open' when widget is visible, '' when closed
  * - thread: thread ID when viewing a specific conversation
  */
-const supportUrlSchema = z.object({
-	support: z.enum(['open', '']).default(''),
-	thread: z.string().default('')
+const supportUrlSchema = v.object({
+	support: v.optional(v.fallback(v.picklist(['open', '']), ''), ''),
+	thread: v.optional(v.fallback(v.string(), ''), '')
 });
 
 /**

--- a/src/lib/components/schemas.ts
+++ b/src/lib/components/schemas.ts
@@ -1,13 +1,13 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 
-export const schema = z.object({
-	id: z.number(),
-	header: z.string(),
-	type: z.string(),
-	status: z.string(),
-	target: z.string(),
-	limit: z.string(),
-	reviewer: z.string()
+export const schema = v.object({
+	id: v.number(),
+	header: v.string(),
+	type: v.string(),
+	status: v.string(),
+	target: v.string(),
+	limit: v.string(),
+	reviewer: v.string()
 });
 
-export type Schema = z.infer<typeof schema>;
+export type Schema = v.InferOutput<typeof schema>;

--- a/src/lib/convex/admin/support/queries.ts
+++ b/src/lib/convex/admin/support/queries.ts
@@ -1,4 +1,5 @@
 import { v } from 'convex/values';
+import * as val from 'valibot';
 import { components } from '../../_generated/api';
 import { paginationOptsValidator } from 'convex/server';
 import { adminQuery } from '../../functions';
@@ -222,9 +223,9 @@ export const listThreadsForAdmin = adminQuery({
 
 			// Build lookup map for user images
 			for (const user of usersResult.page) {
-				const parsed = betterAuthUserSchema.safeParse(user);
-				if (parsed.success && userIds.includes(parsed.data._id) && parsed.data.image) {
-					userImageMap.set(parsed.data._id, parsed.data.image);
+				const parsed = val.safeParse(betterAuthUserSchema, user);
+				if (parsed.success && userIds.includes(parsed.output._id) && parsed.output.image) {
+					userImageMap.set(parsed.output._id, parsed.output.image);
 				}
 			}
 		}
@@ -431,11 +432,11 @@ export const listInternalUserNotes = adminQuery({
 				where: [{ field: 'role', operator: 'eq', value: 'admin' }]
 			});
 
-			// Build lookup map for admins we need using Zod validation
+			// Build lookup map for admins we need using Valibot validation
 			for (const admin of adminsResult.page) {
-				const parsed = betterAuthUserSchema.safeParse(admin);
-				if (parsed.success && adminIds.includes(parsed.data._id)) {
-					adminMap.set(parsed.data._id, parsed.data);
+				const parsed = val.safeParse(betterAuthUserSchema, admin);
+				if (parsed.success && adminIds.includes(parsed.output._id)) {
+					adminMap.set(parsed.output._id, parsed.output);
 				}
 			}
 		}
@@ -498,7 +499,7 @@ export const listAdmins = adminQuery({
 			where: [{ field: 'role', operator: 'eq', value: 'admin' }]
 		});
 
-		// Parse and filter valid admin records using Zod validation
+		// Parse and filter valid admin records using Valibot validation
 		const admins = parseBetterAuthUsers(result.page);
 
 		// Return admin info

--- a/src/lib/convex/support/threads.ts
+++ b/src/lib/convex/support/threads.ts
@@ -1,6 +1,6 @@
 import { mutation, query, internalMutation } from '../_generated/server';
 import { v } from 'convex/values';
-import { z } from 'zod';
+import * as val from 'valibot';
 import { supportAgent } from './agent';
 import { components, internal } from '../_generated/api';
 import { paginationOptsValidator } from 'convex/server';
@@ -596,7 +596,10 @@ export const updateNotificationEmail = mutation({
 		const normalizedEmail = args.email.trim().toLowerCase();
 
 		// Validate email format only if non-empty (empty = unsubscribe)
-		if (normalizedEmail && !z.string().email().safeParse(normalizedEmail).success) {
+		if (
+			normalizedEmail &&
+			!val.safeParse(val.pipe(val.string(), val.email()), normalizedEmail).success
+		) {
 			throw new Error('Invalid email format');
 		}
 

--- a/src/lib/schemas/auth.ts
+++ b/src/lib/schemas/auth.ts
@@ -1,13 +1,13 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 
 // Email validation schema (reusable across the app)
-export const emailSchema = z.string().email();
+export const emailSchema = v.pipe(v.string(), v.email());
 
 // URL params schema (for signin/signup tabs)
-export const authParamsSchema = z.object({
-	tab: z.enum(['signin', 'signup']).default('signin'),
-	redirectTo: z.string().default('')
+export const authParamsSchema = v.object({
+	tab: v.optional(v.fallback(v.picklist(['signin', 'signup']), 'signin'), 'signin'),
+	redirectTo: v.optional(v.fallback(v.string(), ''), '')
 });
 
 // Types
-export type AuthParams = z.infer<typeof authParamsSchema>;
+export type AuthParams = v.InferOutput<typeof authParamsSchema>;

--- a/src/lib/schemas/pricing-params.ts
+++ b/src/lib/schemas/pricing-params.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 
-export const pricingParamsSchema = z.object({
-	checkout: z.string().default('')
+export const pricingParamsSchema = v.object({
+	checkout: v.optional(v.fallback(v.string(), ''), '')
 });

--- a/src/routes/[[lang]]/admin/settings/data.remote.ts
+++ b/src/routes/[[lang]]/admin/settings/data.remote.ts
@@ -7,7 +7,7 @@ import { emailSchema } from './email-schema';
 /**
  * Remote form for adding a custom email recipient
  *
- * Uses SvelteKit remote functions with Zod validation.
+ * Uses SvelteKit remote functions with Valibot validation.
  * Calls Convex mutation server-side with proper authentication.
  */
 export const addEmailForm = form(emailSchema, async ({ email }, issue) => {

--- a/src/routes/[[lang]]/admin/settings/email-schema.ts
+++ b/src/routes/[[lang]]/admin/settings/email-schema.ts
@@ -1,10 +1,10 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 
 /**
- * Zod schema for email validation
+ * Valibot schema for email validation
  * Used for both server-side validation in data.remote.ts and
  * client-side preflight validation in add-email-dialog.svelte
  */
-export const emailSchema = z.object({
-	email: z.string().email('Please enter a valid email address')
+export const emailSchema = v.object({
+	email: v.pipe(v.string(), v.email('Please enter a valid email address'))
 });

--- a/src/routes/[[lang]]/admin/support/+page.svelte
+++ b/src/routes/[[lang]]/admin/support/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
-	import { z } from 'zod';
+	import * as v from 'valibot';
 	import { useSearchParams } from 'runed/kit';
 	import { Debounced } from 'runed';
 	import { page } from '$app/stores';
@@ -20,10 +20,10 @@
 	import { adminCache } from '$lib/hooks/admin-cache.svelte';
 
 	// Filter state schema (thread managed separately to avoid reload on selection)
-	const filterSchema = z.object({
-		mode: z.enum(['all', 'unassigned', 'my-inbox']).default('all'),
-		status: z.enum(['open', 'done']).default('open'),
-		search: z.string().default('')
+	const filterSchema = v.object({
+		mode: v.optional(v.fallback(v.picklist(['all', 'unassigned', 'my-inbox']), 'all'), 'all'),
+		status: v.optional(v.fallback(v.picklist(['open', 'done']), 'open'), 'open'),
+		search: v.optional(v.fallback(v.string(), ''), '')
 	});
 
 	// Filter state management via useSearchParams


### PR DESCRIPTION
Unify validation libraries by migrating all Zod schemas to Valibot.
Forms already used Valibot; this completes the migration for URL params,
runtime validation, and misc schemas.

- Add valibot as direct dependency
- Remove zod from devDependencies
- Migrate 10 files: auth, pricing-params, support URL state, admin
  support filters, email schemas, Better Auth types, component schemas
- Update safeParse calls to use Valibot syntax

Resolves: #125