### PR TITLE
fix(search): search visibility to live client auth with sticky state

### DIFF
--- a/src/blocks/team/team-two.svelte
+++ b/src/blocks/team/team-two.svelte
@@ -72,6 +72,7 @@
 							alt="team member"
 							width="826"
 							height="1239"
+							draggable={false}
 							loading="lazy"
 							decoding="async"
 						/>
@@ -92,6 +93,7 @@
 								</span>
 								<a
 									href={resolve(member.link)}
+									draggable={false}
 									class="group-hover:text-primary-600 dark:group-hover:text-primary-400 inline-block translate-y-8 text-sm tracking-wide opacity-0 transition-all duration-500 group-hover:translate-y-0 group-hover:opacity-100 hover:underline"
 								>
 									<T keyName="team.linktree" />

--- a/src/routes/[[lang]]/+layout.svelte
+++ b/src/routes/[[lang]]/+layout.svelte
@@ -15,10 +15,6 @@
 	languageContext.set(() => data.lang);
 	setGlobalSearchContext();
 
-	const viewer = $derived(data.viewer as (typeof data.viewer & { role?: string }) | null);
-	const isAuthenticated = $derived(Boolean(viewer));
-	const userRole = $derived(viewer?.role ?? null);
-
 	// Intentionally capture initial language; watch() syncs URL navigation changes below.
 	// svelte-ignore state_referenced_locally
 	const tolgee = Tolgee()
@@ -67,6 +63,6 @@
 </script>
 
 <TolgeeProvider {tolgee}>
-	<CommandMenu {isAuthenticated} {userRole} />
+	<CommandMenu />
 	{@render children()}
 </TolgeeProvider>


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Refactored global search command menu to use live client-side authentication instead of server-side props, implementing a sticky state pattern that prevents UI flickering during auth transitions by caching the last known auth state.

Key changes:
- Replaced `isAuthenticated` and `userRole` props with direct `useAuth()` and `useQuery(api.auth.getCurrentUser)` calls
- Implemented `lastStableAuth` state that persists during auth loading states to prevent route visibility flicker
- Added `draggable={false}` to team section images and links to improve UX
- Removed prop drilling through layout component, simplifying component interface

**Issue found:** Initial `lastStableAuth` state reads from potentially uninitialized reactive sources (`auth.isAuthenticated` and `viewer.data`), creating a race condition where the initial cached state may be unpredictable

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one logical issue that should be fixed to prevent race conditions
- The refactor correctly implements sticky state pattern to prevent UI flicker, and the changes are well-isolated. However, the initialization of `lastStableAuth` has a race condition where it reads from reactive sources before they're guaranteed to be initialized, which could cause unpredictable initial state
- Pay close attention to `src/lib/components/global-search/command-menu.svelte` - fix the `lastStableAuth` initialization race condition

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/blocks/team/team-two.svelte | Added `draggable={false}` to images and links to prevent accidental drag behavior during user interactions |
| src/lib/components/global-search/command-menu.svelte | Refactored to use live client-side auth with sticky state pattern, moving auth logic from props to Convex queries to prevent flickering during auth state transitions |
| src/routes/[[lang]]/+layout.svelte | Removed auth props from `CommandMenu` component as auth state is now managed internally |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Layout as +layout.svelte
    participant Menu as command-menu.svelte
    participant Auth as useAuth
    participant Query as useQuery
    participant State as State Management

    Layout->>Menu: Render component
    Menu->>Auth: Get auth status
    Auth-->>Menu: isLoading, isAuthenticated
    Menu->>Query: Fetch current user
    Query-->>Menu: User with role
    
    Note over Menu,State: Initialize sticky state
    
    alt Auth is loading
        State->>Menu: Use cached state
    else Auth loaded
        State->>State: Update cached state
        State->>Menu: Use fresh state
    end
    
    Menu->>Menu: Filter routes by permissions
    Menu->>Menu: Render visible routes
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->