### PR TITLE
fix(a11y): add aria-labels to icon-only buttons for 100% Lighthouse score

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,3 +296,15 @@ A customizable Svelte component for building node-based editors and interactive 
 ## esbuild/Vite Error: The service was stopped
 
 `bun i -f` should fix the issue.
+
+## Lighthouse
+
+### 1. Generate report
+
+`npx lighthouse URL --only-categories=accessibility --output=json --chrome-flags="--headless=new" 2>/dev/null > /tmp/lh.json`
+
+### 2. Query score + failing elements
+
+`cat /tmp/lh.json | jq '{score: (.categories.accessibility.score*100|floor), failures: [.audits|to_entries[]|select(.value.score==0 and .value.scoreDisplayMode=="binary")|{id:.key,elements:[.value.details.items[]?|{selector:.node.selector,snippet:.node.snippet}]}]}'`
+
+Swap accessibility for performance, seo, best-practices as needed.

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -270,8 +270,11 @@
 	"aria": {
 		"breadcrumb": "Brotkrümel",
 		"change_language": "Sprache ändern",
+		"feedback_close": "Feedback schließen",
+		"feedback_open": "Feedback öffnen",
 		"github_repository": "GitHub-Repository",
 		"home": "Startseite",
+		"logout": "Abmelden",
 		"menu_close": "Menü schließen",
 		"menu_open": "Menü öffnen",
 		"remove_attachment": "Anhang entfernen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -270,8 +270,11 @@
 	"aria": {
 		"breadcrumb": "breadcrumb",
 		"change_language": "Change language",
+		"feedback_close": "Close feedback",
+		"feedback_open": "Open feedback",
 		"github_repository": "GitHub repository",
 		"home": "home",
+		"logout": "Log out",
 		"menu_close": "Close Menu",
 		"menu_open": "Open Menu",
 		"remove_attachment": "Remove attachment",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -270,8 +270,11 @@
 	"aria": {
 		"breadcrumb": "migas de pan",
 		"change_language": "Cambiar idioma",
+		"feedback_close": "Cerrar comentarios",
+		"feedback_open": "Abrir comentarios",
 		"github_repository": "Repositorio de GitHub",
 		"home": "inicio",
+		"logout": "Cerrar sesión",
 		"menu_close": "Cerrar menú",
 		"menu_open": "Abrir menú",
 		"remove_attachment": "Eliminar adjunto",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -270,8 +270,11 @@
 	"aria": {
 		"breadcrumb": "fil d'Ariane",
 		"change_language": "Changer la langue",
+		"feedback_close": "Fermer les commentaires",
+		"feedback_open": "Ouvrir les commentaires",
 		"github_repository": "Dépôt GitHub",
 		"home": "accueil",
+		"logout": "Se déconnecter",
 		"menu_close": "Fermer le menu",
 		"menu_open": "Ouvrir le menu",
 		"remove_attachment": "Supprimer la pièce jointe",

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -231,6 +231,7 @@
 									size="icon"
 									class="size-9 rounded-full"
 									onclick={handleCameraClick}
+									aria-label={$t('chat.tooltip.mark_bug')}
 								>
 									<Camera class="h-[18px] w-[18px]" />
 								</Button>
@@ -249,7 +250,13 @@
 								{/snippet}
 								{#snippet children(props)}
 									<FileUploadTrigger asChild={true}>
-										<Button {...props} variant="outline" size="icon" class="size-9 rounded-full">
+										<Button
+											{...props}
+											variant="outline"
+											size="icon"
+											class="size-9 rounded-full"
+											aria-label={$t('chat.tooltip.attach_files')}
+										>
 											<Paperclip class="h-[18px] w-[18px]" />
 										</Button>
 									</FileUploadTrigger>

--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -113,6 +113,7 @@
 				class="h-8 w-8 rounded-full text-muted-foreground"
 				onclick={handleSubmit}
 				disabled={!input.trim() || threadContext.isSending || threadContext.hasPendingToolCalls}
+				aria-label={$t('chat.aria.send')}
 			>
 				<ArrowUp class="size-5" />
 			</Button>

--- a/src/lib/components/customer-support/feedback-button.svelte
+++ b/src/lib/components/customer-support/feedback-button.svelte
@@ -4,6 +4,9 @@
 	import FeedbackWidget from './feedback-widget.svelte';
 	import { on } from 'svelte/events';
 	import type { ChatUIContext } from '$lib/chat';
+	import { getTranslate } from '@tolgee/svelte';
+
+	const { t } = getTranslate();
 
 	let {
 		isFeedbackOpen = false,
@@ -45,6 +48,7 @@
 			variant="default"
 			size="icon"
 			onclick={toggleOpen}
+			aria-label={isFeedbackOpen ? $t('aria.feedback_close') : $t('aria.feedback_open')}
 			class="h-12 w-12 rounded-full transition-colors transition-transform duration-200 ease-in-out hover:scale-110 hover:bg-primary active:scale-105"
 		>
 			<div class="relative size-6">

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -40,7 +40,7 @@
 				class="-mx-2 flex w-[calc(100%+1rem)] items-center justify-between rounded-2xl border border-black/[0.06] px-6 py-4 [box-shadow:inset_0_1px_1px_0_rgba(255,255,255,0.5)] backdrop-blur-[5px] transition-[height,transform] duration-300 [background:linear-gradient(137deg,rgba(252,252,255,0.9)_4.87%,rgba(240,240,248,0.95)_75.88%)] lg:-mx-8 lg:w-[calc(100%+4rem)] lg:px-8 dark:border-white/[0.06] dark:[box-shadow:inset_0_1px_1px_0_rgba(255,255,255,0.15)] dark:[background:linear-gradient(137deg,rgba(17,18,20,0.75)_4.87%,rgba(12,13,15,0.9)_75.88%)]"
 			>
 				<!-- Logo -->
-				<a href={localizedHref('/')} aria-label="home" class="flex items-center space-x-2">
+				<a href={localizedHref('/')} class="flex items-center space-x-2">
 					<Logo class="size-5" />
 					<span class="font-semibold">SaaS Starter</span>
 				</a>
@@ -83,6 +83,7 @@
 							size="icon"
 							class="size-8"
 							onclick={() => authClient.signOut()}
+							aria-label={$t('aria.logout')}
 						>
 							<LogOut class="size-4" />
 						</Button>


### PR DESCRIPTION
- Add aria-label to feedback button (open/close states)
- Add aria-label to logout button in marketing header
- Add aria-label to send button in ai-chatbar
- Add aria-labels to camera and file buttons in ChatInput
- Remove mismatched aria-label from logo link (visible text suffices)
- Add Lighthouse CLI instructions to AGENTS.md