### PR TITLE
fix(about): add and apply no-drag utility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ This applies to all icon libraries and large component libraries. Individual imp
 - Only create a new component if it doesn't exist in any of the above libraries.
 - When implementing a new component, follow the existing shadcn-svelte component api and patterns in `src/lib/components/ui/`
 - Use Tailwind CSS classes for layout and styling in general. Do not add additional styling classes to the shadcn svelte components. They look good by default.
+- Prefer reusable Tailwind utilities (defined globally with `@utility` in `src/routes/layout.css`) over component-local `<style>` blocks for shared styling patterns (for example `no-drag`).
 
 #### Animations
 

--- a/src/blocks/team/team-two.svelte
+++ b/src/blocks/team/team-two.svelte
@@ -67,7 +67,7 @@
 				{#each members as member, index (member.name)}
 					<div class="group overflow-hidden">
 						<img
-							class="h-96 w-full rounded-md object-cover object-top grayscale transition-all duration-500 group-hover:h-[22.5rem] group-hover:rounded-xl hover:grayscale-0"
+							class="h-96 w-full rounded-md object-cover object-top grayscale transition-all duration-500 no-drag group-hover:h-[22.5rem] group-hover:rounded-xl hover:grayscale-0"
 							src={member.avatar}
 							alt="team member"
 							width="826"
@@ -94,7 +94,7 @@
 								<a
 									href={resolve(member.link)}
 									draggable={false}
-									class="group-hover:text-primary-600 dark:group-hover:text-primary-400 inline-block translate-y-8 text-sm tracking-wide opacity-0 transition-all duration-500 group-hover:translate-y-0 group-hover:opacity-100 hover:underline"
+									class="group-hover:text-primary-600 dark:group-hover:text-primary-400 inline-block translate-y-8 text-sm tracking-wide opacity-0 transition-all duration-500 no-drag group-hover:translate-y-0 group-hover:opacity-100 hover:underline"
 								>
 									<T keyName="team.linktree" />
 								</a>

--- a/src/blocks/team/team-two.svelte
+++ b/src/blocks/team/team-two.svelte
@@ -72,6 +72,7 @@
 							alt="team member"
 							width="826"
 							height="1239"
+							draggable={false}
 							loading="lazy"
 							decoding="async"
 						/>
@@ -92,6 +93,7 @@
 								</span>
 								<a
 									href={resolve(member.link)}
+									draggable={false}
 									class="group-hover:text-primary-600 dark:group-hover:text-primary-400 inline-block translate-y-8 text-sm tracking-wide opacity-0 transition-all duration-500 group-hover:translate-y-0 group-hover:opacity-100 hover:underline"
 								>
 									<T keyName="team.linktree" />

--- a/src/routes/[[lang]]/+layout.svelte
+++ b/src/routes/[[lang]]/+layout.svelte
@@ -15,10 +15,6 @@
 	languageContext.set(() => data.lang);
 	setGlobalSearchContext();
 
-	const viewer = $derived(data.viewer as (typeof data.viewer & { role?: string }) | null);
-	const isAuthenticated = $derived(Boolean(viewer));
-	const userRole = $derived(viewer?.role ?? null);
-
 	// Intentionally capture initial language; watch() syncs URL navigation changes below.
 	// svelte-ignore state_referenced_locally
 	const tolgee = Tolgee()
@@ -67,6 +63,6 @@
 </script>
 
 <TolgeeProvider {tolgee}>
-	<CommandMenu {isAuthenticated} {userRole} />
+	<CommandMenu />
 	{@render children()}
 </TolgeeProvider>

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -332,6 +332,10 @@
 	}
 }
 
+@utility no-drag {
+	-webkit-user-drag: none;
+}
+
 @layer components {
 	.scrollbar-thin {
 		&::-webkit-scrollbar {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `no-drag` utility to prevent unwanted drag behavior on images and links, and refactors the global search command menu to fetch authentication state client-side instead of via props.

**Key changes:**
- Added `no-drag` Tailwind utility (`-webkit-user-drag: none`) in `src/routes/layout.css`
- Applied `no-drag` class and `draggable={false}` to team member images and links to improve UX
- Updated `AGENTS.md` to recommend reusable utilities over component-local styles
- Refactored `CommandMenu` to use `useAuth()` and `useQuery()` for live auth state
- Implemented sticky state pattern (`lastStableAuth`) to prevent menu flickering during auth loading
- Removed auth props from `+layout.svelte` since `CommandMenu` now handles auth internally

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations for the auth state refactor
- The `no-drag` utility changes are straightforward and safe. The auth refactor is well-implemented with sticky state handling, but adds client-side queries that should be verified to work correctly during initial page loads and auth transitions
- Pay attention to `src/lib/components/global-search/command-menu.svelte` to verify auth state behaves correctly during loading states

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/routes/layout.css | Added `no-drag` utility to prevent dragging on images and links |
| src/blocks/team/team-two.svelte | Applied `no-drag` class and `draggable={false}` to team member images and links |
| src/lib/components/global-search/command-menu.svelte | Refactored to fetch auth state client-side with sticky state handling during loading |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Layout as +layout.svelte
    participant CM as CommandMenu
    participant Auth as useAuth()
    participant Query as useQuery()
    participant Convex as Convex Backend
    
    Layout->>CM: Render (no props)
    CM->>Auth: Get auth state
    Auth-->>CM: isLoading, isAuthenticated
    CM->>Query: api.auth.getCurrentUser
    Query->>Convex: Fetch user data
    Convex-->>Query: user with role
    Query-->>CM: viewer.data
    
    alt Auth is loading
        CM->>CM: Use lastStableAuth
        Note over CM: Prevents menu flicker<br/>during auth check
    else Auth loaded
        CM->>CM: Update lastStableAuth
        CM->>CM: Calculate effectiveAuth
        Note over CM: isAuthenticated + role
    end
    
    CM->>CM: Filter routes by effectiveAuth
    CM->>CM: Render visible routes
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->