### PR TITLE
perf: remove forced timeout from Rive requestIdleCallback

### DIFF
--- a/src/lib/components/RiveBackground.svelte
+++ b/src/lib/components/RiveBackground.svelte
@@ -153,21 +153,15 @@
 			if (destroyed) return;
 
 			if (requestIdleCallback) {
-				idleId = requestIdleCallback(
-					() => {
-						void startRive();
-					},
-					{ timeout: isDesktop ? 2500 : 5000 }
-				);
+				idleId = requestIdleCallback(() => {
+					void startRive();
+				});
 				return;
 			}
 
-			timeoutId = window.setTimeout(
-				() => {
-					void startRive();
-				},
-				isDesktop ? 1500 : 3000
-			);
+			timeoutId = window.setTimeout(() => {
+				void startRive();
+			}, 10000);
 		}
 
 		if (!defer) {


### PR DESCRIPTION
The requestIdleCallback had a timeout of 2.5s (desktop) / 5s (mobile),
forcing Rive WASM initialization even when the main thread was busy.
This caused 16 long tasks (785ms TBT) during page load.

Remove the timeout so the browser only fires Rive init when genuinely
idle. Bump the setTimeout fallback to 10s for browsers without
requestIdleCallback support.