### PR TITLE
feat(i18n): make Tolgee optional, fall back to committed JSON files

### DIFF
--- a/docs/setup/i18n/i18n-setup.md
+++ b/docs/setup/i18n/i18n-setup.md
@@ -1,18 +1,22 @@
 # Internationalization (i18n) Setup Guide
 
-This project uses **Tolgee** for cloud-hosted translation management with SEO-friendly URL-based localization.
+This project uses SEO-friendly URL-based localization (`/en/`, `/de/`, etc.) with translations stored as committed JSON files in `src/i18n/`. **Tolgee is entirely optional** -- the i18n system works out of the box without any Tolgee account or API key.
 
-## ⚠️ Tolgee Free Tier Limitations
+## Tolgee is Optional
 
-This template includes **many translation keys that exceed Tolgee Cloud's free tier** (~1000 keys).
+Without a `TOLGEE_API_KEY`, the deploy script skips Tolgee entirely and builds with the committed JSON files. The full i18n system still works: URL-based routing, the `<T>` component, language switcher, SEO hreflang tags, and backend translations in Convex all read from those static JSON imports. You just edit the JSON files directly and commit them.
 
-**You have two options:**
+Setting up Tolgee adds a translation management dashboard, in-context editing (Alt+Click in dev), and CLI-based sync. Choose the option that fits your needs:
 
-### Option 1: Delete Unused Keys
+### Option 1: No Tolgee (default)
 
-Remove translations you don't need via the Tolgee dashboard to stay within the free tier limit.
+Edit `src/i18n/*.json` files directly, commit them, and deploy. Nothing else needed.
 
-### Option 2: Self-Host Tolgee (Recommended)
+### Option 2: Delete Unused Keys (Tolgee Cloud free tier)
+
+This template includes many translation keys that exceed Tolgee Cloud's free tier (~1000 keys). Remove translations you don't need via the Tolgee dashboard to stay within the free tier limit.
+
+### Option 3: Self-Host Tolgee
 
 Self-hosting gives you unlimited keys and full control. The easiest way is using **Coolify's one-click deploy**:
 

--- a/scripts/vercel-deploy.ts
+++ b/scripts/vercel-deploy.ts
@@ -2,7 +2,7 @@
  * Vercel deployment script (cross-platform TypeScript version)
  *
  * Handles:
- * - Tolgee translation tagging and pulling
+ * - Tolgee translation tagging and pulling (optional, requires TOLGEE_API_KEY)
  * - Convex environment variable validation (production and preview)
  * - Convex deployment
  * - E2E config file generation (preview only)
@@ -138,37 +138,49 @@ async function runCommandWithRetry(
 async function main(): Promise<void> {
 	console.log(`Vercel Environment: ${VERCEL_ENV}`);
 
-	// Tag translations based on environment
-	if (VERCEL_ENV === 'production') {
-		console.log('Tagging production keys...');
-		if (
-			!runCommand('tolgee', [
-				'tag',
-				'--filter-extracted',
-				'--tag',
-				'production',
-				'--untag',
-				'preview'
-			])
-		) {
-			console.error(`${colors.red}Tolgee tagging failed${colors.reset}`);
-			process.exit(1);
+	// =============================================================================
+	// Tolgee translation sync (optional — skipped when TOLGEE_API_KEY is not set)
+	// Without a key, the build uses the committed JSON files in src/i18n/
+	// =============================================================================
+	const TOLGEE_API_KEY = process.env.TOLGEE_API_KEY;
+
+	if (TOLGEE_API_KEY) {
+		// Tag translations based on environment
+		if (VERCEL_ENV === 'production') {
+			console.log('Tagging production keys...');
+			if (
+				!runCommand('tolgee', [
+					'tag',
+					'--filter-extracted',
+					'--tag',
+					'production',
+					'--untag',
+					'preview'
+				])
+			) {
+				console.error(`${colors.red}Tolgee tagging failed${colors.reset}`);
+				process.exit(1);
+			}
+		} else if (VERCEL_ENV === 'preview') {
+			console.log('Tagging preview keys...');
+			if (!runCommand('tolgee', ['tag', '--filter-extracted', '--tag', 'preview'])) {
+				console.error(`${colors.red}Tolgee tagging failed${colors.reset}`);
+				process.exit(1);
+			}
+		} else {
+			console.log(`${colors.yellow}Unknown environment, skipping tagging${colors.reset}`);
 		}
-	} else if (VERCEL_ENV === 'preview') {
-		console.log('Tagging preview keys...');
-		if (!runCommand('tolgee', ['tag', '--filter-extracted', '--tag', 'preview'])) {
-			console.error(`${colors.red}Tolgee tagging failed${colors.reset}`);
+
+		// Pull latest translations
+		console.log('Pulling latest translations...');
+		if (!runCommand('tolgee', ['pull'])) {
+			console.error(`${colors.red}Tolgee pull failed${colors.reset}`);
 			process.exit(1);
 		}
 	} else {
-		console.log(`${colors.yellow}Unknown environment, skipping tagging${colors.reset}`);
-	}
-
-	// Pull latest translations
-	console.log('Pulling latest translations...');
-	if (!runCommand('tolgee', ['pull'])) {
-		console.error(`${colors.red}Tolgee pull failed${colors.reset}`);
-		process.exit(1);
+		console.log(
+			`${colors.yellow}TOLGEE_API_KEY not set — skipping Tolgee sync, using committed translations${colors.reset}`
+		);
 	}
 
 	// =============================================================================


### PR DESCRIPTION
Skip Tolgee tag/pull when TOLGEE_API_KEY is not set so users without a
Tolgee account can deploy with the committed src/i18n/*.json files. When
the key IS set, failures remain hard errors so misconfiguration surfaces
immediately.