### PR TITLE
fix: use derived user initials for avatar fallback

### DIFF
--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -28,6 +28,15 @@
 	let { user, isImpersonating = false }: Props = $props();
 	const sidebar = useSidebar();
 
+	const initials = $derived(
+		user.name
+			.split(' ')
+			.map((n) => n[0])
+			.join('')
+			.toUpperCase()
+			.slice(0, 2)
+	);
+
 	async function signOut() {
 		haptic.trigger('light');
 		const result = await authClient.signOut();
@@ -76,7 +85,7 @@
 					>
 						<Avatar.Root class="size-8 rounded-lg">
 							<Avatar.Image src={user.avatar} alt={user.name} />
-							<Avatar.Fallback class="rounded-lg">CN</Avatar.Fallback>
+							<Avatar.Fallback class="rounded-lg">{initials}</Avatar.Fallback>
 						</Avatar.Root>
 						<div class="grid flex-1 text-left text-sm leading-tight">
 							<span class="truncate font-medium">{user.name}</span>
@@ -96,7 +105,7 @@
 					<div class="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
 						<Avatar.Root class="size-8 rounded-lg">
 							<Avatar.Image src={user.avatar} alt={user.name} />
-							<Avatar.Fallback class="rounded-lg">CN</Avatar.Fallback>
+							<Avatar.Fallback class="rounded-lg">{initials}</Avatar.Fallback>
 						</Avatar.Root>
 						<div class="grid flex-1 text-left text-sm leading-tight">
 							<span class="truncate font-medium">{user.name}</span>

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -30,12 +30,14 @@
 	const sidebar = useSidebar();
 
 	const initials = $derived(
-		user.name
-			.split(' ')
+		(user.name ?? '')
+			.trim()
+			.split(/\s+/)
+			.filter(Boolean)
 			.map((n) => n[0])
 			.join('')
 			.toUpperCase()
-			.slice(0, 2)
+			.slice(0, 2) || '?'
 	);
 
 	async function signOut() {


### PR DESCRIPTION
## Summary
- Replace hardcoded "CN" avatar fallback with dynamically derived initials from the user's name
- Adds a `$derived` reactive value that splits the name, takes first letters, and caps at 2 characters

## Test plan
- [ ] Verify sidebar avatar shows correct initials when no profile image is loaded
- [ ] Verify dropdown menu avatar also shows correct initials