### PR TITLE
fix(chat): correct placement of scroll to bottom btn

### DIFF
--- a/src/lib/components/prompt-kit/chat-container/chat-container-root.svelte
+++ b/src/lib/components/prompt-kit/chat-container/chat-container-root.svelte
@@ -7,6 +7,7 @@
 	} from './chat-container-context.svelte';
 	import { cn } from '$lib/utils';
 	import { watch } from 'runed';
+	import { untrack } from 'svelte';
 
 	let {
 		children,
@@ -14,6 +15,7 @@
 		resize = 'smooth',
 		initial = 'instant',
 		ref = $bindable(null),
+		ctx,
 		...restProps
 	}: {
 		children?: import('svelte').Snippet;
@@ -21,10 +23,12 @@
 		resize?: ResizeMode;
 		initial?: InitialMode;
 		ref?: HTMLElement | null;
+		/** Optional externally-created context instance. If omitted, one is created internally. */
+		ctx?: ChatContainerContext;
 		[key: string]: any;
 	} = $props();
 
-	const context = chatContainerContext.set(new ChatContainerContext());
+	const context = chatContainerContext.set(untrack(() => ctx) ?? new ChatContainerContext());
 	$effect(() => {
 		context.setModes(resize, initial);
 	});

--- a/src/lib/components/prompt-kit/chat-container/chat-container-root.svelte
+++ b/src/lib/components/prompt-kit/chat-container/chat-container-root.svelte
@@ -13,12 +13,14 @@
 		class: className,
 		resize = 'smooth',
 		initial = 'instant',
+		ref = $bindable(null),
 		...restProps
 	}: {
 		children?: import('svelte').Snippet;
 		class?: string;
 		resize?: ResizeMode;
 		initial?: InitialMode;
+		ref?: HTMLElement | null;
 		[key: string]: any;
 	} = $props();
 
@@ -27,20 +29,18 @@
 		context.setModes(resize, initial);
 	});
 
-	let containerElement: HTMLElement;
-
 	watch(
-		() => containerElement,
+		() => ref,
 		() => {
-			if (containerElement) {
-				context.setElement(containerElement);
+			if (ref) {
+				context.setElement(ref);
 			}
 		}
 	);
 </script>
 
 <div
-	bind:this={containerElement}
+	bind:this={ref}
 	class={cn(' scrollbar-thin flex flex-col overflow-y-auto', className)}
 	role="log"
 	{...restProps}

--- a/src/lib/components/prompt-kit/scroll-button/ScrollButton.svelte
+++ b/src/lib/components/prompt-kit/scroll-button/ScrollButton.svelte
@@ -48,6 +48,7 @@
 	bind:ref
 	{variant}
 	{size}
+	aria-label="Scroll to bottom"
 	class={cn(
 		'h-10 w-10 rounded-full transition-all duration-150 ease-out',
 		!resolvedIsAtBottom

--- a/src/lib/components/prompt-kit/scroll-button/ScrollButton.svelte
+++ b/src/lib/components/prompt-kit/scroll-button/ScrollButton.svelte
@@ -7,6 +7,8 @@
 		variant?: ButtonVariant;
 		size?: ButtonSize;
 		ref?: HTMLElement | null;
+		isAtBottom?: boolean;
+		onScrollToBottom?: () => void;
 		onclick?: (event: MouseEvent) => void;
 	};
 </script>
@@ -22,16 +24,22 @@
 		variant = 'outline',
 		size = 'sm',
 		ref = $bindable(null),
+		isAtBottom,
+		onScrollToBottom,
 		onclick
 	}: ScrollButtonProps = $props();
 
 	// Lazy context retrieval to avoid SSR issues
 	const scrollContext = browser ? chatContainerContext.getOr(null) : null;
 
-	const isAtBottom = $derived(scrollContext?.isAtBottom ?? true);
+	const resolvedIsAtBottom = $derived(isAtBottom ?? scrollContext?.isAtBottom ?? true);
 
 	const handleClick = (event: MouseEvent) => {
-		scrollContext?.scrollToBottom();
+		if (onScrollToBottom) {
+			onScrollToBottom();
+		} else {
+			scrollContext?.scrollToBottom();
+		}
 		onclick?.(event);
 	};
 </script>
@@ -42,7 +50,7 @@
 	{size}
 	class={cn(
 		'h-10 w-10 rounded-full transition-all duration-150 ease-out',
-		!isAtBottom
+		!resolvedIsAtBottom
 			? 'translate-y-0 scale-100 opacity-100'
 			: 'pointer-events-none translate-y-4 scale-95 opacity-0',
 		className


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the chat UI so the “scroll to bottom” button is rendered as an overlay outside the scroll container, and adds plumbing to bind the scroll viewport element out of `ChatContainerRoot`. `ScrollButton` is extended to optionally accept `isAtBottom` and an `onScrollToBottom` callback, while still falling back to the existing `ChatContainerContext` behavior when those props aren’t provided.

Within the codebase, this keeps the chat container context in place for auto-scroll and state, but `ChatMessages.svelte` now also computes its own `isAtBottom` from the bound scroll viewport to drive button visibility in its new placement.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge; changes are localized to chat UI behavior and component props.
- No definite runtime errors or broken contracts were found in the changed files: ScrollButton preserves context-based fallback behavior, and ChatContainerRoot’s ref binding still wires into ChatContainerContext. Main residual concern is maintainability: ChatMessages now duplicates scroll-state tracking that already exists in ChatContainerContext, which could drift over time but is not an immediate defect.
- src/lib/chat/ui/ChatMessages.svelte (local scroll tracking duplicates context semantics)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/chat/ui/ChatMessages.svelte | Moves ScrollButton overlay outside the scroll container and adds local scroll viewport tracking (isAtBottom + scrollToBottom handler) via a bound ref and ResizeObserver. |
| src/lib/components/prompt-kit/chat-container/chat-container-root.svelte | Exposes the internal scroll container element via a bindable `ref` prop and wires ChatContainerContext to that element. |
| src/lib/components/prompt-kit/scroll-button/ScrollButton.svelte | Adds optional `isAtBottom` and `onScrollToBottom` props while preserving existing context-based fallback behavior. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant ChatMessages as ChatMessages.svelte
  participant ChatRoot as ChatContainerRoot.svelte
  participant Ctx as ChatContainerContext
  participant ScrollBtn as ScrollButton.svelte

  ChatMessages->>ChatRoot: render + bind:ref=scrollViewport
  ChatRoot->>Ctx: setElement(ref)

  Note over ChatMessages: local scroll state tracking
  ChatMessages->>ChatRoot: onscroll => updateScrollState()
  ChatMessages->>ChatMessages: isAtBottom = (scrollTop+clientHeight >= scrollHeight-50)

  ChatMessages->>ScrollBtn: props {isAtBottom, onScrollToBottom}
  ScrollBtn->>ScrollBtn: resolvedIsAtBottom = prop ?? Ctx.isAtBottom ?? true

  alt user clicks scroll button
    ScrollBtn->>ChatMessages: onScrollToBottom()
    ChatMessages->>ChatRoot: scrollViewport.scrollTo({top: scrollHeight, behavior:'smooth'})
  else no handler passed
    ScrollBtn->>Ctx: scrollToBottom()
  end

  Note over Ctx: Context also tracks isAtBottom via scroll/mutation/resize observers
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->