### PR TITLE
fix: skeleton badge tokens, README rewrite, preview auth

### DIFF
--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -294,6 +294,7 @@ export const { onCreate, onUpdate, onDelete } = authComponent.triggersApi();
 export const createAuthOptions = (ctx: GenericCtx<DataModel>): BetterAuthOptions => {
 	return {
 		baseURL: requireEnv('SITE_URL'),
+		trustedOrigins: ['https://*.vercel.app'],
 		secret: requireEnv('BETTER_AUTH_SECRET'),
 		database: authComponent.adapter(ctx),
 		user: {

--- a/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
+++ b/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
@@ -320,7 +320,7 @@
 									<span class="text-muted-foreground/50">-</span>
 								</Table.Cell>
 								<Table.Cell>
-									<Skeleton class="h-[22px] w-14 rounded-md" />
+									<Skeleton class="h-5 w-14 rounded-4xl" />
 								</Table.Cell>
 								<Table.Cell class="[&:has([role=checkbox])]:ps-3">
 									<div class="flex items-center justify-center">

--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -191,8 +191,8 @@
 
 							<!-- Badges -->
 							<div class="flex flex-wrap items-center gap-1.5 pl-10">
-								<Skeleton class="h-[22px] w-10" />
-								<Skeleton class="h-[22px] w-10" />
+								<Skeleton class="h-5 w-10 rounded-4xl" />
+								<Skeleton class="h-5 w-10 rounded-4xl" />
 							</div>
 						</div>
 					</div>

--- a/src/routes/[[lang]]/admin/users/+page.svelte
+++ b/src/routes/[[lang]]/admin/users/+page.svelte
@@ -556,10 +556,10 @@
 										<Skeleton class="h-4 w-48" />
 									</Table.Cell>
 									<Table.Cell>
-										<Skeleton class="h-5 w-12 rounded-md" />
+										<Skeleton class="h-5 w-12 rounded-4xl" />
 									</Table.Cell>
 									<Table.Cell>
-										<Skeleton class="h-5 w-[65px] rounded-md" />
+										<Skeleton class="h-5 w-[65px] rounded-4xl" />
 									</Table.Cell>
 									<Table.Cell>
 										<Skeleton class="h-4 w-20" />


### PR DESCRIPTION
## Summary

- Align admin skeleton badge placeholders with Badge component tokens (`h-5`, `rounded-4xl`)
- Rewrite README with current local dev, preview, and production workflows
- Add Vercel preview domains to Better Auth `trustedOrigins` (fixes 403 on preview sign-up)