### PR TITLE
feat(support): add rate limiter with smart burst/sustained limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,3 +292,7 @@ A customizable Svelte component for building node-based editors and interactive 
 
 - Make the plan extremely concise. Sacrifice grammar for the sake of concision.
 - At the end of each plan, give me a list of unresolved questions to answer, if any, using the question tool.
+
+## esbuild/Vite Error: The service was stopped
+
+`bun i -f` should fix the issue.

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@better-auth/passkey": "^1.4.10",
         "@convex-dev/agent": "^0.3.0",
         "@convex-dev/better-auth": "^0.10.0",
+        "@convex-dev/rate-limiter": "^0.3.2",
         "@convex-dev/resend": "^0.2.0",
         "@mmailaender/convex-better-auth-svelte": "^0.5.0",
         "@openrouter/ai-sdk-provider": "^1.2.3",

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -16,23 +16,12 @@
 		},
 		"convex": {
 			"type": "local",
-			"command": [
-				"bunx",
-				"-y",
-				"convex@latest",
-				"mcp",
-				"start"
-			],
+			"command": ["bunx", "-y", "convex@latest", "mcp", "start"],
 			"enabled": true
 		},
 		"jsrepo": {
 			"type": "local",
-			"command": [
-				"bunx",
-				"-y",
-				"jsrepo",
-				"mcp"
-			],
+			"command": ["bunx", "-y", "jsrepo", "mcp"],
 			"enabled": false
 		},
 		"konva-documentation": {
@@ -47,11 +36,7 @@
 		},
 		"lighthouse": {
 			"type": "local",
-			"command": [
-				"bunx",
-				"-y",
-				"@danielsogl/lighthouse-mcp@latest"
-			],
+			"command": ["bunx", "-y", "@danielsogl/lighthouse-mcp@latest"],
 			"enabled": false
 		}
 	},
@@ -65,14 +50,8 @@
 						"output": 65535
 					},
 					"modalities": {
-						"input": [
-							"text",
-							"image",
-							"pdf"
-						],
-						"output": [
-							"text"
-						]
+						"input": ["text", "image", "pdf"],
+						"output": ["text"]
 					},
 					"variants": {
 						"low": {
@@ -90,14 +69,8 @@
 						"output": 65536
 					},
 					"modalities": {
-						"input": [
-							"text",
-							"image",
-							"pdf"
-						],
-						"output": [
-							"text"
-						]
+						"input": ["text", "image", "pdf"],
+						"output": ["text"]
 					},
 					"variants": {
 						"minimal": {
@@ -121,14 +94,8 @@
 						"output": 64000
 					},
 					"modalities": {
-						"input": [
-							"text",
-							"image",
-							"pdf"
-						],
-						"output": [
-							"text"
-						]
+						"input": ["text", "image", "pdf"],
+						"output": ["text"]
 					}
 				},
 				"antigravity-claude-sonnet-4-5-thinking": {
@@ -138,14 +105,8 @@
 						"output": 64000
 					},
 					"modalities": {
-						"input": [
-							"text",
-							"image",
-							"pdf"
-						],
-						"output": [
-							"text"
-						]
+						"input": ["text", "image", "pdf"],
+						"output": ["text"]
 					},
 					"variants": {
 						"low": {
@@ -167,14 +128,8 @@
 						"output": 64000
 					},
 					"modalities": {
-						"input": [
-							"text",
-							"image",
-							"pdf"
-						],
-						"output": [
-							"text"
-						]
+						"input": ["text", "image", "pdf"],
+						"output": ["text"]
 					},
 					"variants": {
 						"low": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@better-auth/passkey": "^1.4.10",
 		"@convex-dev/agent": "^0.3.0",
 		"@convex-dev/better-auth": "^0.10.0",
+		"@convex-dev/rate-limiter": "^0.3.2",
 		"@convex-dev/resend": "^0.2.0",
 		"@mmailaender/convex-better-auth-svelte": "^0.5.0",
 		"@openrouter/ai-sdk-provider": "^1.2.3",

--- a/src/lib/components/RiveBackground.svelte
+++ b/src/lib/components/RiveBackground.svelte
@@ -107,6 +107,7 @@
 				bind:this={canvas}
 				class="pointer-events-none absolute -z-3 h-full w-full"
 				style="mix-blend-mode: multiply;"
+				tabindex="-1"
 			></canvas>
 
 			<!-- Canvas Cover (Fade in Effect) -->

--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -111,11 +111,7 @@
 				onclick={handleSubmit}
 				disabled={!input.trim() || threadContext.isSending || threadContext.hasPendingToolCalls}
 			>
-				{#if threadContext.isSending}
-					<Square class="size-5 fill-current" />
-				{:else}
-					<ArrowUp class="size-5" />
-				{/if}
+				<ArrowUp class="size-5" />
 			</Button>
 		</PromptInput>
 	</div>

--- a/src/lib/components/customer-support/feedback-button.svelte
+++ b/src/lib/components/customer-support/feedback-button.svelte
@@ -49,14 +49,14 @@
 		>
 			<div class="relative size-6">
 				<ChevronDown
-					class="absolute inset-0 size-6 transition-all duration-200 ease-out {isFeedbackOpen
+					class="absolute inset-0 size-6 transition-all duration-200 ease-in-out {isFeedbackOpen
 						? 'blur-0 scale-100 opacity-100'
 						: 'scale-0 opacity-0 blur-sm'}"
 				/>
 				<div class="-scale-x-100">
 					<MessageSquare
 						class="absolute inset-0 size-6 fill-current transition-all duration-200 ease-in-out {isFeedbackOpen
-							? 'scale-0 opacity-0 blur-xs'
+							? 'scale-0 opacity-0 blur-sm'
 							: 'blur-0 scale-100 opacity-100'}"
 					/>
 				</div>

--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotToolbar.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotToolbar.svelte
@@ -13,7 +13,7 @@
 	}
 </script>
 
-<div class="fixed top-4 left-1/2 z-[110] -translate-x-1/2">
+<div class="fixed top-[1.625rem] left-1/2 z-[110] -translate-x-1/2">
 	<div
 		class="flex items-center gap-1 rounded-xl border border-border bg-background/95 p-1.5 shadow-lg backdrop-blur-sm"
 	>

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -318,6 +318,7 @@
 			class=" w-full rounded-full active:scale-99"
 			onclick={() => ctx.startNewThread()}
 			size="lg"
+			disabled={ctx.isRateLimited}
 		>
 			<Send />
 			Start a new conversation

--- a/src/lib/components/prompt-kit/file-upload/file-upload-trigger.svelte
+++ b/src/lib/components/prompt-kit/file-upload/file-upload-trigger.svelte
@@ -23,19 +23,8 @@
 </script>
 
 {#if asChild}
-	<div
-		role="button"
-		tabindex="0"
-		class={className}
-		onclick={handleClick}
-		onkeydown={(e) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				e.preventDefault();
-				handleClick(e as any);
-			}
-		}}
-		{...restProps}
-	>
+	<!-- When asChild, we don't add tabindex since the child element handles focus -->
+	<div role="presentation" class={className} onclick={handleClick} {...restProps}>
 		{@render children()}
 	</div>
 {:else}

--- a/src/lib/components/prompt-kit/prompt-input/PromptInput.svelte
+++ b/src/lib/components/prompt-kit/prompt-input/PromptInput.svelte
@@ -60,8 +60,13 @@
 	}
 
 	function handleKeyDown(e: KeyboardEvent) {
+		// Don't intercept Enter from buttons or other interactive elements
+		const target = e.target as HTMLElement;
+		if (target.closest('button, a, [role="button"]')) {
+			return;
+		}
+
 		// Only handle Enter key to focus textarea from wrapper
-		// Don't intercept Space key as it prevents typing spaces in the textarea
 		if (e.key === 'Enter') {
 			e.preventDefault();
 			handleClick();

--- a/src/lib/components/prompt-kit/prompt-input/PromptInputAction.svelte
+++ b/src/lib/components/prompt-kit/prompt-input/PromptInputAction.svelte
@@ -1,34 +1,34 @@
 <script lang="ts">
-	import { Tooltip as TooltipPrimitive } from 'bits-ui';
-	import TooltipContent from '$lib/components/ui/tooltip/tooltip-content.svelte';
-	import TooltipTrigger from '$lib/components/ui/tooltip/tooltip-trigger.svelte';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import type { Snippet } from 'svelte';
 	import { promptInputContext } from './prompt-input-context.svelte.js';
 
 	let {
 		tooltip,
 		children,
 		class: className,
-		side = 'top',
-		...restProps
+		side = 'top'
 	}: {
-		tooltip: import('svelte').Snippet;
-		children: import('svelte').Snippet;
+		tooltip?: Snippet;
+		children: Snippet<[Record<string, unknown>]>;
 		class?: string;
 		side?: 'top' | 'bottom' | 'left' | 'right';
-	} & Partial<TooltipPrimitive.RootProps> = $props();
+	} = $props();
 
 	const context = promptInputContext.get();
-
-	function handleClick(event: MouseEvent) {
-		event.stopPropagation();
-	}
 </script>
 
-<TooltipPrimitive.Root {...restProps} delayDuration={0}>
-	<TooltipTrigger disabled={context.disabled} onclick={handleClick}>
-		{@render children()}
-	</TooltipTrigger>
-	<TooltipContent {side} class={className}>
-		{@render tooltip()}
-	</TooltipContent>
-</TooltipPrimitive.Root>
+{#if tooltip}
+	<Tooltip.Root>
+		<Tooltip.Trigger disabled={context.disabled}>
+			{#snippet child({ props })}
+				{@render children(props)}
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content {side} class="z-250 {className}">
+			{@render tooltip()}
+		</Tooltip.Content>
+	</Tooltip.Root>
+{:else}
+	{@render children({})}
+{/if}

--- a/src/lib/components/ui/FollowingPointer/FollowingPointer.svelte
+++ b/src/lib/components/ui/FollowingPointer/FollowingPointer.svelte
@@ -110,8 +110,7 @@
 	onmousedown={handleBadgeMouseDown}
 	onmouseup={handleBadgeMouseUp}
 	style="cursor: none;"
-	role="button"
-	tabindex="0"
+	tabindex="-1"
 	class={cn('relative', className)}
 >
 	<AnimatePresence>

--- a/src/lib/convex/_generated/api.d.ts
+++ b/src/lib/convex/_generated/api.d.ts
@@ -48,7 +48,9 @@ import type * as support_agent from "../support/agent.js";
 import type * as support_files from "../support/files.js";
 import type * as support_messages from "../support/messages.js";
 import type * as support_migration from "../support/migration.js";
+import type * as support_rateLimit from "../support/rateLimit.js";
 import type * as support_threads from "../support/threads.js";
+import type * as support_types from "../support/types.js";
 import type * as tests from "../tests.js";
 import type * as users from "../users.js";
 import type * as utils_anonymousUser from "../utils/anonymousUser.js";
@@ -100,7 +102,9 @@ declare const fullApi: ApiFromModules<{
   "support/files": typeof support_files;
   "support/messages": typeof support_messages;
   "support/migration": typeof support_migration;
+  "support/rateLimit": typeof support_rateLimit;
   "support/threads": typeof support_threads;
+  "support/types": typeof support_types;
   tests: typeof tests;
   users: typeof users;
   "utils/anonymousUser": typeof utils_anonymousUser;
@@ -4350,6 +4354,140 @@ export declare const components: {
           null
         >;
       };
+    };
+  };
+  rateLimiter: {
+    lib: {
+      checkRateLimit: FunctionReference<
+        "query",
+        "internal",
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          count?: number;
+          key?: string;
+          name: string;
+          reserve?: boolean;
+          throws?: boolean;
+        },
+        { ok: true; retryAfter?: number } | { ok: false; retryAfter: number }
+      >;
+      clearAll: FunctionReference<
+        "mutation",
+        "internal",
+        { before?: number },
+        null
+      >;
+      getServerTime: FunctionReference<"mutation", "internal", {}, number>;
+      getValue: FunctionReference<
+        "query",
+        "internal",
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          key?: string;
+          name: string;
+          sampleShards?: number;
+        },
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          shard: number;
+          ts: number;
+          value: number;
+        }
+      >;
+      rateLimit: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          count?: number;
+          key?: string;
+          name: string;
+          reserve?: boolean;
+          throws?: boolean;
+        },
+        { ok: true; retryAfter?: number } | { ok: false; retryAfter: number }
+      >;
+      resetRateLimit: FunctionReference<
+        "mutation",
+        "internal",
+        { key?: string; name: string },
+        null
+      >;
+    };
+    time: {
+      getServerTime: FunctionReference<"mutation", "internal", {}, number>;
     };
   };
 };

--- a/src/lib/convex/convex.config.ts
+++ b/src/lib/convex/convex.config.ts
@@ -3,12 +3,14 @@ import betterAuth from './betterAuth/convex.config';
 import resend from '@convex-dev/resend/convex.config';
 import autumn from '@useautumn/convex/convex.config';
 import agent from '@convex-dev/agent/convex.config';
+import rateLimiter from '@convex-dev/rate-limiter/convex.config';
 
 const app = defineApp();
 app.use(betterAuth);
 app.use(resend);
 app.use(autumn);
 app.use(agent);
+app.use(rateLimiter);
 /**
  * Convex application configured with Autumn billing, Resend email, and AI Agent.
  *

--- a/src/lib/convex/support/rateLimit.ts
+++ b/src/lib/convex/support/rateLimit.ts
@@ -1,0 +1,43 @@
+import { RateLimiter, MINUTE } from '@convex-dev/rate-limiter';
+import { components } from '../_generated/api';
+
+/**
+ * Rate limiter for customer support agent
+ *
+ * Prevents abuse of the AI support agent by limiting:
+ * - Per-user message frequency (authenticated vs anonymous)
+ * - Global LLM calls for cost protection
+ *
+ * Rate limit keying strategy:
+ * - Authenticated users: keyed by server-verified user ID
+ * - Anonymous users: keyed by anonymous user ID (fallback: thread ID)
+ */
+export const supportRateLimiter = new RateLimiter(components.rateLimiter, {
+	// Authenticated user message limit
+	// Token bucket: 5-message burst for natural conversation, then 1 every 12s sustained
+	supportMessage: {
+		kind: 'token bucket',
+		rate: 5,
+		period: MINUTE,
+		capacity: 5
+	},
+
+	// Anonymous user message limit (stricter to prevent abuse)
+	// Token bucket: 3-message burst, then 1 every 20s sustained
+	supportMessageAnon: {
+		kind: 'token bucket',
+		rate: 3,
+		period: MINUTE,
+		capacity: 3
+	},
+
+	// Global LLM call limit (cost protection)
+	// Soft-fails when exceeded - saves explanatory message for user
+	// Sharded for high throughput across all users
+	globalLLM: {
+		kind: 'fixed window',
+		rate: 500,
+		period: MINUTE,
+		shards: 5
+	}
+});

--- a/src/lib/convex/support/types.ts
+++ b/src/lib/convex/support/types.ts
@@ -1,0 +1,38 @@
+import { ConvexError } from 'convex/values';
+
+/**
+ * Rate limit error data structure
+ *
+ * Used for consistent error handling between backend and frontend.
+ */
+export type RateLimitErrorData = {
+	code: 'RATE_LIMITED';
+	message: string;
+	retryAfter: number;
+};
+
+/**
+ * Type guard to check if an error is a rate limit error
+ */
+export function isRateLimitError(error: unknown): error is ConvexError<RateLimitErrorData> {
+	if (!(error instanceof ConvexError)) return false;
+	const data = error.data as { code?: string } | undefined;
+	return data?.code === 'RATE_LIMITED';
+}
+
+/**
+ * Create a rate limit ConvexError with consistent structure
+ *
+ * @param retryAfter - Time in milliseconds until the rate limit resets
+ * @param message - User-friendly error message
+ */
+export function createRateLimitError(
+	retryAfter: number,
+	message: string
+): ConvexError<RateLimitErrorData> {
+	return new ConvexError({
+		code: 'RATE_LIMITED' as const,
+		message,
+		retryAfter
+	});
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
 	import { browser } from '$app/environment';
 	import { useConvexClient } from 'convex-svelte';
 	import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 
 	let { children, data } = $props();
 
@@ -64,17 +65,19 @@
 <PostHogIdentify />
 <Toaster />
 
-{#if $navigating}
-	<!--
-		Loading animation for next page since SvelteKit doesn't show any indicator.
-		- delay 100ms because most page loads are instant, and we don't want to flash
-		- long 12s duration because we don't actually know how long it will take
-		- exponential easing so fast loads (>100ms and <1s) still see enough progress,
-		  while slow networks see it moving for a full 12 seconds
-	-->
-	<div
-		class="fixed top-0 right-0 left-0 z-50 h-1 w-full bg-primary"
-		in:slide={{ delay: 100, duration: 12000, axis: 'x', easing: expoOut }}
-	></div>
-{/if}
-{@render children()}
+<Tooltip.Provider>
+	{#if $navigating}
+		<!--
+			Loading animation for next page since SvelteKit doesn't show any indicator.
+			- delay 100ms because most page loads are instant, and we don't want to flash
+			- long 12s duration because we don't actually know how long it will take
+			- exponential easing so fast loads (>100ms and <1s) still see enough progress,
+			  while slow networks see it moving for a full 12 seconds
+		-->
+		<div
+			class="fixed top-0 right-0 left-0 z-50 h-1 w-full bg-primary"
+			in:slide={{ delay: 100, duration: 12000, axis: 'x', easing: expoOut }}
+		></div>
+	{/if}
+	{@render children()}
+</Tooltip.Provider>


### PR DESCRIPTION
Add @convex-dev/rate-limiter for customer support abuse prevention:
- Auth users: 5-message burst, 5/min sustained (1 every 12s)
- Anonymous: 3-message burst, 3/min sustained (1 every 20s)
- Global LLM: 500/min cost protection

Thread creation limit removed (redundant - threads only created via messages).

Includes rate limit UI state management, auto-expiry, and user-friendly error toasts.

Accessibility improvements:
- Fix duplicate tabindex on nested interactive elements
- Add Tooltip.Provider wrapper in root layout
- Fix inert attribute on hidden elements
- Improve PromptInputAction snippet API