### PR TITLE
style: use ghost buttons for header and footer nav items

### DIFF
--- a/src/lib/components/marketing/marketing-footer.svelte
+++ b/src/lib/components/marketing/marketing-footer.svelte
@@ -2,6 +2,7 @@
 	import { T } from '@tolgee/svelte';
 	import { localizedHref } from '$lib/utils/i18n';
 	import { resolve } from '$app/paths';
+	import Button from '$lib/components/ui/button/button.svelte';
 </script>
 
 <footer class="mt-auto pt-24">
@@ -14,28 +15,34 @@
 					<T keyName="footer.copyright" params={{ year: new Date().getFullYear().toString() }} />
 				</p>
 				<nav
-					class="flex flex-col items-end gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center sm:gap-3"
+					class="flex flex-col items-end gap-0 text-xs text-muted-foreground sm:flex-row sm:items-center sm:gap-1"
 				>
-					<a
+					<Button
+						variant="ghost"
+						size="sm"
 						href={resolve(localizedHref('/impressum'))}
-						class="transition-colors duration-150 hover:text-accent-foreground"
+						class="h-7 text-xs text-muted-foreground"
 					>
 						<T keyName="footer.impressum" />
-					</a>
+					</Button>
 					<span class="hidden sm:inline" aria-hidden="true">&middot;</span>
-					<a
+					<Button
+						variant="ghost"
+						size="sm"
 						href={resolve(localizedHref('/terms'))}
-						class="transition-colors duration-150 hover:text-accent-foreground"
+						class="h-7 text-xs text-muted-foreground"
 					>
 						<T keyName="footer.terms" />
-					</a>
+					</Button>
 					<span class="hidden sm:inline" aria-hidden="true">&middot;</span>
-					<a
+					<Button
+						variant="ghost"
+						size="sm"
 						href={resolve(localizedHref('/privacy'))}
-						class="transition-colors duration-150 hover:text-accent-foreground"
+						class="h-7 text-xs text-muted-foreground"
 					>
 						<T keyName="footer.privacy" />
-					</a>
+					</Button>
 				</nav>
 			</div>
 		</div>

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -77,21 +77,27 @@
 				class="-mx-2 flex w-[calc(100%+1rem)] items-center justify-between rounded-2xl border border-black/[0.06] px-6 py-4 [box-shadow:inset_0_1px_1px_0_rgba(255,255,255,0.5)] backdrop-blur-[5px] transition-[height,transform] duration-300 [background:linear-gradient(137deg,rgba(252,252,255,0.9)_4.87%,rgba(240,240,248,0.95)_75.88%)] lg:-mx-8 lg:w-[calc(100%+4rem)] lg:px-8 dark:border-white/[0.06] dark:[box-shadow:inset_0_1px_1px_0_rgba(255,255,255,0.15)] dark:[background:linear-gradient(137deg,rgba(17,18,20,0.75)_4.87%,rgba(12,13,15,0.9)_75.88%)]"
 			>
 				<!-- Logo -->
-				<a href={resolve(localizedHref('/'))} class="flex items-center space-x-2">
+				<Button
+					variant="ghost"
+					href={resolve(localizedHref('/'))}
+					class="-ml-3 flex items-center gap-2 px-3 font-semibold"
+				>
 					<Logo class="size-5" />
-					<span class="font-semibold">SaaS Starter</span>
-				</a>
+					SaaS Starter
+				</Button>
 
 				<!-- Desktop Navigation -->
-				<ul class="hidden gap-8 text-sm lg:flex">
+				<ul class="hidden gap-2 text-sm lg:flex">
 					{#each menuItems as item (item.translationKey)}
 						<li>
-							<a
+							<Button
+								variant="ghost"
+								size="sm"
 								href={resolve(item.href)}
-								class="block text-muted-foreground transition-colors duration-150 hover:text-accent-foreground"
+								class="text-muted-foreground"
 							>
-								<span><T keyName={item.translationKey} /></span>
-							</a>
+								<T keyName={item.translationKey} />
+							</Button>
 						</li>
 					{/each}
 				</ul>
@@ -199,16 +205,17 @@
 		<div
 			class="fixed top-24 right-4 left-4 z-30 rounded-2xl border border-white/[0.06] bg-background/95 p-6 backdrop-blur-xl lg:hidden"
 		>
-			<ul class="space-y-4 text-base">
+			<ul class="space-y-1 text-base">
 				{#each menuItems as item (item.translationKey)}
 					<li>
-						<a
+						<Button
+							variant="ghost"
 							href={resolve(item.href)}
-							class="block text-muted-foreground transition-colors duration-150 hover:text-accent-foreground"
+							class="w-full justify-start text-muted-foreground"
 							onclick={() => (menuState = false)}
 						>
-							<span><T keyName={item.translationKey} /></span>
-						</a>
+							<T keyName={item.translationKey} />
+						</Button>
 					</li>
 				{/each}
 			</ul>

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -80,7 +80,7 @@
 				<Button
 					variant="ghost"
 					href={resolve(localizedHref('/'))}
-					class="-ml-3 flex items-center gap-2 px-3 font-semibold"
+					class="-ml-4 flex items-center gap-2 px-3 font-semibold"
 				>
 					<Logo class="size-5" />
 					SaaS Starter

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -80,7 +80,7 @@
 				<Button
 					variant="ghost"
 					href={resolve(localizedHref('/'))}
-					class="-ml-4 flex items-center gap-2 px-3 font-semibold"
+					class="-ml-3.5 flex items-center gap-2 px-3 font-semibold"
 				>
 					<Logo class="size-5" />
 					SaaS Starter


### PR DESCRIPTION
Adds active:scale-97 press effect to all navigation links by converting
plain anchor tags to shadcn Button components with ghost variant.