### PR TITLE
feat(haptics): add rune-based web-haptics wrapper

### DIFF
--- a/.env.convex.example
+++ b/.env.convex.example
@@ -32,6 +32,7 @@ RESEND_WEBHOOK_SECRET=whsec_your_secret_here
 # Email Asset URL (REQUIRED)
 # Production URL for email assets (logo images, footer links)
 # IMPORTANT: Always use production domain - email clients can't access localhost/preview URLs
+# IMPORTANT: Must include the https:// protocol prefix, otherwise image src will be broken
 # Note: For OAuth redirects, use SITE_URL (which can be preview URL)
 # Command: bunx convex env set EMAIL_ASSET_URL https://yourdomain.com
 EMAIL_ASSET_URL=https://yourdomain.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This project is a saas template built with SvelteKit, Convex, Typescript and mod
 
 When you need up-to-date information about technologies used in this project, use btca to query source repositories directly.
 
-**Available resources**: svelte, sveltekit, shadcnSvelte, shadcnSvelteExtras, bitsUi, runed, formsnap, superforms, paneforge, svelteInfinite, motionSvelte, svAnimate, threlte, xyflow, cnblocks, aiElements, convex, convexSvelte, convexAgent, convexHelpers, convexResend, convexPresence, convexRag, convexStripe, convexRateLimiter, convexActionCache, convexFilesControl, convexTimeline, convexMigrations, convexAggregate, convexShardedCounter, convexGeospatial, convexWorkpool, convexWorkflow, convexRetrier, convexCrons, betterAuth, betterSvelteEmail, tailwind, vercelAi, tanstackTable, tolgee, playwright, vitest, valibot, nprogress, renovate
+**Available resources**: svelte, sveltekit, shadcnSvelte, shadcnSvelteExtras, bitsUi, runed, formsnap, superforms, paneforge, svelteInfinite, motionSvelte, svAnimate, threlte, xyflow, cnblocks, aiElements, convex, convexSvelte, convexAgent, convexHelpers, convexResend, convexPresence, convexRag, convexStripe, convexRateLimiter, convexActionCache, convexFilesControl, convexTimeline, convexMigrations, convexAggregate, convexShardedCounter, convexGeospatial, convexWorkpool, convexWorkflow, convexRetrier, convexCrons, betterAuth, betterSvelteEmail, tailwind, vercelAi, tanstackTable, tolgee, playwright, vitest, valibot, nprogress, renovate, webHaptics
 
 ### Usage
 

--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -363,6 +363,14 @@
 			"name": "motionCore",
 			"url": "https://github.com/motion-core/motion-core",
 			"branch": "master"
+		},
+		{
+			"type": "git",
+			"name": "webHaptics",
+			"url": "https://github.com/lochie/web-haptics",
+			"branch": "main",
+			"searchPath": "packages/web-haptics/src",
+			"specialNotes": "Haptic feedback for mobile web. Svelte integration via createWebHaptics. Patterns: success, error, warning, etc. Check apps/svelte-example for usage."
 		}
 	],
 	"model": "claude-haiku-4.5",

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "svelte-toolbelt": "^0.10.6",
         "valibot": "^1.2.0",
         "vercel": "^50.0.0",
+        "web-haptics": "^0.0.6",
       },
       "devDependencies": {
         "@dnd-kit-svelte/core": "0.0.11",
@@ -2275,6 +2276,8 @@
     "vscode-uri": ["vscode-uri@3.0.8", "", {}, "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "web-haptics": ["web-haptics@0.0.6", "", { "peerDependencies": { "react": ">=18", "react-dom": ">=18", "svelte": ">=4", "vue": ">=3" }, "optionalPeers": ["react", "react-dom", "svelte", "vue"] }, "sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw=="],
 
     "web-vitals": ["web-vitals@4.2.4", "", {}, "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
 		"svelte-streamdown": "^3.0.0",
 		"svelte-toolbelt": "^0.10.6",
 		"valibot": "^1.2.0",
-		"vercel": "^50.0.0"
+		"vercel": "^50.0.0",
+		"web-haptics": "^0.0.6"
 	},
 	"devDependencies": {
 		"@dnd-kit-svelte/core": "0.0.11",

--- a/src/lib/hooks/use-haptic.svelte.ts
+++ b/src/lib/hooks/use-haptic.svelte.ts
@@ -1,0 +1,130 @@
+import { browser } from '$app/environment';
+import { MediaQuery } from 'svelte/reactivity';
+import type { ActionReturn } from 'svelte/action';
+import type { defaultPatterns, HapticInput as WebHapticsInput, WebHaptics } from 'web-haptics';
+
+export type HapticPreset = keyof typeof defaultPatterns;
+export type HapticInput = HapticPreset | number | number[];
+
+let WebHapticsClass: typeof WebHaptics | undefined;
+if (browser) {
+	import('web-haptics').then((m) => {
+		WebHapticsClass = m.WebHaptics;
+	});
+}
+
+export class UseHaptic {
+	#debug = $state(false);
+	#isActive = $state(false);
+	#engine: WebHaptics | null = null;
+	#reducedMotion: MediaQuery | null = null;
+	#activeTimeout: ReturnType<typeof setTimeout> | undefined;
+
+	constructor(options?: { debug?: boolean }) {
+		this.#debug = options?.debug ?? false;
+		if (browser) {
+			this.#reducedMotion = new MediaQuery('prefers-reduced-motion: reduce');
+		}
+	}
+
+	get isSupported(): boolean {
+		return browser && typeof navigator !== 'undefined' && 'vibrate' in navigator;
+	}
+
+	get isActive(): boolean {
+		return this.#isActive;
+	}
+
+	get prefersReducedMotion(): boolean {
+		return this.#reducedMotion?.current ?? false;
+	}
+
+	get debug(): boolean {
+		return this.#debug;
+	}
+
+	set debug(value: boolean) {
+		this.#debug = value;
+		this.#engine?.setDebug(value);
+	}
+
+	trigger(input?: HapticInput): void {
+		if (!browser || this.prefersReducedMotion) return;
+
+		const engine = this.#ensureEngine();
+		if (!engine) return;
+
+		if (this.#activeTimeout) clearTimeout(this.#activeTimeout);
+		this.#isActive = true;
+
+		const duration = this.#estimateDuration(input);
+		this.#activeTimeout = setTimeout(() => {
+			this.#isActive = false;
+		}, duration);
+
+		engine.trigger(input as WebHapticsInput);
+	}
+
+	cancel(): void {
+		this.#engine?.cancel();
+		if (this.#activeTimeout) clearTimeout(this.#activeTimeout);
+		this.#isActive = false;
+	}
+
+	destroy(): void {
+		this.cancel();
+		this.#engine?.destroy();
+		this.#engine = null;
+	}
+
+	#ensureEngine(): WebHaptics | null {
+		if (!browser || !WebHapticsClass) return null;
+		if (this.#engine) return this.#engine;
+		this.#engine = new WebHapticsClass({ debug: this.#debug });
+		return this.#engine;
+	}
+
+	#estimateDuration(input?: HapticInput): number {
+		if (input === undefined || typeof input === 'string') return 100;
+		if (typeof input === 'number') return input;
+		if (Array.isArray(input)) return input.reduce((sum, n) => sum + n, 0);
+		return 100;
+	}
+}
+
+export const haptic = new UseHaptic();
+
+export function hapticAction(
+	node: HTMLElement,
+	param: HapticPreset | { pattern: HapticPreset; event?: string }
+): ActionReturn<HapticPreset | { pattern: HapticPreset; event?: string }> {
+	let pattern: HapticPreset = typeof param === 'string' ? param : param.pattern;
+	let eventName: string = typeof param === 'string' ? 'click' : (param.event ?? 'click');
+
+	function resolve(p: typeof param) {
+		if (typeof p === 'string') {
+			pattern = p;
+			eventName = 'click';
+		} else {
+			pattern = p.pattern;
+			eventName = p.event ?? 'click';
+		}
+	}
+
+	function handler() {
+		haptic.trigger(pattern);
+	}
+
+	node.addEventListener(eventName, handler);
+
+	return {
+		update(newParam) {
+			node.removeEventListener(eventName, handler);
+			resolve(newParam);
+			node.addEventListener(eventName, handler);
+		},
+		destroy() {
+			node.removeEventListener(eventName, handler);
+		}
+	};
+}


### PR DESCRIPTION
Svelte 5 rune-native wrapper for the web-haptics library with:
- UseHaptic class with lazy engine init and reduced-motion support
- Singleton haptic instance for app-wide use
- hapticAction Svelte action for declarative use:hapticAction={'preset'}