### PR TITLE
refactor(convex): Remove dead code and cap unbounded queries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "references/cya-playground"]
+	path = references/cya-playground
+	url = https://github.com/mikecann/cya-playground

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "references/cya-playground"]
-	path = references/cya-playground
-	url = https://github.com/mikecann/cya-playground

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,18 @@ NEVER use `bun run dev` to start the development server, its already running in 
 
 **E2E Test Security:** `src/lib/convex/tests.ts` contains public mutations (verify emails, promote to admin, delete users) gated by `AUTH_E2E_TEST_SECRET`. These are safe ONLY because the env var is NOT set in production. NEVER set `AUTH_E2E_TEST_SECRET` in the production Convex environment (`--prod`). If it's unset, all test endpoints are dead code.
 
+### Intentional Anti-Pattern Comments
+
+When using a pattern that would normally be flagged (e.g. unbounded `.collect()`, sequential deletes) but is acceptable in context, always add a short inline comment explaining why. This prevents future reviewers and agents from re-flagging it.
+
+```typescript
+// Bounded: adminNotificationPreferences table is small (admin users + custom emails, typically <100 rows)
+const allPrefs = await ctx.db.query('adminNotificationPreferences').collect();
+
+// Sequential deletes in test cleanup (test-only, small dataset)
+for (const pref of allPreferences) { ... }
+```
+
 ### Convex Components Storage
 
 Convex components have isolated tables and storage namespaces. App code cannot use `ctx.storage.getUrl` to access a component's stored files. Use the component's APIs (e.g., download grants or HTTP routes) to fetch files/blobs instead.

--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -81,7 +81,7 @@
 								{/snippet}
 							</Sidebar.MenuButton>
 							{#if item.badge && item.badge > 0}
-								<Sidebar.MenuBadge>{item.badge}</Sidebar.MenuBadge>
+								<Sidebar.MenuBadge>{item.badge >= 100 ? '99+' : item.badge}</Sidebar.MenuBadge>
 							{/if}
 						</Sidebar.MenuItem>
 					{/each}

--- a/src/lib/convex/admin/notificationPreferences/queries.ts
+++ b/src/lib/convex/admin/notificationPreferences/queries.ts
@@ -150,6 +150,7 @@ async function getFilteredSortedRecipients(
 		sortBy?: NotificationRecipientSortBy;
 	}
 ) {
+	// Bounded: adminNotificationPreferences table is small (admin users + custom emails, typically <100 rows)
 	const allPrefs = await ctx.db.query('adminNotificationPreferences').collect();
 	const activePrefs = allPrefs.filter(
 		(preference) => preference.isAdminUser || preference.userId === undefined
@@ -325,6 +326,7 @@ export const getRecipientsForNotificationType = internalQuery({
 	},
 	returns: v.array(v.string()),
 	handler: async (ctx, args): Promise<string[]> => {
+		// Bounded: adminNotificationPreferences table is small (admin users + custom emails, typically <100 rows)
 		const allPrefs = await ctx.db.query('adminNotificationPreferences').collect();
 
 		// Map notification type to field name
@@ -359,6 +361,7 @@ export const getSupportNotificationRecipients = internalQuery({
 	},
 	returns: v.array(v.string()),
 	handler: async (ctx, args): Promise<string[]> => {
+		// Bounded: adminNotificationPreferences table is small (admin users + custom emails, typically <100 rows)
 		const allPrefs = await ctx.db.query('adminNotificationPreferences').collect();
 
 		// Map notification type to field name

--- a/src/lib/convex/admin/support/notifications.ts
+++ b/src/lib/convex/admin/support/notifications.ts
@@ -445,7 +445,7 @@ export const getNotificationTargetEmails = internalQuery({
 	},
 	returns: v.array(v.string()),
 	handler: async (ctx, args) => {
-		// Get all preferences
+		// Bounded: adminNotificationPreferences table is small (admin users + custom emails, typically <100 rows)
 		const allPrefs = await ctx.db.query('adminNotificationPreferences').collect();
 
 		// Map notification type to field name

--- a/src/lib/convex/admin/support/queries.ts
+++ b/src/lib/convex/admin/support/queries.ts
@@ -484,13 +484,13 @@ export const getAwaitingResponseCount = adminQuery({
 	args: {},
 	returns: v.number(),
 	handler: async (ctx) => {
-		// Count all handed-off threads awaiting admin response
+		// Capped at 100 to avoid unbounded scan; UI shows "99+" for >= 100
 		const awaitingThreads = await ctx.db
 			.query('supportThreads')
 			.withIndex('by_needs_response', (q) =>
 				q.eq('isHandedOff', true).eq('status', 'open').eq('awaitingAdminResponse', true)
 			)
-			.collect();
+			.take(100);
 		return awaitingThreads.length;
 	}
 });
@@ -526,41 +526,5 @@ export const listAdmins = adminQuery({
 			email: admin.email,
 			image: admin.image ?? null
 		}));
-	}
-});
-
-/**
- * Debug helper to inspect supportThreads table
- * Usage: bunx convex run admin/support/queries:debugSupportThreads
- */
-export const debugSupportThreads = adminQuery({
-	args: {},
-	returns: v.object({
-		count: v.number(),
-		threads: v.array(
-			v.object({
-				_id: v.string(),
-				threadId: v.string(),
-				userId: v.optional(v.string()),
-				status: v.union(v.literal('open'), v.literal('done')),
-				assignedTo: v.optional(v.string())
-			})
-		)
-	}),
-	handler: async (ctx) => {
-		const supportThreads = await ctx.db.query('supportThreads').collect();
-
-		console.log(`[debugSupportThreads] Found ${supportThreads.length} total supportThreads`);
-
-		return {
-			count: supportThreads.length,
-			threads: supportThreads.map((t) => ({
-				_id: t._id,
-				threadId: t.threadId,
-				userId: t.userId,
-				status: t.status,
-				assignedTo: t.assignedTo
-			}))
-		};
 	}
 });

--- a/src/lib/convex/emails/queries.ts
+++ b/src/lib/convex/emails/queries.ts
@@ -76,53 +76,6 @@ export const listEmailEventsByType = adminQuery({
 		return events;
 	}
 });
-
-/**
- * Get email statistics
- *
- * Returns aggregated statistics about email events.
- * Useful for dashboards and monitoring.
- *
- * @security Requires admin role - email statistics are sensitive operational data
- */
-export const getEmailStats = adminQuery({
-	args: {},
-	handler: async (ctx) => {
-		const allEvents = await ctx.db.query('emailEvents').collect();
-
-		const stats = {
-			total: allEvents.length,
-			delivered: 0,
-			bounced: 0,
-			complained: 0,
-			opened: 0,
-			clicked: 0
-		};
-
-		for (const event of allEvents) {
-			switch (event.eventType) {
-				case 'email.delivered':
-					stats.delivered++;
-					break;
-				case 'email.bounced':
-					stats.bounced++;
-					break;
-				case 'email.complained':
-					stats.complained++;
-					break;
-				case 'email.opened':
-					stats.opened++;
-					break;
-				case 'email.clicked':
-					stats.clicked++;
-					break;
-			}
-		}
-
-		return stats;
-	}
-});
-
 /**
  * Get email status
  *

--- a/src/lib/convex/support/files.ts
+++ b/src/lib/convex/support/files.ts
@@ -200,6 +200,7 @@ export const storeFileMetadata = internalMutation({
 export const cleanupLegacyFileMetadata = internalMutation({
 	args: {},
 	handler: async (ctx) => {
+		// Sequential deletes in one-time cleanup mutation (small dataset)
 		const allRecords = await ctx.db.query('fileMetadata').collect();
 		let deleted = 0;
 

--- a/src/lib/convex/tests.ts
+++ b/src/lib/convex/tests.ts
@@ -372,7 +372,7 @@ export const cleanupTestData = mutation({
 		const testPatterns = ['test-e2e-', 'test-dup-', 'test-remove-'];
 		let deletedCount = 0;
 
-		// Find and delete test notification recipients
+		// Sequential deletes in test cleanup (test-only, small dataset)
 		const allPreferences = await ctx.db.query('adminNotificationPreferences').collect();
 
 		for (const pref of allPreferences) {


### PR DESCRIPTION
Delete unused getEmailStats and debugSupportThreads (unbounded .collect()).
Cap getAwaitingResponseCount at 100 with .take(100), show 99+ in sidebar badge.
Add justification comments to intentional anti-patterns.
Document anti-pattern comment convention in AGENTS.md.