### PR TITLE
perf: optimize frontend performance

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -19,6 +19,13 @@
 			type="font/woff2"
 			crossorigin
 		/>
+		<link
+			rel="preload"
+			href="%sveltekit.assets%/fonts/outfit-v15-latin-600.woff2"
+			as="font"
+			type="font/woff2"
+			crossorigin
+		/>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/blocks/integration/card/integration-card.svelte
+++ b/src/blocks/integration/card/integration-card.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/button/button.svelte';
 	import Card from '$lib/components/ui/card/card.svelte';
-	import { ChevronRight } from '@lucide/svelte';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import type { Snippet } from 'svelte';
 
 	type IntegrationCardProps = {

--- a/src/blocks/team/team-two.svelte
+++ b/src/blocks/team/team-two.svelte
@@ -72,6 +72,8 @@
 							alt="team member"
 							width="826"
 							height="1239"
+							loading="lazy"
+							decoding="async"
 						/>
 						<div class="px-2 pt-2 sm:pt-4 sm:pb-0">
 							<div class="flex justify-between">

--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -159,7 +159,13 @@
 						{#if uploadState?.status === 'uploading'}
 							<LoaderCircleIcon class="size-4 shrink-0 animate-spin" />
 						{:else if preview}
-							<img src={preview} alt={filename} class="size-8 rounded object-cover" />
+							<img
+								src={preview}
+								alt={filename}
+								class="size-8 rounded object-cover"
+								loading="lazy"
+								decoding="async"
+							/>
 						{:else if isScreenshot(attachment)}
 							<ImageIcon class="size-4 shrink-0" />
 						{:else}

--- a/src/lib/components/ai-elements/conversation/ConversationScrollButton.svelte
+++ b/src/lib/components/ai-elements/conversation/ConversationScrollButton.svelte
@@ -17,7 +17,7 @@
 
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { ArrowDown } from '@lucide/svelte';
+	import ArrowDown from '@lucide/svelte/icons/arrow-down';
 	import { stickToBottomContext } from './stick-to-bottom-context.svelte.js';
 	import { fly } from 'svelte/transition';
 	import { backOut } from 'svelte/easing';


### PR DESCRIPTION
- Fix Lucide barrel imports to use individual imports (reduces bundle size)
- Add font preload for 600 weight (prevents font loading waterfall)
- Add lazy loading to below-fold images (team avatars, chat attachments)
- Remove unused Cloudinary preconnect