### PR TITLE
feat(i18n): make Tolgee optional, fall back to committed JSON files

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -42,6 +42,11 @@ VITE_TOLGEE_API_URL=https://app.tolgee.io
 # @public @optional
 VITE_TOLGEE_API_KEY=
 
+# Tolgee CLI API key for deploy-time tag/pull (server-side, not exposed to browser)
+# When unset, the deploy script skips Tolgee sync and uses committed JSON files
+# @sensitive @optional
+TOLGEE_API_KEY=
+
 # ====================================
 # Autumn Billing
 # ====================================

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ bunx convex env set KEY value                 # set backend env vars (see .env-c
 
 ### Connect Vercel
 
-Set these in your Vercel project settings (scoped to **Preview**):
+Set this in your Vercel project settings (scoped to **Preview**):
 
 | Variable            | Value                                                                         |
 | ------------------- | ----------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Set these in your Vercel project settings (scoped to **Preview**):
 | Variable            | Value                                                                         |
 | ------------------- | ----------------------------------------------------------------------------- |
 | `CONVEX_DEPLOY_KEY` | Your dev deploy key from the [Convex dashboard](https://dashboard.convex.dev) |
-| `TOLGEE_API_KEY`    | Tolgee API key for translation pulls                                          |
 
 The deploy script auto-computes `PUBLIC_CONVEX_URL` and `PUBLIC_CONVEX_SITE_URL` from the Convex deploy output. It also sets `SITE_URL` on each preview Convex instance to match the Vercel preview URL.
 
@@ -78,14 +77,13 @@ Push a branch and Vercel creates a preview deployment with its own Convex previe
 
 ### Set Vercel production env vars
 
-Add the same two variables scoped to **Production**, using your production deploy key:
+Add the same variable scoped to **Production**, using your production deploy key:
 
 | Variable            | Value                      |
 | ------------------- | -------------------------- |
 | `CONVEX_DEPLOY_KEY` | Your production deploy key |
-| `TOLGEE_API_KEY`    | Tolgee API key             |
 
-Optional (if those features are used): `AUTUMN_SECRET_KEY`, `AUTUMN_PROD_SECRET_KEY`, `PUBLIC_POSTHOG_API_KEY`, `PUBLIC_POSTHOG_HOST`.
+Optional (if those features are used): `TOLGEE_API_KEY`, `AUTUMN_SECRET_KEY`, `AUTUMN_PROD_SECRET_KEY`, `PUBLIC_POSTHOG_API_KEY`, `PUBLIC_POSTHOG_HOST`.
 
 ### Set Convex production env vars
 

--- a/SETUP-DRAFT.md
+++ b/SETUP-DRAFT.md
@@ -230,14 +230,16 @@ This project uses multiple environment variable configurations organized by purp
 
 ```bash
 # Create .env.local and fill in values (see .env.schema for all available vars)
-# Required: CONVEX_DEPLOYMENT, PUBLIC_CONVEX_URL, VITE_TOLGEE_API_KEY
+# Required: CONVEX_DEPLOYMENT, PUBLIC_CONVEX_URL
+# Optional: VITE_TOLGEE_API_KEY (for in-context editing)
 ```
 
 **2. GitHub Actions** (Repository Secrets)
 
 ```bash
 # Add to: Repository Settings → Secrets → Actions
-# Required: AUTH_E2E_TEST_SECRET, TOLGEE_API_KEY
+# Required: AUTH_E2E_TEST_SECRET
+# Optional: TOLGEE_API_KEY (for translation sync during deploys)
 # CI tests use preview deployments with dynamic URL discovery via .well-known/e2e-config.json
 ```
 
@@ -245,7 +247,8 @@ This project uses multiple environment variable configurations organized by purp
 
 ```bash
 # Add to: Vercel Dashboard → Project Settings → Environment Variables
-# Required: PUBLIC_CONVEX_URL, CONVEX_DEPLOY_KEY, TOLGEE_API_KEY
+# Required: PUBLIC_CONVEX_URL, CONVEX_DEPLOY_KEY
+# Optional: TOLGEE_API_KEY (for translation sync during deploys)
 # See .env.schema for all available vars with types and descriptions
 ```
 
@@ -275,18 +278,18 @@ bunx convex env set KEY value
 
 - `PUBLIC_CONVEX_URL` - Production Convex URL (runtime)
 - `CONVEX_DEPLOY_KEY` - Deploy Convex functions (build-time)
-- `TOLGEE_API_KEY` - Pull translations (build-time)
+- `TOLGEE_API_KEY` - Pull translations (build-time, optional)
 
 **GitHub Actions** (Repository Secrets):
 
 - `AUTH_E2E_TEST_SECRET` - E2E test auth
-- `TOLGEE_API_KEY` - Tag production keys
+- `TOLGEE_API_KEY` - Tag production keys (optional)
 
 **Local Development** (`.env.local`):
 
 - `CONVEX_DEPLOYMENT` - Dev deployment name
 - `PUBLIC_CONVEX_URL` - Dev Convex URL
-- `VITE_TOLGEE_API_KEY` - DevTools in-context editing + CLI (derived via npm scripts)
+- `VITE_TOLGEE_API_KEY` - DevTools in-context editing + CLI (optional, derived via npm scripts)
 
 **E2E Testing** (`.env.test`):
 

--- a/docs/setup/i18n/i18n-setup.md
+++ b/docs/setup/i18n/i18n-setup.md
@@ -1,18 +1,24 @@
 # Internationalization (i18n) Setup Guide
 
-This project uses **Tolgee** for cloud-hosted translation management with SEO-friendly URL-based localization.
+This project uses **Tolgee** for cloud-hosted translation management with SEO-friendly URL-based localization. Tolgee Cloud is **optional** -- the app works out of the box with committed JSON translation files.
 
-## ⚠️ Tolgee Free Tier Limitations
+## Tolgee Cloud is Optional
 
-This template includes **many translation keys that exceed Tolgee Cloud's free tier** (~1000 keys).
+This template includes **many translation keys that exceed Tolgee Cloud's free tier** (500 keys on the free plan, this project has ~1,100). You have three options:
 
-**You have two options:**
+### Option 1: Skip Tolgee Entirely (Easiest)
 
-### Option 1: Delete Unused Keys
+No Tolgee account needed. Edit translation files directly in `src/i18n/{lang}.json` and commit them. The deploy script detects that `TOLGEE_API_KEY` is not set and builds using committed JSON files as-is.
 
-Remove translations you don't need via the Tolgee dashboard to stay within the free tier limit.
+- In-context editing (Alt+Click) is not available without Tolgee
+- Translation management is done through your editor and version control
+- No external service dependency
 
-### Option 2: Self-Host Tolgee (Recommended)
+### Option 2: Delete Unused Keys
+
+If you want to use Tolgee Cloud's free tier, remove translations you don't need via the Tolgee dashboard to stay within the 500-key limit.
+
+### Option 3: Self-Host Tolgee
 
 Self-hosting gives you unlimited keys and full control. The easiest way is using **Coolify's one-click deploy**:
 

--- a/scripts/vercel-deploy.ts
+++ b/scripts/vercel-deploy.ts
@@ -2,7 +2,7 @@
  * Vercel deployment script (cross-platform TypeScript version)
  *
  * Handles:
- * - Tolgee translation tagging and pulling
+ * - Tolgee translation tagging and pulling (optional, skipped without TOLGEE_API_KEY)
  * - Convex environment variable validation (production and preview)
  * - Convex deployment
  * - E2E config file generation (preview only)
@@ -138,37 +138,46 @@ async function runCommandWithRetry(
 async function main(): Promise<void> {
 	console.log(`Vercel Environment: ${VERCEL_ENV}`);
 
-	// Tag translations based on environment
-	if (VERCEL_ENV === 'production') {
-		console.log('Tagging production keys...');
-		if (
-			!runCommand('tolgee', [
-				'tag',
-				'--filter-extracted',
-				'--tag',
-				'production',
-				'--untag',
-				'preview'
-			])
-		) {
-			console.error(`${colors.red}Tolgee tagging failed${colors.reset}`);
-			process.exit(1);
+	// Tolgee translation sync (optional — skipped when TOLGEE_API_KEY is not set)
+	const TOLGEE_API_KEY = process.env.TOLGEE_API_KEY;
+
+	if (TOLGEE_API_KEY) {
+		// Tag translations based on environment
+		if (VERCEL_ENV === 'production') {
+			console.log('Tagging production keys...');
+			if (
+				!runCommand('tolgee', [
+					'tag',
+					'--filter-extracted',
+					'--tag',
+					'production',
+					'--untag',
+					'preview'
+				])
+			) {
+				console.error(`${colors.red}Tolgee tagging failed${colors.reset}`);
+				process.exit(1);
+			}
+		} else if (VERCEL_ENV === 'preview') {
+			console.log('Tagging preview keys...');
+			if (!runCommand('tolgee', ['tag', '--filter-extracted', '--tag', 'preview'])) {
+				console.error(`${colors.red}Tolgee tagging failed${colors.reset}`);
+				process.exit(1);
+			}
+		} else {
+			console.log(`${colors.yellow}Unknown environment, skipping tagging${colors.reset}`);
 		}
-	} else if (VERCEL_ENV === 'preview') {
-		console.log('Tagging preview keys...');
-		if (!runCommand('tolgee', ['tag', '--filter-extracted', '--tag', 'preview'])) {
-			console.error(`${colors.red}Tolgee tagging failed${colors.reset}`);
+
+		// Pull latest translations
+		console.log('Pulling latest translations...');
+		if (!runCommand('tolgee', ['pull'])) {
+			console.error(`${colors.red}Tolgee pull failed${colors.reset}`);
 			process.exit(1);
 		}
 	} else {
-		console.log(`${colors.yellow}Unknown environment, skipping tagging${colors.reset}`);
-	}
-
-	// Pull latest translations
-	console.log('Pulling latest translations...');
-	if (!runCommand('tolgee', ['pull'])) {
-		console.error(`${colors.red}Tolgee pull failed${colors.reset}`);
-		process.exit(1);
+		console.log(
+			`${colors.yellow}TOLGEE_API_KEY not set, skipping Tolgee sync (using committed translations)${colors.reset}`
+		);
 	}
 
 	// =============================================================================

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,14 +14,14 @@ export type CoercedEnvSchema = {
   
   /**
    * **CONVEX_DEPLOYMENT** 🔐 _sensitive_  
-   * Deployment used by `bunx convex dev`  
+   * Local dev deployment identifier, auto-set by `bunx convex dev`  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   CONVEX_DEPLOYMENT?: string;
   
   /**
    * **PUBLIC_CONVEX_URL**  
-   * Convex URLs for the default cloud-backed dev workflow  
+   * Convex deployment API URL  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M24%2021V9h-2v14h8v-2zm-4-6v-4c0-1.103-.897-2-2-2h-6v14h2v-6h1.48l2.335%206h2.145l-2.333-6H18c1.103%200%202-.897%202-2m-6-4h4v4h-4zM8%2023H4c-1.103%200-2-.897-2-2V9h2v12h4V9h2v12c0%201.103-.897%202-2%202%22%2F%3E%3C%2Fsvg%3E)   
    */
   PUBLIC_CONVEX_URL: string;
@@ -35,7 +35,7 @@ export type CoercedEnvSchema = {
   
   /**
    * **VITE_TOLGEE_API_URL**  
-   * Tolgee Cloud Configuration (https://app.tolgee.io)  
+   * Tolgee Cloud API URL  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M24%2021V9h-2v14h8v-2zm-4-6v-4c0-1.103-.897-2-2-2h-6v14h2v-6h1.48l2.335%206h2.145l-2.333-6H18c1.103%200%202-.897%202-2m-6-4h4v4h-4zM8%2023H4c-1.103%200-2-.897-2-2V9h2v12h4V9h2v12c0%201.103-.897%202-2%202%22%2F%3E%3C%2Fsvg%3E)   
    */
   VITE_TOLGEE_API_URL: string;
@@ -48,6 +48,14 @@ export type CoercedEnvSchema = {
   VITE_TOLGEE_API_KEY?: string;
   
   /**
+   * **TOLGEE_API_KEY** 🔐 _sensitive_  
+   * Tolgee CLI API key for deploy-time tag/pull (server-side, not exposed to browser)  
+   * When unset, the deploy script skips Tolgee sync and uses committed JSON files  
+   * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
+   */
+  TOLGEE_API_KEY?: string;
+  
+  /**
    * **AUTUMN_SECRET_KEY** 🔐 _sensitive_  
    * Autumn billing test/dev secret key  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
@@ -56,14 +64,14 @@ export type CoercedEnvSchema = {
   
   /**
    * **AUTUMN_PROD_SECRET_KEY** 🔐 _sensitive_  
-   * Autumn Billing  
+   * Autumn billing production secret key  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   AUTUMN_PROD_SECRET_KEY?: string;
   
   /**
    * **PUBLIC_POSTHOG_API_KEY**  
-   * PostHog Analytics (https://posthog.com)  
+   * PostHog project API key (client-safe)  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   PUBLIC_POSTHOG_API_KEY?: string;
@@ -147,7 +155,7 @@ export type CoercedEnvSchema = {
   
   /**
    * **RESEND_API_KEY** 🔐 _sensitive_  
-   * SvelteKit-side copies of Resend/Auth email vars (for email preview server routes)  
+   * Resend API key for local email preview sending  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   RESEND_API_KEY?: string;


### PR DESCRIPTION
Skip Tolgee tag/pull when TOLGEE_API_KEY is not set so users without a
Tolgee account can deploy with the committed src/i18n/*.json files. When
the key IS set, failures remain hard errors so misconfiguration surfaces
immediately.