### PR TITLE
fix(chat): keep progressive blur pinned to the bottom2

### DIFF
--- a/src/lib/chat/ui/ChatMessages.svelte
+++ b/src/lib/chat/ui/ChatMessages.svelte
@@ -136,47 +136,49 @@
 	);
 </script>
 
-<ChatContainerRoot class="relative h-full {className}">
-	<ChatContainerContent class="!h-full">
-		{#if ctx.displayMessages.length === 0}
-			<!-- Empty state -->
-			{#if emptyState}
-				{@render emptyState()}
+<div class="relative h-full {className}">
+	<ChatContainerRoot class="relative h-full">
+		<ChatContainerContent class="!h-full">
+			{#if ctx.displayMessages.length === 0}
+				<!-- Empty state -->
+				{#if emptyState}
+					{@render emptyState()}
+				{/if}
+			{:else}
+				<!-- Messages list with fade-in animation on first load -->
+				<div class="px-9 py-20 {ctx.messagesFade.animationClass}">
+					{#each ctx.displayMessages as message, index (message.id)}
+						<ChatMessage
+							{message}
+							attachments={getAttachments(message)}
+							isFirstInGroup={isFirstInGroup(index, ctx.displayMessages)}
+							isHandoffMessage={message.displayText?.startsWith(HANDOFF_MESSAGE)}
+							{showEmailPrompt}
+							{currentEmail}
+							{isEmailPending}
+							{defaultEmail}
+							{onSubmitEmail}
+						/>
+					{/each}
+				</div>
 			{/if}
-		{:else}
-			<!-- Messages list with fade-in animation on first load -->
-			<div class="px-9 py-20 {ctx.messagesFade.animationClass}">
-				{#each ctx.displayMessages as message, index (message.id)}
-					<ChatMessage
-						{message}
-						attachments={getAttachments(message)}
-						isFirstInGroup={isFirstInGroup(index, ctx.displayMessages)}
-						isHandoffMessage={message.displayText?.startsWith(HANDOFF_MESSAGE)}
-						{showEmailPrompt}
-						{currentEmail}
-						{isEmailPending}
-						{defaultEmail}
-						{onSubmitEmail}
-					/>
-				{/each}
-			</div>
-		{/if}
 
-		<!-- Scroll anchor for auto-scroll functionality -->
-		<ChatContainerScrollAnchor />
+			<!-- Scroll anchor for auto-scroll functionality -->
+			<ChatContainerScrollAnchor />
+		</ChatContainerContent>
 
-		<!-- Overlay area pinned to bottom of scroll container -->
-		<div class="pointer-events-none relative sticky bottom-0 z-10 mt-auto min-h-16 w-full">
-			<!-- Progressive blur as background overlay - only shown when there are messages -->
-			{#if ctx.displayMessages.length > 0}
-				<ProgressiveBlur
-					class="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-20 w-full"
-					direction="bottom"
-					blurIntensity={1}
-				/>
-			{/if}
-			<!-- Scroll button over the blur -->
+		<!-- Scroll button pinned to bottom overlay, not in normal content flow -->
+		<div class="pointer-events-none absolute inset-x-0 bottom-0 z-20 h-16 w-full">
 			<ScrollButton class="pointer-events-auto absolute right-9 bottom-6 z-20" />
 		</div>
-	</ChatContainerContent>
-</ChatContainerRoot>
+	</ChatContainerRoot>
+
+	<!-- Blur pinned to chat viewport bottom (outside scroll container) -->
+	{#if ctx.displayMessages.length > 0}
+		<ProgressiveBlur
+			class="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-20 w-full"
+			direction="bottom"
+			blurIntensity={1}
+		/>
+	{/if}
+</div>


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the chat message viewport structure so the progressive blur background stays pinned to the bottom of the overall chat viewport rather than participating in the scrollable content flow. Concretely, `ChatMessages.svelte` now wraps `ChatContainerRoot` in a relative container and moves `ProgressiveBlur` + the `ScrollButton` into absolutely-positioned overlays anchored at the bottom.

The change fits with the existing `prompt-kit/chat-container` pattern where `ChatContainerRoot` is the scrollable element and `ChatContainerScrollAnchor` drives auto-scroll; the blur and scroll-to-bottom button are now rendered outside the scrolling content to avoid being pushed upward by content height/layout changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a small, localized DOM/layout refactor in `ChatMessages.svelte` that keeps existing scroll-anchor behavior intact and only repositions overlays via absolute positioning; no new logic paths or data handling were added.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/chat/ui/ChatMessages.svelte | Refactors chat container layout to pin ProgressiveBlur and scroll button to viewport bottom via absolute positioning; no functional regressions found, but layering/pointer-events should be validated with chat-container root overflow behavior. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User as User
  participant ChatMessages as ChatMessages.svelte
  participant Root as ChatContainerRoot
  participant Content as ChatContainerContent
  participant Anchor as ChatContainerScrollAnchor
  participant Btn as ScrollButton
  participant Blur as ProgressiveBlur

  User->>ChatMessages: render
  ChatMessages->>Root: mount (scroll container)
  Root->>Content: render children
  Content->>Anchor: render scroll anchor
  ChatMessages->>Btn: render (absolute bottom overlay)
  ChatMessages->>Blur: render when messages>0 (absolute bottom)
  User->>Btn: click
  Btn->>Root: scrollContext.scrollToBottom()
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->