### PR TITLE
feat: Add marketing footer, Terms of Service, and Privacy Policy

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,11 +9,13 @@ import globals from 'globals';
 import ts from 'typescript-eslint';
 import svelteConfig from './svelte.config.js';
 import requireMarketingMarkdownRule from './eslint/rules/require-marketing-markdown.js';
+import requireMarketingRouteRegistrationRule from './eslint/rules/require-marketing-route-registration.js';
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
 const localPlugin = {
 	rules: {
-		'require-marketing-markdown': requireMarketingMarkdownRule
+		'require-marketing-markdown': requireMarketingMarkdownRule,
+		'require-marketing-route-registration': requireMarketingRouteRegistrationRule
 	}
 };
 
@@ -126,7 +128,8 @@ export default defineConfig(
 			local: localPlugin
 		},
 		rules: {
-			'local/require-marketing-markdown': 'error'
+			'local/require-marketing-markdown': 'error',
+			'local/require-marketing-route-registration': 'error'
 		}
 	},
 	// Convex best-practice rules (legacy plugin config converted via fixupConfigRules)

--- a/eslint/rules/require-marketing-route-registration.js
+++ b/eslint/rules/require-marketing-route-registration.js
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MARKETING_ROUTE_SEGMENT = `${path.sep}src${path.sep}routes${path.sep}[[lang]]${path.sep}(marketing)${path.sep}`;
+
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Require marketing pages to be registered in public-routes.ts for llms.txt and sitemap'
+		},
+		schema: [],
+		messages: {
+			notRegistered:
+				"Marketing page '{{routeKey}}' is not registered in src/lib/marketing/public-routes.ts. Add it to PUBLIC_MARKETING_ROUTES for llms.txt, sitemap, and Accept: text/markdown support."
+		}
+	},
+	create(context) {
+		const filename = context.filename ?? context.getFilename();
+
+		const shouldCheck =
+			filename.endsWith(`${path.sep}+page.svelte`) && filename.includes(MARKETING_ROUTE_SEGMENT);
+
+		if (!shouldCheck) {
+			return {};
+		}
+
+		return {
+			Program(node) {
+				// Extract route key from path: .../[[lang]]/(marketing)/about/+page.svelte → "about"
+				// Root marketing page: .../[[lang]]/(marketing)/+page.svelte → "home"
+				const dir = path.dirname(filename);
+				const marketingIdx = dir.indexOf(MARKETING_ROUTE_SEGMENT);
+				const afterMarketing = dir.slice(marketingIdx + MARKETING_ROUTE_SEGMENT.length);
+				const routeKey = afterMarketing || 'home';
+
+				// Read public-routes.ts and check if this route key is registered
+				const publicRoutesPath = path.resolve(
+					dir.slice(0, marketingIdx),
+					'src',
+					'lib',
+					'marketing',
+					'public-routes.ts'
+				);
+
+				if (!fs.existsSync(publicRoutesPath)) {
+					return;
+				}
+
+				const content = fs.readFileSync(publicRoutesPath, 'utf-8');
+
+				// Check for the route key in PUBLIC_MARKETING_ROUTES array
+				// Matches patterns like: key: 'about' or key: "about"
+				const keyPattern = new RegExp(`key:\\s*['"]${routeKey}['"]`);
+				if (!keyPattern.test(content)) {
+					context.report({
+						node,
+						messageId: 'notRegistered',
+						data: { routeKey }
+					});
+				}
+			}
+		};
+	}
+};

--- a/eslint/rules/require-marketing-route-registration.js
+++ b/eslint/rules/require-marketing-route-registration.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const MARKETING_ROUTE_SEGMENT = `${path.sep}src${path.sep}routes${path.sep}[[lang]]${path.sep}(marketing)${path.sep}`;
+const MARKETING_ROUTE_SEGMENT = `${path.sep}src${path.sep}routes${path.sep}[[lang]]${path.sep}(marketing)`;
 
 export default {
 	meta: {
@@ -32,7 +32,9 @@ export default {
 				// Root marketing page: .../[[lang]]/(marketing)/+page.svelte → "home"
 				const dir = path.dirname(filename);
 				const marketingIdx = dir.indexOf(MARKETING_ROUTE_SEGMENT);
-				const afterMarketing = dir.slice(marketingIdx + MARKETING_ROUTE_SEGMENT.length);
+				const afterMarketing = dir
+					.slice(marketingIdx + MARKETING_ROUTE_SEGMENT.length)
+					.replace(/^[/\\]/, '');
 				const routeKey = afterMarketing || 'home';
 
 				// Read public-routes.ts and check if this route key is registered

--- a/src/lib/components/obfuscated-email.svelte
+++ b/src/lib/components/obfuscated-email.svelte
@@ -27,7 +27,7 @@
 	onclick={handleClick}
 	class="cursor-pointer {className}"
 	type="button"
-	aria-label="{user}@{domain}.{tld}"
+	aria-label="{user} at {domain} dot {tld}"
 	>{user}<span class="hidden" aria-hidden="true">.nope</span>@<span
 		class="hidden"
 		aria-hidden="true">null.</span

--- a/src/lib/components/obfuscated-email.svelte
+++ b/src/lib/components/obfuscated-email.svelte
@@ -19,6 +19,9 @@
 
 <!-- Hidden span decoys reduce the chance of naive regex scrapers extracting a valid email address.
      The mailto: is only assembled via JS onclick. Not a guarantee against headless-browser scrapers. -->
+<!-- Anti-scraping: aria-label intentionally NOT localized via Tolgee. Putting email parts
+     in i18n bundles would defeat the obfuscation. English "at"/"dot" format is acceptable
+     since this component is only used for static contact info on legal pages. -->
 <button
 	onclick={handleClick}
 	class="cursor-pointer {className}"

--- a/src/lib/components/obfuscated-email.svelte
+++ b/src/lib/components/obfuscated-email.svelte
@@ -23,7 +23,11 @@
   which doesn't match email regex. Humans see "daniel@sticker.name" correctly.
   Copy-paste includes the hidden text, producing an invalid address.
 -->
-<button onclick={handleClick} class="cursor-pointer {className}" type="button"
+<button
+	onclick={handleClick}
+	class="cursor-pointer {className}"
+	type="button"
+	aria-label="{user}@{domain}.{tld}"
 	>{user}<span class="hidden" aria-hidden="true">.nope</span>@<span
 		class="hidden"
 		aria-hidden="true">null.</span

--- a/src/lib/components/obfuscated-email.svelte
+++ b/src/lib/components/obfuscated-email.svelte
@@ -17,12 +17,8 @@
 	}
 </script>
 
-<!--
-  Anti-scraping: hidden <span> decoys break regex pattern matching.
-  Bots see "daniel<hidden junk>@<hidden junk>sticker<hidden junk>.<hidden junk>name"
-  which doesn't match email regex. Humans see "daniel@sticker.name" correctly.
-  Copy-paste includes the hidden text, producing an invalid address.
--->
+<!-- Hidden span decoys reduce the chance of naive regex scrapers extracting a valid email address.
+     The mailto: is only assembled via JS onclick. Not a guarantee against headless-browser scrapers. -->
 <button
 	onclick={handleClick}
 	class="cursor-pointer {className}"

--- a/src/lib/markdown/marketing.test.ts
+++ b/src/lib/markdown/marketing.test.ts
@@ -96,6 +96,8 @@ describe('marketing markdown helpers', () => {
 
 		expect(llms).toContain('# SaaS Starter');
 		expect(llms).toContain('https://example.com/en/about');
+		expect(llms).toContain('https://example.com/en/privacy');
+		expect(llms).toContain('https://example.com/en/terms');
 		expect(llms).toContain('Accept: text/markdown');
 	});
 
@@ -132,6 +134,8 @@ describe('marketing markdown helpers', () => {
 		expect(sitemap).toContain('<loc>https://example.com/en</loc>');
 		expect(sitemap).toContain('<loc>https://example.com/de/about</loc>');
 		expect(sitemap).toContain('<loc>https://example.com/fr/pricing</loc>');
+		expect(sitemap).toContain('<loc>https://example.com/en/privacy</loc>');
+		expect(sitemap).toContain('<loc>https://example.com/en/terms</loc>');
 		expect(sitemap).not.toContain('/en/app');
 		expect(sitemap).not.toContain('/en/admin');
 	});

--- a/src/lib/markdown/marketing.ts
+++ b/src/lib/markdown/marketing.ts
@@ -127,9 +127,9 @@ function xmlEscape(value: string): string {
 
 export function renderLlmsTxt(origin: string): string {
 	const baseOrigin = origin.replace(/\/$/, '');
-	const [homeUrl, aboutUrl, pricingUrl] = getLocalizedMarketingUrls(baseOrigin).filter((url) =>
-		url.startsWith(`${baseOrigin}/en`)
-	);
+	const [homeUrl, aboutUrl, pricingUrl, privacyUrl, termsUrl] = getLocalizedMarketingUrls(
+		baseOrigin
+	).filter((url) => url.startsWith(`${baseOrigin}/en`));
 
 	return [
 		'# SaaS Starter',
@@ -145,6 +145,8 @@ export function renderLlmsTxt(origin: string): string {
 		`- [Home](${homeUrl}): product overview, positioning, and core integrations`,
 		`- [About](${aboutUrl}): team overview and roles`,
 		`- [Pricing](${pricingUrl}): pricing tiers, included features, and billing notes`,
+		`- [Privacy Policy](${privacyUrl}): how personal data is collected, used, and protected`,
+		`- [Terms of Service](${termsUrl}): terms and conditions for using the service`,
 		'',
 		'## Markdown Access',
 		'',

--- a/src/lib/marketing/public-routes.test.ts
+++ b/src/lib/marketing/public-routes.test.ts
@@ -8,13 +8,17 @@ import {
 import { marketingMarkdown as aboutMarketingMarkdown } from '../../routes/[[lang]]/(marketing)/about/page.md';
 import { marketingMarkdown as homeMarketingMarkdown } from '../../routes/[[lang]]/(marketing)/page.md';
 import { marketingMarkdown as pricingMarketingMarkdown } from '../../routes/[[lang]]/(marketing)/pricing/page.md';
+import { marketingMarkdown as privacyMarketingMarkdown } from '../../routes/[[lang]]/(marketing)/privacy/page.md';
+import { marketingMarkdown as termsMarketingMarkdown } from '../../routes/[[lang]]/(marketing)/terms/page.md';
 
 describe('public marketing route registry', () => {
 	it('defines the canonical public marketing routes', () => {
 		expect(PUBLIC_MARKETING_ROUTES).toEqual([
 			{ key: 'home', pathSuffix: '' },
 			{ key: 'about', pathSuffix: '/about' },
-			{ key: 'pricing', pathSuffix: '/pricing' }
+			{ key: 'pricing', pathSuffix: '/pricing' },
+			{ key: 'privacy', pathSuffix: '/privacy' },
+			{ key: 'terms', pathSuffix: '/terms' }
 		]);
 	});
 
@@ -27,6 +31,11 @@ describe('public marketing route registry', () => {
 			lang: 'fr',
 			routeKey: 'pricing'
 		});
+		expect(matchPublicMarketingRoute('/en/privacy')).toEqual({
+			lang: 'en',
+			routeKey: 'privacy'
+		});
+		expect(matchPublicMarketingRoute('/de/terms')).toEqual({ lang: 'de', routeKey: 'terms' });
 	});
 
 	it('rejects non-marketing or non-localized paths', () => {
@@ -42,6 +51,8 @@ describe('public marketing route registry', () => {
 		expect(getMarketingMarkdownDocument('home')).toBe(homeMarketingMarkdown);
 		expect(getMarketingMarkdownDocument('about')).toBe(aboutMarketingMarkdown);
 		expect(getMarketingMarkdownDocument('pricing')).toBe(pricingMarketingMarkdown);
+		expect(getMarketingMarkdownDocument('privacy')).toBe(privacyMarketingMarkdown);
+		expect(getMarketingMarkdownDocument('terms')).toBe(termsMarketingMarkdown);
 	});
 
 	it('generates the expected localized public marketing URLs', () => {
@@ -49,15 +60,23 @@ describe('public marketing route registry', () => {
 			'https://example.com/en',
 			'https://example.com/en/about',
 			'https://example.com/en/pricing',
+			'https://example.com/en/privacy',
+			'https://example.com/en/terms',
 			'https://example.com/de',
 			'https://example.com/de/about',
 			'https://example.com/de/pricing',
+			'https://example.com/de/privacy',
+			'https://example.com/de/terms',
 			'https://example.com/es',
 			'https://example.com/es/about',
 			'https://example.com/es/pricing',
+			'https://example.com/es/privacy',
+			'https://example.com/es/terms',
 			'https://example.com/fr',
 			'https://example.com/fr/about',
-			'https://example.com/fr/pricing'
+			'https://example.com/fr/pricing',
+			'https://example.com/fr/privacy',
+			'https://example.com/fr/terms'
 		]);
 	});
 });

--- a/src/lib/marketing/public-routes.ts
+++ b/src/lib/marketing/public-routes.ts
@@ -46,18 +46,10 @@ export function matchPublicMarketingRoute(pathname: string): MatchedPublicMarket
 		return null;
 	}
 
-	const routeKey: PublicMarketingRouteKey =
-		section === 'about'
-			? 'about'
-			: section === 'pricing'
-				? 'pricing'
-				: section === 'privacy'
-					? 'privacy'
-					: section === 'terms'
-						? 'terms'
-						: 'home';
-
-	return { lang, routeKey };
+	return {
+		lang,
+		routeKey: (section ?? 'home') as PublicMarketingRouteKey
+	};
 }
 
 export function getMarketingMarkdownDocument(routeKey: PublicMarketingRouteKey) {


### PR DESCRIPTION
- Marketing footer matching header island style with fade-to-background mask
- Terms of Service page with Raycast-style prose layout (GDPR, German law)
- Privacy Policy page covering data collection, processors, user rights
- Markdown content rendered via @humanspeak/svelte-markdown (Svelte 5)
- Obfuscated email component (hidden decoy spans break bot regex)
- @tailwindcss/typography plugin for prose styling
- Removed unused marked dependency
- i18n keys for footer/meta in all 4 locales