### PR TITLE
fix(chat): restore UIMessageChunk delta field reading in StreamProcessor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,7 @@ This project uses **PostHog** for product analytics with an optional **Cloudflar
 - Located in `e2e/` directory
 - Test users are automatically created with unique emails each run (via globalSetup) and deleted after tests (via globalTeardown)
 - Requires `.env.test` with: AUTH_E2E_TEST_SECRET (must match Convex backend) and PUBLIC_CONVEX_URL
+- `AuthenticatedLayout` sets `data-hydrated` on `<html>` in `onMount`; `waitForAuthenticated` in `e2e/utils/auth.ts` waits for it so clicks happen after Svelte hydration, not on inert SSR markup.
 - See `.env.schema` for all available env vars with types and descriptions
 
 #### `data-testid` convention

--- a/e2e/utils/auth.ts
+++ b/e2e/utils/auth.ts
@@ -1,12 +1,15 @@
 import { expect, type Page } from '@playwright/test';
 
 /**
- * Wait for the app to be fully loaded with authenticated state.
+ * Wait for the app to be fully loaded, hydrated, and authenticated.
  * Handles transient app-load failures in CI by retrying page load.
  *
  * 1. Wait for URL to match the app route
- * 2. Wait for the authenticated UI shell
- * 3. If it does not appear, reload and retry (up to maxRetries)
+ * 2. Wait for the authenticated UI shell to be visible
+ * 3. Wait for Svelte hydration (data-hydrated attribute on <html>)
+ * 4. If the shell does not appear, reload and retry (up to maxRetries)
+ *
+ * After this returns, event handlers are attached and elements are interactive.
  */
 export async function waitForAuthenticated(page: Page, timeout = 30000, maxRetries = 3) {
 	const perAttemptTimeout = Math.max(5000, Math.floor(timeout / maxRetries));
@@ -17,6 +20,9 @@ export async function waitForAuthenticated(page: Page, timeout = 30000, maxRetri
 
 		try {
 			await expect(page.locator('#user-menu-trigger')).toBeVisible({ timeout: perAttemptTimeout });
+			// Wait for Svelte hydration to complete so event handlers are attached.
+			// The app layout sets data-hydrated on <html> in onMount.
+			await page.locator('html[data-hydrated]').waitFor({ timeout: perAttemptTimeout });
 			return;
 		} catch (error) {
 			if (attempt < maxRetries) {

--- a/src/lib/chat/core/StreamProcessor.test.ts
+++ b/src/lib/chat/core/StreamProcessor.test.ts
@@ -196,7 +196,7 @@ describe('extractReasoning', () => {
 });
 
 describe('deriveUIMessagesFromTextStreamParts', () => {
-	it('appends repeated reasoning delta ids into one logical reasoning part', () => {
+	it('appends repeated reasoning delta ids into one logical reasoning part (TextStreamPart format)', () => {
 		const [messages] = deriveUIMessagesFromTextStreamParts(
 			'thread-1',
 			[createStreamMessage({ streamId: 'stream-1', order: 1, stepOrder: 0 })],
@@ -226,6 +226,104 @@ describe('deriveUIMessagesFromTextStreamParts', () => {
 		expect(messages).toHaveLength(1);
 		expect(messages[0]!.parts?.filter((part) => part.type === 'reasoning')).toHaveLength(1);
 		expect(extractReasoning(messages[0]!.parts as MessagePart[])).toBe('First second');
+	});
+
+	it('handles UIMessageChunk format where text content is in delta field', () => {
+		const [messages] = deriveUIMessagesFromTextStreamParts(
+			'thread-1',
+			[createStreamMessage({ streamId: 'stream-1', order: 1, stepOrder: 0 })],
+			[],
+			[
+				{
+					streamId: 'stream-1',
+					start: 0,
+					end: 1,
+					parts: [{ type: 'text-start', id: 'text-1' }]
+				},
+				{
+					streamId: 'stream-1',
+					start: 1,
+					end: 2,
+					parts: [{ type: 'text-delta', id: 'text-1', delta: 'Hello ' }]
+				},
+				{
+					streamId: 'stream-1',
+					start: 2,
+					end: 3,
+					parts: [{ type: 'text-delta', id: 'text-1', delta: 'world' }]
+				}
+			] as any
+		);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0]!.text).toBe('Hello world');
+	});
+
+	it('handles UIMessageChunk format for reasoning deltas (delta field)', () => {
+		const [messages] = deriveUIMessagesFromTextStreamParts(
+			'thread-1',
+			[createStreamMessage({ streamId: 'stream-1', order: 1, stepOrder: 0 })],
+			[],
+			[
+				{
+					streamId: 'stream-1',
+					start: 0,
+					end: 1,
+					parts: [{ type: 'reasoning-start', id: 'reason-1' }]
+				},
+				{
+					streamId: 'stream-1',
+					start: 1,
+					end: 2,
+					parts: [{ type: 'reasoning-delta', id: 'reason-1', delta: 'Thinking ' }]
+				},
+				{
+					streamId: 'stream-1',
+					start: 2,
+					end: 3,
+					parts: [{ type: 'reasoning-delta', id: 'reason-1', delta: 'about it' }]
+				}
+			] as any
+		);
+
+		expect(messages).toHaveLength(1);
+		expect(extractReasoning(messages[0]!.parts as MessagePart[])).toBe('Thinking about it');
+	});
+
+	it('does NOT produce "undefined" strings when delta parts lack a text field', () => {
+		// This is the exact bug scenario: UIMessageChunk format parts have `delta`
+		// field but no `text` field. Without the fix, part.text would be undefined
+		// and string concatenation would produce literal "undefined" strings.
+		const [messages] = deriveUIMessagesFromTextStreamParts(
+			'thread-1',
+			[createStreamMessage({ streamId: 'stream-1', order: 1, stepOrder: 0 })],
+			[],
+			[
+				{
+					streamId: 'stream-1',
+					start: 0,
+					end: 1,
+					parts: [{ type: 'text-start', id: 'text-1' }]
+				},
+				{
+					streamId: 'stream-1',
+					start: 1,
+					end: 2,
+					// Simulates UIMessageChunk: has `delta` but no `text`
+					parts: [{ type: 'text-delta', id: 'text-1', delta: 'Hi' }]
+				},
+				{
+					streamId: 'stream-1',
+					start: 2,
+					end: 3,
+					parts: [{ type: 'text-delta', id: 'text-1', delta: ' there' }]
+				}
+			] as any
+		);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0]!.text).toBe('Hi there');
+		expect(messages[0]!.text).not.toContain('undefined');
 	});
 });
 

--- a/src/lib/chat/core/StreamProcessor.ts
+++ b/src/lib/chat/core/StreamProcessor.ts
@@ -5,6 +5,12 @@
  * Processes streaming deltas into UIMessages with progressive text and reasoning.
  *
  * Based on @convex-dev/agent deltas processing.
+ *
+ * IMPORTANT: The @convex-dev/agent library stores stream deltas in two possible formats:
+ * - "UIMessageChunk" format: text/reasoning content is in a `delta` field
+ * - "TextStreamPart" format: text/reasoning content is in a `text` field
+ *
+ * When reading text from delta parts, always use getDeltaText() to handle both formats.
  */
 
 import type { TextStreamPart, ToolSet, ProviderMetadata } from 'ai';
@@ -17,6 +23,15 @@ import type {
 	TextUIPart,
 	StreamStatus
 } from './types.js';
+
+/**
+ * Extract text content from a stream delta part, handling both formats:
+ * - UIMessageChunk format: content is in `delta` field
+ * - TextStreamPart format: content is in `text` field
+ */
+function getDeltaText(part: { text?: string; delta?: string }): string {
+	return (part as { delta?: string }).delta ?? part.text ?? '';
+}
 
 /**
  * Create a blank UIMessage from stream metadata
@@ -245,7 +260,7 @@ export function updateFromTextStreamParts(
 				}
 				if (part.type === 'text-delta') {
 					const textPart = textPartsById.get(part.id)!;
-					textPart.text += part.text;
+					textPart.text += getDeltaText(part);
 					textPart.providerMetadata = mergeProviderMetadata(
 						textPart.providerMetadata,
 						part.providerMetadata
@@ -268,7 +283,7 @@ export function updateFromTextStreamParts(
 				}
 				if (part.type === 'reasoning-delta') {
 					const reasoningPart = reasoningPartsById.get(part.id)!;
-					reasoningPart.text = (reasoningPart.text ?? '') + part.text;
+					reasoningPart.text = (reasoningPart.text ?? '') + getDeltaText(part);
 					reasoningPart.providerMetadata = mergeProviderMetadata(
 						reasoningPart.providerMetadata,
 						part.providerMetadata

--- a/src/lib/components/authenticated/authenticated-layout.svelte
+++ b/src/lib/components/authenticated/authenticated-layout.svelte
@@ -6,6 +6,7 @@
 	import { ScrollArea } from '$lib/components/ui/scroll-area';
 	import type { Snippet } from 'svelte';
 	import type { SidebarConfig, User } from './types';
+	import { onMount } from 'svelte';
 
 	interface Props {
 		children?: Snippet;
@@ -35,6 +36,11 @@
 			document.documentElement.classList.remove('auth-shell-bg');
 			document.body.classList.remove('auth-shell-bg');
 		};
+	});
+
+	// Signal that Svelte hydration is complete (used by E2E tests via waitForAuthenticated)
+	onMount(() => {
+		document.documentElement.dataset.hydrated = '';
 	});
 </script>
 

--- a/src/routes/[[lang]]/app/+layout.svelte
+++ b/src/routes/[[lang]]/app/+layout.svelte
@@ -5,7 +5,6 @@
 	import { page } from '$app/state';
 	import type { LayoutData } from './$types';
 	import type { Snippet } from 'svelte';
-	import { onMount } from 'svelte';
 
 	interface Props {
 		children?: Snippet;
@@ -21,11 +20,6 @@
 	const sidebarConfig = $derived(
 		getAppSidebarConfig({ pathname: page.url.pathname, lang: page.params.lang }, viewer?.role)
 	);
-
-	// Signal that Svelte hydration is complete (used by E2E tests)
-	onMount(() => {
-		document.documentElement.dataset.hydrated = '';
-	});
 </script>
 
 <PostHogIdentify />

--- a/src/routes/[[lang]]/app/+layout.svelte
+++ b/src/routes/[[lang]]/app/+layout.svelte
@@ -5,6 +5,7 @@
 	import { page } from '$app/state';
 	import type { LayoutData } from './$types';
 	import type { Snippet } from 'svelte';
+	import { onMount } from 'svelte';
 
 	interface Props {
 		children?: Snippet;
@@ -20,6 +21,11 @@
 	const sidebarConfig = $derived(
 		getAppSidebarConfig({ pathname: page.url.pathname, lang: page.params.lang }, viewer?.role)
 	);
+
+	// Signal that Svelte hydration is complete (used by E2E tests)
+	onMount(() => {
+		document.documentElement.dataset.hydrated = '';
+	});
 </script>
 
 <PostHogIdentify />


### PR DESCRIPTION
Commit b80c350 accidentally replaced `(part as { delta?: string }).delta`
with `part.text` during a type refactor. The @convex-dev/agent library
stores stream deltas in UIMessageChunk format where content lives in a
`delta` field, not `text`. Reading `part.text` yields undefined, which
string concatenation turns into literal "undefined" strings in the chat.

Introduce getDeltaText() that reads `part.delta ?? part.text ?? ''` to
handle both UIMessageChunk and TextStreamPart formats safely.