### PR TITLE
fix(global-search): update command trigger to use platform-specific key representation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,10 @@ This applies to all icon libraries and large component libraries. Individual imp
 - Use Tailwind CSS classes for layout and styling in general. Do not add additional styling classes to the shadcn svelte components. They look good by default.
 - Prefer reusable Tailwind utilities (defined globally with `@utility` in `src/routes/layout.css`) over component-local `<style>` blocks for shared styling patterns (for example `no-drag`).
 
+#### Keyboard Shortcuts
+
+Never hardcode `⌘` or `Ctrl`. Use `cmdOrCtrl` / `optionOrAlt` from `$lib/hooks/is-mac.svelte` to show the correct modifier per platform.
+
 #### Animations
 
 Simple animations should be implemented with plain CSS whenever possible.

--- a/src/lib/components/global-search/command-trigger.svelte
+++ b/src/lib/components/global-search/command-trigger.svelte
@@ -3,6 +3,7 @@
 	import * as Kbd from '$lib/components/ui/kbd/index.js';
 	import { cn } from '$lib/utils.js';
 	import { getTranslate } from '@tolgee/svelte';
+	import { cmdOrCtrl } from '$lib/hooks/is-mac.svelte';
 	import { useGlobalSearchContext } from './context.svelte';
 
 	interface Props {
@@ -29,7 +30,7 @@
 	<span class="inline-flex lg:hidden">{$t('search.command.trigger_mobile')}</span>
 	<div class="absolute end-1.5 top-1.5 hidden gap-1 sm:flex">
 		<Kbd.Group>
-			<Kbd.Root class="border">⌘</Kbd.Root>
+			<Kbd.Root class="border">{cmdOrCtrl}</Kbd.Root>
 			<Kbd.Root class="border">K</Kbd.Root>
 		</Kbd.Group>
 	</div>

--- a/src/lib/hooks/is-mac.svelte.ts
+++ b/src/lib/hooks/is-mac.svelte.ts
@@ -1,0 +1,6 @@
+import { browser } from '$app/environment';
+
+const isMac = browser ? /Mac|iPhone|iPod|iPad/.test(navigator.platform) : true;
+
+export const cmdOrCtrl = isMac ? '⌘' : 'Ctrl';
+export const optionOrAlt = isMac ? '⌥' : 'Alt';


### PR DESCRIPTION
- Replaced hardcoded command key with dynamic  import to ensure correct display for Mac and non-Mac users in the global search command trigger component.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the global search command trigger to display the platform-appropriate modifier key by importing `cmdOrCtrl` from a new `$lib/hooks/is-mac.svelte.ts` helper, and documents the convention in `AGENTS.md`.

The main concern is SSR behavior: `is-mac.svelte.ts` currently treats SSR as Mac (`isMac = true` when `browser` is false). That means server-rendered HTML will always show Mac symbols (e.g. `⌘`), and non-Mac clients will hydrate to `Ctrl`/`Alt`, creating an SSR/CSR mismatch and a visible flicker in the shortcut hint.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a likely SSR/CSR mismatch in platform key rendering for non-Mac users.
- The UI change is straightforward, but the new `is-mac.svelte.ts` helper defaults SSR to Mac which will make server-rendered shortcut labels differ from hydrated client labels on non-Mac devices (flicker and potential hydration warnings).
- src/lib/hooks/is-mac.svelte.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Docs-only update adding guidance to use platform-specific modifier helpers instead of hardcoding ⌘/Ctrl. |
| src/lib/components/global-search/command-trigger.svelte | Replaces hardcoded ⌘ in the shortcut hint with `cmdOrCtrl` imported from the platform helper; correctness depends on the helper's SSR behavior. |
| src/lib/hooks/is-mac.svelte.ts | Adds `cmdOrCtrl`/`optionOrAlt` exports based on runtime platform detection, but currently defaults to Mac on SSR which can cause hydration mismatch for non-Mac users. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant U as User
  participant UI as CommandTrigger.svelte
  participant M as is-mac.svelte.ts
  participant SSR as SvelteKit SSR
  participant CSR as Browser Hydration

  SSR->>M: import cmdOrCtrl (browser=false)
  M-->>SSR: cmdOrCtrl = "⌘" (default true)
  SSR->>UI: render shortcut hint with cmdOrCtrl
  UI-->>U: HTML shows "⌘ K"

  CSR->>M: evaluate isMac using navigator.platform
  M-->>CSR: cmdOrCtrl = "Ctrl" (non-Mac)
  CSR->>UI: hydrate and reconcile text nodes
  UI-->>U: shortcut hint updates to "Ctrl K" (mismatch/flicker)
```

<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=3117f550-5cd9-4885-a3e6-f5c3ade9549b))
- Context from `dashboard` - .cursor/rules/shadcn-svelte-extras.mdc ([source](https://app.greptile.com/review/custom-context?memory=661dc35e-5cd3-4118-92ff-c6159d4ad102))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=67cdd4df-97d5-46b7-8fc3-4a2437ee5745))
</details>


<!-- /greptile_comment -->