### PR TITLE
refactor: replace Sidebar.MenuButton with Button variant="ghost"

### DIFF
--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -75,7 +75,7 @@
 								href={resolve(item.url)}
 								onclick={() => haptic.trigger('light')}
 								class="peer/menu-button w-full justify-start gap-2 {item.isActive
-									? 'bg-muted text-foreground font-medium'
+									? 'bg-muted font-medium text-foreground'
 									: ''}"
 								data-active={item.isActive || undefined}
 								data-size="default"

--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -2,6 +2,7 @@
 	import NavUser from '../nav-user.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import { resolve } from '$app/paths';
 	import type { ComponentProps } from 'svelte';
 	import { T } from '@tolgee/svelte';
@@ -24,15 +25,16 @@
 					<DropdownMenu.Root>
 						<DropdownMenu.Trigger>
 							{#snippet child({ props })}
-								<Sidebar.MenuButton
-									class="data-[slot=sidebar-menu-button]:!p-1.5 data-[state=open]:bg-sidebar-accent"
+								<Button
+									variant="ghost"
+									class="w-full justify-start gap-2 px-1.5 data-[state=open]:bg-muted"
 									{...props}
 								>
 									<config.header.icon class="!size-5" />
 									<span class="text-base font-semibold">
 										<T keyName={config.header.titleKey} />
 									</span>
-								</Sidebar.MenuButton>
+								</Button>
 							{/snippet}
 						</DropdownMenu.Trigger>
 						<DropdownMenu.Content align="start" class="w-56">
@@ -47,16 +49,16 @@
 						</DropdownMenu.Content>
 					</DropdownMenu.Root>
 				{:else}
-					<Sidebar.MenuButton class="data-[slot=sidebar-menu-button]:!p-1.5">
-						{#snippet child({ props })}
-							<a href={resolve(config.header.href)} {...props}>
-								<config.header.icon class="!size-5" />
-								<span class="text-base font-semibold">
-									<T keyName={config.header.titleKey} />
-								</span>
-							</a>
-						{/snippet}
-					</Sidebar.MenuButton>
+					<Button
+						variant="ghost"
+						href={resolve(config.header.href)}
+						class="w-full justify-start gap-2 px-1.5"
+					>
+						<config.header.icon class="!size-5" />
+						<span class="text-base font-semibold">
+							<T keyName={config.header.titleKey} />
+						</span>
+					</Button>
 				{/if}
 			</Sidebar.MenuItem>
 		</Sidebar.Menu>
@@ -68,18 +70,21 @@
 				<Sidebar.Menu>
 					{#each config.navItems as item (item.translationKey)}
 						<Sidebar.MenuItem>
-							<Sidebar.MenuButton
-								class={item.isActive ? 'bg-sidebar-accent text-sidebar-accent-foreground' : ''}
+							<Button
+								variant="ghost"
+								href={resolve(item.url)}
+								onclick={() => haptic.trigger('light')}
+								class="peer/menu-button w-full justify-start gap-2 {item.isActive
+									? 'bg-muted text-foreground font-medium'
+									: ''}"
+								data-active={item.isActive || undefined}
+								data-size="default"
 							>
-								{#snippet child({ props })}
-									<a href={resolve(item.url)} onclick={() => haptic.trigger('light')} {...props}>
-										{#if item.icon}
-											<item.icon />
-										{/if}
-										<span><T keyName={item.translationKey} /></span>
-									</a>
-								{/snippet}
-							</Sidebar.MenuButton>
+								{#if item.icon}
+									<item.icon />
+								{/if}
+								<span><T keyName={item.translationKey} /></span>
+							</Button>
 							{#if item.badge && item.badge > 0}
 								<Sidebar.MenuBadge>{item.badge >= 100 ? '99+' : item.badge}</Sidebar.MenuBadge>
 							{/if}
@@ -96,14 +101,15 @@
 				{#each config.footerLinks as link (link.translationKey)}
 					{#if link.condition !== false}
 						<Sidebar.MenuItem>
-							<Sidebar.MenuButton>
-								{#snippet child({ props })}
-									<a href={resolve(link.url)} onclick={() => haptic.trigger('light')} {...props}>
-										<link.icon />
-										<span><T keyName={link.translationKey} /></span>
-									</a>
-								{/snippet}
-							</Sidebar.MenuButton>
+							<Button
+								variant="ghost"
+								href={resolve(link.url)}
+								onclick={() => haptic.trigger('light')}
+								class="w-full justify-start gap-2"
+							>
+								<link.icon />
+								<span><T keyName={link.translationKey} /></span>
+							</Button>
 						</Sidebar.MenuItem>
 					{/if}
 				{/each}

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -2,6 +2,7 @@
 	import * as Avatar from '$lib/components/ui/avatar/index.js';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import { useSidebar } from '$lib/components/ui/sidebar/index.js';
 	import { authClient } from '$lib/auth-client';
 	import { goto } from '$app/navigation';
@@ -67,9 +68,9 @@
 		<DropdownMenu.Root>
 			<DropdownMenu.Trigger id="user-menu-trigger">
 				{#snippet child({ props })}
-					<Sidebar.MenuButton
-						size="lg"
-						class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground {isImpersonating
+					<Button
+						variant="ghost"
+						class="h-12 w-full justify-start gap-2 px-2 data-[state=open]:bg-muted {isImpersonating
 							? 'ring-2 ring-warning'
 							: ''}"
 						{...props}
@@ -83,7 +84,7 @@
 							<span class="truncate text-xs">{user.email}</span>
 						</div>
 						<ChevronsUpDownIcon class="ml-auto size-4" />
-					</Sidebar.MenuButton>
+					</Button>
 				{/snippet}
 			</DropdownMenu.Trigger>
 			<DropdownMenu.Content


### PR DESCRIPTION
Unify sidebar interactive elements with standard Shadcn Button ghost
variant instead of custom sidebar-specific MenuButton styling. Uses
standard bg-muted hover colors and press effects throughout.