### PR TITLE
feat(a11y): add lang="en" to legal pages and ESLint rules for localized screen reader text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,7 +327,8 @@ No barrel imports from icon libraries — use individual imports (`@lucide/svelt
 - Accessibility localization rule (all UI):
   - Never hardcode human-facing `aria-label` or `.sr-only` text in English.
   - Always localize screen-reader labels via Tolgee keys (not only tables, applies to all UI controls and navigation).
-  - Accessible naming convention: prefer localized `.sr-only` text for icon-only buttons, use localized `aria-label` when hidden text is not practical, and avoid redundant double-labeling.
+  - Accessible naming convention: prefer localized `.sr-only` text for icon-only buttons, use localized `aria-label` when hidden text is not practical, and avoid redundant double-labeling. Exception: keep `aria-label` in shadcn-svelte components as-is (their upstream pattern) to minimize theme maintenance diff.
+  - Add `lang="en"` to content blocks that bypass Tolgee (e.g., legal pages rendered from raw English markdown).
   - Never add ARIA labels to non-functional buttons (no click handler). Hide decorative buttons from the a11y tree with `aria-hidden="true"` + `tabindex="-1"`, or remove them.
   - `<noscript>` content never needs `dark:` variants — dark mode requires JS (ModeWatcher). Noscript users always see light theme.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,12 +10,16 @@ import ts from 'typescript-eslint';
 import svelteConfig from './svelte.config.js';
 import requireMarketingMarkdownRule from './eslint/rules/require-marketing-markdown.js';
 import requireMarketingRouteRegistrationRule from './eslint/rules/require-marketing-route-registration.js';
+import noHardcodedAriaLabelRule from './eslint/rules/no-hardcoded-aria-label.js';
+import noHardcodedSrOnlyRule from './eslint/rules/no-hardcoded-sr-only.js';
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
 const localPlugin = {
 	rules: {
 		'require-marketing-markdown': requireMarketingMarkdownRule,
-		'require-marketing-route-registration': requireMarketingRouteRegistrationRule
+		'require-marketing-route-registration': requireMarketingRouteRegistrationRule,
+		'no-hardcoded-aria-label': noHardcodedAriaLabelRule,
+		'no-hardcoded-sr-only': noHardcodedSrOnlyRule
 	}
 };
 
@@ -142,6 +146,16 @@ export default defineConfig(
 		rules: {
 			'local/require-marketing-markdown': 'error',
 			'local/require-marketing-route-registration': 'error'
+		}
+	},
+	{
+		files: ['src/**/*.svelte'],
+		plugins: {
+			local: localPlugin
+		},
+		rules: {
+			'local/no-hardcoded-aria-label': 'error',
+			'local/no-hardcoded-sr-only': 'error'
 		}
 	},
 	// Convex best-practice rules (legacy plugin config converted via fixupConfigRules)

--- a/eslint/rules/no-hardcoded-aria-label.js
+++ b/eslint/rules/no-hardcoded-aria-label.js
@@ -5,8 +5,10 @@
  * All aria-label values must be localized via $t() calls.
  *
  * ✅ aria-label={$t('aria.close')}
+ * ✅ aria-label={someVariable}       (variable may come from $t() upstream — not our call)
  * ❌ aria-label="Close"
  * ❌ aria-label="Close {name}"
+ * ❌ aria-label={'Close'}            (string literal inside expression)
  */
 export default {
 	meta: {
@@ -40,9 +42,17 @@ export default {
 
 				if (allLocalized) return;
 
-				// If any value part is a SvelteLiteral (hardcoded string), flag it
-				const hasLiteral = node.value.some((v) => v.type === 'SvelteLiteral');
-				if (hasLiteral) {
+				// Flag if any value part contains a hardcoded string:
+				// - SvelteLiteral: aria-label="Close" or aria-label="Close {name}"
+				// - SvelteMustacheTag with a Literal expression: aria-label={'Close'}
+				const hasHardcodedString = node.value.some(
+					(v) =>
+						v.type === 'SvelteLiteral' ||
+						(v.type === 'SvelteMustacheTag' &&
+							v.expression?.type === 'Literal' &&
+							typeof v.expression.value === 'string')
+				);
+				if (hasHardcodedString) {
 					context.report({ node, messageId: 'hardcodedAriaLabel' });
 				}
 			}

--- a/eslint/rules/no-hardcoded-aria-label.js
+++ b/eslint/rules/no-hardcoded-aria-label.js
@@ -1,0 +1,51 @@
+/**
+ * ESLint rule: no-hardcoded-aria-label
+ *
+ * Flags aria-label attributes with hardcoded string values in Svelte templates.
+ * All aria-label values must be localized via $t() calls.
+ *
+ * ✅ aria-label={$t('aria.close')}
+ * ❌ aria-label="Close"
+ * ❌ aria-label="Close {name}"
+ */
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow hardcoded strings in aria-label attributes (must use $t())'
+		},
+		schema: [],
+		messages: {
+			hardcodedAriaLabel:
+				"aria-label contains a hardcoded string. Use $t() for localization: aria-label={$t('aria.key')}"
+		}
+	},
+	create(context) {
+		return {
+			SvelteAttribute(node) {
+				// Only check aria-label attributes
+				if (node.key?.name !== 'aria-label') return;
+
+				// No value means boolean attribute (aria-label without value) — unusual but not our concern
+				if (!node.value || node.value.length === 0) return;
+
+				// If every value part is a SvelteMustacheTag wrapping a $t() call, it's fine
+				const allLocalized = node.value.every(
+					(v) =>
+						v.type === 'SvelteMustacheTag' &&
+						v.expression?.type === 'CallExpression' &&
+						v.expression.callee?.type === 'Identifier' &&
+						v.expression.callee.name === '$t'
+				);
+
+				if (allLocalized) return;
+
+				// If any value part is a SvelteLiteral (hardcoded string), flag it
+				const hasLiteral = node.value.some((v) => v.type === 'SvelteLiteral');
+				if (hasLiteral) {
+					context.report({ node, messageId: 'hardcodedAriaLabel' });
+				}
+			}
+		};
+	}
+};

--- a/eslint/rules/no-hardcoded-aria-label.test.ts
+++ b/eslint/rules/no-hardcoded-aria-label.test.ts
@@ -61,4 +61,15 @@ describe('no-hardcoded-aria-label', () => {
 		const reports = lint('<button aria-label></button>');
 		expect(reports).toHaveLength(0);
 	});
+
+	it("flags string literal inside expression: aria-label={'Close'}", () => {
+		const reports = lint("<button aria-label={'Close'}></button>");
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('hardcodedAriaLabel');
+	});
+
+	it('allows variable expressions (may come from $t() upstream)', () => {
+		const reports = lint('<button aria-label={label}></button>');
+		expect(reports).toHaveLength(0);
+	});
 });

--- a/eslint/rules/no-hardcoded-aria-label.test.ts
+++ b/eslint/rules/no-hardcoded-aria-label.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import parser from 'svelte-eslint-parser';
 import rule from './no-hardcoded-aria-label.js';
 

--- a/eslint/rules/no-hardcoded-aria-label.test.ts
+++ b/eslint/rules/no-hardcoded-aria-label.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import parser from 'svelte-eslint-parser';
+import rule from './no-hardcoded-aria-label.js';
+
+function lint(template: string): { messageId: string }[] {
+	const reports: { messageId: string }[] = [];
+	const ast = parser.parseForESLint(template, {});
+
+	const context = {
+		report: (opts: { messageId: string }) => reports.push(opts),
+		getFilename: () => 'test.svelte',
+		filename: 'test.svelte'
+	};
+
+	const listeners = rule.create(context);
+
+	function walk(node: Record<string, unknown>) {
+		if (!node || typeof node !== 'object') return;
+		const type = node.type as string;
+		if (type && typeof listeners[type] === 'function') {
+			(listeners[type] as (n: unknown) => void)(node);
+		}
+		for (const key of Object.keys(node)) {
+			if (key === 'parent') continue;
+			const val = node[key];
+			if (Array.isArray(val)) val.forEach((v) => walk(v as Record<string, unknown>));
+			else if (val && typeof val === 'object' && (val as Record<string, unknown>).type)
+				walk(val as Record<string, unknown>);
+		}
+	}
+
+	walk(ast.ast as unknown as Record<string, unknown>);
+	return reports;
+}
+
+describe('no-hardcoded-aria-label', () => {
+	it('flags hardcoded aria-label string', () => {
+		const reports = lint('<button aria-label="Close"></button>');
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('hardcodedAriaLabel');
+	});
+
+	it('allows $t() in aria-label', () => {
+		const reports = lint("<button aria-label={$t('aria.close')}></button>");
+		expect(reports).toHaveLength(0);
+	});
+
+	it('flags mixed literal and expression in aria-label', () => {
+		// aria-label="Delete {name}" is actually expressed as aria-label="Delete {name}" in Svelte
+		const reports = lint('<button aria-label="Delete {name}"></button>');
+		expect(reports).toHaveLength(1);
+	});
+
+	it('ignores non-aria-label attributes', () => {
+		const reports = lint('<button title="Close"></button>');
+		expect(reports).toHaveLength(0);
+	});
+
+	it('ignores aria-label on elements without value', () => {
+		// Unusual but shouldn't crash
+		const reports = lint('<button aria-label></button>');
+		expect(reports).toHaveLength(0);
+	});
+});

--- a/eslint/rules/no-hardcoded-sr-only.js
+++ b/eslint/rules/no-hardcoded-sr-only.js
@@ -1,0 +1,64 @@
+/**
+ * ESLint rule: no-hardcoded-sr-only
+ *
+ * Flags .sr-only elements that contain hardcoded text instead of $t() calls.
+ * All screen-reader-only text must be localized.
+ *
+ * ✅ <span class="sr-only">{$t('aria.copy')}</span>
+ * ❌ <span class="sr-only">Copy</span>
+ */
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow hardcoded text in .sr-only elements (must use $t())'
+		},
+		schema: [],
+		messages: {
+			hardcodedSrOnly:
+				"sr-only element contains hardcoded text. Use $t() for localization: {$t('aria.key')}"
+		}
+	},
+	create(context) {
+		return {
+			SvelteElement(node) {
+				if (!hasSrOnlyClass(node)) return;
+
+				// Check children for hardcoded text
+				const hasHardcodedText = node.children.some(
+					(child) => child.type === 'SvelteText' && child.value.trim() !== ''
+				);
+
+				if (hasHardcodedText) {
+					context.report({ node: node.startTag, messageId: 'hardcodedSrOnly' });
+				}
+			}
+		};
+	}
+};
+
+/**
+ * Check if a SvelteElement has the sr-only class.
+ * Handles: class="sr-only", class="foo sr-only bar"
+ */
+function hasSrOnlyClass(node) {
+	const startTag = node.startTag;
+	if (!startTag?.attributes) return false;
+
+	for (const attr of startTag.attributes) {
+		if (attr.type !== 'SvelteAttribute' || attr.key?.name !== 'class') continue;
+
+		// Static class value: class="sr-only" or class="foo sr-only"
+		for (const valuePart of attr.value || []) {
+			if (valuePart.type === 'SvelteLiteral' && hasSrOnlyToken(valuePart.value)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+function hasSrOnlyToken(classString) {
+	return classString.split(/\s+/).includes('sr-only');
+}

--- a/eslint/rules/no-hardcoded-sr-only.test.ts
+++ b/eslint/rules/no-hardcoded-sr-only.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import parser from 'svelte-eslint-parser';
+import rule from './no-hardcoded-sr-only.js';
+
+function lint(template: string): { messageId: string }[] {
+	const reports: { messageId: string }[] = [];
+	const ast = parser.parseForESLint(template, {});
+
+	const context = {
+		report: (opts: { messageId: string }) => reports.push(opts),
+		getFilename: () => 'test.svelte',
+		filename: 'test.svelte'
+	};
+
+	const listeners = rule.create(context);
+
+	function walk(node: Record<string, unknown>) {
+		if (!node || typeof node !== 'object') return;
+		const type = node.type as string;
+		if (type && typeof listeners[type] === 'function') {
+			(listeners[type] as (n: unknown) => void)(node);
+		}
+		for (const key of Object.keys(node)) {
+			if (key === 'parent') continue;
+			const val = node[key];
+			if (Array.isArray(val)) val.forEach((v) => walk(v as Record<string, unknown>));
+			else if (val && typeof val === 'object' && (val as Record<string, unknown>).type)
+				walk(val as Record<string, unknown>);
+		}
+	}
+
+	walk(ast.ast as unknown as Record<string, unknown>);
+	return reports;
+}
+
+describe('no-hardcoded-sr-only', () => {
+	it('flags hardcoded text in sr-only element', () => {
+		const reports = lint('<span class="sr-only">Close</span>');
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('hardcodedSrOnly');
+	});
+
+	it('allows $t() in sr-only element', () => {
+		const reports = lint('<span class="sr-only">{$t(\'aria.close\')}</span>');
+		expect(reports).toHaveLength(0);
+	});
+
+	it('flags hardcoded text when sr-only is among multiple classes', () => {
+		const reports = lint('<span class="mt-2 sr-only text-sm">Close</span>');
+		expect(reports).toHaveLength(1);
+	});
+
+	it('ignores elements without sr-only class', () => {
+		const reports = lint('<span class="hidden">Close</span>');
+		expect(reports).toHaveLength(0);
+	});
+
+	it('ignores sr-only elements with only whitespace text', () => {
+		const reports = lint('<span class="sr-only"> {$t(\'aria.close\')} </span>');
+		expect(reports).toHaveLength(0);
+	});
+
+	it('ignores elements without class attribute', () => {
+		const reports = lint('<span>Close</span>');
+		expect(reports).toHaveLength(0);
+	});
+});

--- a/src/lib/components/obfuscated-email.svelte
+++ b/src/lib/components/obfuscated-email.svelte
@@ -22,6 +22,7 @@
 <!-- Anti-scraping: aria-label intentionally NOT localized via Tolgee. Putting email parts
      in i18n bundles would defeat the obfuscation. English "at"/"dot" format is acceptable
      since this component is only used for static contact info on legal pages. -->
+<!-- eslint-disable local/no-hardcoded-aria-label -->
 <button
 	onclick={handleClick}
 	class="cursor-pointer {className}"
@@ -32,3 +33,4 @@
 		aria-hidden="true">null.</span
 	>{domain}<span class="hidden" aria-hidden="true">.fake</span>.{tld}</button
 >
+<!-- eslint-enable local/no-hardcoded-aria-label -->

--- a/src/lib/components/ui/loading-bar/loading-bar.svelte
+++ b/src/lib/components/ui/loading-bar/loading-bar.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import { Progress as ProgressPrimitive } from 'bits-ui';
 	import { watch } from 'runed';
+	import { getTranslate } from '@tolgee/svelte';
 	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+
+	const { t } = getTranslate();
 
 	type LoadingBarProps = WithoutChildrenOrChild<ProgressPrimitive.RootProps> & {
 		start?: number;
@@ -88,11 +91,10 @@
 	);
 </script>
 
-<!-- aria-label is hardcoded English: low-level UI primitive without access to Tolgee i18n context -->
 <ProgressPrimitive.Root
 	bind:ref
 	data-slot="progress"
-	aria-label="Loading"
+	aria-label={$t('aria.loading')}
 	class={cn(
 		'relative h-2 w-full overflow-hidden rounded-full',
 		showBackground && 'bg-primary/20',

--- a/src/routes/[[lang]]/(marketing)/impressum/+page.svelte
+++ b/src/routes/[[lang]]/(marketing)/impressum/+page.svelte
@@ -24,7 +24,8 @@ ${LEGAL_CONFIG.address}`;
 
 <SEOHead title={$t('meta.impressum.title')} description={$t('meta.impressum.description')} />
 
-<div class="mx-auto prose prose-sm max-w-3xl px-6 pt-40 pb-24 lg:px-12 dark:prose-invert">
+<!-- Impressum content is intentionally English-only. -->
+<div lang="en" class="mx-auto prose prose-sm max-w-3xl px-6 pt-40 pb-24 lg:px-12 dark:prose-invert">
 	<SvelteMarkdown {source} />
 	<p>
 		Email:

--- a/src/routes/[[lang]]/(marketing)/privacy/+page.svelte
+++ b/src/routes/[[lang]]/(marketing)/privacy/+page.svelte
@@ -11,7 +11,7 @@
 <SEOHead title={$t('meta.privacy.title')} description={$t('meta.privacy.description')} />
 
 <!-- Legal text is intentionally English-only — the English version is the governed version. -->
-<div class="mx-auto prose prose-sm max-w-3xl px-6 pt-40 pb-24 lg:px-12 dark:prose-invert">
+<div lang="en" class="mx-auto prose prose-sm max-w-3xl px-6 pt-40 pb-24 lg:px-12 dark:prose-invert">
 	<SvelteMarkdown {source} />
 	<p>
 		For privacy-related questions or to exercise your rights, please contact us at

--- a/src/routes/[[lang]]/(marketing)/terms/+page.svelte
+++ b/src/routes/[[lang]]/(marketing)/terms/+page.svelte
@@ -11,7 +11,7 @@
 <SEOHead title={$t('meta.terms.title')} description={$t('meta.terms.description')} />
 
 <!-- Legal text is intentionally English-only — the English version is the governed version. -->
-<div class="mx-auto prose prose-sm max-w-3xl px-6 pt-40 pb-24 lg:px-12 dark:prose-invert">
+<div lang="en" class="mx-auto prose prose-sm max-w-3xl px-6 pt-40 pb-24 lg:px-12 dark:prose-invert">
 	<SvelteMarkdown {source} />
 	<p>
 		To report any violations of these Terms of Service or to pose any questions, please contact us


### PR DESCRIPTION
Legal pages (terms, privacy, impressum) now declare lang="en" so screen
readers use the correct speech synthesis voice when the UI locale is
non-English.

Two custom ESLint rules enforce that all screen reader text goes through
$t(): no-hardcoded-aria-label and no-hardcoded-sr-only. The obfuscated
email component is exempted since localizing its aria-label would defeat
the anti-scraping obfuscation.

AGENTS.md updated with the shadcn-svelte aria-label exception and the
lang="en" guideline for untranslated content blocks.