### PR TITLE
fix(auth): validate OAuth callbackURL against open redirect

### DIFF
--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -221,7 +221,7 @@
 		try {
 			await authClient.signIn.social({
 				provider,
-				callbackURL: params.redirectTo || localizedHref('/app')
+				callbackURL: safeRedirectPath(params.redirectTo, localizedHref('/app'))
 			});
 		} catch (error) {
 			console.error(`[SignIn] OAuth ${provider} error:`, error);


### PR DESCRIPTION
Apply safeRedirectPath to OAuth sign-in flow for defense in depth.
Better Auth validates callbackURL server-side, but this ensures
consistent validation across all redirect paths.