### PR TITLE
fix(email): rename isPending to isEmailPending for consistency

### DIFF
--- a/src/lib/chat/ui/ChatMessage.svelte
+++ b/src/lib/chat/ui/ChatMessage.svelte
@@ -15,6 +15,7 @@
 		isHandoffMessage = false,
 		showEmailPrompt = false,
 		currentEmail = '',
+		isEmailPending = false,
 		defaultEmail = '',
 		onSubmitEmail
 	}: {
@@ -30,6 +31,8 @@
 		showEmailPrompt?: boolean;
 		/** Currently saved notification email */
 		currentEmail?: string;
+		/** True while email mutation is in flight (green check hidden until confirmed) */
+		isEmailPending?: boolean;
 		/** Default email (from logged-in user) */
 		defaultEmail?: string;
 		/** Callback when email is submitted */
@@ -101,7 +104,7 @@
 					<Response content={message.displayText} animation={{ enabled: true }} />
 				{/if}
 				{#if isHandoffMessage && showEmailPrompt && onSubmitEmail}
-					<InlineEmailPrompt {currentEmail} {defaultEmail} {onSubmitEmail} />
+					<InlineEmailPrompt {currentEmail} {isEmailPending} {defaultEmail} {onSubmitEmail} />
 				{/if}
 			</MessageBubble>
 		{/if}

--- a/src/lib/chat/ui/ChatMessages.svelte
+++ b/src/lib/chat/ui/ChatMessages.svelte
@@ -19,6 +19,7 @@
 		extractAttachments,
 		showEmailPrompt = false,
 		currentEmail = '',
+		isEmailPending = false,
 		defaultEmail = '',
 		onSubmitEmail,
 		class: className = ''
@@ -31,6 +32,8 @@
 		showEmailPrompt?: boolean;
 		/** Currently saved notification email */
 		currentEmail?: string;
+		/** True while email mutation is in flight (green check hidden until confirmed) */
+		isEmailPending?: boolean;
 		/** Default email (from logged-in user) */
 		defaultEmail?: string;
 		/** Callback when email is submitted */
@@ -128,6 +131,7 @@
 						isHandoffMessage={message.displayText?.startsWith(HANDOFF_MESSAGE)}
 						{showEmailPrompt}
 						{currentEmail}
+						{isEmailPending}
 						{defaultEmail}
 						{onSubmitEmail}
 					/>

--- a/src/lib/chat/ui/InlineEmailPrompt.svelte
+++ b/src/lib/chat/ui/InlineEmailPrompt.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import * as v from 'valibot';
-	import { toast } from 'svelte-sonner';
 	import * as InputGroup from '$lib/components/ui/input-group';
 	import { Button } from '$lib/components/ui/button';
 	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
@@ -12,11 +11,14 @@
 
 	let {
 		currentEmail = '',
+		isEmailPending = false,
 		defaultEmail = '',
 		onSubmitEmail
 	}: {
 		/** Currently saved notification email from thread */
 		currentEmail?: string;
+		/** True while email mutation is in flight (green check hidden until confirmed) */
+		isEmailPending?: boolean;
 		/** Fallback email (e.g., from logged-in user) */
 		defaultEmail?: string;
 		onSubmitEmail: (email: string) => Promise<void>;
@@ -28,6 +30,10 @@
 	let email = $state(currentEmail || defaultEmail || '');
 	let isSubmitting = $state(false);
 
+	// Local optimistic state - allows immediate UI feedback before Convex query propagates
+	// null = use currentEmail, true = optimistically subscribed, false = optimistically unsubscribed
+	let optimisticSubscribed = $state<boolean | null>(null);
+
 	// Track the previous currentEmail to detect external changes (e.g., switching threads)
 	// Intentionally snapshot previous value for change detection.
 	// svelte-ignore state_referenced_locally
@@ -36,10 +42,12 @@
 	// Sync email only when currentEmail prop actually changes externally
 	$effect(() => {
 		if (currentEmail !== prevCurrentEmail) {
-			// External change (e.g., switching threads) - sync to new value
+			// External change (e.g., switching threads or Convex query update) - sync to new value
 			// Use empty string if currentEmail is empty (don't fall back to defaultEmail after unsubscribe)
 			email = currentEmail || '';
 			prevCurrentEmail = currentEmail;
+			// Clear optimistic state - real value has arrived
+			optimisticSubscribed = null;
 		}
 	});
 
@@ -48,8 +56,13 @@
 	// Check if email has changed from the saved value
 	const hasChanges = $derived(email.trim() !== (currentEmail || ''));
 
-	// Is user currently subscribed (saved email exists and matches current input)
-	const _isSubscribed = $derived(!!currentEmail && currentEmail === email.trim());
+	// Is user currently subscribed - use local optimistic state if set, otherwise use server state
+	const isSubscribed = $derived(optimisticSubscribed ?? !!currentEmail);
+
+	// Show green check only when subscribed AND server has confirmed (not pending, no local optimistic override)
+	const showConfirmed = $derived(
+		!!currentEmail && !isEmailPending && optimisticSubscribed === null
+	);
 
 	// Can subscribe: valid email AND email has changed from saved value
 	const canSubscribe = $derived(isValidEmail && hasChanges);
@@ -57,12 +70,15 @@
 	async function handleSubmit() {
 		if (!canSubscribe || isSubmitting) return;
 
+		// Optimistic: immediately show subscribed state
+		optimisticSubscribed = true;
 		isSubmitting = true;
+
 		try {
 			await onSubmitEmail(email.trim());
-			toast.success($t('chat.email.saved_success'));
 		} catch {
-			toast.error($t('chat.email.save_failed'));
+			// Rollback optimistic state on error
+			optimisticSubscribed = null;
 		} finally {
 			isSubmitting = false;
 		}
@@ -71,13 +87,17 @@
 	async function handleUnsubscribe() {
 		if (isSubmitting) return;
 
+		// Optimistic: immediately show unsubscribed state (enables input)
+		optimisticSubscribed = false;
+		email = '';
 		isSubmitting = true;
+
 		try {
-			email = '';
 			await onSubmitEmail('');
-			toast.success($t('chat.email.unsubscribed'));
 		} catch {
-			toast.error($t('chat.email.unsubscribe_failed'));
+			// Rollback optimistic state on error
+			optimisticSubscribed = null;
+			email = currentEmail || '';
 		} finally {
 			isSubmitting = false;
 		}
@@ -90,17 +110,17 @@
 			type="email"
 			placeholder={$t('chat.email.placeholder')}
 			bind:value={email}
-			disabled={!!currentEmail}
+			disabled={isSubscribed}
 			onkeydown={(e) => e.key === 'Enter' && canSubscribe && handleSubmit()}
 		/>
-		{#if currentEmail}
+		{#if showConfirmed}
 			<InputGroup.Addon align="inline-end">
 				<CircleCheckIcon class="h-4 w-4 text-green-600" />
 			</InputGroup.Addon>
 		{/if}
 	</InputGroup.Root>
 
-	{#if currentEmail}
+	{#if isSubscribed}
 		<Button variant="outline" size="icon" onclick={handleUnsubscribe} disabled={isSubmitting}>
 			<BellOffIcon class="h-4 w-4" />
 		</Button>

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -67,10 +67,8 @@
 			if (threadQuery.data.assignedAdmin && !threadContext.assignedAdmin) {
 				threadContext.assignedAdmin = threadQuery.data.assignedAdmin;
 			}
-			// Sync notificationEmail if query has data and context doesn't
-			if (threadQuery.data.notificationEmail && !threadContext.notificationEmail) {
-				threadContext.notificationEmail = threadQuery.data.notificationEmail;
-			}
+			// Always sync notificationEmail from query (source of truth, includes optimistic updates)
+			threadContext.notificationEmail = threadQuery.data.notificationEmail ?? null;
 		}
 	});
 
@@ -254,6 +252,7 @@
 						{extractAttachments}
 						showEmailPrompt={threadContext.isHandedOff}
 						currentEmail={threadContext.notificationEmail ?? ''}
+						isEmailPending={threadContext.isEmailPending}
 						defaultEmail={page.data.viewer?.email ?? ''}
 						onSubmitEmail={handleSubmitEmail}
 					/>


### PR DESCRIPTION
- Rename isPending prop to isEmailPending in InlineEmailPrompt for consistency with parent components
- Update comment in support-thread-context to accurately describe green check conditions