### PR TITLE
fix: Prevent auth buttons flash during session refresh

### DIFF
--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -20,7 +20,19 @@
 	const auth = useAuth();
 	let signingOut = $state(false);
 	const isAuthenticated = $derived(auth.isAuthenticated && !signingOut);
-	const isAuthLoading = $derived(auth.isLoading);
+
+	// Capture once: did the server have a valid JWT?
+	const ssrAuthenticated = auth.isAuthenticated;
+
+	let sessionChecked = $state(false);
+	$effect(() => {
+		const unsub = authClient.useSession().subscribe((s) => {
+			if (!s.isPending) sessionChecked = true;
+		});
+		return unsub;
+	});
+
+	const showAuthButtons = $derived(ssrAuthenticated || (sessionChecked && !auth.isLoading));
 
 	async function signOut() {
 		signingOut = true;
@@ -90,7 +102,7 @@
 					</Button>
 					<LightSwitch variant="ghost" />
 					<LanguageSwitcher variant="ghost" />
-					{#if !isAuthLoading}
+					{#if showAuthButtons}
 						<div class="flex items-center gap-3 motion-safe:animate-fade-in">
 							{#if isAuthenticated}
 								<Button size="sm" href={localizedHref('/app')}>
@@ -175,7 +187,7 @@
 				{/each}
 			</ul>
 			<div class="mt-6 flex flex-col gap-3">
-				{#if !isAuthLoading}
+				{#if showAuthButtons}
 					<div class="flex flex-col gap-3 motion-safe:animate-fade-in">
 						{#if isAuthenticated}
 							<Button size="sm" href={localizedHref('/app')} class="w-full">

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -102,35 +102,48 @@
 					</Button>
 					<LightSwitch variant="ghost" />
 					<LanguageSwitcher variant="ghost" />
-					{#if showAuthButtons}
-						<div class="flex items-center gap-3 motion-safe:animate-fade-in">
-							{#if isAuthenticated}
-								<Button size="sm" href={localizedHref('/app')}>
-									<T keyName="nav.dashboard" />
-								</Button>
-								<Button
-									variant="outline"
-									size="icon"
-									class="size-8"
-									onclick={() => signOut()}
-									aria-label={$t('aria.logout')}
-								>
-									<LogOut class="size-4" />
-								</Button>
-							{:else if isAtTop}
-								<Button variant="ghost" size="sm" href={localizedHref('/signin')}>
-									<T keyName="nav.login" />
-								</Button>
-								<Button size="sm" href={localizedHref('/signin?tab=signup')}>
-									<T keyName="nav.signup" />
-								</Button>
-							{:else}
-								<Button size="sm" href={localizedHref('/signin?tab=signup')}>
-									<T keyName="nav.get_started" />
-								</Button>
-							{/if}
+					<div class="relative flex items-center">
+						<!-- Spacer: always reserves width of widest button combo -->
+						<div class="pointer-events-none invisible flex items-center gap-3" aria-hidden="true">
+							<Button variant="ghost" size="sm" tabindex={-1}>
+								<T keyName="nav.login" />
+							</Button>
+							<Button size="sm" tabindex={-1}>
+								<T keyName="nav.signup" />
+							</Button>
 						</div>
-					{/if}
+						{#if showAuthButtons}
+							<div
+								class="absolute inset-y-0 right-0 flex items-center gap-3 motion-safe:animate-fade-in"
+							>
+								{#if isAuthenticated}
+									<Button size="sm" href={localizedHref('/app')}>
+										<T keyName="nav.dashboard" />
+									</Button>
+									<Button
+										variant="outline"
+										size="icon"
+										class="size-8"
+										onclick={() => signOut()}
+										aria-label={$t('aria.logout')}
+									>
+										<LogOut class="size-4" />
+									</Button>
+								{:else if isAtTop}
+									<Button variant="ghost" size="sm" href={localizedHref('/signin')}>
+										<T keyName="nav.login" />
+									</Button>
+									<Button size="sm" href={localizedHref('/signin?tab=signup')}>
+										<T keyName="nav.signup" />
+									</Button>
+								{:else}
+									<Button size="sm" href={localizedHref('/signin?tab=signup')}>
+										<T keyName="nav.get_started" />
+									</Button>
+								{/if}
+							</div>
+						{/if}
+					</div>
 				</div>
 
 				<!-- Mobile Menu Button -->


### PR DESCRIPTION
When returning after JWT expiry, marketing header briefly showed
Login/Sign Up before switching to Dashboard/Logout. Use SSR auth
snapshot as fast-path and gate on client session check for uncertain
state.