### PR TITLE
fix(ux): Skip unnecessary fade-in on auth buttons and fix support button flash

### DIFF
--- a/src/lib/components/customer-support/lazy-customer-support.svelte
+++ b/src/lib/components/customer-support/lazy-customer-support.svelte
@@ -21,8 +21,12 @@
 
 	async function openSupport(): Promise<void> {
 		isLoading = true;
-		await preload();
-		isLoading = false;
+		try {
+			await preload();
+		} finally {
+			isLoading = false;
+		}
+		if (!CustomerSupport) return;
 		isOpen = true;
 		const url = new URL(window.location.href);
 		url.searchParams.set('support', 'open');

--- a/src/lib/components/customer-support/lazy-customer-support.svelte
+++ b/src/lib/components/customer-support/lazy-customer-support.svelte
@@ -5,15 +5,27 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import MessageSquareIcon from '@lucide/svelte/icons/message-square';
 	import { getTranslate } from '@tolgee/svelte';
+	import type { Component } from 'svelte';
 
 	const { t } = getTranslate();
 
-	let shouldLoad = $state(false);
+	let isOpen = $state(false);
+	let isLoading = $state(false);
+	let CustomerSupport: Component | null = $state(null);
+
+	async function preload(): Promise<void> {
+		if (CustomerSupport) return;
+		const mod = await import('./customer-support.svelte');
+		CustomerSupport = mod.default;
+	}
 
 	async function openSupport(): Promise<void> {
+		isLoading = true;
+		await preload();
+		isLoading = false;
+		isOpen = true;
 		const url = new URL(window.location.href);
 		url.searchParams.set('support', 'open');
-		shouldLoad = true;
 		await goto(resolve(`${window.location.pathname}${url.search}`), {
 			keepFocus: true,
 			noScroll: true
@@ -23,7 +35,8 @@
 	onMount(() => {
 		const currentUrl = new URL(window.location.href);
 		if (currentUrl.searchParams.get('support') === 'open') {
-			shouldLoad = true;
+			isOpen = true;
+			preload();
 			return;
 		}
 
@@ -40,15 +53,15 @@
 			'touchstart'
 		];
 
-		function loadOnce(): void {
-			if (shouldLoad) return;
-			shouldLoad = true;
+		function preloadOnce(): void {
+			if (CustomerSupport) return;
+			preload();
 			cleanup();
 		}
 
 		function cleanup(): void {
 			for (const eventName of interactionEvents) {
-				window.removeEventListener(eventName, loadOnce);
+				window.removeEventListener(eventName, preloadOnce);
 			}
 
 			if (idleId !== null && cancelIdleCallback) {
@@ -61,28 +74,27 @@
 		}
 
 		for (const eventName of interactionEvents) {
-			window.addEventListener(eventName, loadOnce, { passive: true, once: true });
+			window.addEventListener(eventName, preloadOnce, { passive: true, once: true });
 		}
 
 		if (requestIdleCallback) {
-			idleId = requestIdleCallback(loadOnce, { timeout: 3000 });
+			idleId = requestIdleCallback(preloadOnce, { timeout: 3000 });
 		} else {
-			timeoutId = window.setTimeout(loadOnce, 2000);
+			timeoutId = window.setTimeout(preloadOnce, 2000);
 		}
 
 		return cleanup;
 	});
 </script>
 
-{#if shouldLoad}
-	{#await import('./customer-support.svelte') then { default: CustomerSupport }}
-		<CustomerSupport />
-	{/await}
+{#if isOpen && CustomerSupport}
+	<CustomerSupport />
 {:else}
 	<div class="fixed right-5 bottom-5 z-200 flex items-end justify-end">
 		<Button
 			variant="default"
 			size="icon"
+			disabled={isLoading}
 			onclick={openSupport}
 			aria-label={$t('aria.feedback_open')}
 			class="h-12 w-12 rounded-xl transition-colors transition-transform duration-200 ease-in-out hover:scale-110 hover:bg-primary active:scale-105"

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -21,8 +21,13 @@
 	let signingOut = $state(false);
 	const isAuthenticated = $derived(auth.isAuthenticated && !signingOut);
 
-	// Capture once: did the server have a valid JWT?
+	// Capture once at mount: did the server have a valid JWT?
 	const ssrAuthenticated = auth.isAuthenticated;
+
+	// Check if a session cookie exists (may need refresh → wait for result).
+	// No session cookie = definitely unauthenticated → show buttons instantly.
+	const hasSessionCookie =
+		typeof document !== 'undefined' && document.cookie.includes('better-auth.session_token');
 
 	let sessionChecked = $state(false);
 	$effect(() => {
@@ -32,7 +37,12 @@
 		return unsub;
 	});
 
-	const showAuthButtons = $derived(ssrAuthenticated || (sessionChecked && !auth.isLoading));
+	// SSR authenticated: show immediately (server knew auth state).
+	// No session cookie: show immediately (definitely unauthenticated).
+	// Session cookie but no JWT: wait for refresh to avoid Login→Dashboard flash.
+	const showAuthButtons = $derived(
+		ssrAuthenticated || !hasSessionCookie || (sessionChecked && !auth.isLoading)
+	);
 
 	async function signOut() {
 		signingOut = true;
@@ -114,7 +124,10 @@
 						</div>
 						{#if showAuthButtons}
 							<div
-								class="absolute inset-y-0 right-0 flex items-center gap-3 motion-safe:animate-fade-in"
+								class={cn(
+									'absolute inset-y-0 right-0 flex items-center gap-3',
+									!ssrAuthenticated && hasSessionCookie && 'motion-safe:animate-fade-in'
+								)}
 							>
 								{#if isAuthenticated}
 									<Button size="sm" href={localizedHref('/app')}>
@@ -201,7 +214,12 @@
 			</ul>
 			<div class="mt-6 flex flex-col gap-3">
 				{#if showAuthButtons}
-					<div class="flex flex-col gap-3 motion-safe:animate-fade-in">
+					<div
+						class={cn(
+							'flex flex-col gap-3',
+							!ssrAuthenticated && hasSessionCookie && 'motion-safe:animate-fade-in'
+						)}
+					>
 						{#if isAuthenticated}
 							<Button size="sm" href={localizedHref('/app')} class="w-full">
 								<T keyName="nav.dashboard" />


### PR DESCRIPTION
Auth buttons: conditionally apply fade-in only when waiting for a
session cookie refresh. Skip fade when SSR authenticated (server knew
auth state) or when no session cookie exists (definitely unauthenticated).

Support button: always render placeholder button to prevent SSR→hydration
flash. Preload component via idle/interaction listeners without unmounting
the button. Disable button if clicked before preload completes.