### PR TITLE
fix: Enable SSR rendering by eagerly loading Tolgee translations

### DIFF
--- a/src/routes/[[lang]]/+layout.svelte
+++ b/src/routes/[[lang]]/+layout.svelte
@@ -24,14 +24,8 @@
 		.init({
 			language: data.lang,
 
-			// Production: Use static translations bundled at build-time (pulled via CLI)
-			// Development: DevTools can still use API key if VITE_TOLGEE_API_KEY is set
-			staticData: {
-				en: () => import('../../i18n/en.json'),
-				de: () => import('../../i18n/de.json'),
-				es: () => import('../../i18n/es.json'),
-				fr: () => import('../../i18n/fr.json')
-			},
+			// Eager imports via data.translations so Tolgee cache is populated at init (enables SSR)
+			staticData: data.translations,
 
 			availableLanguages: ['en', 'de', 'es', 'fr'],
 			defaultLanguage: 'en',

--- a/src/routes/[[lang]]/+layout.svelte
+++ b/src/routes/[[lang]]/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Tolgee, DevTools, TolgeeProvider } from '@tolgee/svelte';
+	import type { TolgeeStaticData } from '@tolgee/svelte';
 	import { FormatIcu } from '@tolgee/format-icu';
 	import { browser } from '$app/environment';
 	import AppAuthOAuthBootstrap from '$lib/components/app/app-auth-oauth-bootstrap.svelte';
@@ -8,6 +9,13 @@
 	import type { LayoutData } from './$types';
 	import { watch } from 'runed';
 	import { languageContext } from '$lib/i18n/context';
+	import en from '../../i18n/en.json';
+	import de from '../../i18n/de.json';
+	import es from '../../i18n/es.json';
+	import fr from '../../i18n/fr.json';
+
+	// Eager imports so Tolgee's cache is populated at init, enabling SSR rendering
+	const translations: TolgeeStaticData = { en, de, es, fr };
 
 	let { data, children }: { data: LayoutData; children: any } = $props();
 
@@ -24,8 +32,7 @@
 		.init({
 			language: data.lang,
 
-			// Eager imports via data.translations so Tolgee cache is populated at init (enables SSR)
-			staticData: data.translations,
+			staticData: translations,
 
 			availableLanguages: ['en', 'de', 'es', 'fr'],
 			defaultLanguage: 'en',

--- a/src/routes/[[lang]]/+layout.ts
+++ b/src/routes/[[lang]]/+layout.ts
@@ -1,6 +1,14 @@
 import { error } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
 import { isSupportedLanguage, DEFAULT_LANGUAGE } from '$lib/i18n/languages';
+import type { TolgeeStaticData } from '@tolgee/svelte';
+import en from '../../i18n/en.json';
+import de from '../../i18n/de.json';
+import es from '../../i18n/es.json';
+import fr from '../../i18n/fr.json';
+
+// Eager imports so Tolgee's cache is populated at init, enabling SSR rendering
+const translations: TolgeeStaticData = { en, de, es, fr };
 
 export const load: LayoutLoad = async ({ params, parent }) => {
 	const parentData = await parent();
@@ -10,7 +18,8 @@ export const load: LayoutLoad = async ({ params, parent }) => {
 	if (!lang) {
 		return {
 			...parentData,
-			lang: DEFAULT_LANGUAGE
+			lang: DEFAULT_LANGUAGE,
+			translations
 		};
 	}
 
@@ -22,6 +31,7 @@ export const load: LayoutLoad = async ({ params, parent }) => {
 
 	return {
 		...parentData,
-		lang
+		lang,
+		translations
 	};
 };

--- a/src/routes/[[lang]]/+layout.ts
+++ b/src/routes/[[lang]]/+layout.ts
@@ -1,14 +1,6 @@
 import { error } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
 import { isSupportedLanguage, DEFAULT_LANGUAGE } from '$lib/i18n/languages';
-import type { TolgeeStaticData } from '@tolgee/svelte';
-import en from '../../i18n/en.json';
-import de from '../../i18n/de.json';
-import es from '../../i18n/es.json';
-import fr from '../../i18n/fr.json';
-
-// Eager imports so Tolgee's cache is populated at init, enabling SSR rendering
-const translations: TolgeeStaticData = { en, de, es, fr };
 
 export const load: LayoutLoad = async ({ params, parent }) => {
 	const parentData = await parent();
@@ -18,8 +10,7 @@ export const load: LayoutLoad = async ({ params, parent }) => {
 	if (!lang) {
 		return {
 			...parentData,
-			lang: DEFAULT_LANGUAGE,
-			translations
+			lang: DEFAULT_LANGUAGE
 		};
 	}
 
@@ -31,7 +22,6 @@ export const load: LayoutLoad = async ({ params, parent }) => {
 
 	return {
 		...parentData,
-		lang,
-		translations
+		lang
 	};
 };


### PR DESCRIPTION
TolgeeProvider gates rendering on isLoaded(), which returns false
during SSR because lazy () => import() functions aren't cached.
Eagerly import translation JSONs in +layout.ts and pass as direct
objects to staticData so pages render server-side.