### PR TITLE
feat(i18n): add comprehensive translations and Tolgee server integration

### DIFF
--- a/.tolgeerc
+++ b/.tolgeerc
@@ -1,7 +1,9 @@
 {
-  "apiUrl": "https://app.tolgee.io",
+  "apiUrl": "https://tolgee.inframs.de",
   "format": "JSON_TOLGEE",
-  "patterns": ["src/**/*.{ts,svelte}"],
+  "patterns": [
+    "src/**/*.{ts,svelte}"
+  ],
   "push": {
     "filesTemplate": "./src/i18n/{languageTag}.json"
   },

--- a/docs/animation-rules.md
+++ b/docs/animation-rules.md
@@ -77,3 +77,25 @@ Is the element entering or exiting the viewport?
             ├── Yes → linear
             └── Default → ease-out
 ```
+
+## Icon Transitions (Toggle States)
+
+For morphing icons (e.g., toggle buttons):
+
+```svelte
+<!-- Icon 1 -->
+<Icon
+	class="transition-all duration-200 ease-in-out {active
+		? 'blur-0 scale-100 opacity-100'
+		: 'scale-0 opacity-0 blur-sm'}"
+/>
+
+<!-- Icon 2 -->
+<Icon
+	class="transition-all duration-200 ease-in-out {active
+		? 'scale-0 opacity-0 blur-sm'
+		: 'blur-0 scale-100 opacity-100'}"
+/>
+```
+
+**Standard:** 200ms, `ease-in-out`, opacity + scale + `blur-sm` → `blur-0`

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -31,9 +31,9 @@
 		"metrics": {
 			"active_sessions": "Aktiv (24h)",
 			"active_sessions_desc": "In den letzten 24 Stunden aktiv",
+			"admin_users": "Plattformverwaltung",
 			"admins": "Admins",
 			"admins_desc": "Benutzer mit Admin-Rechten",
-			"admin_users": "Plattformverwaltung",
 			"banned_users": "Gesperrte Benutzer",
 			"banned_users_desc": "Zugriff eingeschränkt",
 			"currently_active": "Tägliche Aktivität",
@@ -69,8 +69,8 @@
 			"delete_email_description": "{email} aus den Benachrichtigungsempfängern entfernen?",
 			"delete_email_title": "E-Mail entfernen",
 			"description": "Admin-Panel-Einstellungen und Benachrichtigungen konfigurieren.",
-			"email_added": "E-Mail hinzugefügt",
 			"email_add_failed": "E-Mail konnte nicht hinzugefügt werden",
+			"email_added": "E-Mail hinzugefügt",
 			"email_exists": "Diese E-Mail existiert bereits",
 			"email_removed": "E-Mail entfernt",
 			"field_new_signups": "Benachrichtigungen für neue Anmeldungen",
@@ -91,7 +91,7 @@
 			"preference_enabled": "{field} aktiviert",
 			"preference_enabling": "{field} wird aktiviert...",
 			"preference_update_failed": "Einstellung konnte nicht aktualisiert werden",
-			"recipient_count": "{count, plural, other {# Empfänger} }",
+			"recipient_count": "{count, plural, other {# Empfänger}}",
 			"save": "Einstellungen speichern",
 			"saved": "Einstellungen gespeichert",
 			"saving": "Speichern...",
@@ -115,6 +115,13 @@
 		},
 		"support": {
 			"all_statuses": "Alle Status",
+			"assignee": {
+				"not_assigned": "Nicht zugewiesen",
+				"unassigned": "Nicht zugewiesen"
+			},
+			"chat": {
+				"placeholder": "Antwort an Kunde..."
+			},
 			"details": {
 				"assignee": "Zugewiesen an",
 				"close_panel": "Details-Panel schließen",
@@ -127,6 +134,13 @@
 				"user_notes": "Benutzernotizen",
 				"user_notes_description": "Notizen werden auf Benutzerebene gespeichert und erscheinen in allen Support-Threads des Benutzers"
 			},
+			"email": {
+				"label": "Benachrichtigungs-E-Mail"
+			},
+			"fallback": {
+				"admin": "Admin",
+				"no_user": "Kein Benutzer mit diesem Thread verknüpft"
+			},
 			"filter": {
 				"all": "Alle",
 				"my_inbox": "Mein Posteingang",
@@ -135,22 +149,45 @@
 			"no_chats": "Keine Chats gefunden",
 			"no_done_chats": "Keine abgeschlossenen Chats",
 			"no_open_chats": "Keine offenen Chats",
+			"note": {
+				"add": "Notiz hinzufügen",
+				"adding": "Wird hinzugefügt...",
+				"placeholder": "Interne Notiz hinzufügen..."
+			},
 			"priority": {
 				"high": "Hoch",
 				"low": "Niedrig",
-				"medium": "Mittel"
+				"medium": "Mittel",
+				"none": "Keine"
+			},
+			"search": {
+				"placeholder": "Chats suchen..."
 			},
 			"select_chat": "Wählen Sie einen Chat, um die Unterhaltung anzuzeigen",
 			"select_chat_for_details": "Wählen Sie einen Chat, um Details anzuzeigen",
 			"status": {
 				"done": "Erledigt",
-				"open": "Offen"
+				"in_progress": "In Bearbeitung",
+				"open": "Offen",
+				"resolved": "Gelöst"
+			},
+			"thread": {
+				"badge": {
+					"new": "Neu"
+				},
+				"load_failed": "Laden fehlgeschlagen",
+				"loading": "Lädt mehr...",
+				"no_messages": "Keine Nachrichten",
+				"retry": "Erneut versuchen"
 			},
 			"title": "Support-Chats"
 		},
 		"title": "Admin-Bereich",
 		"users": {
 			"actions_column": "Aktionen",
+			"ban_reason": {
+				"default": "Verstoß gegen die Nutzungsbedingungen"
+			},
 			"banned": "Gesperrt",
 			"created": "Erstellt",
 			"email": "E-Mail",
@@ -159,7 +196,10 @@
 				"all_status": "Alle Status",
 				"clear": "Zurücksetzen",
 				"role_admin": "Admin",
-				"role_user": "Benutzer"
+				"role_user": "Benutzer",
+				"status_banned": "Gesperrt",
+				"status_unverified": "Nicht verifiziert",
+				"status_verified": "Verifiziert"
 			},
 			"loading": "Benutzer werden geladen...",
 			"menu_open": "Menü öffnen",
@@ -176,10 +216,29 @@
 			"rows_per_page": "Zeilen pro Seite",
 			"search_placeholder": "Benutzer suchen...",
 			"select_all": "Alle auswählen",
-			"selected": "{selected} von {total} Benutzer ausgewählt",
 			"select_row": "Zeile auswählen",
+			"selected": "{selected} von {total} Benutzer ausgewählt",
 			"status": "Status",
 			"title": "Benutzerverwaltung",
+			"toast": {
+				"assignment_failed": "Zuweisung konnte nicht aktualisiert werden: {message}",
+				"assignment_updated": "Zuweisung aktualisiert",
+				"ban_failed": "Benutzer konnte nicht gesperrt werden: {message}",
+				"banned": "Benutzer wurde gesperrt",
+				"impersonate_failed": "Identitätswechsel fehlgeschlagen: {message}",
+				"note_added": "Notiz hinzugefügt",
+				"note_failed": "Notiz konnte nicht hinzugefügt werden: {message}",
+				"priority_failed": "Priorität konnte nicht aktualisiert werden: {message}",
+				"priority_updated": "Priorität aktualisiert",
+				"revoke_failed": "Sitzungen konnten nicht widerrufen werden: {message}",
+				"revoked": "Alle Sitzungen wurden widerrufen",
+				"role_failed": "Rolle konnte nicht geändert werden: {message}",
+				"role_updated": "Benutzerrolle auf {role} geändert",
+				"status_failed": "Status konnte nicht aktualisiert werden: {message}",
+				"status_updated": "Status aktualisiert",
+				"unban_failed": "Sperre konnte nicht aufgehoben werden: {message}",
+				"unbanned": "Benutzersperre wurde aufgehoben"
+			},
 			"total": "Benutzer",
 			"unnamed": "Unbenannt",
 			"unverified": "Nicht verifiziert",
@@ -199,12 +258,25 @@
 			"account": "Konto",
 			"billing": "Abrechnung",
 			"impersonating_banner": "Sie agieren als dieser Benutzer",
+			"impersonation_stop_failed": "Identitätswechsel konnte nicht beendet werden",
+			"impersonation_stopped": "Identitätswechsel beendet",
 			"logout": "Abmelden",
 			"notifications": "Benachrichtigungen",
 			"settings": "Einstellungen",
 			"stop_impersonating": "Identitätswechsel beenden",
 			"upgrade_pro": "Auf Pro upgraden"
 		}
+	},
+	"aria": {
+		"breadcrumb": "Brotkrümel",
+		"change_language": "Sprache ändern",
+		"github_repository": "GitHub-Repository",
+		"home": "Startseite",
+		"menu_close": "Menü schließen",
+		"menu_open": "Menü öffnen",
+		"remove_attachment": "Anhang entfernen",
+		"select_value": "Wert auswählen",
+		"toggle_sidebar": "Seitenleiste umschalten"
 	},
 	"auth": {
 		"back_to_home": "Zurück zur Startseite",
@@ -221,41 +293,10 @@
 			"password_min_length": "Passwort muss mindestens {minLength} Zeichen lang sein",
 			"password_number": "Passwort muss mindestens eine Zahl enthalten",
 			"password_required": "Passwort ist erforderlich",
-			"passwords_do_not_match": "Passwörter stimmen nicht überein",
 			"password_uppercase": "Passwort muss mindestens einen Großbuchstaben enthalten",
+			"passwords_do_not_match": "Passwörter stimmen nicht überein",
 			"signup_failed": "Konto konnte nicht erstellt werden. E-Mail wird möglicherweise bereits verwendet.",
 			"verification_invalid": "Ungültiger oder abgelaufener Verifizierungscode. Bitte versuchen Sie es erneut."
-		},
-		"messages": {
-			"invalid_credentials": "Ungültige E-Mail oder Passwort",
-			"user_already_exists": "Ein Konto mit dieser E-Mail existiert bereits",
-			"email_not_verified": "Bitte bestätigen Sie Ihre E-Mail-Adresse",
-			"invalid_token": "Ungültiger oder abgelaufener Token",
-			"password_compromised": "Dieses Passwort wurde kompromittiert",
-			"too_many_attempts": "Zu viele Versuche. Bitte versuchen Sie es später erneut.",
-			"rate_limited": "Zu viele Anfragen. Bitte versuchen Sie es später erneut.",
-			"oauth_failed": "Soziale Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.",
-			"passkey_failed": "Passkey-Authentifizierung fehlgeschlagen",
-			"signup_failed": "Konto konnte nicht erstellt werden",
-			"signup_disabled": "Registrierung ist deaktiviert",
-			"auth_cancelled": "Authentifizierung abgebrochen",
-			"reset_link_sent": "Bitte prüfen Sie Ihre E-Mail für den Reset-Link.",
-			"password_reset_success": "Ihr Passwort wurde erfolgreich zurückgesetzt.",
-			"missing_reset_token": "Fehlender oder ungültiger Reset-Token",
-			"reset_failed": "Passwort konnte nicht zurückgesetzt werden",
-			"request_reset_failed": "Passwort-Reset konnte nicht angefordert werden",
-			"email_change_failed": "E-Mail konnte nicht geändert werden",
-			"email_same_as_current": "Neue E-Mail muss sich von der aktuellen E-Mail unterscheiden",
-			"email_updated": "E-Mail erfolgreich aktualisiert",
-			"email_verification_sent": "Bestätigungs-E-Mail wurde an Ihre aktuelle Adresse gesendet. Bitte prüfen Sie Ihren Posteingang, um die Änderung zu bestätigen.",
-			"password_change_failed": "Passwort konnte nicht geändert werden",
-			"password_changed": "Passwort erfolgreich geändert",
-			"passkey_load_failed": "Passkeys konnten nicht geladen werden",
-			"passkey_add_failed": "Passkey konnte nicht hinzugefügt werden",
-			"passkey_added": "Passkey erfolgreich hinzugefügt",
-			"passkey_delete_failed": "Passkey konnte nicht gelöscht werden",
-			"passkey_deleted": "Passkey gelöscht",
-			"generic_error": "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 		},
 		"forgot_password": {
 			"back_to_signin": "Zurück zur Anmeldung",
@@ -266,6 +307,37 @@
 		},
 		"login": "Anmelden",
 		"logout": "Abmelden",
+		"messages": {
+			"auth_cancelled": "Authentifizierung abgebrochen",
+			"email_change_failed": "E-Mail konnte nicht geändert werden",
+			"email_not_verified": "Bitte bestätigen Sie Ihre E-Mail-Adresse",
+			"email_same_as_current": "Neue E-Mail muss sich von der aktuellen E-Mail unterscheiden",
+			"email_updated": "E-Mail erfolgreich aktualisiert",
+			"email_verification_sent": "Bestätigungs-E-Mail wurde an Ihre aktuelle Adresse gesendet. Bitte prüfen Sie Ihren Posteingang, um die Änderung zu bestätigen.",
+			"generic_error": "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut.",
+			"invalid_credentials": "Ungültige E-Mail oder Passwort",
+			"invalid_token": "Ungültiger oder abgelaufener Token",
+			"missing_reset_token": "Fehlender oder ungültiger Reset-Token",
+			"oauth_failed": "Soziale Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.",
+			"passkey_add_failed": "Passkey konnte nicht hinzugefügt werden",
+			"passkey_added": "Passkey erfolgreich hinzugefügt",
+			"passkey_delete_failed": "Passkey konnte nicht gelöscht werden",
+			"passkey_deleted": "Passkey gelöscht",
+			"passkey_failed": "Passkey-Authentifizierung fehlgeschlagen",
+			"passkey_load_failed": "Passkeys konnten nicht geladen werden",
+			"password_change_failed": "Passwort konnte nicht geändert werden",
+			"password_changed": "Passwort erfolgreich geändert",
+			"password_compromised": "Dieses Passwort wurde kompromittiert",
+			"password_reset_success": "Ihr Passwort wurde erfolgreich zurückgesetzt.",
+			"rate_limited": "Zu viele Anfragen. Bitte versuchen Sie es später erneut.",
+			"request_reset_failed": "Passwort-Reset konnte nicht angefordert werden",
+			"reset_failed": "Passwort konnte nicht zurückgesetzt werden",
+			"reset_link_sent": "Bitte prüfen Sie Ihre E-Mail für den Reset-Link.",
+			"signup_disabled": "Registrierung ist deaktiviert",
+			"signup_failed": "Konto konnte nicht erstellt werden",
+			"too_many_attempts": "Zu viele Versuche. Bitte versuchen Sie es später erneut.",
+			"user_already_exists": "Ein Konto mit dieser E-Mail existiert bereits"
+		},
 		"reset_password": {
 			"back_to_signin": "Zurück zur Anmeldung",
 			"button_loading": "Wird zurückgesetzt...",
@@ -328,7 +400,31 @@
 			"title": "E-Mail-Verifizierung"
 		}
 	},
+	"backend": {
+		"files": {
+			"fetch_failed": "Die hochgeladene Datei konnte nicht abgerufen werden. Bitte versuchen Sie es erneut.",
+			"type_not_allowed": "Dateityp nicht erlaubt. Unterstützt: PNG, JPEG, WebP, GIF, PDF"
+		},
+		"support": {
+			"handoff": {
+				"response": "Natürlich! Ich verbinde Sie jetzt. Bitte geben Sie unten Ihre E-Mail-Adresse ein und wir benachrichtigen Sie, wenn unser Support-Team geantwortet hat. In der Zwischenzeit können Sie gerne weitere Details hinzufügen, die uns helfen könnten."
+			},
+			"rate_limit": {
+				"global": "Ich habe gerade eine hohe Auslastung. Bitte versuchen Sie es in einem Moment erneut.",
+				"user": "Zu viele Nachrichten. Bitte warten Sie, bevor Sie eine weitere senden."
+			},
+			"summary": {
+				"default": "Neues Support-Gespräch"
+			},
+			"title": {
+				"default": "Kundensupport"
+			}
+		}
+	},
 	"chat": {
+		"action": {
+			"talk_to_human": "Mit Experte sprechen"
+		},
 		"alerts": {
 			"limit_reached": {
 				"description": "Sie haben alle {total} kostenlosen Nachrichten für diesen Monat verbraucht.",
@@ -340,11 +436,40 @@
 				"title": "Wenig Nachrichten übrig"
 			}
 		},
+		"aria": {
+			"remove_attachment": "{filename} entfernen",
+			"send": "Senden"
+		},
+		"attachment": {
+			"dialog_title": "Anhang",
+			"file_fallback": "Datei",
+			"generic_fallback": "Anhang",
+			"image_fallback": "Bild"
+		},
+		"avatar": {
+			"team_member": "Teammitglied"
+		},
 		"buttons": {
 			"processing": "Wird verarbeitet...",
 			"upgrade": "Auf Pro upgraden"
 		},
 		"description": "Öffnen Sie diese App in mehreren Browser-Fenstern, um die Echtzeit-Datenbank in Aktion zu sehen",
+		"email": {
+			"placeholder": "Email",
+			"save_failed": "E-Mail konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
+			"saved_success": "E-Mail gespeichert! Wir benachrichtigen Sie, wenn wir antworten.",
+			"subscribe_button": "Abonnieren",
+			"unsubscribe_failed": "Abmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.",
+			"unsubscribed": "E-Mail-Benachrichtigungen abbestellt."
+		},
+		"error": {
+			"file_max_size": "Maximale Größe ist {maxSize}",
+			"file_too_large": "Datei zu groß: \"{filename}\"",
+			"max_attachments": "Maximal {max} Anhänge erlaubt",
+			"pasted_file_too_large": "Eingefügte Datei zu groß"
+		},
+		"greeting": "Wie können wir helfen?",
+		"greeting_hi": "Hallo",
 		"header": {
 			"messages_left": "({remaining}/{total} Nachricht übrig)",
 			"messages_left_plural": "({remaining}/{total} Nachrichten übrig)",
@@ -362,12 +487,47 @@
 			"send_failed": "Nachricht konnte nicht gesendet werden",
 			"sent_success": "Nachricht gesendet!"
 		},
-		"title": "Community Chat"
+		"reasoning": {
+			"connecting": "Verbinde...",
+			"thinking": "Denke nach...",
+			"thought_for_few_seconds": "Nachgedacht für einige Sekunden",
+			"thought_for_seconds": "Nachgedacht für {duration} Sekunde",
+			"thought_for_seconds_plural": "Nachgedacht für {duration} Sekunden"
+		},
+		"suggestion": {
+			"help_label": "Hilfe erhalten",
+			"help_text": "Können Sie mir helfen mit...",
+			"issue_label": "Problem melden",
+			"issue_text": "Ich habe ein Problem gefunden mit...",
+			"question_label": "Frage stellen",
+			"question_text": "Ich habe eine Frage zu..."
+		},
+		"title": "Community Chat",
+		"tooltip": {
+			"attach_files": "Dateien anhängen",
+			"mark_bug": "Fehler markieren"
+		}
 	},
 	"common": {
 		"adding": "Wird hinzugefügt...",
 		"cancel": "Abbrechen",
 		"confirm": "Bestätigen"
+	},
+	"email": {
+		"body": {
+			"no_messages": "Keine Nachrichten",
+			"ticket_message": "{userName} hat eine neue Nachricht zu einem zuvor geschlossenen Ticket gesendet",
+			"ticket_new": "Neues Support-Ticket",
+			"ticket_reopened": "Support-Ticket wiedereröffnet",
+			"ticket_started": "{userName} hat ein neues Support-Gespräch gestartet"
+		},
+		"subject": {
+			"reset_password": "Passwort zurücksetzen",
+			"support_reply": "Neue Antwort auf Ihre Support-Anfrage",
+			"ticket_new": "Neues Support-Ticket von {userName}",
+			"ticket_reopened": "Support-Ticket wiedereröffnet von {userName}",
+			"verify": "E-Mail-Adresse bestätigen"
+		}
 	},
 	"hero": {
 		"companies_text": "Vertrauen der besten Teams",
@@ -526,9 +686,21 @@
 	},
 	"settings": {
 		"account": {
+			"avatar": {
+				"alt": "Profilvorschau",
+				"ready": "Bild bereit zum Speichern",
+				"removed": "Bild entfernt - klicken Sie auf Speichern zur Bestätigung",
+				"select_error": "Bitte wählen Sie eine Bilddatei aus",
+				"size_error": "Bild muss kleiner als {size} sein",
+				"upload_failed": "Bild konnte nicht hochgeladen werden"
+			},
 			"description": "Aktualisieren Sie hier Ihre Kontoinformationen.",
+			"error": "Profil konnte nicht aktualisiert werden",
 			"file_helper": "PNG, JPG oder GIF bis zu 2MB.",
 			"link_from_url": "Link von URL",
+			"name": {
+				"placeholder": "Ihr Name"
+			},
 			"name_helper": "Dies ist Ihr öffentlich angezeigter Name.",
 			"name_label": "Name",
 			"no_image": "Kein Bild",
@@ -538,9 +710,11 @@
 			"remove_button": "Entfernen",
 			"save_button": "Änderungen speichern",
 			"saving": "Speichern...",
+			"success": "Profil erfolgreich aktualisiert",
 			"title": "Kontoinformationen",
 			"upload_file": "Datei hochladen",
-			"url_helper": "Fügen Sie einen Bildlink ein, anstatt hochzuladen."
+			"url_helper": "Fügen Sie einen Bildlink ein, anstatt hochzuladen.",
+			"url_placeholder": "https://example.com/avatar.jpg"
 		},
 		"description": "Verwalten Sie Ihre Kontoeinstellungen und Präferenzen.",
 		"email": {
@@ -550,6 +724,7 @@
 			"new_email_label": "Neue E-Mail-Adresse",
 			"not_verified_description": "Ihre aktuelle E-Mail ist nicht verifiziert. Die neue E-Mail wird sofort ohne Verifizierung aktualisiert.",
 			"not_verified_title": "E-Mail nicht verifiziert",
+			"placeholder": "Neue E-Mail-Adresse eingeben",
 			"title": "E-Mail-Adresse",
 			"unverified_badge": "Nicht verifiziert",
 			"update_button": "E-Mail aktualisieren",
@@ -565,6 +740,11 @@
 			"error_title": "Fehler",
 			"new_password_label": "Neues Passwort",
 			"password_helper": "Muss mindestens 8 Zeichen lang sein.",
+			"placeholder": {
+				"confirm": "Neues Passwort bestätigen",
+				"current": "Aktuelles Passwort eingeben",
+				"new": "Neues Passwort eingeben"
+			},
 			"revoke_sessions_label": "Von allen anderen Geräten abmelden",
 			"security_notice_description": "Das Ändern Ihres Passworts erfordert eine erneute Anmeldung auf allen Geräten, es sei denn, Sie deaktivieren die obige Option.",
 			"security_notice_title": "Sicherheitshinweis",
@@ -574,14 +754,18 @@
 		},
 		"security": {
 			"add_button": "Passkey hinzufügen",
-			"adding": "Wird hinzugefügt...",
 			"add_passkey_helper": "Geben Sie Ihrem Passkey einen Namen, um zu identifizieren, auf welchem Gerät er registriert ist.",
 			"add_passkey_title": "Passkey hinzufügen",
+			"adding": "Wird hinzugefügt...",
 			"created_at": "Erstellt am ",
 			"description": "Verwalten Sie Ihre Passkeys und Sicherheitseinstellungen.",
 			"error_title": "Fehler",
 			"loading": "Passkeys werden geladen...",
 			"no_passkeys": "Sie haben noch keine Passkeys registriert.",
+			"passkey": {
+				"placeholder": "Passkey-Name (optional)",
+				"unnamed": "Unbenannter Passkey"
+			},
 			"passkey_info_description": "Passkeys sind eine sichere, passwortlose Anmeldemethode. Sie verwenden Biometrie oder Geräte-PIN und werden sicher auf Ihren Geräten gespeichert.",
 			"passkey_info_title": "Was sind Passkeys?",
 			"passkey_name_label": "Passkey-Name",
@@ -595,6 +779,84 @@
 			"security": "Sicherheit"
 		},
 		"title": "Einstellungen"
+	},
+	"support": {
+		"avatar": {
+			"team_member": "Teammitglied"
+		},
+		"button": {
+			"start_new_conversation": "Neue Unterhaltung starten"
+		},
+		"chatbar": {
+			"placeholder": "Frag mich alles..."
+		},
+		"greeting": {
+			"hi": "Hey",
+			"how_can_we_help": "Wie können wir Ihnen heute helfen?"
+		},
+		"header": {
+			"support_team": "Support-Team"
+		},
+		"message": {
+			"role_kai": "Kai",
+			"role_support": "Support",
+			"role_you": "Sie"
+		},
+		"screenshot": {
+			"action": {
+				"cancel": "Abbrechen (Esc)",
+				"redo": "Wiederholen (Strg+Umschalt+Z)",
+				"undo": "Rückgängig (Strg+Z)"
+			},
+			"aria_label": "Screenshot-Editor",
+			"capture_failed": "Screenshot fehlgeschlagen. Überprüfen Sie die Konsole für Details.",
+			"capturing": "Wird aufgenommen...",
+			"next": "Weiter",
+			"tool": {
+				"arrow": "Pfeil (A)",
+				"circle": "Kreis (C)",
+				"color": "Farbe ändern",
+				"pen": "Stift (P)",
+				"rectangle": "Rechteck (R)"
+			}
+		},
+		"suggestion": {
+			"bug_report_label": "Problem melden",
+			"bug_report_text": "Ich habe einen Fehler gefunden!",
+			"feature_request_label": "Feature anfragen",
+			"feature_request_text": "Ich würde mir wünschen",
+			"help_label": "Hilfe bei...",
+			"help_text": "Helfen Sie mir bei der Einrichtung.",
+			"question_label": "Frage stellen",
+			"question_text": "Warum SaaS Starter?"
+		},
+		"thread": {
+			"new_conversation": "Neue Unterhaltung"
+		},
+		"time": {
+			"days_ago": "vor {days} Tagen",
+			"few_seconds_ago": "vor wenigen Sekunden",
+			"hours_ago": "vor {hours} Stunden",
+			"just_now": "gerade eben",
+			"minutes_ago": "vor {minutes} Minuten",
+			"one_hour_ago": "vor 1 Stunde",
+			"one_minute_ago": "vor 1 Minute",
+			"yesterday": "gestern"
+		},
+		"widget": {
+			"error": {
+				"rate_limit": "Langsamer! Bitte warten Sie {seconds}s, bevor Sie eine weitere Nachricht senden.",
+				"send_failed": "Nachricht konnte nicht gesendet werden. Bitte versuchen Sie es erneut."
+			},
+			"header": {
+				"bot_response": "Unser Bot antwortet sofort",
+				"messages": "Nachrichten",
+				"with_team": "Ihre Anfrage ist bei unserem Team"
+			},
+			"input": {
+				"placeholder": "Nachricht eingeben oder Vorschlag anklicken..."
+			}
+		}
 	},
 	"team": {
 		"description": "Während des Arbeitsprozesses führen wir regelmäßige Anpassungen mit dem Kunden durch, denn er ist die einzige Person, die spüren kann, ob ein neuer Anzug passt oder nicht.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -31,9 +31,9 @@
 		"metrics": {
 			"active_sessions": "Active (24h)",
 			"active_sessions_desc": "Active in the last 24 hours",
+			"admin_users": "Managing the platform",
 			"admins": "Admins",
 			"admins_desc": "Users with admin privileges",
-			"admin_users": "Managing the platform",
 			"banned_users": "Banned Users",
 			"banned_users_desc": "Access restricted",
 			"currently_active": "Daily activity",
@@ -69,8 +69,8 @@
 			"delete_email_description": "Remove {email} from notification recipients?",
 			"delete_email_title": "Remove Email",
 			"description": "Configure admin panel settings and notifications.",
-			"email_added": "Email added",
 			"email_add_failed": "Failed to add email",
+			"email_added": "Email added",
 			"email_exists": "This email already exists",
 			"email_removed": "Email removed",
 			"field_new_signups": "New signup notifications",
@@ -115,6 +115,13 @@
 		},
 		"support": {
 			"all_statuses": "All statuses",
+			"assignee": {
+				"not_assigned": "Not assigned",
+				"unassigned": "Unassigned"
+			},
+			"chat": {
+				"placeholder": "Reply to customer..."
+			},
 			"details": {
 				"assignee": "Assignee",
 				"close_panel": "Close details panel",
@@ -127,6 +134,13 @@
 				"user_notes": "User Notes",
 				"user_notes_description": "Notes are saved at the user level and appear across all their support threads"
 			},
+			"email": {
+				"label": "Notification Email"
+			},
+			"fallback": {
+				"admin": "Admin",
+				"no_user": "No user associated with this thread"
+			},
 			"filter": {
 				"all": "All",
 				"my_inbox": "My Inbox",
@@ -135,10 +149,19 @@
 			"no_chats": "No chats found",
 			"no_done_chats": "No completed chats",
 			"no_open_chats": "No open chats",
+			"note": {
+				"add": "Add Note",
+				"adding": "Adding...",
+				"placeholder": "Add an internal note..."
+			},
 			"priority": {
 				"high": "High",
 				"low": "Low",
-				"medium": "Medium"
+				"medium": "Medium",
+				"none": "None"
+			},
+			"search": {
+				"placeholder": "Search chats..."
 			},
 			"select_chat": "Select a chat to view conversation",
 			"select_chat_for_details": "Select a chat to view details",
@@ -148,11 +171,23 @@
 				"open": "Open",
 				"resolved": "Resolved"
 			},
+			"thread": {
+				"badge": {
+					"new": "New"
+				},
+				"load_failed": "Failed to load more",
+				"loading": "Loading more...",
+				"no_messages": "No messages",
+				"retry": "Retry"
+			},
 			"title": "Support Chats"
 		},
 		"title": "Admin Panel",
 		"users": {
 			"actions_column": "Actions",
+			"ban_reason": {
+				"default": "Violated terms of service"
+			},
 			"banned": "Banned",
 			"created": "Created",
 			"email": "Email",
@@ -161,7 +196,10 @@
 				"all_status": "All Status",
 				"clear": "Clear",
 				"role_admin": "Admin",
-				"role_user": "User"
+				"role_user": "User",
+				"status_banned": "Banned",
+				"status_unverified": "Unverified",
+				"status_verified": "Verified"
 			},
 			"loading": "Loading users...",
 			"menu_open": "Open menu",
@@ -178,10 +216,29 @@
 			"rows_per_page": "Rows per page",
 			"search_placeholder": "Search users...",
 			"select_all": "Select all",
-			"selected": "{selected} of {total} users selected",
 			"select_row": "Select row",
+			"selected": "{selected} of {total} users selected",
 			"status": "Status",
 			"title": "User Management",
+			"toast": {
+				"assignment_failed": "Failed to update assignment: {message}",
+				"assignment_updated": "Assignment updated",
+				"ban_failed": "Failed to ban user: {message}",
+				"banned": "User has been banned",
+				"impersonate_failed": "Failed to impersonate user: {message}",
+				"note_added": "Note added",
+				"note_failed": "Failed to add note: {message}",
+				"priority_failed": "Failed to update priority: {message}",
+				"priority_updated": "Priority updated",
+				"revoke_failed": "Failed to revoke sessions: {message}",
+				"revoked": "All sessions have been revoked",
+				"role_failed": "Failed to set role: {message}",
+				"role_updated": "User role updated to {role}",
+				"status_failed": "Failed to update status: {message}",
+				"status_updated": "Status updated",
+				"unban_failed": "Failed to unban user: {message}",
+				"unbanned": "User has been unbanned"
+			},
 			"total": "users",
 			"unnamed": "Unnamed",
 			"unverified": "Unverified",
@@ -201,12 +258,25 @@
 			"account": "Account",
 			"billing": "Billing",
 			"impersonating_banner": "You are impersonating this user",
+			"impersonation_stop_failed": "Failed to stop impersonation",
+			"impersonation_stopped": "Stopped impersonating",
 			"logout": "Log out",
 			"notifications": "Notifications",
 			"settings": "Settings",
 			"stop_impersonating": "Stop Impersonating",
 			"upgrade_pro": "Upgrade to Pro"
 		}
+	},
+	"aria": {
+		"breadcrumb": "breadcrumb",
+		"change_language": "Change language",
+		"github_repository": "GitHub repository",
+		"home": "home",
+		"menu_close": "Close Menu",
+		"menu_open": "Open Menu",
+		"remove_attachment": "Remove attachment",
+		"select_value": "Select a value",
+		"toggle_sidebar": "Toggle Sidebar"
 	},
 	"auth": {
 		"back_to_home": "Back to home",
@@ -223,41 +293,10 @@
 			"password_min_length": "Password must be at least {minLength} characters",
 			"password_number": "Password must contain at least one number",
 			"password_required": "Password is required",
-			"passwords_do_not_match": "Passwords do not match",
 			"password_uppercase": "Password must contain at least one uppercase letter",
+			"passwords_do_not_match": "Passwords do not match",
 			"signup_failed": "Failed to create account. Email may already be in use.",
 			"verification_invalid": "Invalid or expired verification code. Please try again."
-		},
-		"messages": {
-			"invalid_credentials": "Invalid email or password",
-			"user_already_exists": "An account with this email already exists",
-			"email_not_verified": "Please verify your email address",
-			"invalid_token": "Invalid or expired token",
-			"password_compromised": "This password has been compromised",
-			"too_many_attempts": "Too many attempts. Please try again later.",
-			"rate_limited": "Too many requests. Please try again later.",
-			"oauth_failed": "Social sign-in failed. Please try again.",
-			"passkey_failed": "Passkey authentication failed",
-			"signup_failed": "Failed to create account",
-			"signup_disabled": "Sign up is disabled",
-			"auth_cancelled": "Authentication was cancelled",
-			"reset_link_sent": "Check your email for a reset link.",
-			"password_reset_success": "Your password has been reset successfully.",
-			"missing_reset_token": "Missing or invalid reset token",
-			"reset_failed": "Failed to reset password",
-			"request_reset_failed": "Failed to request password reset",
-			"email_change_failed": "Failed to change email",
-			"email_same_as_current": "New email must be different from current email",
-			"email_updated": "Email updated successfully",
-			"email_verification_sent": "Verification email sent to your current address. Please check your inbox to approve the change.",
-			"password_change_failed": "Failed to change password",
-			"password_changed": "Password changed successfully",
-			"passkey_load_failed": "Failed to load passkeys",
-			"passkey_add_failed": "Failed to add passkey",
-			"passkey_added": "Passkey added successfully",
-			"passkey_delete_failed": "Failed to delete passkey",
-			"passkey_deleted": "Passkey deleted",
-			"generic_error": "An error occurred. Please try again."
 		},
 		"forgot_password": {
 			"back_to_signin": "Back to sign in",
@@ -268,6 +307,37 @@
 		},
 		"login": "Login",
 		"logout": "Logout",
+		"messages": {
+			"auth_cancelled": "Authentication was cancelled",
+			"email_change_failed": "Failed to change email",
+			"email_not_verified": "Please verify your email address",
+			"email_same_as_current": "New email must be different from current email",
+			"email_updated": "Email updated successfully",
+			"email_verification_sent": "Verification email sent to your current address. Please check your inbox to approve the change.",
+			"generic_error": "An error occurred. Please try again.",
+			"invalid_credentials": "Invalid email or password",
+			"invalid_token": "Invalid or expired token",
+			"missing_reset_token": "Missing or invalid reset token",
+			"oauth_failed": "Social sign-in failed. Please try again.",
+			"passkey_add_failed": "Failed to add passkey",
+			"passkey_added": "Passkey added successfully",
+			"passkey_delete_failed": "Failed to delete passkey",
+			"passkey_deleted": "Passkey deleted",
+			"passkey_failed": "Passkey authentication failed",
+			"passkey_load_failed": "Failed to load passkeys",
+			"password_change_failed": "Failed to change password",
+			"password_changed": "Password changed successfully",
+			"password_compromised": "This password has been compromised",
+			"password_reset_success": "Your password has been reset successfully.",
+			"rate_limited": "Too many requests. Please try again later.",
+			"request_reset_failed": "Failed to request password reset",
+			"reset_failed": "Failed to reset password",
+			"reset_link_sent": "Check your email for a reset link.",
+			"signup_disabled": "Sign up is disabled",
+			"signup_failed": "Failed to create account",
+			"too_many_attempts": "Too many attempts. Please try again later.",
+			"user_already_exists": "An account with this email already exists"
+		},
 		"reset_password": {
 			"back_to_signin": "Back to sign in",
 			"button_loading": "Resetting...",
@@ -330,7 +400,31 @@
 			"title": "Email Verification"
 		}
 	},
+	"backend": {
+		"files": {
+			"fetch_failed": "Failed to retrieve uploaded file. Please try uploading again.",
+			"type_not_allowed": "File type not allowed. Supported: PNG, JPEG, WebP, GIF, PDF"
+		},
+		"support": {
+			"handoff": {
+				"response": "Sure! I will connect you now. Please enter your email below and we'll notify you when our support team has responded. In the meantime, feel free to add any additional details that might help us assist you better."
+			},
+			"rate_limit": {
+				"global": "I'm currently experiencing high demand. Please try sending your message again in a moment.",
+				"user": "Too many messages. Please wait before sending another."
+			},
+			"summary": {
+				"default": "New support conversation"
+			},
+			"title": {
+				"default": "Customer Support"
+			}
+		}
+	},
 	"chat": {
+		"action": {
+			"talk_to_human": "Talk to a human"
+		},
 		"alerts": {
 			"limit_reached": {
 				"description": "You've used all {total} of your free messages this month.",
@@ -342,11 +436,40 @@
 				"title": "Low on Messages"
 			}
 		},
+		"aria": {
+			"remove_attachment": "Remove {filename}",
+			"send": "Send"
+		},
+		"attachment": {
+			"dialog_title": "Attachment",
+			"file_fallback": "File",
+			"generic_fallback": "Attachment",
+			"image_fallback": "Image"
+		},
+		"avatar": {
+			"team_member": "Team member"
+		},
 		"buttons": {
 			"processing": "Processing...",
 			"upgrade": "Upgrade to Pro"
 		},
 		"description": "Open this app in multiple browser windows to see the real-time database in action",
+		"email": {
+			"placeholder": "Email",
+			"save_failed": "Failed to save email. Please try again.",
+			"saved_success": "Email saved! We'll notify you when we respond.",
+			"subscribe_button": "Subscribe",
+			"unsubscribe_failed": "Failed to unsubscribe. Please try again.",
+			"unsubscribed": "Unsubscribed from email notifications."
+		},
+		"error": {
+			"file_max_size": "Maximum size is {maxSize}",
+			"file_too_large": "File too large: \"{filename}\"",
+			"max_attachments": "Maximum {max} attachments allowed",
+			"pasted_file_too_large": "Pasted file too large"
+		},
+		"greeting": "How can we help?",
+		"greeting_hi": "Hi",
 		"header": {
 			"messages_left": "({remaining}/{total} message left)",
 			"messages_left_plural": "({remaining}/{total} messages left)",
@@ -364,12 +487,47 @@
 			"send_failed": "Failed to send message",
 			"sent_success": "Message sent!"
 		},
-		"title": "Community Chat"
+		"reasoning": {
+			"connecting": "Connecting...",
+			"thinking": "Thinking...",
+			"thought_for_few_seconds": "Thought for a few seconds",
+			"thought_for_seconds": "Thought for {duration} second",
+			"thought_for_seconds_plural": "Thought for {duration} seconds"
+		},
+		"suggestion": {
+			"help_label": "Get help",
+			"help_text": "Can you help me with...",
+			"issue_label": "Report an issue",
+			"issue_text": "I found an issue with...",
+			"question_label": "Ask a question",
+			"question_text": "I have a question about..."
+		},
+		"title": "Community Chat",
+		"tooltip": {
+			"attach_files": "Attach files",
+			"mark_bug": "Mark the bug"
+		}
 	},
 	"common": {
 		"adding": "Adding...",
 		"cancel": "Cancel",
 		"confirm": "Confirm"
+	},
+	"email": {
+		"body": {
+			"no_messages": "No messages",
+			"ticket_message": "{userName} has sent a new message to a previously closed ticket",
+			"ticket_new": "New support ticket",
+			"ticket_reopened": "Support ticket reopened",
+			"ticket_started": "{userName} has started a new support conversation"
+		},
+		"subject": {
+			"reset_password": "Reset your password",
+			"support_reply": "New reply to your support request",
+			"ticket_new": "New support ticket from {userName}",
+			"ticket_reopened": "Support ticket reopened by {userName}",
+			"verify": "Verify your email"
+		}
 	},
 	"hero": {
 		"companies_text": "Powering the best teams",
@@ -528,9 +686,21 @@
 	},
 	"settings": {
 		"account": {
+			"avatar": {
+				"alt": "Profile preview",
+				"ready": "Image ready to save",
+				"removed": "Image removed - click Save to confirm",
+				"select_error": "Please select an image file",
+				"size_error": "Image must be less than {size}",
+				"upload_failed": "Failed to upload image"
+			},
 			"description": "Update your account information here.",
+			"error": "Failed to update profile",
 			"file_helper": "PNG, JPG, or GIF up to 2MB.",
 			"link_from_url": "Link from URL",
+			"name": {
+				"placeholder": "Your name"
+			},
 			"name_helper": "This is your public display name.",
 			"name_label": "Name",
 			"no_image": "No image",
@@ -540,9 +710,11 @@
 			"remove_button": "Remove",
 			"save_button": "Save Changes",
 			"saving": "Saving...",
+			"success": "Profile updated successfully",
 			"title": "Account Information",
 			"upload_file": "Upload a file",
-			"url_helper": "Paste an image link instead of uploading."
+			"url_helper": "Paste an image link instead of uploading.",
+			"url_placeholder": "https://example.com/avatar.jpg"
 		},
 		"description": "Manage your account settings and preferences.",
 		"email": {
@@ -552,6 +724,7 @@
 			"new_email_label": "New Email Address",
 			"not_verified_description": "Your current email is not verified. The new email will be updated immediately without verification.",
 			"not_verified_title": "Email Not Verified",
+			"placeholder": "Enter new email address",
 			"title": "Email Address",
 			"unverified_badge": "Unverified",
 			"update_button": "Update Email",
@@ -567,6 +740,11 @@
 			"error_title": "Error",
 			"new_password_label": "New Password",
 			"password_helper": "Must be at least 10 characters long.",
+			"placeholder": {
+				"confirm": "Confirm new password",
+				"current": "Enter current password",
+				"new": "Enter new password"
+			},
 			"revoke_sessions_label": "Sign out of all other devices",
 			"security_notice_description": "Changing your password will require you to sign in again on all devices unless you uncheck the option above.",
 			"security_notice_title": "Security Notice",
@@ -576,14 +754,18 @@
 		},
 		"security": {
 			"add_button": "Add Passkey",
-			"adding": "Adding...",
 			"add_passkey_helper": "Give your passkey a name to identify which device it's registered on.",
 			"add_passkey_title": "Add a Passkey",
+			"adding": "Adding...",
 			"created_at": "Created ",
 			"description": "Manage your passkeys and security settings.",
 			"error_title": "Error",
 			"loading": "Loading passkeys...",
 			"no_passkeys": "You haven't registered any passkeys yet.",
+			"passkey": {
+				"placeholder": "Passkey name (optional)",
+				"unnamed": "Unnamed Passkey"
+			},
 			"passkey_info_description": "Passkeys are a secure, passwordless way to sign in. They use biometrics or device PIN and are stored securely on your devices.",
 			"passkey_info_title": "What are Passkeys?",
 			"passkey_name_label": "Passkey name",
@@ -597,6 +779,84 @@
 			"security": "Security"
 		},
 		"title": "Settings"
+	},
+	"support": {
+		"avatar": {
+			"team_member": "Team member"
+		},
+		"button": {
+			"start_new_conversation": "Start a new conversation"
+		},
+		"chatbar": {
+			"placeholder": "Ask me anything..."
+		},
+		"greeting": {
+			"hi": "Hi",
+			"how_can_we_help": "How can we help you today?"
+		},
+		"header": {
+			"support_team": "Support Team"
+		},
+		"message": {
+			"role_kai": "Kai",
+			"role_support": "Support",
+			"role_you": "You"
+		},
+		"screenshot": {
+			"action": {
+				"cancel": "Cancel (Esc)",
+				"redo": "Redo (Ctrl+Shift+Z)",
+				"undo": "Undo (Ctrl+Z)"
+			},
+			"aria_label": "Screenshot editor",
+			"capture_failed": "Failed to capture screenshot. Check console for details.",
+			"capturing": "Capturing...",
+			"next": "Next",
+			"tool": {
+				"arrow": "Arrow (A)",
+				"circle": "Circle (C)",
+				"color": "Change Color",
+				"pen": "Pen (P)",
+				"rectangle": "Rectangle (R)"
+			}
+		},
+		"suggestion": {
+			"bug_report_label": "Report an issue",
+			"bug_report_text": "I found a bug!",
+			"feature_request_label": "Request a feature",
+			"feature_request_text": "I would love to see",
+			"help_label": "Help me with...",
+			"help_text": "Help me set up the project.",
+			"question_label": "Ask a question",
+			"question_text": "Why SaaS Starter?"
+		},
+		"thread": {
+			"new_conversation": "New conversation"
+		},
+		"time": {
+			"days_ago": "{days} days ago",
+			"few_seconds_ago": "a few seconds ago",
+			"hours_ago": "{hours} hours ago",
+			"just_now": "just now",
+			"minutes_ago": "{minutes} minutes ago",
+			"one_hour_ago": "1 hour ago",
+			"one_minute_ago": "1 minute ago",
+			"yesterday": "yesterday"
+		},
+		"widget": {
+			"error": {
+				"rate_limit": "Slow down! Please wait {seconds}s before sending another message.",
+				"send_failed": "Failed to send message. Please try again."
+			},
+			"header": {
+				"bot_response": "Our bot will reply instantly",
+				"messages": "Messages",
+				"with_team": "Your request is with our team"
+			},
+			"input": {
+				"placeholder": "Type a message or click a suggestion..."
+			}
+		}
 	},
 	"team": {
 		"description": "During the working process, we perform regular fitting with the client because he is the only person who can feel whether a new suit fits or not.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -31,9 +31,9 @@
 		"metrics": {
 			"active_sessions": "Activos (24h)",
 			"active_sessions_desc": "Activos en las últimas 24 horas",
+			"admin_users": "Gestionando la plataforma",
 			"admins": "Admins",
 			"admins_desc": "Usuarios con privilegios de admin",
-			"admin_users": "Gestionando la plataforma",
 			"banned_users": "Usuarios Bloqueados",
 			"banned_users_desc": "Acceso restringido",
 			"currently_active": "Actividad diaria",
@@ -69,8 +69,8 @@
 			"delete_email_description": "¿Eliminar {email} de los destinatarios de notificaciones?",
 			"delete_email_title": "Eliminar Email",
 			"description": "Configura los ajustes del panel de administración y las notificaciones.",
-			"email_added": "Email agregado",
 			"email_add_failed": "No se pudo agregar el email",
+			"email_added": "Email agregado",
 			"email_exists": "Este email ya existe",
 			"email_removed": "Email eliminado",
 			"field_new_signups": "Notificaciones de nuevos registros",
@@ -115,6 +115,13 @@
 		},
 		"support": {
 			"all_statuses": "Todos los estados",
+			"assignee": {
+				"not_assigned": "No asignado",
+				"unassigned": "Sin asignar"
+			},
+			"chat": {
+				"placeholder": "Responder al cliente..."
+			},
 			"details": {
 				"assignee": "Asignado a",
 				"close_panel": "Cerrar panel de detalles",
@@ -127,6 +134,13 @@
 				"user_notes": "Notas del Usuario",
 				"user_notes_description": "Las notas se guardan a nivel de usuario y aparecen en todos sus hilos de soporte"
 			},
+			"email": {
+				"label": "Email de notificación"
+			},
+			"fallback": {
+				"admin": "Admin",
+				"no_user": "No hay usuario asociado con este hilo"
+			},
 			"filter": {
 				"all": "Todos",
 				"my_inbox": "Mi bandeja de entrada",
@@ -135,22 +149,45 @@
 			"no_chats": "No se encontraron chats",
 			"no_done_chats": "No hay chats completados",
 			"no_open_chats": "No hay chats abiertos",
+			"note": {
+				"add": "Agregar nota",
+				"adding": "Agregando...",
+				"placeholder": "Agregar una nota interna..."
+			},
 			"priority": {
 				"high": "Alta",
 				"low": "Baja",
-				"medium": "Media"
+				"medium": "Media",
+				"none": "Ninguna"
+			},
+			"search": {
+				"placeholder": "Buscar chats..."
 			},
 			"select_chat": "Seleccione un chat para ver la conversación",
 			"select_chat_for_details": "Seleccione un chat para ver detalles",
 			"status": {
 				"done": "Hecho",
-				"open": "Abierto"
+				"in_progress": "En progreso",
+				"open": "Abierto",
+				"resolved": "Resuelto"
+			},
+			"thread": {
+				"badge": {
+					"new": "Nuevo"
+				},
+				"load_failed": "Error al cargar más",
+				"loading": "Cargando más...",
+				"no_messages": "Sin mensajes",
+				"retry": "Reintentar"
 			},
 			"title": "Chats de Soporte"
 		},
 		"title": "Panel de Admin",
 		"users": {
 			"actions_column": "Acciones",
+			"ban_reason": {
+				"default": "Violación de los términos de servicio"
+			},
 			"banned": "Bloqueado",
 			"created": "Creado",
 			"email": "Correo",
@@ -159,7 +196,10 @@
 				"all_status": "Todos los estados",
 				"clear": "Limpiar",
 				"role_admin": "Admin",
-				"role_user": "Usuario"
+				"role_user": "Usuario",
+				"status_banned": "Bloqueado",
+				"status_unverified": "No verificado",
+				"status_verified": "Verificado"
 			},
 			"loading": "Cargando usuarios...",
 			"menu_open": "Abrir menú",
@@ -176,10 +216,29 @@
 			"rows_per_page": "Filas por página",
 			"search_placeholder": "Buscar usuarios...",
 			"select_all": "Seleccionar todo",
-			"selected": "{selected} de {total} usuarios seleccionados",
 			"select_row": "Seleccionar fila",
+			"selected": "{selected} de {total} usuarios seleccionados",
 			"status": "Estado",
 			"title": "Gestión de Usuarios",
+			"toast": {
+				"assignment_failed": "Error al actualizar asignación: {message}",
+				"assignment_updated": "Asignación actualizada",
+				"ban_failed": "Error al bloquear usuario: {message}",
+				"banned": "Usuario bloqueado",
+				"impersonate_failed": "Error al suplantar usuario: {message}",
+				"note_added": "Nota agregada",
+				"note_failed": "Error al agregar nota: {message}",
+				"priority_failed": "Error al actualizar prioridad: {message}",
+				"priority_updated": "Prioridad actualizada",
+				"revoke_failed": "Error al revocar sesiones: {message}",
+				"revoked": "Todas las sesiones han sido revocadas",
+				"role_failed": "Error al cambiar rol: {message}",
+				"role_updated": "Rol de usuario actualizado a {role}",
+				"status_failed": "Error al actualizar estado: {message}",
+				"status_updated": "Estado actualizado",
+				"unban_failed": "Error al desbloquear usuario: {message}",
+				"unbanned": "Usuario desbloqueado"
+			},
 			"total": "usuarios",
 			"unnamed": "Sin nombre",
 			"unverified": "No verificado",
@@ -199,12 +258,25 @@
 			"account": "Cuenta",
 			"billing": "Facturación",
 			"impersonating_banner": "Estás suplantando a este usuario",
+			"impersonation_stop_failed": "Error al dejar de suplantar",
+			"impersonation_stopped": "Suplantación detenida",
 			"logout": "Cerrar sesión",
 			"notifications": "Notificaciones",
 			"settings": "Configuración",
 			"stop_impersonating": "Dejar de suplantar",
 			"upgrade_pro": "Actualizar a Pro"
 		}
+	},
+	"aria": {
+		"breadcrumb": "migas de pan",
+		"change_language": "Cambiar idioma",
+		"github_repository": "Repositorio de GitHub",
+		"home": "inicio",
+		"menu_close": "Cerrar menú",
+		"menu_open": "Abrir menú",
+		"remove_attachment": "Eliminar adjunto",
+		"select_value": "Seleccionar un valor",
+		"toggle_sidebar": "Alternar barra lateral"
 	},
 	"auth": {
 		"back_to_home": "Volver al inicio",
@@ -221,41 +293,10 @@
 			"password_min_length": "La contraseña debe tener al menos {minLength} caracteres",
 			"password_number": "La contraseña debe contener al menos un número",
 			"password_required": "La contraseña es obligatoria",
-			"passwords_do_not_match": "Las contraseñas no coinciden",
 			"password_uppercase": "La contraseña debe contener al menos una letra mayúscula",
+			"passwords_do_not_match": "Las contraseñas no coinciden",
 			"signup_failed": "No se pudo crear la cuenta. Es posible que el correo electrónico ya esté en uso.",
 			"verification_invalid": "Código de verificación inválido o caducado. Por favor, inténtalo de nuevo."
-		},
-		"messages": {
-			"invalid_credentials": "Correo electrónico o contraseña inválidos",
-			"user_already_exists": "Ya existe una cuenta con este correo electrónico",
-			"email_not_verified": "Por favor verifica tu correo electrónico",
-			"invalid_token": "Token inválido o caducado",
-			"password_compromised": "Esta contraseña está comprometida",
-			"too_many_attempts": "Demasiados intentos. Inténtalo más tarde.",
-			"rate_limited": "Demasiadas solicitudes. Inténtalo más tarde.",
-			"oauth_failed": "El inicio de sesión social falló. Inténtalo de nuevo.",
-			"passkey_failed": "La autenticación con passkey falló",
-			"signup_failed": "No se pudo crear la cuenta",
-			"signup_disabled": "El registro está deshabilitado",
-			"auth_cancelled": "La autenticación fue cancelada",
-			"reset_link_sent": "Revisa tu correo para el enlace de restablecimiento.",
-			"password_reset_success": "Tu contraseña se restableció correctamente.",
-			"missing_reset_token": "Falta el token de restablecimiento o es inválido",
-			"reset_failed": "No se pudo restablecer la contraseña",
-			"request_reset_failed": "No se pudo solicitar el restablecimiento de contraseña",
-			"email_change_failed": "No se pudo cambiar el correo",
-			"email_same_as_current": "El nuevo correo debe ser diferente al actual",
-			"email_updated": "Correo actualizado correctamente",
-			"email_verification_sent": "Se envió un correo de verificación a tu dirección actual. Revisa tu bandeja de entrada para aprobar el cambio.",
-			"password_change_failed": "No se pudo cambiar la contraseña",
-			"password_changed": "Contraseña cambiada correctamente",
-			"passkey_load_failed": "No se pudieron cargar las passkeys",
-			"passkey_add_failed": "No se pudo agregar la passkey",
-			"passkey_added": "Passkey agregada correctamente",
-			"passkey_delete_failed": "No se pudo eliminar la passkey",
-			"passkey_deleted": "Passkey eliminada",
-			"generic_error": "Ocurrió un error. Inténtalo de nuevo."
 		},
 		"forgot_password": {
 			"back_to_signin": "Volver a iniciar sesión",
@@ -266,6 +307,37 @@
 		},
 		"login": "Iniciar sesión",
 		"logout": "Cerrar sesión",
+		"messages": {
+			"auth_cancelled": "La autenticación fue cancelada",
+			"email_change_failed": "No se pudo cambiar el correo",
+			"email_not_verified": "Por favor verifica tu correo electrónico",
+			"email_same_as_current": "El nuevo correo debe ser diferente al actual",
+			"email_updated": "Correo actualizado correctamente",
+			"email_verification_sent": "Se envió un correo de verificación a tu dirección actual. Revisa tu bandeja de entrada para aprobar el cambio.",
+			"generic_error": "Ocurrió un error. Inténtalo de nuevo.",
+			"invalid_credentials": "Correo electrónico o contraseña inválidos",
+			"invalid_token": "Token inválido o caducado",
+			"missing_reset_token": "Falta el token de restablecimiento o es inválido",
+			"oauth_failed": "El inicio de sesión social falló. Inténtalo de nuevo.",
+			"passkey_add_failed": "No se pudo agregar la passkey",
+			"passkey_added": "Passkey agregada correctamente",
+			"passkey_delete_failed": "No se pudo eliminar la passkey",
+			"passkey_deleted": "Passkey eliminada",
+			"passkey_failed": "La autenticación con passkey falló",
+			"passkey_load_failed": "No se pudieron cargar las passkeys",
+			"password_change_failed": "No se pudo cambiar la contraseña",
+			"password_changed": "Contraseña cambiada correctamente",
+			"password_compromised": "Esta contraseña está comprometida",
+			"password_reset_success": "Tu contraseña se restableció correctamente.",
+			"rate_limited": "Demasiadas solicitudes. Inténtalo más tarde.",
+			"request_reset_failed": "No se pudo solicitar el restablecimiento de contraseña",
+			"reset_failed": "No se pudo restablecer la contraseña",
+			"reset_link_sent": "Revisa tu correo para el enlace de restablecimiento.",
+			"signup_disabled": "El registro está deshabilitado",
+			"signup_failed": "No se pudo crear la cuenta",
+			"too_many_attempts": "Demasiados intentos. Inténtalo más tarde.",
+			"user_already_exists": "Ya existe una cuenta con este correo electrónico"
+		},
 		"reset_password": {
 			"back_to_signin": "Volver a iniciar sesión",
 			"button_loading": "Restableciendo...",
@@ -328,7 +400,31 @@
 			"title": "Verificación de correo electrónico"
 		}
 	},
+	"backend": {
+		"files": {
+			"fetch_failed": "No se pudo recuperar el archivo subido. Por favor intenta subirlo de nuevo.",
+			"type_not_allowed": "Tipo de archivo no permitido. Soportados: PNG, JPEG, WebP, GIF, PDF"
+		},
+		"support": {
+			"handoff": {
+				"response": "¡Claro! Te conecto ahora. Por favor ingresa tu email abajo y te notificaremos cuando nuestro equipo de soporte haya respondido. Mientras tanto, puedes agregar detalles adicionales que nos ayuden a asistirte mejor."
+			},
+			"rate_limit": {
+				"global": "Estoy experimentando alta demanda. Por favor intenta enviar tu mensaje de nuevo en un momento.",
+				"user": "Demasiados mensajes. Por favor espera antes de enviar otro."
+			},
+			"summary": {
+				"default": "Nueva conversación de soporte"
+			},
+			"title": {
+				"default": "Soporte al Cliente"
+			}
+		}
+	},
 	"chat": {
+		"action": {
+			"talk_to_human": "Hablar con una persona"
+		},
 		"alerts": {
 			"limit_reached": {
 				"description": "Has usado todos los {total} mensajes gratuitos de este mes.",
@@ -340,11 +436,40 @@
 				"title": "Pocos Mensajes"
 			}
 		},
+		"aria": {
+			"remove_attachment": "Eliminar {filename}",
+			"send": "Enviar"
+		},
+		"attachment": {
+			"dialog_title": "Adjunto",
+			"file_fallback": "Archivo",
+			"generic_fallback": "Adjunto",
+			"image_fallback": "Imagen"
+		},
+		"avatar": {
+			"team_member": "Miembro del equipo"
+		},
 		"buttons": {
 			"processing": "Procesando...",
 			"upgrade": "Actualizar a Pro"
 		},
 		"description": "Abre esta aplicación en múltiples ventanas del navegador para ver la base de datos en tiempo real en acción",
+		"email": {
+			"placeholder": "Email",
+			"save_failed": "Error al guardar email. Por favor intenta de nuevo.",
+			"saved_success": "¡Email guardado! Te notificaremos cuando respondamos.",
+			"subscribe_button": "Suscribirse",
+			"unsubscribe_failed": "Error al cancelar suscripción. Por favor intenta de nuevo.",
+			"unsubscribed": "Suscripción a notificaciones por email cancelada."
+		},
+		"error": {
+			"file_max_size": "Tamaño máximo es {maxSize}",
+			"file_too_large": "Archivo muy grande: \"{filename}\"",
+			"max_attachments": "Máximo {max} adjuntos permitidos",
+			"pasted_file_too_large": "Archivo pegado muy grande"
+		},
+		"greeting": "¿Cómo podemos ayudarte?",
+		"greeting_hi": "Hola",
 		"header": {
 			"messages_left": "({remaining}/{total} mensaje restante)",
 			"messages_left_plural": "({remaining}/{total} mensajes restantes)",
@@ -362,12 +487,47 @@
 			"send_failed": "Error al enviar mensaje",
 			"sent_success": "¡Mensaje enviado!"
 		},
-		"title": "Chat Comunitario"
+		"reasoning": {
+			"connecting": "Conectando...",
+			"thinking": "Pensando...",
+			"thought_for_few_seconds": "Pensó durante unos segundos",
+			"thought_for_seconds": "Pensó durante {duration} segundo",
+			"thought_for_seconds_plural": "Pensó durante {duration} segundos"
+		},
+		"suggestion": {
+			"help_label": "Obtener ayuda",
+			"help_text": "¿Puedes ayudarme con...",
+			"issue_label": "Reportar un problema",
+			"issue_text": "Encontré un problema con...",
+			"question_label": "Hacer una pregunta",
+			"question_text": "Tengo una pregunta sobre..."
+		},
+		"title": "Chat Comunitario",
+		"tooltip": {
+			"attach_files": "Adjuntar archivos",
+			"mark_bug": "Marcar el error"
+		}
 	},
 	"common": {
 		"adding": "Agregando...",
 		"cancel": "Cancelar",
 		"confirm": "Confirmar"
+	},
+	"email": {
+		"body": {
+			"no_messages": "Sin mensajes",
+			"ticket_message": "{userName} ha enviado un nuevo mensaje a un ticket previamente cerrado",
+			"ticket_new": "Nuevo ticket de soporte",
+			"ticket_reopened": "Ticket de soporte reabierto",
+			"ticket_started": "{userName} ha iniciado una nueva conversación de soporte"
+		},
+		"subject": {
+			"reset_password": "Restablecer tu contraseña",
+			"support_reply": "Nueva respuesta a tu solicitud de soporte",
+			"ticket_new": "Nuevo ticket de soporte de {userName}",
+			"ticket_reopened": "Ticket de soporte reabierto por {userName}",
+			"verify": "Verifica tu email"
+		}
 	},
 	"hero": {
 		"companies_text": "Impulsando a los mejores equipos",
@@ -526,9 +686,21 @@
 	},
 	"settings": {
 		"account": {
+			"avatar": {
+				"alt": "Vista previa del perfil",
+				"ready": "Imagen lista para guardar",
+				"removed": "Imagen eliminada - haz clic en Guardar para confirmar",
+				"select_error": "Por favor selecciona un archivo de imagen",
+				"size_error": "La imagen debe ser menor de {size}",
+				"upload_failed": "Error al subir la imagen"
+			},
 			"description": "Actualiza la información de tu cuenta aquí.",
+			"error": "Error al actualizar el perfil",
 			"file_helper": "PNG, JPG o GIF hasta 2MB.",
 			"link_from_url": "Enlace desde URL",
+			"name": {
+				"placeholder": "Tu nombre"
+			},
 			"name_helper": "Este es tu nombre público.",
 			"name_label": "Nombre",
 			"no_image": "Sin imagen",
@@ -538,9 +710,11 @@
 			"remove_button": "Eliminar",
 			"save_button": "Guardar cambios",
 			"saving": "Guardando...",
+			"success": "Perfil actualizado correctamente",
 			"title": "Información de la cuenta",
 			"upload_file": "Subir archivo",
-			"url_helper": "Pega un enlace de imagen en lugar de subir."
+			"url_helper": "Pega un enlace de imagen en lugar de subir.",
+			"url_placeholder": "https://example.com/avatar.jpg"
 		},
 		"description": "Administra la configuración de tu cuenta y preferencias.",
 		"email": {
@@ -550,6 +724,7 @@
 			"new_email_label": "Nueva dirección de correo",
 			"not_verified_description": "Tu correo actual no está verificado. El nuevo correo se actualizará inmediatamente sin verificación.",
 			"not_verified_title": "Correo no verificado",
+			"placeholder": "Ingresa nueva dirección de email",
 			"title": "Dirección de correo electrónico",
 			"unverified_badge": "No verificado",
 			"update_button": "Actualizar correo",
@@ -565,6 +740,11 @@
 			"error_title": "Error",
 			"new_password_label": "Nueva contraseña",
 			"password_helper": "Debe tener al menos 8 caracteres.",
+			"placeholder": {
+				"confirm": "Confirmar nueva contraseña",
+				"current": "Ingresa contraseña actual",
+				"new": "Ingresa nueva contraseña"
+			},
 			"revoke_sessions_label": "Cerrar sesión en todos los demás dispositivos",
 			"security_notice_description": "Cambiar tu contraseña requerirá que inicies sesión nuevamente en todos los dispositivos a menos que desmarques la opción anterior.",
 			"security_notice_title": "Aviso de seguridad",
@@ -574,14 +754,18 @@
 		},
 		"security": {
 			"add_button": "Añadir Passkey",
-			"adding": "Añadiendo...",
 			"add_passkey_helper": "Dale un nombre a tu passkey para identificar en qué dispositivo está registrado.",
 			"add_passkey_title": "Añadir un Passkey",
+			"adding": "Añadiendo...",
 			"created_at": "Creado ",
 			"description": "Administra tus passkeys y configuración de seguridad.",
 			"error_title": "Error",
 			"loading": "Cargando passkeys...",
 			"no_passkeys": "Aún no has registrado ningún passkey.",
+			"passkey": {
+				"placeholder": "Nombre del passkey (opcional)",
+				"unnamed": "Passkey sin nombre"
+			},
 			"passkey_info_description": "Los passkeys son una forma segura de iniciar sesión sin contraseña. Utilizan biometría o PIN del dispositivo y se almacenan de forma segura en tus dispositivos.",
 			"passkey_info_title": "¿Qué son los Passkeys?",
 			"passkey_name_label": "Nombre del passkey",
@@ -595,6 +779,84 @@
 			"security": "Seguridad"
 		},
 		"title": "Configuración"
+	},
+	"support": {
+		"avatar": {
+			"team_member": "Miembro del equipo"
+		},
+		"button": {
+			"start_new_conversation": "Iniciar nueva conversación"
+		},
+		"chatbar": {
+			"placeholder": "Pregúntame lo que quieras..."
+		},
+		"greeting": {
+			"hi": "Hola",
+			"how_can_we_help": "¿Cómo podemos ayudarte hoy?"
+		},
+		"header": {
+			"support_team": "Equipo de Soporte"
+		},
+		"message": {
+			"role_kai": "Kai",
+			"role_support": "Soporte",
+			"role_you": "Tú"
+		},
+		"screenshot": {
+			"action": {
+				"cancel": "Cancelar (Esc)",
+				"redo": "Rehacer (Ctrl+Shift+Z)",
+				"undo": "Deshacer (Ctrl+Z)"
+			},
+			"aria_label": "Editor de captura de pantalla",
+			"capture_failed": "Error al capturar pantalla. Revisa la consola para más detalles.",
+			"capturing": "Capturando...",
+			"next": "Siguiente",
+			"tool": {
+				"arrow": "Flecha (A)",
+				"circle": "Círculo (C)",
+				"color": "Cambiar color",
+				"pen": "Lápiz (P)",
+				"rectangle": "Rectángulo (R)"
+			}
+		},
+		"suggestion": {
+			"bug_report_label": "Reportar un problema",
+			"bug_report_text": "¡Encontré un error!",
+			"feature_request_label": "Solicitar una función",
+			"feature_request_text": "Me gustaría ver",
+			"help_label": "Ayúdame con...",
+			"help_text": "Ayúdame a configurar el proyecto.",
+			"question_label": "Hacer una pregunta",
+			"question_text": "¿Por qué SaaS Starter?"
+		},
+		"thread": {
+			"new_conversation": "Nueva conversación"
+		},
+		"time": {
+			"days_ago": "hace {days} días",
+			"few_seconds_ago": "hace unos segundos",
+			"hours_ago": "hace {hours} horas",
+			"just_now": "justo ahora",
+			"minutes_ago": "hace {minutes} minutos",
+			"one_hour_ago": "hace 1 hora",
+			"one_minute_ago": "hace 1 minuto",
+			"yesterday": "ayer"
+		},
+		"widget": {
+			"error": {
+				"rate_limit": "¡Más despacio! Por favor espera {seconds}s antes de enviar otro mensaje.",
+				"send_failed": "Error al enviar mensaje. Por favor intenta de nuevo."
+			},
+			"header": {
+				"bot_response": "Nuestro bot responderá al instante",
+				"messages": "Mensajes",
+				"with_team": "Tu solicitud está con nuestro equipo"
+			},
+			"input": {
+				"placeholder": "Escribe un mensaje o haz clic en una sugerencia..."
+			}
+		}
 	},
 	"team": {
 		"description": "Durante el proceso de trabajo, realizamos ajustes regulares con el cliente porque él es la única persona que puede sentir si un traje nuevo le queda bien o no.",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -31,9 +31,9 @@
 		"metrics": {
 			"active_sessions": "Actifs (24h)",
 			"active_sessions_desc": "Actifs au cours des 24 dernières heures",
+			"admin_users": "Gestion de la plateforme",
 			"admins": "Admins",
 			"admins_desc": "Utilisateurs avec privilèges admin",
-			"admin_users": "Gestion de la plateforme",
 			"banned_users": "Utilisateurs Bannis",
 			"banned_users_desc": "Accès restreint",
 			"currently_active": "Activité quotidienne",
@@ -69,8 +69,8 @@
 			"delete_email_description": "Supprimer {email} des destinataires de notifications ?",
 			"delete_email_title": "Supprimer l'Email",
 			"description": "Configurez les paramètres du panneau d'administration et les notifications.",
-			"email_added": "Email ajouté",
 			"email_add_failed": "Impossible d'ajouter l'email",
+			"email_added": "Email ajouté",
 			"email_exists": "Cet email existe déjà",
 			"email_removed": "Email supprimé",
 			"field_new_signups": "Notifications de nouvelles inscriptions",
@@ -115,6 +115,13 @@
 		},
 		"support": {
 			"all_statuses": "Tous les statuts",
+			"assignee": {
+				"not_assigned": "Non assigné",
+				"unassigned": "Non assigné"
+			},
+			"chat": {
+				"placeholder": "Répondre au client..."
+			},
 			"details": {
 				"assignee": "Assigné à",
 				"close_panel": "Fermer le panneau des détails",
@@ -127,6 +134,13 @@
 				"user_notes": "Notes Utilisateur",
 				"user_notes_description": "Les notes sont enregistrées au niveau de l utilisateur et apparaissent dans tous leurs fils de support"
 			},
+			"email": {
+				"label": "Email de notification"
+			},
+			"fallback": {
+				"admin": "Admin",
+				"no_user": "Aucun utilisateur associé à ce fil"
+			},
 			"filter": {
 				"all": "Tous",
 				"my_inbox": "Ma boîte de réception",
@@ -135,22 +149,45 @@
 			"no_chats": "Aucun chat trouvé",
 			"no_done_chats": "Aucun chat terminé",
 			"no_open_chats": "Aucun chat ouvert",
+			"note": {
+				"add": "Ajouter une note",
+				"adding": "Ajout en cours...",
+				"placeholder": "Ajouter une note interne..."
+			},
 			"priority": {
 				"high": "Haute",
 				"low": "Basse",
-				"medium": "Moyenne"
+				"medium": "Moyenne",
+				"none": "Aucune"
+			},
+			"search": {
+				"placeholder": "Rechercher des chats..."
 			},
 			"select_chat": "Sélectionnez un chat pour voir la conversation",
 			"select_chat_for_details": "Sélectionnez un chat pour voir les détails",
 			"status": {
 				"done": "Terminé",
-				"open": "Ouvert"
+				"in_progress": "En cours",
+				"open": "Ouvert",
+				"resolved": "Résolu"
+			},
+			"thread": {
+				"badge": {
+					"new": "Nouveau"
+				},
+				"load_failed": "Échec du chargement",
+				"loading": "Chargement...",
+				"no_messages": "Aucun message",
+				"retry": "Réessayer"
 			},
 			"title": "Chats de Support"
 		},
 		"title": "Panneau Admin",
 		"users": {
 			"actions_column": "Actions",
+			"ban_reason": {
+				"default": "Violation des conditions d'utilisation"
+			},
 			"banned": "Banni",
 			"created": "Créé",
 			"email": "E-mail",
@@ -159,7 +196,10 @@
 				"all_status": "Tous les statuts",
 				"clear": "Effacer",
 				"role_admin": "Admin",
-				"role_user": "Utilisateur"
+				"role_user": "Utilisateur",
+				"status_banned": "Banni",
+				"status_unverified": "Non vérifié",
+				"status_verified": "Vérifié"
 			},
 			"loading": "Chargement des utilisateurs...",
 			"menu_open": "Ouvrir le menu",
@@ -176,10 +216,29 @@
 			"rows_per_page": "Lignes par page",
 			"search_placeholder": "Rechercher des utilisateurs...",
 			"select_all": "Tout sélectionner",
-			"selected": "{selected} sur {total} utilisateurs sélectionnés",
 			"select_row": "Sélectionner la ligne",
+			"selected": "{selected} sur {total} utilisateurs sélectionnés",
 			"status": "Statut",
 			"title": "Gestion des Utilisateurs",
+			"toast": {
+				"assignment_failed": "Échec de la mise à jour de l'assignation : {message}",
+				"assignment_updated": "Assignation mise à jour",
+				"ban_failed": "Échec du bannissement : {message}",
+				"banned": "Utilisateur banni",
+				"impersonate_failed": "Échec de l'usurpation : {message}",
+				"note_added": "Note ajoutée",
+				"note_failed": "Échec de l'ajout de la note : {message}",
+				"priority_failed": "Échec de la mise à jour de la priorité : {message}",
+				"priority_updated": "Priorité mise à jour",
+				"revoke_failed": "Échec de la révocation des sessions : {message}",
+				"revoked": "Toutes les sessions ont été révoquées",
+				"role_failed": "Échec du changement de rôle : {message}",
+				"role_updated": "Rôle de l'utilisateur changé en {role}",
+				"status_failed": "Échec de la mise à jour du statut : {message}",
+				"status_updated": "Statut mis à jour",
+				"unban_failed": "Échec du débannissement : {message}",
+				"unbanned": "Utilisateur débanni"
+			},
 			"total": "utilisateurs",
 			"unnamed": "Sans nom",
 			"unverified": "Non vérifié",
@@ -199,12 +258,25 @@
 			"account": "Compte",
 			"billing": "Facturation",
 			"impersonating_banner": "Vous usurpez l'identité de cet utilisateur",
+			"impersonation_stop_failed": "Échec de l'arrêt de l'usurpation",
+			"impersonation_stopped": "Usurpation arrêtée",
 			"logout": "Se déconnecter",
 			"notifications": "Notifications",
 			"settings": "Paramètres",
 			"stop_impersonating": "Arrêter l'usurpation",
 			"upgrade_pro": "Passer à Pro"
 		}
+	},
+	"aria": {
+		"breadcrumb": "fil d'Ariane",
+		"change_language": "Changer la langue",
+		"github_repository": "Dépôt GitHub",
+		"home": "accueil",
+		"menu_close": "Fermer le menu",
+		"menu_open": "Ouvrir le menu",
+		"remove_attachment": "Supprimer la pièce jointe",
+		"select_value": "Sélectionner une valeur",
+		"toggle_sidebar": "Basculer la barre latérale"
 	},
 	"auth": {
 		"back_to_home": "Retour à l'accueil",
@@ -221,41 +293,10 @@
 			"password_min_length": "Le mot de passe doit contenir au moins {minLength} caractères",
 			"password_number": "Le mot de passe doit contenir au moins un chiffre",
 			"password_required": "Le mot de passe est requis",
-			"passwords_do_not_match": "Les mots de passe ne correspondent pas",
 			"password_uppercase": "Le mot de passe doit contenir au moins une lettre majuscule",
+			"passwords_do_not_match": "Les mots de passe ne correspondent pas",
 			"signup_failed": "Impossible de créer le compte. L'e-mail est peut-être déjà utilisé.",
 			"verification_invalid": "Code de vérification invalide ou expiré. Veuillez réessayer."
-		},
-		"messages": {
-			"invalid_credentials": "E-mail ou mot de passe invalide",
-			"user_already_exists": "Un compte avec cet e-mail existe déjà",
-			"email_not_verified": "Veuillez vérifier votre adresse e-mail",
-			"invalid_token": "Jeton invalide ou expiré",
-			"password_compromised": "Ce mot de passe est compromis",
-			"too_many_attempts": "Trop de tentatives. Réessayez plus tard.",
-			"rate_limited": "Trop de requêtes. Réessayez plus tard.",
-			"oauth_failed": "La connexion sociale a échoué. Veuillez réessayer.",
-			"passkey_failed": "L'authentification par passkey a échoué",
-			"signup_failed": "Impossible de créer le compte",
-			"signup_disabled": "L'inscription est désactivée",
-			"auth_cancelled": "L'authentification a été annulée",
-			"reset_link_sent": "Vérifiez votre e-mail pour le lien de réinitialisation.",
-			"password_reset_success": "Votre mot de passe a été réinitialisé avec succès.",
-			"missing_reset_token": "Jeton de réinitialisation manquant ou invalide",
-			"reset_failed": "Impossible de réinitialiser le mot de passe",
-			"request_reset_failed": "Impossible de demander la réinitialisation du mot de passe",
-			"email_change_failed": "Impossible de modifier l'e-mail",
-			"email_same_as_current": "Le nouvel e-mail doit être différent de l'actuel",
-			"email_updated": "E-mail mis à jour avec succès",
-			"email_verification_sent": "Un e-mail de vérification a été envoyé à votre adresse actuelle. Vérifiez votre boîte de réception pour approuver le changement.",
-			"password_change_failed": "Impossible de changer le mot de passe",
-			"password_changed": "Mot de passe modifié avec succès",
-			"passkey_load_failed": "Impossible de charger les passkeys",
-			"passkey_add_failed": "Impossible d'ajouter la passkey",
-			"passkey_added": "Passkey ajoutée avec succès",
-			"passkey_delete_failed": "Impossible de supprimer la passkey",
-			"passkey_deleted": "Passkey supprimée",
-			"generic_error": "Une erreur est survenue. Veuillez réessayer."
 		},
 		"forgot_password": {
 			"back_to_signin": "Retour à la connexion",
@@ -266,6 +307,37 @@
 		},
 		"login": "Connexion",
 		"logout": "Déconnexion",
+		"messages": {
+			"auth_cancelled": "L'authentification a été annulée",
+			"email_change_failed": "Impossible de modifier l'e-mail",
+			"email_not_verified": "Veuillez vérifier votre adresse e-mail",
+			"email_same_as_current": "Le nouvel e-mail doit être différent de l'actuel",
+			"email_updated": "E-mail mis à jour avec succès",
+			"email_verification_sent": "Un e-mail de vérification a été envoyé à votre adresse actuelle. Vérifiez votre boîte de réception pour approuver le changement.",
+			"generic_error": "Une erreur est survenue. Veuillez réessayer.",
+			"invalid_credentials": "E-mail ou mot de passe invalide",
+			"invalid_token": "Jeton invalide ou expiré",
+			"missing_reset_token": "Jeton de réinitialisation manquant ou invalide",
+			"oauth_failed": "La connexion sociale a échoué. Veuillez réessayer.",
+			"passkey_add_failed": "Impossible d'ajouter la passkey",
+			"passkey_added": "Passkey ajoutée avec succès",
+			"passkey_delete_failed": "Impossible de supprimer la passkey",
+			"passkey_deleted": "Passkey supprimée",
+			"passkey_failed": "L'authentification par passkey a échoué",
+			"passkey_load_failed": "Impossible de charger les passkeys",
+			"password_change_failed": "Impossible de changer le mot de passe",
+			"password_changed": "Mot de passe modifié avec succès",
+			"password_compromised": "Ce mot de passe est compromis",
+			"password_reset_success": "Votre mot de passe a été réinitialisé avec succès.",
+			"rate_limited": "Trop de requêtes. Réessayez plus tard.",
+			"request_reset_failed": "Impossible de demander la réinitialisation du mot de passe",
+			"reset_failed": "Impossible de réinitialiser le mot de passe",
+			"reset_link_sent": "Vérifiez votre e-mail pour le lien de réinitialisation.",
+			"signup_disabled": "L'inscription est désactivée",
+			"signup_failed": "Impossible de créer le compte",
+			"too_many_attempts": "Trop de tentatives. Réessayez plus tard.",
+			"user_already_exists": "Un compte avec cet e-mail existe déjà"
+		},
 		"reset_password": {
 			"back_to_signin": "Retour à la connexion",
 			"button_loading": "Réinitialisation...",
@@ -328,7 +400,31 @@
 			"title": "Vérification de l'e-mail"
 		}
 	},
+	"backend": {
+		"files": {
+			"fetch_failed": "Impossible de récupérer le fichier téléchargé. Veuillez réessayer.",
+			"type_not_allowed": "Type de fichier non autorisé. Formats supportés : PNG, JPEG, WebP, GIF, PDF"
+		},
+		"support": {
+			"handoff": {
+				"response": "Bien sûr ! Je vous connecte maintenant. Veuillez entrer votre email ci-dessous et nous vous notifierons quand notre équipe de support aura répondu. En attendant, n'hésitez pas à ajouter des détails supplémentaires qui pourraient nous aider."
+			},
+			"rate_limit": {
+				"global": "Je suis actuellement très sollicité. Veuillez réessayer d'envoyer votre message dans un instant.",
+				"user": "Trop de messages. Veuillez patienter avant d'en envoyer un autre."
+			},
+			"summary": {
+				"default": "Nouvelle conversation de support"
+			},
+			"title": {
+				"default": "Support Client"
+			}
+		}
+	},
 	"chat": {
+		"action": {
+			"talk_to_human": "Parler à un humain"
+		},
 		"alerts": {
 			"limit_reached": {
 				"description": "Vous avez utilisé tous vos {total} messages gratuits de ce mois.",
@@ -340,11 +436,40 @@
 				"title": "Peu de Messages"
 			}
 		},
+		"aria": {
+			"remove_attachment": "Supprimer {filename}",
+			"send": "Envoyer"
+		},
+		"attachment": {
+			"dialog_title": "Pièce jointe",
+			"file_fallback": "Fichier",
+			"generic_fallback": "Pièce jointe",
+			"image_fallback": "Image"
+		},
+		"avatar": {
+			"team_member": "Membre de l'équipe"
+		},
 		"buttons": {
 			"processing": "Traitement...",
 			"upgrade": "Passer à Pro"
 		},
 		"description": "Ouvrez cette application dans plusieurs fenêtres de navigateur pour voir la base de données en temps réel en action",
+		"email": {
+			"placeholder": "Email",
+			"save_failed": "Échec de l'enregistrement de l'email. Veuillez réessayer.",
+			"saved_success": "Email enregistré ! Nous vous notifierons lorsque nous répondrons.",
+			"subscribe_button": "S'abonner",
+			"unsubscribe_failed": "Échec du désabonnement. Veuillez réessayer.",
+			"unsubscribed": "Désabonné des notifications par email."
+		},
+		"error": {
+			"file_max_size": "Taille maximale : {maxSize}",
+			"file_too_large": "Fichier trop volumineux : \"{filename}\"",
+			"max_attachments": "Maximum {max} pièces jointes autorisées",
+			"pasted_file_too_large": "Fichier collé trop volumineux"
+		},
+		"greeting": "Comment pouvons-nous vous aider ?",
+		"greeting_hi": "Bonjour",
 		"header": {
 			"messages_left": "({remaining}/{total} message restant)",
 			"messages_left_plural": "({remaining}/{total} messages restants)",
@@ -362,12 +487,47 @@
 			"send_failed": "Échec de l'envoi du message",
 			"sent_success": "Message envoyé !"
 		},
-		"title": "Chat Communautaire"
+		"reasoning": {
+			"connecting": "Connexion...",
+			"thinking": "Réflexion...",
+			"thought_for_few_seconds": "A réfléchi pendant quelques secondes",
+			"thought_for_seconds": "A réfléchi pendant {duration} seconde",
+			"thought_for_seconds_plural": "A réfléchi pendant {duration} secondes"
+		},
+		"suggestion": {
+			"help_label": "Obtenir de l'aide",
+			"help_text": "Pouvez-vous m'aider avec...",
+			"issue_label": "Signaler un problème",
+			"issue_text": "J'ai trouvé un problème avec...",
+			"question_label": "Poser une question",
+			"question_text": "J'ai une question sur..."
+		},
+		"title": "Chat Communautaire",
+		"tooltip": {
+			"attach_files": "Joindre des fichiers",
+			"mark_bug": "Marquer le bug"
+		}
 	},
 	"common": {
 		"adding": "Ajout en cours...",
 		"cancel": "Annuler",
 		"confirm": "Confirmer"
+	},
+	"email": {
+		"body": {
+			"no_messages": "Aucun message",
+			"ticket_message": "{userName} a envoyé un nouveau message sur un ticket précédemment fermé",
+			"ticket_new": "Nouveau ticket de support",
+			"ticket_reopened": "Ticket de support rouvert",
+			"ticket_started": "{userName} a démarré une nouvelle conversation de support"
+		},
+		"subject": {
+			"reset_password": "Réinitialisez votre mot de passe",
+			"support_reply": "Nouvelle réponse à votre demande de support",
+			"ticket_new": "Nouveau ticket de support de {userName}",
+			"ticket_reopened": "Ticket de support rouvert par {userName}",
+			"verify": "Vérifiez votre email"
+		}
 	},
 	"hero": {
 		"companies_text": "Propulsant les meilleures équipes",
@@ -526,9 +686,21 @@
 	},
 	"settings": {
 		"account": {
+			"avatar": {
+				"alt": "Aperçu du profil",
+				"ready": "Image prête à enregistrer",
+				"removed": "Image supprimée - cliquez sur Enregistrer pour confirmer",
+				"select_error": "Veuillez sélectionner un fichier image",
+				"size_error": "L'image doit être inférieure à {size}",
+				"upload_failed": "Échec du téléchargement de l'image"
+			},
 			"description": "Mettez à jour les informations de votre compte ici.",
+			"error": "Échec de la mise à jour du profil",
 			"file_helper": "PNG, JPG ou GIF jusqu'à 2 Mo.",
 			"link_from_url": "Lien depuis URL",
+			"name": {
+				"placeholder": "Votre nom"
+			},
 			"name_helper": "C'est votre nom d'affichage public.",
 			"name_label": "Nom",
 			"no_image": "Pas d'image",
@@ -538,9 +710,11 @@
 			"remove_button": "Supprimer",
 			"save_button": "Enregistrer",
 			"saving": "Enregistrement...",
+			"success": "Profil mis à jour avec succès",
 			"title": "Informations du compte",
 			"upload_file": "Télécharger un fichier",
-			"url_helper": "Collez un lien d'image au lieu de télécharger."
+			"url_helper": "Collez un lien d'image au lieu de télécharger.",
+			"url_placeholder": "https://example.com/avatar.jpg"
 		},
 		"description": "Gérez les paramètres et préférences de votre compte.",
 		"email": {
@@ -550,6 +724,7 @@
 			"new_email_label": "Nouvelle adresse e-mail",
 			"not_verified_description": "Votre e-mail actuel n'est pas vérifié. Le nouvel e-mail sera mis à jour immédiatement sans vérification.",
 			"not_verified_title": "E-mail non vérifié",
+			"placeholder": "Entrez la nouvelle adresse email",
 			"title": "Adresse e-mail",
 			"unverified_badge": "Non vérifié",
 			"update_button": "Mettre à jour l'e-mail",
@@ -565,6 +740,11 @@
 			"error_title": "Erreur",
 			"new_password_label": "Nouveau mot de passe",
 			"password_helper": "Doit contenir au moins 8 caractères.",
+			"placeholder": {
+				"confirm": "Confirmez le nouveau mot de passe",
+				"current": "Entrez le mot de passe actuel",
+				"new": "Entrez le nouveau mot de passe"
+			},
 			"revoke_sessions_label": "Se déconnecter de tous les autres appareils",
 			"security_notice_description": "Changer votre mot de passe vous obligera à vous reconnecter sur tous les appareils, sauf si vous décochez l'option ci-dessus.",
 			"security_notice_title": "Avis de sécurité",
@@ -574,14 +754,18 @@
 		},
 		"security": {
 			"add_button": "Ajouter un Passkey",
-			"adding": "Ajout en cours...",
 			"add_passkey_helper": "Donnez un nom à votre passkey pour identifier sur quel appareil il est enregistré.",
 			"add_passkey_title": "Ajouter un Passkey",
+			"adding": "Ajout en cours...",
 			"created_at": "Créé le ",
 			"description": "Gérez vos passkeys et paramètres de sécurité.",
 			"error_title": "Erreur",
 			"loading": "Chargement des passkeys...",
 			"no_passkeys": "Vous n'avez pas encore enregistré de passkey.",
+			"passkey": {
+				"placeholder": "Nom du passkey (optionnel)",
+				"unnamed": "Passkey sans nom"
+			},
 			"passkey_info_description": "Les passkeys sont un moyen sécurisé de se connecter sans mot de passe. Ils utilisent la biométrie ou le code PIN de l'appareil et sont stockés en toute sécurité sur vos appareils.",
 			"passkey_info_title": "Que sont les Passkeys ?",
 			"passkey_name_label": "Nom du passkey",
@@ -595,6 +779,84 @@
 			"security": "Sécurité"
 		},
 		"title": "Paramètres"
+	},
+	"support": {
+		"avatar": {
+			"team_member": "Membre de l'équipe"
+		},
+		"button": {
+			"start_new_conversation": "Démarrer une nouvelle conversation"
+		},
+		"chatbar": {
+			"placeholder": "Posez-moi une question…"
+		},
+		"greeting": {
+			"hi": "Salut",
+			"how_can_we_help": "Comment pouvons-nous vous aider aujourd'hui ?"
+		},
+		"header": {
+			"support_team": "Équipe de Support"
+		},
+		"message": {
+			"role_kai": "Kai",
+			"role_support": "Support",
+			"role_you": "Vous"
+		},
+		"screenshot": {
+			"action": {
+				"cancel": "Annuler (Échap)",
+				"redo": "Rétablir (Ctrl+Maj+Z)",
+				"undo": "Annuler (Ctrl+Z)"
+			},
+			"aria_label": "Éditeur de capture d'écran",
+			"capture_failed": "Échec de la capture d'écran. Consultez la console pour plus de détails.",
+			"capturing": "Capture en cours...",
+			"next": "Suivant",
+			"tool": {
+				"arrow": "Flèche (A)",
+				"circle": "Cercle (C)",
+				"color": "Changer la couleur",
+				"pen": "Stylo (P)",
+				"rectangle": "Rectangle (R)"
+			}
+		},
+		"suggestion": {
+			"bug_report_label": "Signaler un problème",
+			"bug_report_text": "J'ai trouvé un bug !",
+			"feature_request_label": "Demander une fonctionnalité",
+			"feature_request_text": "J'aimerais voir",
+			"help_label": "Aidez-moi avec...",
+			"help_text": "Aidez-moi à configurer le projet.",
+			"question_label": "Poser une question",
+			"question_text": "Pourquoi SaaS Starter ?"
+		},
+		"thread": {
+			"new_conversation": "Nouvelle conversation"
+		},
+		"time": {
+			"days_ago": "il y a {days} jours",
+			"few_seconds_ago": "il y a quelques secondes",
+			"hours_ago": "il y a {hours} heures",
+			"just_now": "à l'instant",
+			"minutes_ago": "il y a {minutes} minutes",
+			"one_hour_ago": "il y a 1 heure",
+			"one_minute_ago": "il y a 1 minute",
+			"yesterday": "hier"
+		},
+		"widget": {
+			"error": {
+				"rate_limit": "Doucement ! Veuillez attendre {seconds}s avant d'envoyer un autre message.",
+				"send_failed": "Échec de l'envoi du message. Veuillez réessayer."
+			},
+			"header": {
+				"bot_response": "Notre bot répondra instantanément",
+				"messages": "Messages",
+				"with_team": "Votre demande est auprès de notre équipe"
+			},
+			"input": {
+				"placeholder": "Tapez un message ou cliquez sur une suggestion..."
+			}
+		}
 	},
 	"team": {
 		"description": "Pendant le processus de travail, nous effectuons des ajustements réguliers avec le client car il est la seule personne qui peut sentir si un nouveau costume lui va bien ou non.",

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -8,3 +8,18 @@ export const authClient = createAuthClient({
 	baseURL: browser ? window.location.origin : undefined,
 	plugins: [convexClient(), passkeyClient(), adminClient()]
 });
+
+/**
+ * Update user with additional fields like locale.
+ * This is a typed wrapper around authClient.updateUser that includes
+ * additional fields defined in the server's user.additionalFields config.
+ */
+export async function updateUserWithLocale(data: {
+	name?: string;
+	image?: string | null;
+	locale?: string;
+}): Promise<void> {
+	// Cast to bypass TypeScript since additionalFields are defined on the server
+	// but not automatically inferred by the client
+	await authClient.updateUser(data as Parameters<typeof authClient.updateUser>[0]);
+}

--- a/src/lib/chat/core/FileUploader.ts
+++ b/src/lib/chat/core/FileUploader.ts
@@ -44,6 +44,7 @@ export async function uploadFileWithProgress(
 	api: {
 		generateUploadUrl: Parameters<ConvexClient['mutation']>[0];
 		saveUploadedFile: Parameters<ConvexClient['action']>[0];
+		locale?: string;
 	}
 ): Promise<UploadResult> {
 	// 1. Generate upload URL
@@ -56,7 +57,8 @@ export async function uploadFileWithProgress(
 	const result = await client.action(api.saveUploadedFile, {
 		storageId,
 		filename,
-		mimeType: file.type
+		mimeType: file.type,
+		locale: api.locale
 	});
 
 	// Ensure progress is 100% after completion

--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import { X, File as FileIcon, Image as ImageIcon, LoaderCircle } from '@lucide/svelte';
+	import { getTranslate } from '@tolgee/svelte';
 	import Progress from '$lib/components/ui/progress/progress.svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import type { Attachment, UploadState } from '../core/types.js';
 	import type { ChatAlignment } from './ChatContext.svelte.js';
+
+	const { t } = getTranslate();
 
 	let {
 		attachments = [],
@@ -35,9 +38,10 @@
 	function getFilename(attachment: Attachment): string {
 		if (attachment.type === 'file') return attachment.name;
 		if (attachment.type === 'screenshot') return attachment.name;
-		if (attachment.type === 'image') return attachment.filename || 'Image';
+		if (attachment.type === 'image')
+			return attachment.filename || $t('chat.attachment.image_fallback');
 		if (attachment.type === 'remote-file') return attachment.filename;
-		return 'Attachment';
+		return $t('chat.attachment.generic_fallback');
 	}
 
 	/**
@@ -90,7 +94,9 @@
 	<Dialog.Content>
 		<Dialog.Header>
 			<Dialog.Title
-				>{selectedAttachment ? getFilename(selectedAttachment) : 'Attachment'}</Dialog.Title
+				>{selectedAttachment
+					? getFilename(selectedAttachment)
+					: $t('chat.attachment.dialog_title')}</Dialog.Title
 			>
 		</Dialog.Header>
 		{#if selectedAttachment}
@@ -169,7 +175,7 @@
 						}}
 						class="shrink-0 rounded-full p-1 hover:bg-secondary/50"
 						type="button"
-						aria-label="Remove {filename}"
+						aria-label={$t('chat.aria.remove_attachment', { filename })}
 					>
 						<X class="size-4" />
 					</button>

--- a/src/lib/chat/ui/ChatContext.svelte.ts
+++ b/src/lib/chat/ui/ChatContext.svelte.ts
@@ -24,6 +24,8 @@ export type ChatAlignment = 'left' | 'right';
 export interface UploadConfig {
 	generateUploadUrl: Parameters<ConvexClient['mutation']>[0];
 	saveUploadedFile: Parameters<ConvexClient['action']>[0];
+	/** Locale for translated error messages */
+	locale?: string;
 }
 
 /**

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import { toast } from 'svelte-sonner';
+	import { getTranslate } from '@tolgee/svelte';
 	import {
 		PromptInput,
 		PromptInputAction,
@@ -20,6 +21,8 @@
 		MAX_FILE_SIZE,
 		MAX_FILE_SIZE_LABEL
 	} from '../core/types.js';
+
+	const { t } = getTranslate();
 
 	let {
 		suggestions = [],
@@ -107,13 +110,13 @@
 		for (const file of files) {
 			// Check attachment limit
 			if (ctx.attachments.length >= MAX_ATTACHMENTS) {
-				toast.error(`Maximum ${MAX_ATTACHMENTS} attachments allowed`);
+				toast.error($t('chat.error.max_attachments', { max: MAX_ATTACHMENTS }));
 				break;
 			}
 			// Check file size
 			if (file.size > MAX_FILE_SIZE) {
-				toast.error(`File too large: "${file.name}"`, {
-					description: `Maximum size is ${MAX_FILE_SIZE_LABEL}`
+				toast.error($t('chat.error.file_too_large', { filename: file.name }), {
+					description: $t('chat.error.file_max_size', { maxSize: MAX_FILE_SIZE_LABEL })
 				});
 				continue;
 			}
@@ -144,7 +147,7 @@
 
 			// Check attachment limit
 			if (ctx.attachments.length >= MAX_ATTACHMENTS) {
-				toast.error(`Maximum ${MAX_ATTACHMENTS} attachments allowed`);
+				toast.error($t('chat.error.max_attachments', { max: MAX_ATTACHMENTS }));
 				break;
 			}
 
@@ -153,8 +156,8 @@
 
 			// Validate file size
 			if (file.size > MAX_FILE_SIZE) {
-				toast.error('Pasted file too large', {
-					description: `Maximum size is ${MAX_FILE_SIZE_LABEL}`
+				toast.error($t('chat.error.pasted_file_too_large'), {
+					description: $t('chat.error.file_max_size', { maxSize: MAX_FILE_SIZE_LABEL })
 				});
 				continue;
 			}
@@ -219,7 +222,7 @@
 					{#if showCameraButton}
 						<PromptInputAction>
 							{#snippet tooltip()}
-								<p>Mark the bug</p>
+								<p>{$t('chat.tooltip.mark_bug')}</p>
 							{/snippet}
 							{#snippet children(props)}
 								<Button
@@ -242,7 +245,7 @@
 						>
 							<PromptInputAction>
 								{#snippet tooltip()}
-									<p>Attach files</p>
+									<p>{$t('chat.tooltip.attach_files')}</p>
 								{/snippet}
 								{#snippet children(props)}
 									<FileUploadTrigger asChild={true}>
@@ -260,7 +263,7 @@
 			{#if actionsRight}
 				{@render actionsRight()}
 			{:else}
-				<div class="flex items-center gap-2">
+				<div class="flex min-w-0 items-center gap-2">
 					{#if showHandoffButton}
 						{@const isVisible =
 							ctx.core.threadId !== null &&
@@ -268,22 +271,22 @@
 							!isHandedOff &&
 							hasShownHandoffButton}
 						<div
-							class="transition-opacity duration-200 {isVisible
+							class="min-w-0 transition-opacity duration-200 {isVisible
 								? 'opacity-100'
 								: 'pointer-events-none opacity-0'}"
 							inert={!isVisible ? true : undefined}
 						>
-							<PromptSuggestion onclick={() => onRequestHandoff?.()}
-								>Talk to a human</PromptSuggestion
-							>
+							<PromptSuggestion class="max-w-full" onclick={() => onRequestHandoff?.()}>
+								<span class="block truncate">{$t('chat.action.talk_to_human')}</span>
+							</PromptSuggestion>
 						</div>
 					{/if}
 					<Button
 						size="icon"
 						disabled={!canSend}
 						onclick={handleSend}
-						class="size-9 rounded-full"
-						aria-label="Send"
+						class="size-9 flex-shrink-0 rounded-full"
+						aria-label={$t('chat.aria.send')}
 					>
 						<ArrowUp class="h-[18px] w-[18px]" />
 					</Button>

--- a/src/lib/chat/ui/ChatMessages.svelte
+++ b/src/lib/chat/ui/ChatMessages.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { getTranslate } from '@tolgee/svelte';
 	import {
 		ChatContainerRoot,
 		ChatContainerContent,
@@ -10,6 +11,8 @@
 	import { getChatUIContext } from './ChatContext.svelte.js';
 	import ChatMessage from './ChatMessage.svelte';
 	import type { DisplayMessage, Attachment } from '../core/types.js';
+
+	const { t } = getTranslate();
 
 	let {
 		emptyState,
@@ -36,10 +39,10 @@
 		class?: string;
 	} = $props();
 
-	// Handoff message text to detect
-	const HANDOFF_MESSAGE = 'Sure! I will connect you now.';
-
 	const ctx = getChatUIContext();
+
+	// Handoff message text to detect - use the same translation as backend
+	const HANDOFF_MESSAGE = $derived($t('backend.support.handoff.response').split('.')[0] + '.');
 
 	/**
 	 * Get the "sender type" for a message to determine grouping
@@ -86,13 +89,13 @@
 							attachments.push({
 								type: 'image',
 								url: url,
-								filename: part.filename || 'Image'
+								filename: part.filename || $t('chat.attachment.image_fallback')
 							});
 						} else {
 							attachments.push({
 								type: 'remote-file',
 								url: url,
-								filename: part.filename || 'File',
+								filename: part.filename || $t('chat.attachment.file_fallback'),
 								contentType: part.mediaType || part.mimeType
 							});
 						}

--- a/src/lib/chat/ui/InlineEmailPrompt.svelte
+++ b/src/lib/chat/ui/InlineEmailPrompt.svelte
@@ -6,6 +6,9 @@
 	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
 	import BellOffIcon from '@lucide/svelte/icons/bell-off';
 	import { emailSchema } from '$lib/schemas/auth';
+	import { getTranslate } from '@tolgee/svelte';
+
+	const { t } = getTranslate();
 
 	let {
 		currentEmail = '',
@@ -53,9 +56,9 @@
 		isSubmitting = true;
 		try {
 			await onSubmitEmail(email.trim());
-			toast.success("Email saved! We'll notify you when we respond.");
+			toast.success($t('chat.email.saved_success'));
 		} catch (error) {
-			toast.error('Failed to save email. Please try again.');
+			toast.error($t('chat.email.save_failed'));
 		} finally {
 			isSubmitting = false;
 		}
@@ -68,9 +71,9 @@
 		try {
 			email = '';
 			await onSubmitEmail('');
-			toast.success('Unsubscribed from email notifications.');
+			toast.success($t('chat.email.unsubscribed'));
 		} catch (error) {
-			toast.error('Failed to unsubscribe. Please try again.');
+			toast.error($t('chat.email.unsubscribe_failed'));
 		} finally {
 			isSubmitting = false;
 		}
@@ -81,7 +84,7 @@
 	<InputGroup.Root>
 		<InputGroup.Input
 			type="email"
-			placeholder="Email"
+			placeholder={$t('chat.email.placeholder')}
 			bind:value={email}
 			disabled={!!currentEmail}
 			onkeydown={(e) => e.key === 'Enter' && canSubscribe && handleSubmit()}
@@ -99,7 +102,7 @@
 		</Button>
 	{:else}
 		<Button variant="outline" onclick={handleSubmit} disabled={!canSubscribe || isSubmitting}>
-			Subscribe
+			{$t('chat.email.subscribe_button')}
 		</Button>
 	{/if}
 </div>

--- a/src/lib/components/ai-elements/reasoning/ReasoningTrigger.svelte
+++ b/src/lib/components/ai-elements/reasoning/ReasoningTrigger.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import { getTranslate } from '@tolgee/svelte';
 	import * as Accordion from '$lib/components/ui/accordion/index.js';
 	import BotIcon from '@lucide/svelte/icons/bot';
 	import ReasoningShimmerLoader from '$lib/components/prompt-kit/loader/reasoning-shimmer-loader.svelte';
+
+	const { t } = getTranslate();
 
 	interface Props {
 		class?: string;
@@ -24,9 +27,11 @@
 	// State 3: Finished - show duration
 	let durationMessage = $derived.by(() => {
 		if (duration && duration > 0) {
-			return `Thought for ${duration} second${duration === 1 ? '' : 's'}`;
+			return duration === 1
+				? $t('chat.reasoning.thought_for_seconds', { duration })
+				: $t('chat.reasoning.thought_for_seconds_plural', { duration });
 		}
-		return 'Thought for a few seconds';
+		return $t('chat.reasoning.thought_for_few_seconds');
 	});
 </script>
 
@@ -44,10 +49,10 @@
 		<BotIcon class="size-4" />
 		{#if !hasContent}
 			<!-- State 1: Connecting - waiting for first reasoning content -->
-			<ReasoningShimmerLoader text="Connecting..." />
+			<ReasoningShimmerLoader text={$t('chat.reasoning.connecting')} />
 		{:else if isStreaming}
 			<!-- State 2: Thinking - receiving reasoning data -->
-			<ReasoningShimmerLoader text="Thinking..." />
+			<ReasoningShimmerLoader text={$t('chat.reasoning.thinking')} />
 		{:else}
 			<!-- State 3: Finished - show duration -->
 			<p>{durationMessage}</p>

--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -5,6 +5,9 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { ArrowUp, Square } from '@lucide/svelte';
 	import { supportThreadContext } from './support-thread-context.svelte';
+	import { getTranslate } from '@tolgee/svelte';
+
+	const { t } = getTranslate();
 
 	let input = $state('');
 	let isFocused = $state(false);
@@ -99,7 +102,7 @@
 		>
 			<PromptInputTextarea
 				class="!h-auto !min-h-auto rounded-3xl bg-transparent !py-0 "
-				placeholder="Ask me anything..."
+				placeholder={$t('support.chatbar.placeholder')}
 				onfocus={handleFocus}
 				onblur={handleBlur}
 			/>

--- a/src/lib/components/customer-support/customer-support.svelte
+++ b/src/lib/components/customer-support/customer-support.svelte
@@ -57,10 +57,11 @@
 	// Get auth state for user identification
 	const auth = useAuth();
 
-	// Upload API configuration
+	// Upload API configuration with locale for translated error messages
 	const uploadConfig: UploadConfig = {
 		generateUploadUrl: api.support.files.generateUploadUrl,
-		saveUploadedFile: api.support.files.saveUploadedFile
+		saveUploadedFile: api.support.files.saveUploadedFile,
+		locale: page.data.lang
 	};
 
 	// Create ChatUIContext at this level so we can handle screenshot uploads

--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotEditor.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { lockscroll } from '@svelte-put/lockscroll';
 	import { snapdom } from '@zumer/snapdom';
+	import { getTranslate } from '@tolgee/svelte';
 	import { getSnapDOMConfig } from '$lib/utils/snapdom-config';
 	import {
 		ScreenshotEditorState,
@@ -8,6 +9,8 @@
 	} from './screenshot-editor-context.svelte';
 	import ScreenshotToolbar from './ScreenshotToolbar.svelte';
 	import ScreenshotCanvas from './ScreenshotCanvas.svelte';
+
+	const { t } = getTranslate();
 
 	let {
 		onCancel,
@@ -27,7 +30,7 @@
 		})
 	);
 
-	// Capture screenshot and download directly
+	// Capture screenshot and pass to callback
 	async function handleSave() {
 		try {
 			editorContext.isSaving = true;
@@ -120,7 +123,7 @@
 			onCancel?.();
 		} catch (error) {
 			console.error('Failed to capture screenshot:', error);
-			alert('Failed to capture screenshot. Check console for details.');
+			alert($t('support.screenshot.capture_failed'));
 		} finally {
 			editorContext.isSaving = false;
 		}
@@ -143,7 +146,7 @@
 	class="fixed inset-0 z-[100]"
 	role="dialog"
 	aria-modal="true"
-	aria-label="Screenshot editor"
+	aria-label={$t('support.screenshot.aria_label')}
 >
 	<ScreenshotToolbar />
 	<ScreenshotCanvas />

--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotToolbar.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotToolbar.svelte
@@ -5,7 +5,9 @@
 	import { screenshotEditorContext } from './screenshot-editor-context.svelte';
 	import { cn } from '$lib/utils';
 	import { DEFAULT_COLORS } from './types';
+	import { getTranslate } from '@tolgee/svelte';
 
+	const { t } = getTranslate();
 	const editor = screenshotEditorContext.get();
 
 	function handleToolClick(tool: typeof editor.currentTool) {
@@ -23,7 +25,7 @@
 			size="icon"
 			class="size-9 "
 			onclick={() => handleToolClick('rect')}
-			title="Rectangle (R)"
+			title={$t('support.screenshot.tool.rectangle')}
 		>
 			<Square class="size-4" />
 		</Button>
@@ -34,7 +36,7 @@
 			size="icon"
 			class="size-9 "
 			onclick={() => handleToolClick('circle')}
-			title="Circle (C)"
+			title={$t('support.screenshot.tool.circle')}
 		>
 			<Circle class="size-4" />
 		</Button>
@@ -45,7 +47,7 @@
 			size="icon"
 			class="size-9 "
 			onclick={() => handleToolClick('arrow')}
-			title="Arrow (A)"
+			title={$t('support.screenshot.tool.arrow')}
 		>
 			<ArrowRight class="size-4" />
 		</Button>
@@ -56,7 +58,7 @@
 			size="icon"
 			class="size-9 "
 			onclick={() => handleToolClick('pen')}
-			title="Pen (P)"
+			title={$t('support.screenshot.tool.pen')}
 		>
 			<Pencil class="size-4" />
 		</Button>
@@ -74,7 +76,7 @@
 						size="icon"
 						class="size-6 rounded-full border-2 border-background ring-2 ring-border"
 						style="background-color: {editor.strokeColor};"
-						title="Change Color"
+						title={$t('support.screenshot.tool.color')}
 					></Button>
 				{/snippet}
 			</Popover.Trigger>
@@ -110,7 +112,7 @@
 			class="size-9 "
 			onclick={() => editor.history.undo()}
 			disabled={!editor.history.canUndo}
-			title="Undo (Ctrl+Z)"
+			title={$t('support.screenshot.action.undo')}
 		>
 			<Undo2 class="size-4" />
 		</Button>
@@ -122,7 +124,7 @@
 			class="size-9 "
 			onclick={() => editor.history.redo()}
 			disabled={!editor.history.canRedo}
-			title="Redo (Ctrl+Shift+Z)"
+			title={$t('support.screenshot.action.redo')}
 		>
 			<Redo2 class="size-4" />
 		</Button>
@@ -136,7 +138,7 @@
 			onclick={editor.handleSave}
 			disabled={editor.isSaving || !editor.hasShapes}
 		>
-			{editor.isSaving ? 'Capturing...' : 'Next'}
+			{editor.isSaving ? $t('support.screenshot.capturing') : $t('support.screenshot.next')}
 		</Button>
 
 		<!-- Close Button -->
@@ -145,7 +147,7 @@
 			size="icon"
 			class="size-9 "
 			onclick={editor.handleCancel}
-			title="Cancel (Esc)"
+			title={$t('support.screenshot.action.cancel')}
 		>
 			<X class="size-4" />
 		</Button>

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { useQuery } from 'convex-svelte';
+	import { getTranslate } from '@tolgee/svelte';
 	import { api } from '$lib/convex/_generated/api';
 	import { Button } from '$lib/components/ui/button';
 	import { Avatar, AvatarImage, AvatarFallback } from '$lib/components/ui/avatar';
@@ -12,6 +13,8 @@
 	import memberFive from '$blocks/team/avatars/member-five.webp';
 	import { motion } from 'motion-sv';
 	import { SvelteSet } from 'svelte/reactivity';
+
+	const { t } = getTranslate();
 
 	const ctx = supportThreadContext.get();
 
@@ -51,14 +54,14 @@
 			// Case 1: 3+ admins - show 3 random admin avatars (no bot icon)
 			return shuffledAdmins.slice(0, 3).map((admin, i) => ({
 				src: admin.image ?? placeholderAvatars[i],
-				alt: admin.name ?? 'Team member',
+				alt: admin.name ?? $t('support.avatar.team_member'),
 				isPlaceholder: false
 			}));
 		} else if (shuffledAdmins.length >= 2) {
 			// Case 2: 2 admins - show 2 admin avatars (bot icon shown separately)
 			return shuffledAdmins.slice(0, 2).map((admin, i) => ({
 				src: admin.image ?? placeholderAvatars[i],
-				alt: admin.name ?? 'Team member',
+				alt: admin.name ?? $t('support.avatar.team_member'),
 				isPlaceholder: false
 			}));
 		} else {
@@ -69,7 +72,7 @@
 			shuffledAdmins.forEach((admin, i) => {
 				result.push({
 					src: admin.image ?? placeholderAvatars[i],
-					alt: admin.name ?? 'Team member',
+					alt: admin.name ?? $t('support.avatar.team_member'),
 					isPlaceholder: false
 				});
 			});
@@ -79,7 +82,7 @@
 			for (let i = 0; i < remaining; i++) {
 				result.push({
 					src: placeholderAvatars[shuffledAdmins.length + i],
-					alt: 'Team member',
+					alt: $t('support.avatar.team_member'),
 					isPlaceholder: true
 				});
 			}
@@ -179,14 +182,14 @@
 		const hours = Math.floor(minutes / 60);
 		const days = Math.floor(hours / 24);
 
-		if (seconds < 10) return 'just now';
-		if (seconds < 60) return 'a few seconds ago';
-		if (minutes === 1) return '1 minute ago';
-		if (minutes < 60) return `${minutes} minutes ago`;
-		if (hours === 1) return '1 hour ago';
-		if (hours < 24) return `${hours} hours ago`;
-		if (days === 1) return 'yesterday';
-		if (days < 7) return `${days} days ago`;
+		if (seconds < 10) return $t('support.time.just_now');
+		if (seconds < 60) return $t('support.time.few_seconds_ago');
+		if (minutes === 1) return $t('support.time.one_minute_ago');
+		if (minutes < 60) return $t('support.time.minutes_ago', { minutes });
+		if (hours === 1) return $t('support.time.one_hour_ago');
+		if (hours < 24) return $t('support.time.hours_ago', { hours });
+		if (days === 1) return $t('support.time.yesterday');
+		if (days < 7) return $t('support.time.days_ago', { days });
 
 		return new Date(timestamp).toLocaleDateString();
 	}
@@ -256,7 +259,7 @@
 						transition={{ duration: 0.4, delay: 0.25, ease: 'easeOut' }}
 						class="mb-4 text-5xl font-semibold text-muted-foreground"
 					>
-						Hi 👋
+						{$t('support.greeting.hi')} 👋
 					</motion.h2>
 
 					<!-- Main heading -->
@@ -266,7 +269,7 @@
 						transition={{ duration: 0.4, delay: 0.5, ease: 'easeOut' }}
 						class="text-3xl font-bold"
 					>
-						How can we help you today?
+						{$t('support.greeting.how_can_we_help')}
 					</motion.h3>
 				</div>
 			</div>
@@ -296,8 +299,8 @@
 									: UsersRound
 								: Bot}
 							image={showAdminAvatar ? thread.assignedAdmin?.image : undefined}
-							title={thread.lastMessage || thread.summary || 'New conversation'}
-							subtitle={`${thread.lastMessageRole === 'user' ? 'You' : showAdminAvatar ? thread.assignedAdmin?.name || 'Support' : thread.lastAgentName || 'Kai'}\u00A0\u00A0·\u00A0\u00A0${formatRelativeTime(thread.lastMessageAt)}`}
+							title={thread.lastMessage || thread.summary || $t('support.thread.new_conversation')}
+							subtitle={`${thread.lastMessageRole === 'user' ? $t('support.message.role_you') : showAdminAvatar ? thread.assignedAdmin?.name || $t('support.message.role_support') : thread.lastAgentName || $t('support.message.role_kai')}\u00A0\u00A0·\u00A0\u00A0${formatRelativeTime(thread.lastMessageAt)}`}
 							bold={false}
 							fallbackText={thread.isHandedOff && thread.assignedAdmin?.name
 								? thread.assignedAdmin.name
@@ -321,7 +324,7 @@
 			disabled={ctx.isRateLimited}
 		>
 			<Send />
-			Start a new conversation
+			{$t('support.button.start_new_conversation')}
 		</Button>
 	</div>
 </div>

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -11,7 +11,9 @@
 	import Logo from '$lib/components/icons/logo.svelte';
 	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 	import { authClient } from '$lib/auth-client';
-	import { T } from '@tolgee/svelte';
+	import { T, getTranslate } from '@tolgee/svelte';
+
+	const { t } = getTranslate();
 
 	const auth = useAuth();
 
@@ -65,7 +67,7 @@
 						href="https://github.com/stickerdaniel/saas-starter"
 						target="_blank"
 						rel="noopener noreferrer"
-						aria-label="GitHub repository"
+						aria-label={$t('aria.github_repository')}
 						class="size-8"
 					>
 						<Github class="size-4" />
@@ -106,7 +108,7 @@
 						href="https://github.com/stickerdaniel/saas-starter"
 						target="_blank"
 						rel="noopener noreferrer"
-						aria-label="GitHub repository"
+						aria-label={$t('aria.github_repository')}
 						class="size-8"
 					>
 						<Github class="size-4" />
@@ -115,7 +117,7 @@
 					<LanguageSwitcher variant="ghost" />
 					<button
 						onclick={() => (menuState = !menuState)}
-						aria-label={menuState == true ? 'Close Menu' : 'Open Menu'}
+						aria-label={menuState ? $t('aria.menu_close') : $t('aria.menu_open')}
 						class="relative z-20 -m-2.5 -mr-4 block cursor-pointer p-2.5 pl-4"
 					>
 						<Menu

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -12,9 +12,11 @@
 	import SparklesIcon from '@lucide/svelte/icons/sparkles';
 	import SettingsIcon from '@lucide/svelte/icons/settings';
 	import UserXIcon from '@lucide/svelte/icons/user-x';
-	import { T } from '@tolgee/svelte';
+	import { T, getTranslate } from '@tolgee/svelte';
 	import { localizedHref } from '$lib/utils/i18n';
 	import { toast } from 'svelte-sonner';
+
+	const { t } = getTranslate();
 
 	interface Props {
 		user: { name: string; email: string; avatar: string };
@@ -37,13 +39,13 @@
 		try {
 			const result = await authClient.admin.stopImpersonating();
 			if (result.error) {
-				toast.error('Failed to stop impersonation');
+				toast.error($t('app.user_menu.impersonation_stop_failed'));
 				return;
 			}
-			toast.success('Stopped impersonating');
+			toast.success($t('app.user_menu.impersonation_stopped'));
 			goto(localizedHref('/admin/users'));
 		} catch (error) {
-			toast.error('Failed to stop impersonation');
+			toast.error($t('app.user_menu.impersonation_stop_failed'));
 		}
 	}
 </script>

--- a/src/lib/components/ui/language-switcher/language-switcher.svelte
+++ b/src/lib/components/ui/language-switcher/language-switcher.svelte
@@ -4,6 +4,9 @@
 	import { buttonVariants } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils/utils';
 	import type { LanguageSwitcherProps } from './types';
+	import { getTranslate } from '@tolgee/svelte';
+
+	const { t } = getTranslate();
 
 	let {
 		languages = [],
@@ -23,10 +26,10 @@
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger
 		class={cn(buttonVariants({ variant, size: 'icon' }), className)}
-		aria-label="Change language"
+		aria-label={$t('aria.change_language')}
 	>
 		<GlobeIcon class="size-4" />
-		<span class="sr-only">Change language</span>
+		<span class="sr-only">{$t('aria.change_language')}</span>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content {align}>
 		<DropdownMenu.RadioGroup bind:value onValueChange={onChange}>

--- a/src/lib/components/ui/sidebar/sidebar-rail.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-rail.svelte
@@ -2,6 +2,9 @@
 	import { cn, type WithElementRef } from '$lib/utils.js';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { sidebarContext } from './context.svelte.js';
+	import { getTranslate } from '@tolgee/svelte';
+
+	const { t } = getTranslate();
 
 	let {
 		ref = $bindable(null),
@@ -17,10 +20,10 @@
 	bind:this={ref}
 	data-sidebar="rail"
 	data-slot="sidebar-rail"
-	aria-label="Toggle Sidebar"
+	aria-label={$t('aria.toggle_sidebar')}
 	tabIndex={-1}
 	onclick={sidebar.toggle}
-	title="Toggle Sidebar"
+	title={$t('aria.toggle_sidebar')}
 	class={cn(
 		'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-[calc(1/2*100%-1px)] after:w-[2px] hover:after:bg-sidebar-border sm:flex',
 		'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',

--- a/src/lib/convex/_generated/api.d.ts
+++ b/src/lib/convex/_generated/api.d.ts
@@ -42,6 +42,7 @@ import type * as files_vacuum from "../files/vacuum.js";
 import type * as functions from "../functions.js";
 import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
+import type * as i18n_translations from "../i18n/translations.js";
 import type * as messages from "../messages.js";
 import type * as storage from "../storage.js";
 import type * as support_agent from "../support/agent.js";
@@ -96,6 +97,7 @@ declare const fullApi: ApiFromModules<{
   functions: typeof functions;
   helpers: typeof helpers;
   http: typeof http;
+  "i18n/translations": typeof i18n_translations;
   messages: typeof messages;
   storage: typeof storage;
   "support/agent": typeof support_agent;
@@ -153,6 +155,7 @@ export declare const components: {
                   email: string;
                   emailVerified: boolean;
                   image?: null | string;
+                  locale?: null | string;
                   name: string;
                   role?: null | string;
                   updatedAt: number;
@@ -250,6 +253,7 @@ export declare const components: {
                     | "banned"
                     | "banReason"
                     | "banExpires"
+                    | "locale"
                     | "_id";
                   operator?:
                     | "lt"
@@ -479,6 +483,7 @@ export declare const components: {
                     | "banned"
                     | "banReason"
                     | "banExpires"
+                    | "locale"
                     | "_id";
                   operator?:
                     | "lt"
@@ -780,6 +785,7 @@ export declare const components: {
                   email?: string;
                   emailVerified?: boolean;
                   image?: null | string;
+                  locale?: null | string;
                   name?: string;
                   role?: null | string;
                   updatedAt?: number;
@@ -799,6 +805,7 @@ export declare const components: {
                     | "banned"
                     | "banReason"
                     | "banExpires"
+                    | "locale"
                     | "_id";
                   operator?:
                     | "lt"
@@ -1071,6 +1078,7 @@ export declare const components: {
                   email?: string;
                   emailVerified?: boolean;
                   image?: null | string;
+                  locale?: null | string;
                   name?: string;
                   role?: null | string;
                   updatedAt?: number;
@@ -1090,6 +1098,7 @@ export declare const components: {
                     | "banned"
                     | "banReason"
                     | "banExpires"
+                    | "locale"
                     | "_id";
                   operator?:
                     | "lt"

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -138,6 +138,16 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>): BetterAuthOptions
 		baseURL: getSiteUrl(),
 		secret: getBetterAuthSecret(),
 		database: authComponent.adapter(ctx),
+		user: {
+			additionalFields: {
+				locale: {
+					type: 'string',
+					required: false,
+					defaultValue: 'en',
+					input: true
+				}
+			}
+		},
 		emailAndPassword: {
 			enabled: true,
 			requireEmailVerification: true,

--- a/src/lib/convex/betterAuth/_generated/component.ts
+++ b/src/lib/convex/betterAuth/_generated/component.ts
@@ -38,6 +38,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                   email: string;
                   emailVerified: boolean;
                   image?: null | string;
+                  locale?: null | string;
                   name: string;
                   role?: null | string;
                   updatedAt: number;
@@ -136,6 +137,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "banned"
                     | "banReason"
                     | "banExpires"
+                    | "locale"
                     | "_id";
                   operator?:
                     | "lt"
@@ -366,6 +368,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "banned"
                     | "banReason"
                     | "banExpires"
+                    | "locale"
                     | "_id";
                   operator?:
                     | "lt"
@@ -670,6 +673,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                   email?: string;
                   emailVerified?: boolean;
                   image?: null | string;
+                  locale?: null | string;
                   name?: string;
                   role?: null | string;
                   updatedAt?: number;
@@ -689,6 +693,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "banned"
                     | "banReason"
                     | "banExpires"
+                    | "locale"
                     | "_id";
                   operator?:
                     | "lt"
@@ -962,6 +967,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                   email?: string;
                   emailVerified?: boolean;
                   image?: null | string;
+                  locale?: null | string;
                   name?: string;
                   role?: null | string;
                   updatedAt?: number;
@@ -981,6 +987,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "banned"
                     | "banReason"
                     | "banExpires"
+                    | "locale"
                     | "_id";
                   operator?:
                     | "lt"

--- a/src/lib/convex/betterAuth/schema.ts
+++ b/src/lib/convex/betterAuth/schema.ts
@@ -23,7 +23,8 @@ export const tables = {
 		role: v.optional(v.union(v.null(), v.string())),
 		banned: v.optional(v.union(v.null(), v.boolean())),
 		banReason: v.optional(v.union(v.null(), v.string())),
-		banExpires: v.optional(v.union(v.null(), v.number()))
+		banExpires: v.optional(v.union(v.null(), v.number())),
+		locale: v.optional(v.union(v.null(), v.string()))
 	})
 		.index('email_name', ['email', 'name'])
 		.index('name', ['name'])

--- a/src/lib/convex/i18n/translations.ts
+++ b/src/lib/convex/i18n/translations.ts
@@ -1,0 +1,138 @@
+/**
+ * Backend translation helper for Convex functions.
+ * Imports the same JSON translation files used by the frontend Tolgee setup.
+ *
+ * Usage:
+ *   import { t, extractLocaleFromUrl } from './i18n/translations';
+ *
+ *   // Translate a key with the user's locale
+ *   const message = t(userLocale, 'backend.support.handoff.response');
+ *
+ *   // With parameters
+ *   const message = t(locale, 'settings.account.avatar.size_error', { size: '2MB' });
+ *
+ *   // Extract locale from a URL path
+ *   const locale = extractLocaleFromUrl('/de/app/settings'); // returns 'de'
+ */
+
+import en from '../../../i18n/en.json';
+import de from '../../../i18n/de.json';
+import es from '../../../i18n/es.json';
+import fr from '../../../i18n/fr.json';
+
+/** Supported locales */
+export const SUPPORTED_LOCALES = ['en', 'de', 'es', 'fr'] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+/** Default locale used as fallback */
+export const DEFAULT_LOCALE: SupportedLocale = 'en';
+
+/** Translation data indexed by locale */
+const translations: Record<SupportedLocale, Record<string, unknown>> = {
+	en,
+	de,
+	es,
+	fr
+};
+
+/**
+ * Get a nested value from an object using dot notation path.
+ * Example: getNestedValue(obj, 'admin.actions.ban') returns obj.admin.actions.ban
+ */
+function getNestedValue(obj: Record<string, unknown>, path: string): string | undefined {
+	const result = path.split('.').reduce<unknown>((current, key) => {
+		if (current && typeof current === 'object' && key in current) {
+			return (current as Record<string, unknown>)[key];
+		}
+		return undefined;
+	}, obj);
+
+	return typeof result === 'string' ? result : undefined;
+}
+
+/**
+ * Translate a key to the specified locale with optional parameter interpolation.
+ *
+ * @param locale - The target locale (e.g., 'en', 'de', 'es', 'fr')
+ * @param key - The translation key in dot notation (e.g., 'admin.actions.ban')
+ * @param params - Optional parameters to interpolate into the string
+ * @returns The translated string, or the key itself if not found
+ *
+ * @example
+ * t('de', 'admin.dialog.ban_description', { email: 'user@example.com' })
+ * // Returns: "Möchten Sie user@example.com wirklich sperren? Der Zugriff auf die App wird blockiert."
+ */
+export function t(
+	locale: string | null | undefined,
+	key: string,
+	params?: Record<string, string | number>
+): string {
+	const effectiveLocale = getValidLocale(locale);
+	const langData = translations[effectiveLocale];
+
+	// Try to get the translation, fallback to English, then to the key itself
+	let text =
+		getNestedValue(langData, key) ?? getNestedValue(translations[DEFAULT_LOCALE], key) ?? key;
+
+	// Interpolate parameters using {paramName} syntax
+	if (params) {
+		Object.entries(params).forEach(([paramKey, value]) => {
+			text = text.replace(new RegExp(`\\{${paramKey}\\}`, 'g'), String(value));
+		});
+	}
+
+	return text;
+}
+
+/**
+ * Extract locale from a URL path.
+ * Looks for a supported locale code at the start of the path.
+ *
+ * @param url - The URL or path to extract locale from
+ * @returns The extracted locale or the default locale if not found
+ *
+ * @example
+ * extractLocaleFromUrl('/de/app/settings') // returns 'de'
+ * extractLocaleFromUrl('https://example.com/fr/support') // returns 'fr'
+ * extractLocaleFromUrl('/app/settings') // returns 'en' (default)
+ */
+export function extractLocaleFromUrl(url: string | null | undefined): SupportedLocale {
+	if (!url) return DEFAULT_LOCALE;
+
+	try {
+		// Handle full URLs by extracting the pathname
+		let pathname: string;
+		if (url.startsWith('http://') || url.startsWith('https://')) {
+			pathname = new URL(url).pathname;
+		} else {
+			pathname = url;
+		}
+
+		// Extract the first path segment after the leading slash
+		const match = pathname.match(/^\/([a-z]{2})(?:\/|$)/i);
+		if (match) {
+			const potentialLocale = match[1].toLowerCase();
+			if (SUPPORTED_LOCALES.includes(potentialLocale as SupportedLocale)) {
+				return potentialLocale as SupportedLocale;
+			}
+		}
+	} catch {
+		// URL parsing failed, return default
+	}
+
+	return DEFAULT_LOCALE;
+}
+
+/**
+ * Check if a locale is supported.
+ */
+export function isSupportedLocale(locale: string | null | undefined): locale is SupportedLocale {
+	return typeof locale === 'string' && SUPPORTED_LOCALES.includes(locale as SupportedLocale);
+}
+
+/**
+ * Get a valid locale, falling back to default if invalid.
+ */
+export function getValidLocale(locale: string | null | undefined): SupportedLocale {
+	return isSupportedLocale(locale) ? locale : DEFAULT_LOCALE;
+}

--- a/src/lib/convex/support/files.ts
+++ b/src/lib/convex/support/files.ts
@@ -2,6 +2,7 @@ import { action, mutation } from '../_generated/server';
 import { v } from 'convex/values';
 import { storeFile } from '@convex-dev/agent';
 import { components } from '../_generated/api';
+import { t } from '../i18n/translations';
 
 /**
  * Allowed file types for upload
@@ -45,7 +46,8 @@ export const saveUploadedFile = action({
 	args: {
 		storageId: v.id('_storage'),
 		filename: v.optional(v.string()),
-		mimeType: v.string()
+		mimeType: v.string(),
+		locale: v.optional(v.string())
 	},
 	handler: async (
 		ctx,
@@ -59,7 +61,7 @@ export const saveUploadedFile = action({
 	}> => {
 		// Validate file type
 		if (!ALLOWED_MIME_TYPES.includes(args.mimeType)) {
-			throw new Error('File type not allowed. Supported: PNG, JPEG, WebP, GIF, PDF');
+			throw new Error(t(args.locale, 'backend.files.type_not_allowed'));
 		}
 
 		// Get storage URL
@@ -71,6 +73,9 @@ export const saveUploadedFile = action({
 
 		// Fetch blob from storage
 		const response = await fetch(url);
+		if (!response.ok) {
+			throw new Error(t(args.locale, 'backend.files.fetch_failed'));
+		}
 		const blob = await response.blob();
 
 		// Register with agent component

--- a/src/lib/convex/tsconfig.json
+++ b/src/lib/convex/tsconfig.json
@@ -11,6 +11,7 @@
 		"jsx": "react-jsx",
 		"skipLibCheck": true,
 		"allowSyntheticDefaultImports": true,
+		"resolveJsonModule": true,
 
 		/* These compiler options are required by Convex */
 		"target": "ESNext",

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -15,6 +15,10 @@
 	import { useMedia } from '$lib/hooks/use-media.svelte';
 	import { SlidingHeader } from '$lib/components/ui/sliding-header';
 	import { adminSupportUI } from '$lib/hooks/admin-support-ui.svelte';
+	import { getTranslate } from '@tolgee/svelte';
+	import { page } from '$app/state';
+
+	const { t } = getTranslate();
 
 	let {
 		threadId,
@@ -34,10 +38,11 @@
 	const media = useMedia();
 	const client = useConvexClient();
 
-	// Upload configuration for file attachments
+	// Upload configuration for file attachments with locale for translated error messages
 	const uploadConfig: UploadConfig = {
 		generateUploadUrl: api.support.files.generateUploadUrl,
-		saveUploadedFile: api.support.files.saveUploadedFile
+		saveUploadedFile: api.support.files.saveUploadedFile,
+		locale: page.data.lang
 	};
 
 	// Create ChatCore for this thread (needed for ChatUIContext)
@@ -112,7 +117,9 @@
 						<PanelBottomOpen class="h-5 w-5" />
 					{/if}
 					<span class="sr-only">
-						{adminSupportUI.detailsOpen ? 'Close details panel' : 'Open details panel'}
+						{adminSupportUI.detailsOpen
+							? $t('admin.support.details.close_panel')
+							: $t('admin.support.details.open_panel')}
 					</span>
 				</Button>
 			</header>
@@ -139,7 +146,9 @@
 							<PanelBottomOpen class="h-5 w-5" />
 						{/if}
 						<span class="sr-only">
-							{adminSupportUI.detailsOpen ? 'Close details panel' : 'Open details panel'}
+							{adminSupportUI.detailsOpen
+								? $t('admin.support.details.close_panel')
+								: $t('admin.support.details.open_panel')}
 						</span>
 					</Button>
 				{/snippet}
@@ -192,7 +201,9 @@
 					>
 						<PanelRightIcon class="size-4" />
 						<span class="sr-only">
-							{adminSupportUI.detailsOpen ? 'Close details panel' : 'Open details panel'}
+							{adminSupportUI.detailsOpen
+								? $t('admin.support.details.close_panel')
+								: $t('admin.support.details.open_panel')}
 						</span>
 					</Button>
 				{/if}
@@ -216,7 +227,7 @@
 
 		<ChatInput
 			class="mx-4 -translate-y-4 p-0"
-			placeholder="Reply to customer..."
+			placeholder={$t('admin.support.chat.placeholder')}
 			showFileButton={true}
 			onSend={async (prompt) => {
 				if (!prompt) return;

--- a/src/routes/[[lang]]/admin/support/thread-details.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-details.svelte
@@ -12,8 +12,10 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
 	import { toast } from 'svelte-sonner';
-	import { T } from '@tolgee/svelte';
+	import { T, getTranslate } from '@tolgee/svelte';
 	import { motion } from 'motion-sv';
+
+	const { t } = getTranslate();
 	import { formatDistanceToNow } from 'date-fns';
 
 	let {
@@ -55,10 +57,12 @@
 				threadId,
 				adminUserId: adminUserId === '' ? undefined : adminUserId
 			});
-			toast.success('Assignment updated');
+			toast.success($t('admin.users.toast.assignment_updated'));
 		} catch (error) {
 			toast.error(
-				`Failed to update assignment: ${error instanceof Error ? error.message : 'Unknown error'}`
+				$t('admin.users.toast.assignment_failed', {
+					message: error instanceof Error ? error.message : 'Unknown error'
+				})
 			);
 		}
 	}
@@ -69,10 +73,12 @@
 				threadId,
 				status
 			});
-			toast.success('Status updated');
+			toast.success($t('admin.users.toast.status_updated'));
 		} catch (error) {
 			toast.error(
-				`Failed to update status: ${error instanceof Error ? error.message : 'Unknown error'}`
+				$t('admin.users.toast.status_failed', {
+					message: error instanceof Error ? error.message : 'Unknown error'
+				})
 			);
 		}
 	}
@@ -83,10 +89,12 @@
 				threadId,
 				priority: priority === '' ? undefined : (priority as 'low' | 'medium' | 'high' | undefined)
 			});
-			toast.success('Priority updated');
+			toast.success($t('admin.users.toast.priority_updated'));
 		} catch (error) {
 			toast.error(
-				`Failed to update priority: ${error instanceof Error ? error.message : 'Unknown error'}`
+				$t('admin.users.toast.priority_failed', {
+					message: error instanceof Error ? error.message : 'Unknown error'
+				})
 			);
 		}
 	}
@@ -101,10 +109,12 @@
 				content: newNoteContent.trim()
 			});
 			newNoteContent = '';
-			toast.success('Note added');
+			toast.success($t('admin.users.toast.note_added'));
 		} catch (error) {
 			toast.error(
-				`Failed to add note: ${error instanceof Error ? error.message : 'Unknown error'}`
+				$t('admin.users.toast.note_failed', {
+					message: error instanceof Error ? error.message : 'Unknown error'
+				})
 			);
 		} finally {
 			isAddingNote = false;
@@ -126,10 +136,10 @@
 						onValueChange={updateAssignment}
 					>
 						<Select.Trigger>
-							{thread.assignedAdmin?.name || 'Not assigned'}
+							{thread.assignedAdmin?.name || $t('admin.support.assignee.not_assigned')}
 						</Select.Trigger>
 						<Select.Content>
-							<Select.Item value="">Unassigned</Select.Item>
+							<Select.Item value=""><T keyName="admin.support.assignee.unassigned" /></Select.Item>
 							{#each adminsQuery.data || [] as admin (admin.id)}
 								<Select.Item value={admin.id}>
 									{admin.name || admin.email}
@@ -166,10 +176,10 @@
 						onValueChange={(v) => updatePriority(v as 'low' | 'medium' | 'high' | '' | undefined)}
 					>
 						<Select.Trigger class="capitalize">
-							{thread.supportMetadata?.priority || 'None'}
+							{thread.supportMetadata?.priority || $t('admin.support.priority.none')}
 						</Select.Trigger>
 						<Select.Content>
-							<Select.Item value="">None</Select.Item>
+							<Select.Item value=""><T keyName="admin.support.priority.none" /></Select.Item>
 							<Select.Item value="low"><T keyName="admin.support.priority.low" /></Select.Item>
 							<Select.Item value="medium"><T keyName="admin.support.priority.medium" /></Select.Item
 							>
@@ -181,7 +191,7 @@
 				<!-- Notification Email -->
 				{#if thread.supportMetadata?.notificationEmail}
 					<div class="space-y-1">
-						<Label>Notification Email</Label>
+						<Label><T keyName="admin.support.email.label" /></Label>
 						<a
 							href="mailto:{thread.supportMetadata
 								.notificationEmail}?subject=Re: Your support request&body=Hi,%0A%0AThank you for reaching out!%0A%0A"
@@ -218,14 +228,14 @@
 
 						<!-- Add Note -->
 						<Textarea
-							placeholder="Add an internal note..."
+							placeholder={$t('admin.support.note.placeholder')}
 							bind:value={newNoteContent}
 							rows={INTERNAL_NOTE_TEXTAREA_ROWS}
 							class="resize-none"
 						/>
 						<div class="flex justify-end">
 							<Button size="sm" onclick={addNote} disabled={!newNoteContent.trim() || isAddingNote}>
-								{isAddingNote ? 'Adding...' : 'Add Note'}
+								{isAddingNote ? $t('admin.support.note.adding') : $t('admin.support.note.add')}
 							</Button>
 						</div>
 
@@ -240,7 +250,9 @@
 								{#each notesQuery.data.page as note (note._id)}
 									<div class="rounded-md bg-muted p-3">
 										<div class="mb-1 flex items-center justify-between">
-											<span class="text-sm font-medium">{note.adminName || 'Admin'}</span>
+											<span class="text-sm font-medium"
+												>{note.adminName || $t('admin.support.fallback.admin')}</span
+											>
 											<span class="text-xs text-muted-foreground">
 												{formatDistanceToNow(new Date(note.createdAt), { addSuffix: true })}
 											</span>
@@ -254,7 +266,9 @@
 				{:else}
 					<div class="space-y-1">
 						<Label><T keyName="admin.support.details.notes" /></Label>
-						<p class="text-sm text-muted-foreground">No user associated with this thread</p>
+						<p class="text-sm text-muted-foreground">
+							<T keyName="admin.support.fallback.no_user" />
+						</p>
 					</div>
 				{/if}
 			</div>

--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -10,8 +10,10 @@
 	import ArchiveIcon from '@lucide/svelte/icons/archive';
 	import Loader2Icon from '@lucide/svelte/icons/loader-2';
 	import { formatDistanceToNow } from 'date-fns';
-	import { T } from '@tolgee/svelte';
+	import { T, getTranslate } from '@tolgee/svelte';
 	import { InfiniteLoader, LoaderState } from 'svelte-infinite';
+
+	const { t } = getTranslate();
 
 	interface Thread {
 		_id: string;
@@ -114,7 +116,7 @@
 			<div class="relative flex-1">
 				<SearchIcon class="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
 				<Input
-					placeholder="Search chats..."
+					placeholder={$t('admin.support.search.placeholder')}
 					class="pl-10"
 					value={searchQuery}
 					oninput={(e) => onSearchChange(e.currentTarget.value)}
@@ -229,13 +231,15 @@
 
 									<!-- Last Message Preview -->
 									<p class="truncate text-sm text-muted-foreground">
-										{thread.lastMessage || 'No messages'}
+										{thread.lastMessage || $t('admin.support.thread.no_messages')}
 									</p>
 
 									<!-- Badges -->
 									<div class="mt-2 flex flex-wrap items-center gap-1.5">
 										{#if thread.supportMetadata.awaitingAdminResponse}
-											<Badge variant="default" class="text-xs">New</Badge>
+											<Badge variant="default" class="text-xs"
+												><T keyName="admin.support.thread.badge.new" /></Badge
+											>
 										{/if}
 										{#if thread.supportMetadata.priority}
 											<Badge
@@ -263,14 +267,20 @@
 					{#snippet loading()}
 						<div class="flex items-center justify-center border-b p-4">
 							<Loader2Icon class="size-5 animate-spin text-muted-foreground" />
-							<span class="ml-2 text-sm text-muted-foreground">Loading more...</span>
+							<span class="ml-2 text-sm text-muted-foreground"
+								><T keyName="admin.support.thread.loading" /></span
+							>
 						</div>
 					{/snippet}
 
 					{#snippet error(attemptLoad)}
 						<div class="flex flex-col items-center justify-center gap-2 p-4">
-							<span class="text-sm text-muted-foreground">Failed to load more</span>
-							<Button variant="outline" size="sm" onclick={attemptLoad}>Retry</Button>
+							<span class="text-sm text-muted-foreground"
+								><T keyName="admin.support.thread.load_failed" /></span
+							>
+							<Button variant="outline" size="sm" onclick={attemptLoad}
+								><T keyName="admin.support.thread.retry" /></Button
+							>
 						</div>
 					{/snippet}
 

--- a/src/routes/[[lang]]/admin/users/+page.svelte
+++ b/src/routes/[[lang]]/admin/users/+page.svelte
@@ -431,7 +431,7 @@
 			const result = await authClient.admin.impersonateUser({ userId });
 			if (result.error) {
 				const message = result.error.message || 'Unknown error';
-				toast.error(`Failed to impersonate user: ${message}`);
+				toast.error($t('admin.users.toast.impersonate_failed', { message }));
 				console.error('Impersonation error:', result.error);
 				return;
 			}
@@ -440,7 +440,7 @@
 			impersonationDialogOpen = true;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
-			toast.error(`Failed to impersonate user: ${message}`);
+			toast.error($t('admin.users.toast.impersonate_failed', { message }));
 			console.error('Impersonation error:', error);
 		}
 	}
@@ -448,28 +448,29 @@
 	async function banUser() {
 		if (!selectedUser) return;
 
+		const defaultBanReason = $t('admin.users.ban_reason.default');
 		try {
 			const result = await authClient.admin.banUser({
 				userId: selectedUser.id,
-				banReason: banReason || 'Violated terms of service'
+				banReason: banReason || defaultBanReason
 			});
 
 			if (result.error) {
 				const message = result.error.message || 'Unknown error';
-				toast.error(`Failed to ban user: ${message}`);
+				toast.error($t('admin.users.toast.ban_failed', { message }));
 				console.error('Ban error:', result.error);
 				return;
 			}
 
 			await logAdminAction('ban_user', selectedUser.id, {
-				reason: banReason || 'Violated terms of service'
+				reason: banReason || defaultBanReason
 			});
 
-			toast.success('User has been banned');
+			toast.success($t('admin.users.toast.banned'));
 			closeDialog();
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
-			toast.error(`Failed to ban user: ${message}`);
+			toast.error($t('admin.users.toast.ban_failed', { message }));
 			console.error('Ban error:', error);
 		}
 	}
@@ -484,17 +485,17 @@
 
 			if (result.error) {
 				const message = result.error.message || 'Unknown error';
-				toast.error(`Failed to unban user: ${message}`);
+				toast.error($t('admin.users.toast.unban_failed', { message }));
 				console.error('Unban error:', result.error);
 				return;
 			}
 
 			await logAdminAction('unban_user', selectedUser.id, {});
-			toast.success('User has been unbanned');
+			toast.success($t('admin.users.toast.unbanned'));
 			closeDialog();
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
-			toast.error(`Failed to unban user: ${message}`);
+			toast.error($t('admin.users.toast.unban_failed', { message }));
 			console.error('Unban error:', error);
 		}
 	}
@@ -509,17 +510,17 @@
 
 			if (result.error) {
 				const message = result.error.message || 'Unknown error';
-				toast.error(`Failed to revoke sessions: ${message}`);
+				toast.error($t('admin.users.toast.revoke_failed', { message }));
 				console.error('Revoke sessions error:', result.error);
 				return;
 			}
 
 			await logAdminAction('revoke_sessions', selectedUser.id, {});
-			toast.success('All sessions have been revoked');
+			toast.success($t('admin.users.toast.revoked'));
 			closeDialog();
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
-			toast.error(`Failed to revoke sessions: ${message}`);
+			toast.error($t('admin.users.toast.revoke_failed', { message }));
 			console.error('Revoke sessions error:', error);
 		}
 	}
@@ -533,11 +534,11 @@
 				role: selectedRole
 			});
 
-			toast.success(`User role updated to ${selectedRole}`);
+			toast.success($t('admin.users.toast.role_updated', { role: selectedRole }));
 			closeRoleDialog();
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
-			toast.error(`Failed to set role: ${message}`);
+			toast.error($t('admin.users.toast.role_failed', { message }));
 			console.error('Set role error:', error);
 		}
 	}

--- a/src/routes/[[lang]]/app/settings/account-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/account-settings.svelte
@@ -5,10 +5,12 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { toast } from 'svelte-sonner';
-	import { T } from '@tolgee/svelte';
+	import { T, getTranslate } from '@tolgee/svelte';
 	import { useConvexClient } from 'convex-svelte';
 	import { api } from '$lib/convex/_generated/api.js';
 	import { PROFILE_IMAGE_MAX_SIZE, PROFILE_IMAGE_MAX_SIZE_LABEL } from '$lib/convex/constants.js';
+
+	const { t } = getTranslate();
 
 	interface Props {
 		user: {
@@ -44,14 +46,14 @@
 
 		// Validate file type
 		if (!file.type.startsWith('image/')) {
-			toast.error('Please select an image file');
+			toast.error($t('settings.account.avatar.select_error'));
 			target.value = '';
 			return;
 		}
 
 		// Validate file size
 		if (file.size > PROFILE_IMAGE_MAX_SIZE) {
-			toast.error(`Image must be less than ${PROFILE_IMAGE_MAX_SIZE_LABEL}`);
+			toast.error($t('settings.account.avatar.size_error', { size: PROFILE_IMAGE_MAX_SIZE_LABEL }));
 			target.value = '';
 			return;
 		}
@@ -74,9 +76,10 @@
 			// Update preview (don't save to DB yet)
 			image = imageUrl || '';
 
-			toast.success('Image ready to save');
+			toast.success($t('settings.account.avatar.ready'));
 		} catch (error) {
-			const message = error instanceof Error ? error.message : 'Failed to upload image';
+			const message =
+				error instanceof Error ? error.message : $t('settings.account.avatar.upload_failed');
 			toast.error(message);
 			target.value = '';
 		} finally {
@@ -86,7 +89,7 @@
 
 	function handleRemoveImage() {
 		image = '';
-		toast.success('Image removed - click Save to confirm');
+		toast.success($t('settings.account.avatar.removed'));
 	}
 
 	async function handleUpdateProfile(e: Event) {
@@ -99,9 +102,9 @@
 				image: image || null
 			});
 
-			toast.success('Profile updated successfully');
+			toast.success($t('settings.account.success'));
 		} catch (error) {
-			const message = error instanceof Error ? error.message : 'Failed to update profile';
+			const message = error instanceof Error ? error.message : $t('settings.account.error');
 			toast.error(message);
 		} finally {
 			isSaving = false;
@@ -118,7 +121,13 @@
 		<form onsubmit={handleUpdateProfile} class="space-y-4">
 			<div class="space-y-2">
 				<Label for="name"><T keyName="settings.account.name_label" /></Label>
-				<Input id="name" type="text" bind:value={name} placeholder="Your name" required />
+				<Input
+					id="name"
+					type="text"
+					bind:value={name}
+					placeholder={$t('settings.account.name.placeholder')}
+					required
+				/>
 				<p class="text-sm text-muted-foreground">
 					<T keyName="settings.account.name_helper" />
 				</p>
@@ -138,7 +147,7 @@
 						{#if image}
 							<img
 								src={image}
-								alt="Profile preview"
+								alt={$t('settings.account.avatar.alt')}
 								class="h-16 w-16 rounded-full border-2 border-border object-cover"
 								onerror={(e) => {
 									if (e.target instanceof HTMLImageElement) {
@@ -205,7 +214,7 @@
 							id="image"
 							type="url"
 							bind:value={image}
-							placeholder="https://example.com/avatar.jpg"
+							placeholder={$t('settings.account.url_placeholder')}
 							aria-describedby="image-helper"
 						/>
 						<p id="image-helper" class="text-sm text-muted-foreground">

--- a/src/routes/[[lang]]/app/settings/email-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/email-settings.svelte
@@ -149,7 +149,7 @@
 							type="email"
 							id="newEmail"
 							name="newEmail"
-							placeholder="Enter new email address"
+							placeholder={$t('settings.email.placeholder')}
 							autocomplete="email"
 							bind:value={formData.newEmail}
 						/>

--- a/src/routes/[[lang]]/app/settings/password-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/password-settings.svelte
@@ -128,7 +128,7 @@
 						type="password"
 						id="currentPassword"
 						name="currentPassword"
-						placeholder="Enter current password"
+						placeholder={$t('settings.password.placeholder.current')}
 						autocomplete="current-password"
 						bind:value={formData.currentPassword}
 					/>
@@ -143,7 +143,7 @@
 						type="password"
 						id="newPassword"
 						name="newPassword"
-						placeholder="Enter new password"
+						placeholder={$t('settings.password.placeholder.new')}
 						autocomplete="new-password"
 						bind:value={formData.newPassword}
 					/>
@@ -161,7 +161,7 @@
 						type="password"
 						id="confirmPassword"
 						name="confirmPassword"
-						placeholder="Confirm new password"
+						placeholder={$t('settings.password.placeholder.confirm')}
 						autocomplete="new-password"
 						bind:value={formData.confirmPassword}
 					/>

--- a/src/routes/[[lang]]/app/settings/security-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/security-settings.svelte
@@ -126,7 +126,7 @@
 						id="passkey-name"
 						type="text"
 						bind:value={newPasskeyName}
-						placeholder="Passkey name (optional)"
+						placeholder={$t('settings.security.passkey.placeholder')}
 					/>
 				</div>
 				<Button onclick={handleAddPasskey} disabled={isAdding}>
@@ -165,7 +165,7 @@
 								<KeyIcon />
 							</Item.Media>
 							<Item.Content>
-								<Item.Title>{passkey.name || 'Unnamed Passkey'}</Item.Title>
+								<Item.Title>{passkey.name || $t('settings.security.passkey.unnamed')}</Item.Title>
 								<Item.Description>
 									<T keyName="settings.security.created_at" />
 									{formatDate(passkey.createdAt)}

--- a/src/routes/login-04/+page.svelte
+++ b/src/routes/login-04/+page.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-	import LoginForm from '$lib/components/login-form.svelte';
-</script>
-
-<div class="flex min-h-svh flex-col items-center justify-center bg-muted p-6 md:p-10">
-	<div class="w-full max-w-sm md:max-w-3xl">
-		<LoginForm />
-	</div>
-</div>


### PR DESCRIPTION
- Add translation utilities in convex/i18n for server-side i18n support
- Update Tolgee config to use self-hosted instance (tolgee.inframs.de)
- Expand translation coverage across all languages (en, de, es, fr)
  - Add support widget translations (greetings, messages, buttons, etc.)
  - Add admin panel translations (users, support, metrics)
  - Add email template translations
  - Add aria labels for accessibility
  - Add backend error messages
- Add impersonation utilities to auth-client for admin user management
- Update components to use translation keys consistently
- Add icon transition rules to animation-rules.md (200ms, ease-in-out with blur)
- Remove unused login-04 page