### PR TITLE
fix(support): resolve intermittent slide-in animation on cold page load

### DIFF
--- a/src/lib/components/customer-support/customer-support.svelte
+++ b/src/lib/components/customer-support/customer-support.svelte
@@ -26,6 +26,11 @@
 	const threadContext = new SupportThreadContext();
 	supportThreadContext.set(threadContext);
 
+	// Pre-set skipAnimation if URL already has a thread (before FeedbackWidget mounts)
+	if (urlState.thread) {
+		threadContext.skipAnimation = true;
+	}
+
 	// URL state sync handlers
 	function setWidgetOpen(open: boolean) {
 		urlState.support = open ? 'open' : '';

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -54,7 +54,9 @@
 	$effect(() => {
 		if (threadContext.skipAnimation && isChatOpen) {
 			requestAnimationFrame(() => {
-				threadContext.skipAnimation = false;
+				setTimeout(() => {
+					threadContext.skipAnimation = false;
+				});
 			});
 		}
 	});

--- a/src/lib/components/ui/sliding-panel/sliding-panel.svelte
+++ b/src/lib/components/ui/sliding-panel/sliding-panel.svelte
@@ -23,19 +23,14 @@
 
 	// Compute transition classes based on direction and open state
 	const slideClasses = $derived.by(() => {
-		const baseClasses = 'absolute inset-0 flex flex-col transition-all overflow-hidden';
+		const transitionClass = duration === 0 ? 'transition-none' : `transition-all ${durationClass}`;
+		const baseClasses = `absolute inset-0 flex flex-col overflow-hidden ${transitionClass}`;
 
 		if (open) {
-			return cn(baseClasses, durationClass, 'translate-x-0 opacity-100', className);
+			return cn(baseClasses, 'translate-x-0 opacity-100', className);
 		} else {
 			const hideTransform = direction === 'right' ? 'translate-x-full' : '-translate-x-full';
-			return cn(
-				baseClasses,
-				durationClass,
-				hideTransform,
-				'opacity-0 pointer-events-none',
-				className
-			);
+			return cn(baseClasses, hideTransform, 'opacity-0 pointer-events-none', className);
 		}
 	});
 </script>


### PR DESCRIPTION
Three fixes for the skipAnimation race condition:

1. Set skipAnimation synchronously in the parent script block before
   children mount, instead of relying on $effect (which runs after
   rendering)

2. Use transition-none instead of transition-all with duration-[0ms]
   to fully disable CSS transitions when skipping animation

3. Use rAF + setTimeout instead of single rAF to guarantee a paint
   cycle has occurred before re-enabling animations