### PR TITLE
docs: add Convex preview env vars to setup guide

### DIFF
--- a/.env-convex.schema
+++ b/.env-convex.schema
@@ -77,7 +77,7 @@ AUTH_GITHUB_SECRET=
 # ====================================
 
 # Secret for test mutations (never set in production)
-# @optional @sensitive
+# @required @sensitive
 AUTH_E2E_TEST_SECRET=
 
 # ====================================

--- a/.env-convex.schema
+++ b/.env-convex.schema
@@ -77,7 +77,7 @@ AUTH_GITHUB_SECRET=
 # ====================================
 
 # Secret for test mutations (never set in production)
-# @required @sensitive
+# @optional @sensitive
 AUTH_E2E_TEST_SECRET=
 
 # ====================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ btca ask -r svelte -r convex -q "How do I integrate Convex with SvelteKit?"
 
 ## Workflow
 
-When starting work that needs its own branch/PR, always create a worktree first with `bun run worktree <type/short-description>` (e.g. `feat/add-billing-page`, `fix/avatar-fallback`).
+When starting work that needs its own branch/PR, always create a worktree first with `bun run worktree <type/short-description>` (e.g. `feature/dark-mode`, `fix/422-password-reset`, `chore/upgrade-svelte-5`, `hotfix/rate-limit-bypass`, `docs/api-reference`).
 
 ## Development Commands
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,24 @@ Visit `http://localhost:5173` and sign in. No external services needed.
 
 To activate all features locally, create `.env.convex.local` and add the keys you need. See the [environment variable matrix](#environment-variables) below for which keys to set and where.
 
+<details>
+<summary><strong>Convex cloud dev deployment (optional)</strong></summary>
+
+The local embedded backend is preferred for day-to-day work. Each git worktree gets its own isolated Convex instance, so you can develop multiple features in parallel without conflicts. Use a cloud backend only when you need to test against cloud-specific behavior.
+
+```bash
+bunx convex init                              # creates a Convex project
+```
+
+Add `CONVEX_DEPLOYMENT` to `.env.local` (printed by `convex init`), then:
+
+```bash
+bun run dev:cloud                             # frontend + cloud Convex backend
+bunx convex env set KEY value                 # set backend env vars (see .env-convex.schema / env matrix below)
+```
+
+</details>
+
 ## 2. Preview Deployments (Vercel + Convex)
 
 Each PR gets its own Vercel preview with an isolated Convex preview backend.
@@ -30,21 +48,6 @@ Set the required Vercel and Convex preview variables listed in the [environment 
 The deploy script (`scripts/vercel-deploy.ts`) tags and pulls translations, runs `bunx convex deploy` to create a preview backend named after the branch, auto-computes `PUBLIC_CONVEX_URL` and `PUBLIC_CONVEX_SITE_URL` from the deploy output, and sets `SITE_URL` on the Convex instance to match the Vercel preview URL. When `PREVIEW_ADMIN_PASSWORD` is set, it also seeds an admin user.
 
 Push a branch and Vercel creates a preview deployment with its own Convex preview backend. Convex cleans up preview deployments after 5 days (14 days on Professional).
-
-### Cloud development (optional)
-
-To develop locally against a cloud Convex backend instead of the embedded one:
-
-```bash
-bunx convex init                              # creates a Convex project (if not done above)
-```
-
-Add `CONVEX_DEPLOYMENT` to `.env.local` (printed by `convex init`), then:
-
-```bash
-bun run dev:cloud                             # frontend + cloud Convex backend
-bunx convex env set KEY value                 # set backend env vars (see .env-convex.schema)
-```
 
 ## 3. Production Deployment
 
@@ -58,7 +61,7 @@ vercel --prod
 
 ### First Admin
 
-Sign up on the site, then either set the user's role to `admin` in the Convex dashboard or run:
+Sign up on the site, then either set the user's role to `admin` in the Convex dashboard or run (with the email you signed up with):
 
 ```bash
 bunx convex run admin/mutations:seedFirstAdmin '{"email":"you@example.com"}' --prod
@@ -138,7 +141,7 @@ Transactional email via [Resend](https://www.convex.dev/components/resend) with 
 
 ### Analytics
 
-[PostHog](https://posthog.com/) with lazy loading and ad-blocker detection. When blocked, it falls back to a [Cloudflare Worker proxy](https://posthog.com/docs/deployment/cloudflare-worker). Only identified users are tracked (`person_profiles: 'identified_only'`).
+[PostHog](https://posthog.com/) with lazy loading and ad-blocker detection. When blocked, it falls back to a [Cloudflare Worker proxy](https://posthog.com/docs/advanced/proxy/cloudflare). Only identified users are tracked (`person_profiles: 'identified_only'`).
 
 ### AI Readiness
 
@@ -199,7 +202,7 @@ Renovate groups non-major updates into a single PR and isolates breaking-change-
 
 ### Email Development
 
-Edit Svelte email components, run `bun run build:emails` to compile to inline HTML. Preview all templates in the browser at `/emails` with mock data, and optionally send test emails when a Resend key is configured.
+Email templates are Svelte components compiled to inline HTML on `postinstall` and during builds. Preview all templates in the browser at `/emails` with mock data, and optionally send test emails when a Resend key is configured.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -17,32 +17,7 @@ A local Convex backend starts automatically with a seeded admin:
 
 Visit `http://localhost:5173` and sign in. No external services needed.
 
-Thanks to [convex-vite-plugin](https://github.com/juliusmarminge/convex-vite-plugin), each git worktree gets its own isolated Convex backend and the frontend is automatically wired to it, so you can develop multiple features in parallel without conflicts. Run `bun run worktree --open-editor` to create a new worktree with all local env vars copied over, or use the VS Code task (`Cmd/Ctrl+Shift+P` > `Run Task`).
-
-### Enable Services Locally
-
-Create `.env.convex.local` at the project root to activate optional integrations:
-
-```bash
-# Email delivery
-RESEND_API_KEY=re_xxxxxxxxxxxx
-AUTH_EMAIL=noreply@yourdomain.com
-EMAIL_ASSET_URL=https://yourdomain.com
-
-# OAuth providers
-AUTH_GOOGLE_ID=your-client-id
-AUTH_GOOGLE_SECRET=your-client-secret
-AUTH_GITHUB_ID=your-client-id
-AUTH_GITHUB_SECRET=your-client-secret
-
-# AI support chat
-OPENROUTER_API_KEY=sk-or-v1-xxxx
-
-# Billing
-AUTUMN_SECRET_KEY=am_sk_xxxx
-```
-
-Without these, the app runs fine. Email, OAuth, AI support, and billing are simply inactive.
+To activate all features locally, create `.env.convex.local` and add the keys you need. See the [environment variable matrix](#environment-variables) below for which keys to set and where.
 
 ## 2. Preview Deployments (Vercel + Convex)
 
@@ -50,32 +25,7 @@ Each PR gets its own Vercel preview with an isolated Convex preview backend.
 
 Create a Convex project at [dashboard.convex.dev](https://dashboard.convex.dev) and connect your repo to [Vercel](https://vercel.com).
 
-### Set Vercel preview env vars
-
-Set these in your Vercel project settings (scoped to **Preview**):
-
-| Variable                 | Value                                                                    |
-| ------------------------ | ------------------------------------------------------------------------ |
-| `CONVEX_DEPLOY_KEY`      | Dev deploy key from the [Convex dashboard](https://dashboard.convex.dev) |
-| `TOLGEE_API_KEY`         | Tolgee API key for translation pulls                                     |
-| `PREVIEW_ADMIN_PASSWORD` | _(optional)_ Password for the auto-seeded `admin@preview.local` account  |
-
-### Set Convex preview env vars
-
-In the [Convex dashboard](https://dashboard.convex.dev) under **Project Settings → Environment Variables**, add these scoped to **Development** and **Preview** so every preview backend inherits them:
-
-| Variable                | Value                                                  |
-| ----------------------- | ------------------------------------------------------ |
-| `BETTER_AUTH_SECRET`    | Secret for signing sessions/tokens                     |
-| `RESEND_API_KEY`        | Resend API key for transactional email                 |
-| `AUTH_EMAIL`            | Sender address (e.g. `noreply@yourdomain.com`)         |
-| `EMAIL_ASSET_URL`       | Production URL for email assets (always public domain) |
-| `AUTUMN_SECRET_KEY`     | Autumn billing secret key                              |
-| `OPENROUTER_API_KEY`    | OpenRouter API key for AI support chat                 |
-| `RESEND_WEBHOOK_SECRET` | Resend webhook signing secret                          |
-| `SUPPORT_EMAIL`         | Support contact email                                  |
-
-The deploy script automatically sets `SITE_URL` and `PREVIEW_ADMIN_PASSWORD` per deployment, so you don't need to add those here.
+Set the required Vercel and Convex preview variables listed in the [environment variable matrix](#environment-variables) below.
 
 The deploy script (`scripts/vercel-deploy.ts`) tags and pulls translations, runs `bunx convex deploy` to create a preview backend named after the branch, auto-computes `PUBLIC_CONVEX_URL` and `PUBLIC_CONVEX_SITE_URL` from the deploy output, and sets `SITE_URL` on the Convex instance to match the Vercel preview URL. When `PREVIEW_ADMIN_PASSWORD` is set, it also seeds an admin user.
 
@@ -98,28 +48,7 @@ bunx convex env set KEY value                 # set backend env vars (see .env-c
 
 ## 3. Production Deployment
 
-### Set Vercel production env vars
-
-Add the same variable scoped to **Production**, using your production deploy key:
-
-| Variable            | Value                      |
-| ------------------- | -------------------------- |
-| `CONVEX_DEPLOY_KEY` | Your production deploy key |
-
-Optional (if those features are used): `TOLGEE_API_KEY`, `AUTUMN_SECRET_KEY`, `AUTUMN_PROD_SECRET_KEY`, `PUBLIC_POSTHOG_API_KEY`, `PUBLIC_POSTHOG_HOST`.
-
-### Set Convex production env vars
-
-```bash
-bunx convex env set BETTER_AUTH_SECRET "your-secret" --prod
-bunx convex env set SITE_URL "https://yourdomain.com" --prod
-bunx convex env set RESEND_API_KEY "re_xxx" --prod
-bunx convex env set AUTH_EMAIL "noreply@yourdomain.com" --prod
-bunx convex env set EMAIL_ASSET_URL "https://yourdomain.com" --prod
-bunx convex env set AUTUMN_SECRET_KEY "am_sk_xxx" --prod
-bunx convex env set OPENROUTER_API_KEY "sk-or-v1-xxx" --prod
-# Optional: AUTH_GOOGLE_ID, AUTH_GOOGLE_SECRET, AUTH_GITHUB_ID, AUTH_GITHUB_SECRET, RESEND_WEBHOOK_SECRET
-```
+Set the required Vercel and Convex production variables listed in the [environment variable matrix](#environment-variables) below.
 
 ### Deploy
 
@@ -138,7 +67,48 @@ bunx convex run admin/mutations:seedFirstAdmin '{"email":"you@example.com"}' --p
 ---
 
 <details>
-<summary><strong>What You Get</strong></summary>
+<summary><strong>Environment Variables</strong></summary>
+
+Two runtimes, two schemas, both managed by [varlock](https://github.com/nickreese/varlock) for type-safe access. `.env.schema` covers SvelteKit (Vite), `.env-convex.schema` covers the Convex backend. The matrix below shows every variable and where it needs to be set.
+
+`✓` required | `○` optional | `·` auto-set by tooling
+
+**Convex backend** (`.env.convex.local` for local, [dashboard](https://dashboard.convex.dev) for cloud):
+
+| Variable                 |                                           | Local | Preview | Prod |
+| ------------------------ | ----------------------------------------- | :---: | :-----: | :--: |
+| `BETTER_AUTH_SECRET`     | Session/token signing secret              |   ·   |    ✓    |  ✓   |
+| `SITE_URL`               | Base URL for OAuth redirects              |   ·   |    ·    |  ✓   |
+| `RESEND_API_KEY`         | Resend API key for transactional email    |   ○   |    ✓    |  ✓   |
+| `AUTH_EMAIL`             | Sender address for auth emails            |   ○   |    ✓    |  ✓   |
+| `EMAIL_ASSET_URL`        | Public URL for email images (always prod) |   ○   |    ✓    |  ✓   |
+| `AUTUMN_SECRET_KEY`      | Autumn billing secret key                 |   ○   |    ✓    |  ✓   |
+| `OPENROUTER_API_KEY`     | OpenRouter API key for AI support chat    |   ○   |    ✓    |  ✓   |
+| `AUTH_E2E_TEST_SECRET`   | Secret for E2E test mutations             |   ·   |    ✓    |      |
+| `AUTH_GOOGLE_ID`         | Google OAuth client ID                    |   ○   |    ○    |  ○   |
+| `AUTH_GOOGLE_SECRET`     | Google OAuth client secret                |   ○   |    ○    |  ○   |
+| `AUTH_GITHUB_ID`         | GitHub OAuth client ID                    |   ○   |    ○    |  ○   |
+| `AUTH_GITHUB_SECRET`     | GitHub OAuth client secret                |   ○   |    ○    |  ○   |
+| `RESEND_WEBHOOK_SECRET`  | Resend webhook signing secret             |   ○   |    ○    |  ○   |
+| `SUPPORT_EMAIL`          | Support contact email                     |   ○   |    ○    |  ○   |
+| `PREVIEW_ADMIN_PASSWORD` | Password for auto-seeded preview admin    |       |    ·    |      |
+
+**Vercel** (project settings):
+
+| Variable                 |                                  | Preview | Prod |
+| ------------------------ | -------------------------------- | :-----: | :--: |
+| `CONVEX_DEPLOY_KEY`      | Convex deploy key                |    ✓    |  ✓   |
+| `TOLGEE_API_KEY`         | Tolgee API key for translations  |    ✓    |  ✓   |
+| `PREVIEW_ADMIN_PASSWORD` | Preview admin password           |    ○    |      |
+| `AUTUMN_SECRET_KEY`      | Autumn billing secret            |         |  ○   |
+| `AUTUMN_PROD_SECRET_KEY` | Autumn production billing secret |         |  ○   |
+| `PUBLIC_POSTHOG_API_KEY` | PostHog analytics API key        |         |  ○   |
+| `PUBLIC_POSTHOG_HOST`    | PostHog analytics host           |         |  ○   |
+
+</details>
+
+<details>
+<summary><strong>Features</strong></summary>
 
 ### Authentication
 
@@ -184,90 +154,52 @@ Automated WCAG 2.1 AA testing via axe-core on all public pages in both light and
 
 ### Real-Time
 
-Everything updates live. Dashboard metrics, admin users table, community chat, support threads, AI agent responses (streamed token-by-token). Powered by Convex reactive queries.
+Everything updates live. Dashboard metrics, admin users table, community chat, support threads, AI agent responses (streamed token-by-token). Powered by Convex reactive queries. Rate limiting on support messages, file uploads, and LLM calls via `@convex-dev/rate-limiter`.
 
-### More
+### User Settings
 
-- **Dark mode** via `mode-watcher`, all components respond to the `.dark` class
-- **Rate limiting** on support messages, file uploads, and LLM calls via `@convex-dev/rate-limiter`
-- **File uploads** with server-side MIME validation, access control, and hourly cleanup crons
-- **Mobile haptics** via `web-haptics` (respects `prefers-reduced-motion`)
-- **User settings**: change name, avatar (upload or URL), password (with strength indicator), email (with re-verification), manage passkeys, view/revoke active sessions
+Change name, avatar (upload or URL), password (with strength indicator), email (with re-verification), manage passkeys, and view/revoke active sessions. File uploads use server-side MIME validation, access control, and hourly cleanup crons.
+
+### Dark Mode
+
+All components respond to the `.dark` class via `mode-watcher`. Mobile haptics via `web-haptics` (respects `prefers-reduced-motion`).
 
 </details>
 
 <details>
 <summary><strong>Developer Experience</strong></summary>
 
-- **Worktrees**: Each worktree gets its own isolated Convex backend, port, and auth secret. `bun run worktree --open-editor` creates one with env vars copied over.
-- **Type-safe env vars**: [varlock](https://github.com/nickreese/varlock) validates and generates types from `.env.schema` and `.env-convex.schema`.
-- **Pre-commit hooks**: `varlock scan` checks for leaked secrets, then `static-checks:staged` runs spell checking, banned pattern detection (deprecated Tailwind tokens, bare `animate-spin`), Prettier, ESLint, and oxlint.
-- **Dead code detection**: [Knip](https://knip.dev/) configured for SvelteKit file-system routing and Convex backend entry points.
-- **Bundle analysis**: `ANALYZE=true bun run build` generates a treemap with gzip/brotli sizes.
-- **VS Code tasks**: Dev server, static checks, i18n sync, email build, and worktree creation all available via `Run Task`.
-- **Dependency automation**: Renovate groups non-major updates, isolates breaking-change-prone packages (Better Auth, AI SDK, ESLint) into separate PRs.
-- **Email development**: Edit Svelte email components, run `bun run build:emails` to compile to inline HTML. Preview all templates in the browser with mock data.
+### Worktrees
 
-</details>
+Each worktree gets its own isolated Convex backend, port, and auth secret via [convex-vite-plugin](https://github.com/juliusmarminge/convex-vite-plugin). Run `bun run worktree --open-editor` to create a new worktree with all local env vars copied over, or use the VS Code task. Develop multiple features in parallel without conflicts.
 
-<details>
-<summary><strong>Environment Variables</strong></summary>
+### Type-Safe Environment Variables
 
-Two runtimes, two schemas:
+[varlock](https://github.com/nickreese/varlock) validates and generates types from `.env.schema` (SvelteKit/Vite) and `.env-convex.schema` (Convex backend). Two runtimes, two schemas, one validation pipeline.
 
-| Schema               | Runtime          | Local file                                                   |
-| -------------------- | ---------------- | ------------------------------------------------------------ |
-| `.env.schema`        | SvelteKit (Vite) | `.env.local`                                                 |
-| `.env-convex.schema` | Convex backend   | `.env.convex.local` (local) or `bunx convex env set` (cloud) |
+### Pre-Commit Hooks
 
-Both schemas are managed by [varlock](https://github.com/nickreese/varlock) for type-safe env access.
+`varlock scan` checks for leaked secrets, then `static-checks:staged` runs spell checking, banned pattern detection (deprecated Tailwind tokens, bare `animate-spin`), Prettier, ESLint, and oxlint on staged files only.
 
-</details>
+### Dead Code Detection
 
-<details>
-<summary><strong>Project Structure</strong></summary>
+[Knip](https://knip.dev/) configured for SvelteKit file-system routing and Convex backend entry points. Catches unused exports, dependencies, and files.
 
-```
-src/
-  lib/
-    convex/           Convex backend (schema, queries, mutations, actions)
-    components/       App components
-    components/ui/    shadcn-svelte primitives
-    emails/           Email templates and shadcn-style email components
-    i18n/             Translation files (en, de, es, fr)
-    markdown/         AI agent markdown rendering
-    marketing/        Public route definitions
-  routes/
-    api/auth/         Better Auth API handler
-    llms.txt/         AI agent discovery
-    sitemap.xml/      Dynamic sitemap
-    robots.txt/       Crawler rules
-    [[lang]]/
-      (auth)/         Sign-in, forgot/reset password, email verification
-      (marketing)/    Landing, pricing, about, legal pages
-      app/            Protected area (dashboard, settings, community chat)
-      admin/          Admin panel (dashboard, users, support, settings)
-```
+### Bundle Analysis
 
-</details>
+`ANALYZE=true bun run build` generates a treemap with gzip/brotli sizes so you can catch bloat before it ships.
 
-<details>
-<summary><strong>Scripts</strong></summary>
+### VS Code Integration
 
-| Command                | Description                              |
-| ---------------------- | ---------------------------------------- |
-| `bun run dev`          | Local dev (embedded Convex backend)      |
-| `bun run dev:cloud`    | Cloud dev (requires `CONVEX_DEPLOYMENT`) |
-| `bun run build`        | Production build                         |
-| `bun run test`         | All tests (E2E + unit)                   |
-| `bun run test:e2e`     | Playwright E2E tests                     |
-| `bun run test:unit`    | Vitest unit tests                        |
-| `bun run lint`         | ESLint + OxLint                          |
-| `bun run check`        | svelte-check type checking               |
-| `bun run build:emails` | Compile email templates                  |
-| `bun run i18n:push`    | Push translations to Tolgee              |
-| `bun run i18n:pull`    | Pull translations from Tolgee            |
-| `bun run worktree`     | Create an isolated git worktree          |
+Dev server, static checks, i18n sync, email build, and worktree creation all available via `Run Task` (`Cmd/Ctrl+Shift+P`).
+
+### Dependency Automation
+
+Renovate groups non-major updates into a single PR and isolates breaking-change-prone packages (Better Auth, AI SDK, ESLint) into separate PRs for safer upgrades.
+
+### Email Development
+
+Edit Svelte email components, run `bun run build:emails` to compile to inline HTML. Preview all templates in the browser at `/emails` with mock data, and optionally send test emails when a Resend key is configured.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -46,32 +46,55 @@ Without these, the app runs fine. Email, OAuth, AI support, and billing are simp
 
 ## 2. Preview Deployments (Vercel + Convex)
 
-Connect to a cloud Convex backend and deploy previews on every PR.
+Each PR gets its own Vercel preview with an isolated Convex preview backend.
 
-### Set up a Convex cloud project
+Create a Convex project at [dashboard.convex.dev](https://dashboard.convex.dev) and connect your repo to [Vercel](https://vercel.com).
+
+### Set Vercel preview env vars
+
+Set these in your Vercel project settings (scoped to **Preview**):
+
+| Variable                 | Value                                                                    |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `CONVEX_DEPLOY_KEY`      | Dev deploy key from the [Convex dashboard](https://dashboard.convex.dev) |
+| `TOLGEE_API_KEY`         | Tolgee API key for translation pulls                                     |
+| `PREVIEW_ADMIN_PASSWORD` | _(optional)_ Password for the auto-seeded `admin@preview.local` account  |
+
+### Set Convex preview env vars
+
+In the [Convex dashboard](https://dashboard.convex.dev) under **Project Settings → Environment Variables**, add these scoped to **Development** and **Preview** so every preview backend inherits them:
+
+| Variable                | Value                                                  |
+| ----------------------- | ------------------------------------------------------ |
+| `BETTER_AUTH_SECRET`    | Secret for signing sessions/tokens                     |
+| `RESEND_API_KEY`        | Resend API key for transactional email                 |
+| `AUTH_EMAIL`            | Sender address (e.g. `noreply@yourdomain.com`)         |
+| `EMAIL_ASSET_URL`       | Production URL for email assets (always public domain) |
+| `AUTUMN_SECRET_KEY`     | Autumn billing secret key                              |
+| `OPENROUTER_API_KEY`    | OpenRouter API key for AI support chat                 |
+| `RESEND_WEBHOOK_SECRET` | Resend webhook signing secret                          |
+| `SUPPORT_EMAIL`         | Support contact email                                  |
+
+The deploy script automatically sets `SITE_URL` and `PREVIEW_ADMIN_PASSWORD` per deployment, so you don't need to add those here.
+
+The deploy script (`scripts/vercel-deploy.ts`) tags and pulls translations, runs `bunx convex deploy` to create a preview backend named after the branch, auto-computes `PUBLIC_CONVEX_URL` and `PUBLIC_CONVEX_SITE_URL` from the deploy output, and sets `SITE_URL` on the Convex instance to match the Vercel preview URL. When `PREVIEW_ADMIN_PASSWORD` is set, it also seeds an admin user.
+
+Push a branch and Vercel creates a preview deployment with its own Convex preview backend. Convex cleans up preview deployments after 5 days (14 days on Professional).
+
+### Cloud development (optional)
+
+To develop locally against a cloud Convex backend instead of the embedded one:
 
 ```bash
-bunx convex init                              # creates a Convex project
+bunx convex init                              # creates a Convex project (if not done above)
 ```
 
-Add `CONVEX_DEPLOYMENT` to `.env.local` (printed by `convex init`). You can now develop against the cloud backend:
+Add `CONVEX_DEPLOYMENT` to `.env.local` (printed by `convex init`), then:
 
 ```bash
 bun run dev:cloud                             # frontend + cloud Convex backend
 bunx convex env set KEY value                 # set backend env vars (see .env-convex.schema)
 ```
-
-### Connect Vercel
-
-Set this in your Vercel project settings (scoped to **Preview**):
-
-| Variable            | Value                                                                         |
-| ------------------- | ----------------------------------------------------------------------------- |
-| `CONVEX_DEPLOY_KEY` | Your dev deploy key from the [Convex dashboard](https://dashboard.convex.dev) |
-
-The deploy script auto-computes `PUBLIC_CONVEX_URL` and `PUBLIC_CONVEX_SITE_URL` from the Convex deploy output. It also sets `SITE_URL` on each preview Convex instance to match the Vercel preview URL.
-
-Push a branch and Vercel creates a preview deployment with its own Convex preview backend.
 
 ## 3. Production Deployment
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SaaS Starter
 
-You want to ship your SaaS, not rebuild auth, billing, and admin panels from scratch. Clone this, run `bun run dev`, and start building your actual product.
+Agents write better code when they have good examples to work from. This starter ships with auth, billing, admin, AI chat, email, i18n, and more, all implemented end-to-end so your agents have real patterns to reference when building new features. It also includes the DX tools and guardrails to make sure what ships stays secure, performant, and maintainable. Clone it, run `bun run dev`, and start building.
 
 ## 1. Local Development
 
@@ -115,57 +115,57 @@ Two runtimes, two schemas, both managed by [varlock](https://github.com/nickrees
 
 ### Authentication
 
-Email/password, Google and GitHub OAuth, and passkeys (WebAuthn) via [Better Auth](https://www.better-auth.com/) with a [local Convex install](https://labs.convex.dev/better-auth/features/local-install) for full feature access. Email verification required on signup, password reset flow, auto sign-in after verification. Role-based route protection (`user`/`admin`) checked via JWT in the SvelteKit hook, no round-trip to the backend.
+Sign in with email/password, Google, GitHub, or passkeys. Powered by [Better Auth](https://www.better-auth.com/) running as a [local Convex install](https://labs.convex.dev/better-auth/features/local-install) so every auth feature works without an external service. New signups verify their email before getting access, password resets work out of the box, and users are signed in automatically after verification. Routes are protected by role (`user` or `admin`) via a JWT check in the SvelteKit hook, with no extra round-trip to the backend.
 
 ### Billing
 
-[Autumn](https://docs.useautumn.com/welcome) wraps Stripe so you configure pricing tiers and usage gates without writing webhook handlers. Define your products in `autumn.config.ts` or generate it at [app.useautumn.com/sandbox/quickstart](https://app.useautumn.com/sandbox/quickstart). Ships with Free (10 messages/month) and Pro ($10/month, unlimited) tiers. The community chat enforces the quota with low-balance warnings and an upgrade flow.
+[Autumn](https://docs.useautumn.com/welcome) sits on top of Stripe and lets you define pricing tiers and usage gates without writing webhook handlers. Configure your products in `autumn.config.ts` or generate a starter config at [app.useautumn.com/sandbox/quickstart](https://app.useautumn.com/sandbox/quickstart). Ships with a Free tier (10 messages/month) and a Pro tier ($10/month, unlimited). The community chat enforces quotas, warns users when they are running low, and offers an upgrade flow.
 
 ### Admin Panel
 
-Full admin area at `/admin` with real-time metrics (total users, active sessions, recent signups), a users table with search/filter/sort and cursor-based pagination, per-user actions (ban, unban, impersonate, role change, session revocation), and a full audit log.
+A full admin area at `/admin` with live metrics (total users, active sessions, recent signups), a searchable users table with filtering, sorting, and cursor-based pagination, per-user actions (ban, unban, impersonate, change role, revoke sessions), and a complete audit log.
 
 ### AI Support Chat
 
-An AI agent powered by [Convex Agent](https://www.convex.dev/components/agent) + [OpenRouter](https://openrouter.ai/) answers product questions, collects bug reports, and guides users through setup. A floating chatbar appears on every page. Users can attach images/PDFs and annotate screenshots with a built-in canvas editor before sending. When a question needs a human, admins take over from a 3-pane support dashboard with thread assignment, priority, internal notes, and status tracking. Users get an email when an admin replies.
+An AI agent built on [Convex Agent](https://www.convex.dev/components/agent) and [OpenRouter](https://openrouter.ai/) answers product questions, collects bug reports, and walks users through setup. A floating chatbar is available on every page. Users can attach images or PDFs and annotate screenshots with a built-in canvas editor before sending. When a question needs a human, admins take over from a 3-pane support dashboard with thread assignment, priority levels, internal notes, and status tracking. Users receive an email when an admin replies.
 
 ### Email System
 
-Transactional email via [Resend](https://www.convex.dev/components/resend) with automatic retries, idempotency, and delivery event tracking. Templates are built as Svelte components using a shadcn-style email component library (same `tv()` variants, same design tokens) and compiled to inline HTML at build time. The logo is auto-generated as an email-safe PNG from your SVG. Preview all templates in the browser at `/emails` during development, with optional "send test email" when a Resend key is configured.
+Transactional email delivered through [Resend](https://www.convex.dev/components/resend) with automatic retries, idempotency, and delivery tracking. Templates are written as Svelte components using a shadcn-style email component library (same `tv()` variants, same design tokens) and compiled to inline HTML at build time. Your logo is converted to an email-safe PNG automatically. During development, preview every template in the browser at `/emails` and optionally send a real test email when a Resend key is configured.
 
 ### Internationalization
 
-4 languages (EN, DE, ES, FR) with URL-based routing (`/de/pricing`, `/fr/about`) via [Tolgee](https://docs.tolgee.io/). In-context editing with Tolgee DevTools in development. The production build automatically tags and pulls the latest translations. A custom ESLint rule enforces that all `aria-label` attributes use translation keys instead of hardcoded strings.
+4 languages (EN, DE, ES, FR) with URL-based routing (`/de/pricing`, `/fr/about`) powered by [Tolgee](https://docs.tolgee.io/). Edit translations in context with Tolgee DevTools during development. Production builds tag and pull the latest translations automatically. A custom ESLint rule ensures every `aria-label` uses a translation key instead of a hardcoded string.
 
 > This project has too many translation keys for Tolgee Cloud's free tier. A self-hosted instance deploys in one click via [Coolify](https://coolify.io/docs/services/tolgee).
 
 ### Analytics
 
-[PostHog](https://posthog.com/) with lazy loading and ad-blocker detection. When blocked, it falls back to a [Cloudflare Worker proxy](https://posthog.com/docs/advanced/proxy/cloudflare). Only identified users are tracked (`person_profiles: 'identified_only'`).
+[PostHog](https://posthog.com/) loads lazily and detects ad blockers. When blocked, tracking falls back to a [Cloudflare Worker proxy](https://posthog.com/docs/advanced/proxy/cloudflare). Only identified users are tracked (`person_profiles: 'identified_only'`).
 
 ### AI Readiness
 
-Marketing pages serve structured markdown when an AI agent sends `Accept: text/markdown`, with YAML frontmatter and `Vary: Accept` for correct CDN caching. A `/llms.txt` endpoint tells agents which pages are available and how to request them. Sitemap and robots.txt are generated dynamically across all 4 languages.
+Marketing pages return structured markdown when an AI agent sends `Accept: text/markdown`, complete with YAML frontmatter and `Vary: Accept` headers for correct CDN caching. A `/llms.txt` endpoint lists available pages and explains how to request them. Sitemap and robots.txt are generated dynamically across all 4 languages.
 
 ### SEO
 
-`<SEOHead>` component on every page emitting OpenGraph, Twitter Cards, canonical URLs, and `hreflang` alternates for all languages plus `x-default`. OG image included at `static/og-image.png` (1200x630).
+Every page includes a `<SEOHead>` component that outputs OpenGraph tags, Twitter Cards, canonical URLs, and `hreflang` alternates for all languages plus `x-default`. An OG image is included at `static/og-image.png` (1200x630).
 
 ### Accessibility
 
-Automated WCAG 2.1 AA testing via axe-core on all public pages in both light and dark mode. Skip-to-content link, semantic HTML, translated `aria-label` attributes, and `motion-safe:` prefixes enforced by a banned-pattern scanner.
+All public pages are tested against WCAG 2.1 AA using axe-core in both light and dark mode. The template includes a skip-to-content link, semantic HTML throughout, translated `aria-label` attributes, and a banned-pattern scanner that enforces `motion-safe:` prefixes on animations.
 
 ### Real-Time
 
-Everything updates live. Dashboard metrics, admin users table, community chat, support threads, AI agent responses (streamed token-by-token). Powered by Convex reactive queries. Rate limiting on support messages, file uploads, and LLM calls via `@convex-dev/rate-limiter`.
+Everything updates live: dashboard metrics, the admin users table, community chat, support threads, and AI agent responses streamed token-by-token. Built on Convex reactive queries. Messages, file uploads, and LLM calls are rate-limited via `@convex-dev/rate-limiter`.
 
 ### User Settings
 
-Change name, avatar (upload or URL), password (with strength indicator), email (with re-verification), manage passkeys, and view/revoke active sessions. File uploads use server-side MIME validation, access control, and hourly cleanup crons.
+Users can update their profile, change their password with live strength feedback, swap their email (triggers re-verification), manage passkeys, and review or revoke active sessions. Uploaded avatars and attachments are validated on the server and cleaned up automatically.
 
 ### Dark Mode
 
-All components respond to the `.dark` class via `mode-watcher`. Mobile haptics via `web-haptics` (respects `prefers-reduced-motion`).
+Every component supports light and dark mode via `mode-watcher`. Interactive elements provide subtle haptic feedback on mobile via `web-haptics` (respects `prefers-reduced-motion`).
 
 </details>
 
@@ -174,35 +174,35 @@ All components respond to the `.dark` class via `mode-watcher`. Mobile haptics v
 
 ### Worktrees
 
-Each worktree gets its own isolated Convex backend, port, and auth secret via [convex-vite-plugin](https://github.com/juliusmarminge/convex-vite-plugin). Run `bun run worktree --open-editor` to create a new worktree with all local env vars copied over, or use the VS Code task. Develop multiple features in parallel without conflicts.
+Each worktree gets its own isolated Convex backend, port, and auth secret via [convex-vite-plugin](https://github.com/juliusmarminge/convex-vite-plugin). Run `bun run worktree feature/dark-mode --open-editor` to create one with all local env vars copied over, or use the VS Code task. Work on multiple features in parallel without stepping on each other.
 
 ### Type-Safe Environment Variables
 
-[varlock](https://github.com/nickreese/varlock) validates and generates types from `.env.schema` (SvelteKit/Vite) and `.env-convex.schema` (Convex backend). Two runtimes, two schemas, one validation pipeline.
+[varlock](https://github.com/nickreese/varlock) validates env vars against two schemas and generates TypeScript types from them. `.env.schema` covers SvelteKit (Vite), `.env-convex.schema` covers the Convex backend. If a required variable is missing or mistyped, you find out before the app starts.
 
 ### Pre-Commit Hooks
 
-`varlock scan` checks for leaked secrets, then `static-checks:staged` runs spell checking, banned pattern detection (deprecated Tailwind tokens, bare `animate-spin`), Prettier, ESLint, and oxlint on staged files only.
+Every commit is checked automatically. `varlock scan` looks for leaked secrets, then `static-checks:staged` runs spell checking, banned pattern detection (catches deprecated Tailwind tokens, bare `animate-spin`, and similar issues), Prettier, ESLint, and oxlint on staged files only.
 
 ### Dead Code Detection
 
-[Knip](https://knip.dev/) configured for SvelteKit file-system routing and Convex backend entry points. Catches unused exports, dependencies, and files.
+[Knip](https://knip.dev/) is configured for SvelteKit file-system routing and Convex backend entry points. It catches unused exports, stale dependencies, and orphaned files so the codebase stays clean.
 
 ### Bundle Analysis
 
-`ANALYZE=true bun run build` generates a treemap with gzip/brotli sizes so you can catch bloat before it ships.
+Run `ANALYZE=true bun run build` to generate a treemap with gzip and brotli sizes. Helps you spot bloat before it reaches production.
 
 ### VS Code Integration
 
-Dev server, static checks, i18n sync, email build, and worktree creation all available via `Run Task` (`Cmd/Ctrl+Shift+P`).
+Dev server, static checks, i18n sync, email build, and worktree creation are all available as VS Code tasks via `Run Task` (`Cmd/Ctrl+Shift+P`).
 
 ### Dependency Automation
 
-Renovate groups non-major updates into a single PR and isolates breaking-change-prone packages (Better Auth, AI SDK, ESLint) into separate PRs for safer upgrades.
+Renovate groups non-major updates into a single PR and creates separate PRs for packages that tend to ship breaking changes (Better Auth, AI SDK, ESLint), so upgrades are easier to review.
 
 ### Email Development
 
-Email templates are Svelte components compiled to inline HTML on `postinstall` and during builds. Preview all templates in the browser at `/emails` with mock data, and optionally send test emails when a Resend key is configured.
+Email templates are Svelte components compiled to inline HTML on `postinstall` and during builds. Preview every template in the browser at `/emails` with mock data, and optionally send a real test email when a Resend key is configured.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Two runtimes, two schemas, both managed by [varlock](https://github.com/nickrees
 | `EMAIL_ASSET_URL`        | Public URL for email images (always prod) |   ○   |    ✓    |  ✓   |
 | `AUTUMN_SECRET_KEY`      | Autumn billing secret key                 |   ○   |    ✓    |  ✓   |
 | `OPENROUTER_API_KEY`     | OpenRouter API key for AI support chat    |   ○   |    ✓    |  ✓   |
-| `AUTH_E2E_TEST_SECRET`   | Secret for E2E test mutations             |   ·   |    ✓    |      |
+| `AUTH_E2E_TEST_SECRET`   | Secret for E2E test mutations             |   ○   |    ○    |      |
 | `AUTH_GOOGLE_ID`         | Google OAuth client ID                    |   ○   |    ○    |  ○   |
 | `AUTH_GOOGLE_SECRET`     | Google OAuth client secret                |   ○   |    ○    |  ○   |
 | `AUTH_GITHUB_ID`         | GitHub OAuth client ID                    |   ○   |    ○    |  ○   |
@@ -98,15 +98,13 @@ Two runtimes, two schemas, both managed by [varlock](https://github.com/nickrees
 
 **Vercel** (project settings):
 
-| Variable                 |                                  | Preview | Prod |
-| ------------------------ | -------------------------------- | :-----: | :--: |
-| `CONVEX_DEPLOY_KEY`      | Convex deploy key                |    ✓    |  ✓   |
-| `TOLGEE_API_KEY`         | Tolgee API key for translations  |    ✓    |  ✓   |
-| `PREVIEW_ADMIN_PASSWORD` | Preview admin password           |    ○    |      |
-| `AUTUMN_SECRET_KEY`      | Autumn billing secret            |         |  ○   |
-| `AUTUMN_PROD_SECRET_KEY` | Autumn production billing secret |         |  ○   |
-| `PUBLIC_POSTHOG_API_KEY` | PostHog analytics API key        |         |  ○   |
-| `PUBLIC_POSTHOG_HOST`    | PostHog analytics host           |         |  ○   |
+| Variable                 |                                 | Preview | Prod |
+| ------------------------ | ------------------------------- | :-----: | :--: |
+| `CONVEX_DEPLOY_KEY`      | Convex deploy key               |    ✓    |  ✓   |
+| `TOLGEE_API_KEY`         | Tolgee API key for translations |    ✓    |  ✓   |
+| `PREVIEW_ADMIN_PASSWORD` | Preview admin password          |    ○    |      |
+| `PUBLIC_POSTHOG_API_KEY` | PostHog analytics API key       |         |  ○   |
+| `PUBLIC_POSTHOG_HOST`    | PostHog analytics host          |         |  ○   |
 
 </details>
 

--- a/scripts/create-worktree.ts
+++ b/scripts/create-worktree.ts
@@ -2,9 +2,9 @@
  * Worktree management with Graphite integration (cross-platform TypeScript version)
  *
  * Usage:
- *   bun scripts/create-worktree.ts <branch-name>           # Full mode: create + setup
- *   bun scripts/create-worktree.ts --setup-only            # Setup mode: setup only (for Cursor)
- *   bun scripts/create-worktree.ts <branch-name> --open-editor cursor
+ *   bun scripts/create-worktree.ts feature/dark-mode           # Full mode: create + setup
+ *   bun scripts/create-worktree.ts --setup-only               # Setup mode: setup only (for Cursor)
+ *   bun scripts/create-worktree.ts feature/dark-mode --open-editor cursor
  */
 
 import { spawnSync } from 'child_process';
@@ -242,13 +242,13 @@ function setupWorktree(rootPath: string): void {
 function showHelp(): void {
 	console.log('Usage:');
 	console.log(
-		'  bun scripts/create-worktree.ts <branch-name>               Create worktree with setup'
+		'  bun scripts/create-worktree.ts feature/dark-mode               Create worktree with setup'
 	);
 	console.log(
-		'  bun scripts/create-worktree.ts --setup-only                Setup only (for Cursor UI)'
+		'  bun scripts/create-worktree.ts --setup-only                    Setup only (for Cursor UI)'
 	);
 	console.log(
-		'  bun scripts/create-worktree.ts <branch-name> --open-editor <editor>   Open in editor after creation'
+		'  bun scripts/create-worktree.ts feature/dark-mode --open-editor cursor   Open in editor after creation'
 	);
 	console.log('');
 	console.log('Options:');

--- a/scripts/create-worktree.ts
+++ b/scripts/create-worktree.ts
@@ -224,12 +224,14 @@ function setupWorktree(rootPath: string): void {
 		console.log('  4. Push & open PR: git push -u origin HEAD && gh pr create');
 	}
 	console.log('');
+	console.log('To iterate (CI fixes, review feedback):');
+	console.log('  1. Make changes');
+	console.log('  2. git add .');
+	console.log('  3. git commit -m "fix: address review feedback"');
 	if (gtReady) {
-		console.log('To stack more changes on top:');
-		console.log('  1. Make more changes');
-		console.log('  2. git add .');
-		console.log('  3. gt create -m "feat: another feature"  # Creates new branch');
-		console.log('  4. gt submit --stack');
+		console.log('  4. gt submit');
+	} else {
+		console.log('  4. git push');
 	}
 	console.log('');
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,14 +14,14 @@ export type CoercedEnvSchema = {
   
   /**
    * **CONVEX_DEPLOYMENT** 🔐 _sensitive_  
-   * Local dev deployment identifier, auto-set by `bunx convex dev`  
+   * Deployment used by `bunx convex dev`  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   CONVEX_DEPLOYMENT?: string;
   
   /**
    * **PUBLIC_CONVEX_URL**  
-   * Convex deployment API URL  
+   * Convex URLs for the default cloud-backed dev workflow  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M24%2021V9h-2v14h8v-2zm-4-6v-4c0-1.103-.897-2-2-2h-6v14h2v-6h1.48l2.335%206h2.145l-2.333-6H18c1.103%200%202-.897%202-2m-6-4h4v4h-4zM8%2023H4c-1.103%200-2-.897-2-2V9h2v12h4V9h2v12c0%201.103-.897%202-2%202%22%2F%3E%3C%2Fsvg%3E)   
    */
   PUBLIC_CONVEX_URL: string;
@@ -35,7 +35,7 @@ export type CoercedEnvSchema = {
   
   /**
    * **VITE_TOLGEE_API_URL**  
-   * Tolgee Cloud API URL  
+   * Tolgee Cloud Configuration (https://app.tolgee.io)  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M24%2021V9h-2v14h8v-2zm-4-6v-4c0-1.103-.897-2-2-2h-6v14h2v-6h1.48l2.335%206h2.145l-2.333-6H18c1.103%200%202-.897%202-2m-6-4h4v4h-4zM8%2023H4c-1.103%200-2-.897-2-2V9h2v12h4V9h2v12c0%201.103-.897%202-2%202%22%2F%3E%3C%2Fsvg%3E)   
    */
   VITE_TOLGEE_API_URL: string;
@@ -64,14 +64,14 @@ export type CoercedEnvSchema = {
   
   /**
    * **AUTUMN_PROD_SECRET_KEY** 🔐 _sensitive_  
-   * Autumn billing production secret key  
+   * Autumn Billing  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   AUTUMN_PROD_SECRET_KEY?: string;
   
   /**
    * **PUBLIC_POSTHOG_API_KEY**  
-   * PostHog project API key (client-safe)  
+   * PostHog Analytics (https://posthog.com)  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   PUBLIC_POSTHOG_API_KEY?: string;
@@ -155,7 +155,7 @@ export type CoercedEnvSchema = {
   
   /**
    * **RESEND_API_KEY** 🔐 _sensitive_  
-   * Resend API key for local email preview sending  
+   * SvelteKit-side copies of Resend/Auth email vars (for email preview server routes)  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   RESEND_API_KEY?: string;


### PR DESCRIPTION
docs: add Convex preview env vars to setup guide

Document the project-level environment variables that need to be
set in the Convex dashboard (scoped to Development + Preview) so
preview backends inherit them. The deploy script handles SITE_URL
and PREVIEW_ADMIN_PASSWORD automatically.

docs: consolidate env vars into single matrix table

Replace scattered env var tables, code blocks, and details toggles
with one environment variable matrix showing every key and where it
needs to be set (Local/Preview/Prod) with required/optional/auto
markers. Move DX into its own details toggle with heading+paragraph
style matching Features. Absorb "More" items into relevant feature
sections. Make AUTH_E2E_TEST_SECRET required in schema.

docs: restructure README toggles and move cloud dev to section 1

Move Convex cloud dev deployment toggle under Local Development
where it belongs. Clarify local backend is preferred for parallel
feature work. Update email dev section to note postinstall handles
compilation. Minor copy fixes.

docs: add branch naming convention and polish copy

fix: make husky pre-commit hook executable