### PR TITLE
fix(support): skip slide-in animation when loading thread from URL

### DIFF
--- a/src/lib/components/customer-support/customer-support.svelte
+++ b/src/lib/components/customer-support/customer-support.svelte
@@ -31,6 +31,8 @@
 		urlState.support = open ? 'open' : '';
 		if (!open) {
 			urlState.thread = ''; // Clear thread when closing widget
+		} else if (threadContext.threadId) {
+			urlState.thread = threadContext.threadId;
 		}
 	}
 

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -48,6 +48,17 @@
 	// Derive chat panel open state
 	const isChatOpen = $derived(threadContext.currentView !== 'overview');
 
+	// Skip animation when loading thread from URL (show instantly)
+	const panelDuration = $derived(threadContext.skipAnimation ? 0 : 300);
+
+	$effect(() => {
+		if (threadContext.skipAnimation && isChatOpen) {
+			requestAnimationFrame(() => {
+				threadContext.skipAnimation = false;
+			});
+		}
+	});
+
 	// Get Convex client
 	const client = useConvexClient();
 
@@ -203,6 +214,7 @@
 >
 	<!-- Animated header with sliding icon and title -->
 	<SlidingHeader
+		skipTransition={threadContext.skipAnimation}
 		isBackView={threadContext.currentView !== 'overview'}
 		defaultIcon={MessagesSquareIcon}
 		defaultTitle={$t('support.widget.header.messages')}
@@ -224,7 +236,7 @@
 		<ThreadsOverview />
 
 		<!-- Chat sheet - slides in from right like iOS/Android navigation -->
-		<SlidingPanel open={isChatOpen} class="bg-secondary">
+		<SlidingPanel open={isChatOpen} duration={panelDuration} class="bg-secondary">
 			<ChatRoot
 				threadId={threadContext.threadId}
 				api={chatApi}

--- a/src/lib/components/customer-support/support-thread-context.svelte.ts
+++ b/src/lib/components/customer-support/support-thread-context.svelte.ts
@@ -65,6 +65,7 @@ export class SupportThreadContext {
 	isSending = $state(false);
 	error = $state<string | null>(null);
 	shouldOpenWidget = $state(false);
+	skipAnimation = $state(false);
 
 	/** True when user starts a new conversation - enables immediate suggestion display */
 	isNewConversation = $state(false);
@@ -575,6 +576,7 @@ export class SupportThreadContext {
 		this.threadId = threadId;
 		this.currentView = 'chat';
 		this.isNewConversation = false;
+		this.skipAnimation = true;
 		// Don't call onThreadChange here - this is triggered BY the URL
 	}
 

--- a/src/lib/components/ui/sliding-header/sliding-header.svelte
+++ b/src/lib/components/ui/sliding-header/sliding-header.svelte
@@ -33,6 +33,7 @@
 		// Styling
 		class?: string;
 		showClose?: boolean;
+		skipTransition?: boolean;
 
 		// Actions
 		actions?: Snippet;
@@ -51,6 +52,7 @@
 		onCloseClick,
 		class: className,
 		showClose = true,
+		skipTransition = false,
 		actions
 	}: Props = $props();
 </script>
@@ -61,8 +63,8 @@
 		<!-- Default icon (visible when NOT in back view) -->
 		{#if !isBackView}
 			<div
-				in:fly={{ x: 20, duration: 200, easing: backOut }}
-				out:fly={{ x: -20, duration: 200, easing: cubicOut }}
+				in:fly={{ x: 20, duration: skipTransition ? 0 : 200, easing: backOut }}
+				out:fly={{ x: -20, duration: skipTransition ? 0 : 200, easing: cubicOut }}
 				class="absolute inset-0 flex items-center justify-center"
 			>
 				<DefaultIcon class="size-5 text-muted-foreground" />
@@ -72,8 +74,8 @@
 		<!-- Back button (visible when in back view) -->
 		{#if isBackView}
 			<div
-				in:fly={{ x: 20, duration: 200, easing: backOut }}
-				out:fly={{ x: -20, duration: 200, easing: cubicOut }}
+				in:fly={{ x: 20, duration: skipTransition ? 0 : 200, easing: backOut }}
+				out:fly={{ x: -20, duration: skipTransition ? 0 : 200, easing: cubicOut }}
 				class="absolute inset-0 flex items-center justify-center"
 			>
 				<Button
@@ -97,8 +99,8 @@
 		<!-- Default title -->
 		{#if !isBackView}
 			<div
-				in:fly={{ y: -40, duration: 300, easing: backOut }}
-				out:fly={{ y: 40, duration: 300, easing: cubicOut }}
+				in:fly={{ y: -40, duration: skipTransition ? 0 : 300, easing: backOut }}
+				out:fly={{ y: 40, duration: skipTransition ? 0 : 300, easing: cubicOut }}
 				class="col-start-1 row-start-1 flex h-10 items-center"
 			>
 				<h2 class="text-xl leading-none font-semibold">{defaultTitle}</h2>
@@ -108,8 +110,8 @@
 		<!-- Back view title -->
 		{#if isBackView}
 			<div
-				in:fly={{ y: -40, duration: 300, easing: backOut }}
-				out:fly={{ y: 40, duration: 300, easing: cubicOut }}
+				in:fly={{ y: -40, duration: skipTransition ? 0 : 300, easing: backOut }}
+				out:fly={{ y: 40, duration: skipTransition ? 0 : 300, easing: cubicOut }}
 				class="col-start-1 row-start-1 flex h-10 items-center"
 			>
 				<AvatarHeading


### PR DESCRIPTION
When navigating directly via URL with ?thread=<id>, the thread view
appeared with a slide-in animation. Now the thread renders instantly
on URL-based navigation while preserving the animation for user-
initiated actions (clicking a thread or the back button).