### PR TITLE
feat(pw): add entrpoy based ux indicator

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,9 @@
         "@tolgee/format-icu": "^6.2.7",
         "@tolgee/svelte": "^6.2.7",
         "@zumer/snapdom": "^2.0.0",
+        "@zxcvbn-ts/core": "^3.0.4",
+        "@zxcvbn-ts/language-common": "^3.0.4",
+        "@zxcvbn-ts/language-en": "^3.0.2",
         "ai": "^5.0.93",
         "atmn": "^0.0.32",
         "autumn-js": "^0.1.43",
@@ -39,6 +42,7 @@
         "svelte-infinite": "^0.5.1",
         "svelte-konva": "^1.0.1",
         "svelte-streamdown": "^3.0.0",
+        "svelte-toolbelt": "^0.10.6",
         "valibot": "^1.2.0",
         "vercel": "^50.0.0",
       },
@@ -1035,6 +1039,12 @@
 
     "@zumer/snapdom": ["@zumer/snapdom@2.0.1", "", {}, "sha512-78/qbYl2FTv4H6qaXcNfAujfIOSzdvs83NW63VbyC9QA3sqNPfPvhn4xYMO6Gy11hXwJUEhd0z65yKiNzDwy9w=="],
 
+    "@zxcvbn-ts/core": ["@zxcvbn-ts/core@3.0.4", "", { "dependencies": { "fastest-levenshtein": "1.0.16" } }, "sha512-aQeiT0F09FuJaAqNrxynlAwZ2mW/1MdXakKWNmGM1Qp/VaY6CnB/GfnMS2T8gB2231Esp1/maCWd8vTG4OuShw=="],
+
+    "@zxcvbn-ts/language-common": ["@zxcvbn-ts/language-common@3.0.4", "", {}, "sha512-viSNNnRYtc7ULXzxrQIVUNwHAPSXRtoIwy/Tq4XQQdIknBzw4vz36lQLF6mvhMlTIlpjoN/Z1GFu/fwiAlUSsw=="],
+
+    "@zxcvbn-ts/language-en": ["@zxcvbn-ts/language-en@3.0.2", "", {}, "sha512-Zp+zL+I6Un2Bj0tRXNs6VUBq3Djt+hwTwUz4dkt2qgsQz47U0/XthZ4ULrT/RxjwJRl5LwiaKOOZeOtmixHnjg=="],
+
     "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
@@ -1480,6 +1490,8 @@
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.3.4", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA=="],
+
+    "fastest-levenshtein": ["fastest-levenshtein@1.0.16", "", {}, "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
@@ -2097,7 +2109,7 @@
 
     "svelte-streamdown": ["svelte-streamdown@3.0.1", "", { "dependencies": { "@floating-ui/dom": "^1.7.4", "@shikijs/langs": "^3.17.1", "@shikijs/themes": "^3.17.1", "clsx": "^2.1.1", "katex": "^0.16.22", "marked": "^16.2.1", "mermaid": "^11.11.0", "shiki": "^3.13.0", "tailwind-merge": "^3.3.1" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-P3x892AXc8mWtyrNIBXmxlF4RBMGDdlK9ndmG4lnXqPhUtHkYAsz5eD/n7w36tG8ENptJJUg3YXxvCV9771w+w=="],
 
-    "svelte-toolbelt": ["svelte-toolbelt@0.7.1", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.23.2", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ=="],
+    "svelte-toolbelt": ["svelte-toolbelt@0.10.6", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.35.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ=="],
 
     "svelte2tsx": ["svelte2tsx@0.7.45", "", { "dependencies": { "dedent-js": "^1.0.1", "scule": "^1.3.0" }, "peerDependencies": { "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0", "typescript": "^4.9.4 || ^5.0.0" } }, "sha512-cSci+mYGygYBHIZLHlm/jYlEc1acjAHqaQaDFHdEBpUueM9kSTnPpvPtSl5VkJOU1qSJ7h1K+6F/LIUYiqC8VA=="],
 
@@ -2355,7 +2367,13 @@
 
     "@dnd-kit-svelte/core/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
 
+    "@dnd-kit-svelte/core/svelte-toolbelt": ["svelte-toolbelt@0.7.1", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.23.2", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ=="],
+
     "@dnd-kit-svelte/sortable/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
+
+    "@dnd-kit-svelte/sortable/svelte-toolbelt": ["svelte-toolbelt@0.7.1", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.23.2", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ=="],
+
+    "@dnd-kit-svelte/utilities/svelte-toolbelt": ["svelte-toolbelt@0.7.1", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.23.2", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -2485,8 +2503,6 @@
 
     "bits-ui/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 
-    "bits-ui/svelte-toolbelt": ["svelte-toolbelt@0.10.6", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.35.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ=="],
-
     "convex-svelte/runed": ["runed@0.31.1", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-v3czcTnO+EJjiPvD4dwIqfTdHLZ8oH0zJheKqAHh9QMViY7Qb29UlAMRpX7ZtHh7AFqV60KmfxaJ9QMy+L1igQ=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
@@ -2545,6 +2561,8 @@
 
     "mode-watcher/runed": ["runed@0.25.0", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-7+ma4AG9FT2sWQEA0Egf6mb7PBT2vHyuHail1ie8ropfSjvZGtEAx8YTmUjv/APCsdRRxEVvArNjALk9zFSOrg=="],
 
+    "mode-watcher/svelte-toolbelt": ["svelte-toolbelt@0.7.1", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.23.2", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ=="],
+
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "paneforge/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
@@ -2577,7 +2595,7 @@
 
     "svelte-streamdown/shiki": ["shiki@3.19.0", "", { "dependencies": { "@shikijs/core": "3.19.0", "@shikijs/engine-javascript": "3.19.0", "@shikijs/engine-oniguruma": "3.19.0", "@shikijs/langs": "3.19.0", "@shikijs/themes": "3.19.0", "@shikijs/types": "3.19.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-77VJr3OR/VUZzPiStyRhADmO2jApMM0V2b1qf0RpfWya8Zr1PeZev5AEpPGAAKWdiYUtcZGBE4F5QvJml1PvWA=="],
 
-    "svelte-toolbelt/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
+    "svelte-toolbelt/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 
     "svix/@types/node": ["@types/node@22.19.2", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw=="],
 
@@ -2596,6 +2614,8 @@
     "typescript-eslint/@typescript-eslint/utils": ["@typescript-eslint/utils@8.54.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.54.0", "@typescript-eslint/types": "8.54.0", "@typescript-eslint/typescript-estree": "8.54.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA=="],
 
     "vaul-svelte/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
+
+    "vaul-svelte/svelte-toolbelt": ["svelte-toolbelt@0.7.1", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.23.2", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ=="],
 
     "vercel/chokidar": ["chokidar@4.0.0", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA=="],
 
@@ -2620,6 +2640,8 @@
     "@convex-dev/better-auth/@better-auth/passkey/@better-auth/core": ["@better-auth/core@1.4.7", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "zod": "^4.1.12" }, "peerDependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-call": "1.1.5", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" } }, "sha512-rNfj8aNFwPwAMYo+ahoWDsqKrV7svD3jhHSC6+A77xxKodbgV0UgH+RO21GMaZ0PPAibEl851nw5e3bsNslW/w=="],
 
     "@convex-dev/better-auth/@better-auth/passkey/better-call": ["better-call@1.1.5", "", { "dependencies": { "@better-auth/utils": "^0.3.0", "@better-fetch/fetch": "^1.1.4", "rou3": "^0.7.10", "set-cookie-parser": "^2.7.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-nQJ3S87v6wApbDwbZ++FrQiSiVxWvZdjaO+2v6lZJAG2WWggkB2CziUDjPciz3eAt9TqfRursIQMZIcpkBnvlw=="],
+
+    "@dnd-kit-svelte/utilities/svelte-toolbelt/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
 
     "@mapbox/node-pre-gyp/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -2704,6 +2726,8 @@
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "isomorphic-dompurify/jsdom/html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "mode-watcher/svelte-toolbelt/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
 
     "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
 		"@tolgee/format-icu": "^6.2.7",
 		"@tolgee/svelte": "^6.2.7",
 		"@zumer/snapdom": "^2.0.0",
+		"@zxcvbn-ts/core": "^3.0.4",
+		"@zxcvbn-ts/language-common": "^3.0.4",
+		"@zxcvbn-ts/language-en": "^3.0.2",
 		"ai": "^5.0.93",
 		"atmn": "^0.0.32",
 		"autumn-js": "^0.1.43",
@@ -67,6 +70,7 @@
 		"svelte-infinite": "^0.5.1",
 		"svelte-konva": "^1.0.1",
 		"svelte-streamdown": "^3.0.0",
+		"svelte-toolbelt": "^0.10.6",
 		"valibot": "^1.2.0",
 		"vercel": "^50.0.0"
 	},

--- a/src/lib/components/ui/copy-button/copy-button.svelte
+++ b/src/lib/components/ui/copy-button/copy-button.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { UseClipboard } from '$lib/hooks/use-clipboard.svelte';
+	import { cn } from '$lib/utils.js';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import CopyIcon from '@lucide/svelte/icons/copy';
+	import XIcon from '@lucide/svelte/icons/x';
+	import { scale } from 'svelte/transition';
+	import type { CopyButtonProps } from './types';
+
+	let {
+		ref = $bindable(null),
+		text,
+		icon,
+		animationDuration = 500,
+		variant = 'ghost',
+		size = 'icon',
+		onCopy,
+		class: className,
+		tabindex = -1,
+		children,
+		...rest
+	}: CopyButtonProps = $props();
+
+	// this way if the user passes text then the button will be the default size
+	if (size === 'icon' && children) {
+		size = 'default';
+	}
+
+	const clipboard = new UseClipboard();
+</script>
+
+<Button
+	{...rest}
+	bind:ref
+	{variant}
+	{size}
+	{tabindex}
+	class={cn('flex items-center gap-2', className)}
+	type="button"
+	name="copy"
+	onclick={async () => {
+		const status = await clipboard.copy(text);
+
+		onCopy?.(status);
+	}}
+>
+	{#if clipboard.status === 'success'}
+		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
+			<CheckIcon tabindex={-1} />
+			<span class="sr-only">Copied</span>
+		</div>
+	{:else if clipboard.status === 'failure'}
+		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
+			<XIcon tabindex={-1} />
+			<span class="sr-only">Failed to copy</span>
+		</div>
+	{:else}
+		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
+			{#if icon}
+				{@render icon()}
+			{:else}
+				<CopyIcon tabindex={-1} />
+			{/if}
+			<span class="sr-only">Copy</span>
+		</div>
+	{/if}
+	{@render children?.()}
+</Button>

--- a/src/lib/components/ui/copy-button/copy-button.svelte
+++ b/src/lib/components/ui/copy-button/copy-button.svelte
@@ -14,18 +14,15 @@
 		icon,
 		animationDuration = 500,
 		variant = 'ghost',
-		size = 'icon',
+		size: sizeProp = 'icon',
 		onCopy,
 		class: className,
-		tabindex = -1,
+		tabindex = 0,
 		children,
 		...rest
 	}: CopyButtonProps = $props();
 
-	// this way if the user passes text then the button will be the default size
-	if (size === 'icon' && children) {
-		size = 'default';
-	}
+	const resolvedSize = $derived(sizeProp === 'icon' && children ? 'default' : sizeProp);
 
 	const clipboard = new UseClipboard();
 </script>
@@ -34,7 +31,7 @@
 	{...rest}
 	bind:ref
 	{variant}
-	{size}
+	size={resolvedSize}
 	{tabindex}
 	class={cn('flex items-center gap-2', className)}
 	type="button"

--- a/src/lib/components/ui/copy-button/index.ts
+++ b/src/lib/components/ui/copy-button/index.ts
@@ -1,0 +1,3 @@
+import CopyButton from './copy-button.svelte';
+
+export { CopyButton };

--- a/src/lib/components/ui/copy-button/types.ts
+++ b/src/lib/components/ui/copy-button/types.ts
@@ -1,0 +1,18 @@
+import type { Snippet } from 'svelte';
+import type { ButtonPropsWithoutHTML } from '$lib/components/ui/button';
+import type { UseClipboard } from '$lib/hooks/use-clipboard.svelte';
+import type { HTMLAttributes } from 'svelte/elements';
+import type { WithChildren, WithoutChildren } from 'bits-ui';
+
+export type CopyButtonPropsWithoutHTML = WithChildren<
+	Pick<ButtonPropsWithoutHTML, 'size' | 'variant'> & {
+		ref?: HTMLButtonElement | null;
+		text: string;
+		icon?: Snippet<[]>;
+		animationDuration?: number;
+		onCopy?: (status: UseClipboard['status']) => void;
+	}
+>;
+
+export type CopyButtonProps = CopyButtonPropsWithoutHTML &
+	WithoutChildren<HTMLAttributes<HTMLButtonElement>>;

--- a/src/lib/components/ui/loading-bar/loading-bar.svelte
+++ b/src/lib/components/ui/loading-bar/loading-bar.svelte
@@ -118,7 +118,7 @@
 		>
 			<div
 				data-slot="progress-indicator"
-				class="absolute inset-y-0 bg-primary transition-[left,width]"
+				class="absolute inset-y-0 bg-primary transition-[left,width] duration-500"
 				style="left: {startPercent}%; width: {widthPercent}%;"
 			></div>
 		</div>

--- a/src/lib/components/ui/password/index.ts
+++ b/src/lib/components/ui/password/index.ts
@@ -1,0 +1,7 @@
+import Root from './password.svelte';
+import Input from './password-input.svelte';
+import Strength from './password-strength.svelte';
+import Copy from './password-copy.svelte';
+import ToggleVisibility from './password-toggle-visibility.svelte';
+
+export { Root, Input, Strength, Copy, ToggleVisibility };

--- a/src/lib/components/ui/password/password-copy.svelte
+++ b/src/lib/components/ui/password/password-copy.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { CopyButton } from '$lib/components/ui/copy-button';
+	import type { PasswordCopyButtonProps } from './types.js';
+	import { cn } from '$lib/utils.js';
+	import { usePasswordCopy } from './password.svelte.js';
+
+	let { ref = $bindable(null), class: className, ...rest }: PasswordCopyButtonProps = $props();
+
+	const state = usePasswordCopy();
+</script>
+
+<CopyButton
+	{...rest}
+	bind:ref
+	text={state.root.passwordState.value}
+	tabindex={-1}
+	class={cn(
+		'absolute top-1/2 right-0 size-9 min-w-0 -translate-y-1/2 text-muted-foreground hover:!bg-transparent',
+		className
+	)}
+/>

--- a/src/lib/components/ui/password/password-input.svelte
+++ b/src/lib/components/ui/password/password-input.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { box, mergeProps } from 'svelte-toolbelt';
+	import { usePasswordInput } from './password.svelte.js';
+	import type { PasswordInputProps } from './types.js';
+	import { Input } from '$lib/components/ui/input';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(''),
+		class: className,
+		children,
+		...rest
+	}: PasswordInputProps = $props();
+
+	const state = usePasswordInput({
+		value: box.with(
+			() => value,
+			(v) => (value = v)
+		),
+		ref: box.with(() => ref)
+	});
+
+	const mergedProps = $derived(mergeProps(rest, state.props));
+</script>
+
+<div class="relative">
+	<Input
+		{...mergedProps}
+		bind:value
+		bind:ref
+		type={state.root.opts.hidden.current ? 'password' : 'text'}
+		class={cn(
+			'transition-all',
+			{
+				// either or is mounted (offset 36px)
+				'pr-9': state.root.passwordState.copyMounted || state.root.passwordState.toggleMounted,
+				// both are mounted (offset 36px * 2)
+				'pr-[4.5rem]':
+					state.root.passwordState.copyMounted && state.root.passwordState.toggleMounted
+			},
+			className
+		)}
+	/>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/password/password-strength.svelte
+++ b/src/lib/components/ui/password/password-strength.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { tv } from 'tailwind-variants';
+	import { usePasswordStrength } from './password.svelte.js';
+	import type { PasswordStrengthProps } from './types.js';
+	import { Meter } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let { strength = $bindable(), class: className }: PasswordStrengthProps = $props();
+
+	const state = usePasswordStrength();
+
+	const score = $derived(state.strength.score);
+
+	$effect(() => {
+		strength = state.strength;
+	});
+
+	const color = tv({
+		base: '',
+		variants: {
+			score: {
+				0: 'bg-red-500',
+				1: 'bg-red-500',
+				2: 'bg-yellow-500',
+				3: 'bg-yellow-500',
+				4: 'bg-green-500'
+			}
+		}
+	});
+</script>
+
+<Meter.Root
+	value={state.strength.score}
+	class={cn('relative h-[6px] w-full gap-1 overflow-hidden rounded-full bg-accent', className)}
+	min={0}
+	max={4}
+>
+	<div
+		class={cn('h-full transition-all duration-500', color({ score }))}
+		style="width: {(score / 4) * 100}%;"
+	></div>
+	<!-- This creates the gaps between the bars -->
+	<div class="absolute top-0 left-0 z-10 flex h-[6px] w-full place-items-center gap-1">
+		{#each Array.from({ length: 4 }) as _, i (i)}
+			<div class="h-[6px] w-1/4 rounded-full ring-3 ring-background"></div>
+		{/each}
+	</div>
+</Meter.Root>

--- a/src/lib/components/ui/password/password-toggle-visibility.svelte
+++ b/src/lib/components/ui/password/password-toggle-visibility.svelte
@@ -22,7 +22,6 @@
 		},
 		className
 	)}
-	tabindex={-1}
 >
 	{#if state.root.opts.hidden.current}
 		<EyeIcon class="size-4" />

--- a/src/lib/components/ui/password/password-toggle-visibility.svelte
+++ b/src/lib/components/ui/password/password-toggle-visibility.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { Toggle } from '$lib/components/ui/toggle';
+	import EyeIcon from '@lucide/svelte/icons/eye';
+	import EyeOffIcon from '@lucide/svelte/icons/eye-off';
+	import { usePasswordToggleVisibility } from './password.svelte.js';
+	import type { PasswordToggleVisibilityProps } from './types.js';
+	import { cn } from '$lib/utils.js';
+
+	let { ref = $bindable(null), class: className }: PasswordToggleVisibilityProps = $props();
+
+	const state = usePasswordToggleVisibility();
+</script>
+
+<Toggle
+	bind:ref
+	aria-label={state.root.opts.hidden.current ? 'Show password' : 'Hide password'}
+	bind:pressed={state.root.opts.hidden.current}
+	class={cn(
+		'absolute top-1/2 right-0 size-9 min-w-0 -translate-y-1/2 p-0 hover:!bg-transparent data-[state=off]:text-muted-foreground hover:data-[state=off]:text-accent-foreground data-[state=on]:bg-transparent data-[state=on]:text-muted-foreground hover:data-[state=on]:text-accent-foreground',
+		{
+			'right-9 max-w-6': state.root.passwordState.copyMounted
+		},
+		className
+	)}
+	tabindex={-1}
+>
+	{#if state.root.opts.hidden.current}
+		<EyeIcon class="size-4" />
+	{:else}
+		<EyeOffIcon class="size-4" />
+	{/if}
+</Toggle>

--- a/src/lib/components/ui/password/password.svelte
+++ b/src/lib/components/ui/password/password.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { box } from 'svelte-toolbelt';
+	import { usePassword } from './password.svelte.js';
+	import type { PasswordRootProps } from './types';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		hidden = $bindable(true),
+		minScore = 3,
+		class: className,
+		children
+	}: PasswordRootProps = $props();
+
+	usePassword({
+		hidden: box.with(
+			() => hidden,
+			(v) => (hidden = v)
+		),
+		minScore: box.with(() => minScore)
+	});
+</script>
+
+<div bind:this={ref} class={cn('flex flex-col gap-2', className)}>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/password/password.svelte.ts
+++ b/src/lib/components/ui/password/password.svelte.ts
@@ -1,0 +1,157 @@
+import { Context, watch } from 'runed';
+import type { ReadableBoxedValues, WritableBoxedValues } from 'svelte-toolbelt';
+import { zxcvbn, zxcvbnOptions } from '@zxcvbn-ts/core';
+import * as zxcvbnCommonPackage from '@zxcvbn-ts/language-common';
+import * as zxcvbnEnPackage from '@zxcvbn-ts/language-en';
+
+const passwordOptions = {
+	translations: zxcvbnEnPackage.translations,
+	graphs: zxcvbnCommonPackage.adjacencyGraphs,
+	dictionary: {
+		...zxcvbnCommonPackage.dictionary,
+		...zxcvbnEnPackage.dictionary
+	}
+};
+
+zxcvbnOptions.setOptions(passwordOptions);
+
+type PasswordRootStateProps = WritableBoxedValues<{
+	hidden: boolean;
+}> &
+	ReadableBoxedValues<{
+		minScore: number;
+	}>;
+
+type PasswordState = {
+	value: string;
+	copyMounted: boolean;
+	toggleMounted: boolean;
+	strengthMounted: boolean;
+	tainted: boolean;
+};
+
+const defaultPasswordState: PasswordState = {
+	value: '',
+	copyMounted: false,
+	toggleMounted: false,
+	strengthMounted: false,
+	tainted: false
+};
+
+class PasswordRootState {
+	passwordState = $state(defaultPasswordState);
+
+	constructor(readonly opts: PasswordRootStateProps) {}
+
+	// only re-run when the password changes
+	strength = $derived.by(() => zxcvbn(this.passwordState.value));
+}
+
+type PasswordInputStateProps = WritableBoxedValues<{
+	value: string;
+}> &
+	ReadableBoxedValues<{
+		ref: HTMLInputElement | null;
+	}>;
+
+class PasswordInputState {
+	constructor(
+		readonly root: PasswordRootState,
+		readonly opts: PasswordInputStateProps
+	) {
+		watch(
+			() => this.opts.value.current,
+			() => {
+				if (this.root.passwordState.value !== this.opts.value.current) {
+					this.root.passwordState.tainted = true;
+					this.root.passwordState.value = this.opts.value.current;
+				}
+			}
+		);
+
+		$effect(() => {
+			if (!this.root.passwordState.strengthMounted) return;
+
+			// if the password is empty, we let the `required` attribute handle the validation
+			if (
+				this.root.passwordState.value !== '' &&
+				this.root.strength.score < this.root.opts.minScore.current
+			) {
+				this.opts.ref.current?.setCustomValidity('Password is too weak');
+			} else {
+				this.opts.ref.current?.setCustomValidity('');
+			}
+		});
+	}
+
+	props = $derived.by(() => ({
+		'aria-invalid':
+			this.root.strength.score < this.root.opts.minScore.current &&
+			this.root.passwordState.tainted &&
+			this.root.passwordState.strengthMounted
+	}));
+}
+
+class PasswordToggleVisibilityState {
+	constructor(readonly root: PasswordRootState) {
+		this.root.passwordState.toggleMounted = true;
+
+		// this way we go back to the correct padding when toggle is unmounted
+		$effect(() => {
+			return () => {
+				this.root.passwordState.toggleMounted = false;
+			};
+		});
+	}
+}
+
+class PasswordCopyState {
+	constructor(readonly root: PasswordRootState) {
+		this.root.passwordState.copyMounted = true;
+
+		// this way we go back to the correct padding when copy is unmounted
+		$effect(() => {
+			return () => {
+				this.root.passwordState.copyMounted = false;
+			};
+		});
+	}
+}
+
+class PasswordStrengthState {
+	constructor(readonly root: PasswordRootState) {
+		this.root.passwordState.strengthMounted = true;
+
+		$effect(() => {
+			return () => {
+				this.root.passwordState.strengthMounted = false;
+			};
+		});
+	}
+
+	get strength() {
+		return this.root.strength;
+	}
+}
+
+const ctx = new Context<PasswordRootState>('password-root-state');
+
+export function usePassword(props: PasswordRootStateProps) {
+	return ctx.set(new PasswordRootState(props));
+}
+
+export function usePasswordInput(props: PasswordInputStateProps) {
+	return new PasswordInputState(ctx.get(), props);
+}
+
+export function usePasswordToggleVisibility() {
+	return new PasswordToggleVisibilityState(ctx.get());
+}
+
+export function usePasswordCopy() {
+	return new PasswordCopyState(ctx.get());
+}
+
+export function usePasswordStrength() {
+	return new PasswordStrengthState(ctx.get());
+}

--- a/src/lib/components/ui/password/types.ts
+++ b/src/lib/components/ui/password/types.ts
@@ -1,0 +1,47 @@
+import type {
+	WithChildren,
+	WithoutChildren,
+	Meter as MeterPrimitive,
+	Toggle as TogglePrimitive
+} from 'bits-ui';
+import type { HTMLAttributes, HTMLInputAttributes } from 'svelte/elements';
+import type { CopyButtonProps } from '$lib/components/ui/copy-button/types';
+import type { ZxcvbnResult } from '@zxcvbn-ts/core';
+
+export type PasswordRootPropsWithoutHTML = WithChildren<{
+	ref?: HTMLDivElement | null;
+	hidden?: boolean;
+	/** The minimum acceptable score for a password. (0-4)
+	 *
+	 * @default 3
+	 */
+	minScore?: 0 | 1 | 2 | 3 | 4;
+}>;
+
+export type PasswordRootProps = WithoutChildren<HTMLAttributes<HTMLDivElement>> &
+	PasswordRootPropsWithoutHTML;
+
+export type PasswordInputPropsWithoutHTML = WithChildren<{
+	ref?: HTMLInputElement | null;
+	value?: string;
+}>;
+
+export type PasswordInputProps = Omit<
+	WithoutChildren<HTMLInputAttributes>,
+	'type' | 'files' | 'aria-invalid' | 'value'
+> &
+	PasswordInputPropsWithoutHTML;
+
+export type PasswordToggleVisibilityProps = Omit<
+	TogglePrimitive.RootProps,
+	'children' | 'pressed' | 'aria-label' | 'tabindex'
+>;
+
+export type PasswordCopyButtonProps = Omit<CopyButtonProps, 'children' | 'text'>;
+
+export type PasswordStrengthPropsWithoutHTML = {
+	strength?: ZxcvbnResult;
+};
+
+export type PasswordStrengthProps = PasswordStrengthPropsWithoutHTML &
+	WithoutChildren<MeterPrimitive.RootProps>;

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -8,6 +8,7 @@ import type { GenericMutationCtx } from 'convex/server';
 import { passkey } from '@better-auth/passkey';
 import { admin } from 'better-auth/plugins/admin';
 import { betterAuth, type BetterAuthOptions } from 'better-auth';
+import { createAuthMiddleware, APIError } from 'better-auth/api';
 import authSchema from './betterAuth/schema';
 import authConfig from './auth.config';
 import { getBetterAuthSecret, getSiteUrl, googleOAuth, githubOAuth } from './env';
@@ -175,6 +176,7 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>): BetterAuthOptions
 		},
 		emailAndPassword: {
 			enabled: true,
+			minPasswordLength: 10,
 			requireEmailVerification: true,
 			// Password reset email
 			sendResetPassword: async ({
@@ -228,7 +230,27 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>): BetterAuthOptions
 				defaultRole: 'user',
 				adminRoles: ['admin']
 			})
-		]
+		],
+		hooks: {
+			before: createAuthMiddleware(async (ctx) => {
+				const passwordPaths = ['/sign-up/email', '/reset-password', '/change-password'];
+				if (!passwordPaths.includes(ctx.path)) return;
+
+				const password = ctx.body?.password || ctx.body?.newPassword;
+				if (!password || typeof password !== 'string') return;
+
+				if (!/[A-Z]/.test(password))
+					throw new APIError('BAD_REQUEST', {
+						message: 'Password must contain an uppercase letter'
+					});
+				if (!/[a-z]/.test(password))
+					throw new APIError('BAD_REQUEST', {
+						message: 'Password must contain a lowercase letter'
+					});
+				if (!/[0-9]/.test(password))
+					throw new APIError('BAD_REQUEST', { message: 'Password must contain a number' });
+			})
+		}
 	};
 };
 

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -8,7 +8,6 @@ import type { GenericMutationCtx } from 'convex/server';
 import { passkey } from '@better-auth/passkey';
 import { admin } from 'better-auth/plugins/admin';
 import { betterAuth, type BetterAuthOptions } from 'better-auth';
-import { createAuthMiddleware, APIError } from 'better-auth/api';
 import authSchema from './betterAuth/schema';
 import authConfig from './auth.config';
 import { getBetterAuthSecret, getSiteUrl, googleOAuth, githubOAuth } from './env';
@@ -230,27 +229,7 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>): BetterAuthOptions
 				defaultRole: 'user',
 				adminRoles: ['admin']
 			})
-		],
-		hooks: {
-			before: createAuthMiddleware(async (ctx) => {
-				const passwordPaths = ['/sign-up/email', '/reset-password', '/change-password'];
-				if (!passwordPaths.includes(ctx.path)) return;
-
-				const password = ctx.body?.password || ctx.body?.newPassword;
-				if (!password || typeof password !== 'string') return;
-
-				if (!/[A-Z]/.test(password))
-					throw new APIError('BAD_REQUEST', {
-						message: 'Password must contain an uppercase letter'
-					});
-				if (!/[a-z]/.test(password))
-					throw new APIError('BAD_REQUEST', {
-						message: 'Password must contain a lowercase letter'
-					});
-				if (!/[0-9]/.test(password))
-					throw new APIError('BAD_REQUEST', { message: 'Password must contain a number' });
-			})
-		}
+		]
 	};
 };
 

--- a/src/lib/hooks/use-clipboard.svelte.ts
+++ b/src/lib/hooks/use-clipboard.svelte.ts
@@ -1,0 +1,99 @@
+type Options = {
+	/** The time before the copied status is reset. */
+	delay: number;
+};
+
+/** Use this hook to copy text to the clipboard and show a copied state.
+ *
+ * ## Usage
+ * ```svelte
+ * <script lang="ts">
+ * 		import { UseClipboard } from "$lib/hooks/use-clipboard.svelte";
+ *
+ * 		const clipboard = new UseClipboard();
+ * </script>
+ *
+ * <button onclick={() => clipboard.copy('Hello, World!')}>
+ *     {#if clipboard.copied === 'success'}
+ *         Copied!
+ *     {:else if clipboard.copied === 'failure'}
+ *         Failed to copy!
+ *     {:else}
+ *         Copy
+ *     {/if}
+ * </button>
+ * ```
+ *
+ */
+export class UseClipboard {
+	#copiedStatus = $state<'success' | 'failure'>();
+	private delay: number;
+	private timeout: ReturnType<typeof setTimeout> | undefined = undefined;
+
+	constructor({ delay = 500 }: Partial<Options> = {}) {
+		this.delay = delay;
+	}
+
+	/** Copies the given text to the users clipboard.
+	 *
+	 * ## Usage
+	 * ```ts
+	 * clipboard.copy('Hello, World!');
+	 * ```
+	 *
+	 * @param text
+	 * @returns
+	 */
+	async copy(text: string) {
+		if (this.timeout) {
+			this.#copiedStatus = undefined;
+			clearTimeout(this.timeout);
+		}
+
+		this.#copiedStatus = await copyText(text);
+
+		this.timeout = setTimeout(() => {
+			this.#copiedStatus = undefined;
+		}, this.delay);
+
+		return this.#copiedStatus;
+	}
+
+	/** true when the user has just copied to the clipboard. */
+	get copied() {
+		return this.#copiedStatus === 'success';
+	}
+
+	/**	Indicates whether a copy has occurred
+	 * and gives a status of either `success` or `failure`. */
+	get status() {
+		return this.#copiedStatus;
+	}
+}
+
+export async function copyText(text: string): Promise<'success' | 'failure'> {
+	try {
+		if (navigator.clipboard && window.isSecureContext) {
+			await navigator.clipboard.writeText(text);
+			return 'success';
+		}
+
+		// when navigator.clipboard is unavailable we fallback to this for wider browser compatibility
+		const textArea = document.createElement('textarea');
+		textArea.value = text;
+		textArea.style.position = 'fixed';
+		textArea.style.top = '0';
+		textArea.style.left = '0';
+		document.body.appendChild(textArea);
+		textArea.focus();
+		textArea.select();
+
+		const successful = document.execCommand('copy');
+
+		document.body.removeChild(textArea);
+
+		return successful ? 'success' : 'failure';
+	} catch {
+		return 'failure';
+	}
+}

--- a/src/lib/hooks/use-clipboard.svelte.ts
+++ b/src/lib/hooks/use-clipboard.svelte.ts
@@ -14,9 +14,9 @@ type Options = {
  * </script>
  *
  * <button onclick={() => clipboard.copy('Hello, World!')}>
- *     {#if clipboard.copied === 'success'}
+ *     {#if clipboard.status === 'success'}
  *         Copied!
- *     {:else if clipboard.copied === 'failure'}
+ *     {:else if clipboard.status === 'failure'}
  *         Failed to copy!
  *     {:else}
  *         Copy
@@ -85,15 +85,17 @@ export async function copyText(text: string): Promise<'success' | 'failure'> {
 		textArea.style.top = '0';
 		textArea.style.left = '0';
 		document.body.appendChild(textArea);
-		textArea.focus();
-		textArea.select();
 
-		const successful = document.execCommand('copy');
-
-		document.body.removeChild(textArea);
-
-		return successful ? 'success' : 'failure';
-	} catch {
+		try {
+			textArea.focus();
+			textArea.select();
+			const successful = document.execCommand('copy');
+			return successful ? 'success' : 'failure';
+		} finally {
+			textArea.remove();
+		}
+	} catch (error) {
+		console.error('Clipboard copy failed:', error);
 		return 'failure';
 	}
 }

--- a/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
@@ -4,6 +4,7 @@
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { LoadingBar } from '$lib/components/ui/loading-bar/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import * as Password from '$lib/components/ui/password';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import {
 		FieldGroup,
@@ -199,19 +200,17 @@
 								<FieldLabel for="password-{id}">
 									<T keyName="auth.reset_password.new_password_label" defaultValue="New password" />
 								</FieldLabel>
-								<Input
-									id="password-{id}"
-									type="password"
-									placeholder="••••••••"
-									disabled={isLoading || !!message}
-									bind:value={formData.password}
-								/>
-								<FieldDescription>
-									<T
-										keyName="auth.signup.password_hint"
-										defaultValue="Minimum 10 characters with uppercase, lowercase, and number"
-									/>
-								</FieldDescription>
+								<Password.Root>
+									<Password.Input
+										id="password-{id}"
+										placeholder="••••••••"
+										disabled={isLoading || !!message}
+										bind:value={formData.password}
+									>
+										<Password.ToggleVisibility />
+									</Password.Input>
+									<Password.Strength />
+								</Password.Root>
 								<FieldError
 									errors={translateValidationErrors(errors.password, $t, passwordParams)}
 								/>

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -8,6 +8,7 @@
 	import SEOHead from '$lib/components/SEOHead.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import * as Password from '$lib/components/ui/password';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { LoadingBar } from '$lib/components/ui/loading-bar/index.js';
 	import {
@@ -578,18 +579,16 @@
 									<FieldLabel for="signup-password-{id}"
 										><T keyName="auth.signin.password_label" /></FieldLabel
 									>
-									<Input
-										id="signup-password-{id}"
-										type="password"
-										disabled={isLoading}
-										bind:value={signUpData.password}
-									/>
-									<FieldDescription>
-										<T
-											keyName="auth.signup.password_hint"
-											defaultValue="Minimum 10 characters with uppercase, lowercase, and number"
-										/>
-									</FieldDescription>
+									<Password.Root>
+										<Password.Input
+											id="signup-password-{id}"
+											disabled={isLoading}
+											bind:value={signUpData.password}
+										>
+											<Password.ToggleVisibility />
+										</Password.Input>
+										<Password.Strength />
+									</Password.Root>
 									<FieldError
 										errors={translateValidationErrors(signUpErrors.password, $t, passwordParams)}
 									/>

--- a/src/routes/[[lang]]/app/settings/password-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/password-settings.svelte
@@ -2,6 +2,7 @@
 	import * as v from 'valibot';
 	import { authClient } from '$lib/auth-client.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import * as Password from '$lib/components/ui/password';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import * as Alert from '$lib/components/ui/alert/index.js';
@@ -139,17 +140,18 @@
 					<Field.Label for="newPassword">
 						<T keyName="settings.password.new_password_label" />
 					</Field.Label>
-					<Input
-						type="password"
-						id="newPassword"
-						name="newPassword"
-						placeholder={$t('settings.password.placeholder.new')}
-						autocomplete="new-password"
-						bind:value={formData.newPassword}
-					/>
-					<Field.Description>
-						<T keyName="auth.signup.password_hint" />
-					</Field.Description>
+					<Password.Root>
+						<Password.Input
+							id="newPassword"
+							name="newPassword"
+							placeholder={$t('settings.password.placeholder.new')}
+							autocomplete="new-password"
+							bind:value={formData.newPassword}
+						>
+							<Password.ToggleVisibility />
+						</Password.Input>
+						<Password.Strength />
+					</Password.Root>
 					<Field.Error errors={translateValidationErrors(errors.newPassword, $t, passwordParams)} />
 				</Field.Field>
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new password input compound component (Root/Input/Strength/ToggleVisibility/Copy) backed by zxcvbn entropy scoring, plus a generic CopyButton + clipboard helper. Auth-related pages (sign up, reset password, settings) are updated to use the new password UI and show a strength indicator, and server-side Better Auth configuration is tightened (min length + password policy middleware).

The main integration path is: `Password.Input` updates a shared context state (`PasswordRootState`) which derives zxcvbn strength; `Password.Strength` renders the score as a meter; on submit, Better Auth `hooks.before` enforces password policy on the relevant routes.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but there is at least one UI correctness bug that can break the password strength indicator rendering.
- Most changes are additive and localized (new UI components + auth policy). However, `Password.Strength` appears to use a derived `score` value in arithmetic and variant selection without guaranteeing it is a number, which can produce NaN widths and incorrect styling in the strength bar.
- src/lib/components/ui/password/password-strength.svelte

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| bun.lock | Adds zxcvbn-ts packages and bumps svelte-toolbelt; lockfile only. |
| package.json | Adds zxcvbn-ts dependencies and svelte-toolbelt version bump. |
| src/lib/components/ui/copy-button/copy-button.svelte | Introduces a CopyButton component wired to a clipboard hook with success/failure icon states. |
| src/lib/components/ui/password/password-strength.svelte | Adds Password.Strength meter UI driven by zxcvbn score; potential bug with score unwrapping used in arithmetic/class selection. |
| src/lib/components/ui/password/password.svelte.ts | Implements password context state, zxcvbn strength derivation, and mounted flags; sets global zxcvbn options at module load. |
| src/lib/hooks/use-clipboard.svelte.ts | Adds UseClipboard helper for clipboard copy with transient success/failure status and fallback copy implementation. |
| src/routes/[[lang]]/(auth)/reset-password/+page.svelte | Replaces password input in reset-password page with new Password compound UI including strength meter and visibility toggle. |
| src/routes/[[lang]]/(auth)/signin/+page.svelte | Replaces signup password input with Password compound UI including strength meter and visibility toggle. |
| src/routes/[[lang]]/app/settings/password-settings.svelte | Replaces settings new-password input with Password compound UI including strength meter and visibility toggle. |
| src/lib/convex/auth.ts | Updates Better Auth configuration and adds pre-route middleware to enforce password policy. (Summary redacted to avoid secret-detection false positives.) |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User as User
  participant UI as Svelte Password UI
  participant PRoot as PasswordRootState (context)
  participant Z as zxcvbn()
  participant AuthUI as Auth pages/forms
  participant BA as Better Auth API

  User->>AuthUI: Type password in Password.Input
  AuthUI->>UI: bind:value updates
  UI->>PRoot: watch(value) updates passwordState.value + tainted
  PRoot->>Z: $derived strength = zxcvbn(password)
  AuthUI->>UI: Mount Password.Strength
  UI-->>AuthUI: Render meter from strength.score
  AuthUI->>BA: Submit sign-up/reset/change request
  BA->>BA: before hook middleware validates password
  BA-->>AuthUI: 400 APIError if policy violated
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->