### PR TITLE
refactor(auth): Split signin/signup into separate routes, add form error animations

### DIFF
--- a/.agents/skills/triage-reviews/SKILL.md
+++ b/.agents/skills/triage-reviews/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: triage-reviews
+description: Fetch PR review comments, verify each against real code/docs, fix valid issues, commit and push
+disable-model-invocation: true
+argument-hint: '[PR number]'
+---
+
+# Triage PR Review Comments
+
+Fetch all review comments on the current PR, verify each finding against real code, fix valid issues, and push.
+
+## Phase 1: Gather Comments
+
+1. Determine the PR number:
+   - Use `$ARGUMENTS` if provided
+   - Otherwise: `gh pr view --json number --jq .number`
+
+2. Fetch ALL comments (reviewers post in multiple places):
+
+   ```
+   gh api --paginate repos/{owner}/{repo}/pulls/{pr}/reviews
+   gh api --paginate repos/{owner}/{repo}/pulls/{pr}/comments
+   gh api --paginate repos/{owner}/{repo}/issues/{pr}/comments
+   ```
+
+3. Extract unique findings — deduplicate across Copilot, Greptile, and human reviewers. Group by file and line.
+
+## Phase 2: Verify Each Finding
+
+For EVERY finding, verify against real code before accepting or rejecting:
+
+1. **Read the actual code** at the referenced file:line
+2. **Check if the issue still exists** — it may already be fixed in a later commit
+3. **Verify correctness** using:
+   - Code analysis (read surrounding context, trace call paths)
+   - Run `btca resources` to see what's available, then `btca ask -r <resource> -q "..."` for library/framework questions
+   - Web search for API behavior, language semantics, or CVEs
+4. **Classify** each finding:
+   - **Valid** — real bug, real gap, or real improvement needed
+   - **False positive** — reviewer misread the code, outdated reference, or style preference
+
+## Phase 3: Fix & Ship
+
+1. Fix all **Valid** findings
+2. Run the project's lint/test commands (check CLAUDE.md for exact commands)
+   - If lint/tests fail, fix the failures before committing
+   - If a failure cannot be fixed automatically, skip that fix and report it as **Valid (unfixed)** in the Phase 4 table
+3. `git add` only changed files, `git commit` with message:
+
+   ```
+   fix: Address PR review feedback
+
+   - <one-line summary per fix>
+   ```
+
+4. Push: `gt submit` (or `git push` if not using Graphite)
+
+## Phase 4: Report
+
+Present a final summary table of ALL findings with verdicts:
+
+| #   | Source | File:Line | Finding | Verdict | Reason |
+| --- | ------ | --------- | ------- | ------- | ------ |
+
+## Notes
+
+- Never dismiss a finding without reading the actual code first
+- If unsure, err toward "Valid" — it's cheaper to fix than to miss a bug
+- For library/API questions, always use btca or web search — don't guess

--- a/.claude/skills/triage-reviews
+++ b/.claude/skills/triage-reviews
@@ -1,0 +1,1 @@
+../../.agents/skills/triage-reviews

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ When starting work that needs its own branch/PR, always create a worktree first 
 
 NEVER use the `EnterWorktree` tool. Always use `bun run worktree` instead and add the worktree path before all consecutive actions. You must do this, the cwd is reset after each action and theres currently no better way to do this.
 
+**Before committing:** Always check `git branch` first. If you're in a worktree, the branch already exists and was created by `bun run worktree` (which runs `gt create` internally). Use `git commit` to add commits, not `gt create`. Only use `gt create` when you need a new stacked branch on top of the current one.
+
 ## Development Commands
 
 ### Core Development

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,11 +1,6 @@
 {
 	"version": 1,
 	"skills": {
-		"autumn-best-practices": {
-			"source": "useautumn/skills",
-			"sourceType": "github",
-			"computedHash": "d4148e55c3c75e121c3e967d8d2d9a8eda3ee9b99a87db853f9b6788d98d713c"
-		},
 		"email-and-password-best-practices": {
 			"source": "better-auth/skills",
 			"sourceType": "github",
@@ -30,6 +25,11 @@
 			"source": "sveltejs/ai-tools",
 			"sourceType": "github",
 			"computedHash": "bec11e369679027edf9d4acbe6d9788f8da33dc14b48b874f231d3ba13705324"
+		},
+		"triage-reviews": {
+			"source": "stickerdaniel/linkedin-mcp-server",
+			"sourceType": "github",
+			"computedHash": "c148529762a856a8f08a4db4b08c1bf7409281347d545f022e04a8e301af6868"
 		}
 	}
 }

--- a/src/blocks/hero/hero-five.svelte
+++ b/src/blocks/hero/hero-five.svelte
@@ -39,7 +39,7 @@
 					>
 						<Button
 							size="lg"
-							href={localizedHref('/signin?tab=signup')}
+							href={localizedHref('/signup')}
 							class=" pointer-events-auto h-12 rounded-full pr-3 pl-5 text-sm"
 						>
 							<span class="text-nowrap"><T keyName="hero.cta" /></span>

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -34,8 +34,8 @@ function decodeJwtPayload(token: string): { role?: string } | null {
 }
 
 // Route matchers
-function isSignInPage(pathname: string): boolean {
-	return /^\/[a-z]{2}\/signin$/.test(pathname);
+function isAuthPage(pathname: string): boolean {
+	return /^\/[a-z]{2}\/(signin|signup)$/.test(pathname);
 }
 
 function isProtectedRoute(pathname: string): boolean {
@@ -166,7 +166,7 @@ const authFirstPattern: Handle = async function authFirstPattern({ event, resolv
 	const langMatch = pathname.match(/^\/([a-z]{2})\//);
 	const lang = langMatch ? langMatch[1] : DEFAULT_LANGUAGE;
 
-	if (isSignInPage(pathname) && authenticated) {
+	if (isAuthPage(pathname) && authenticated) {
 		const destination = safeRedirectPath(redirectToParam ?? '', `/${lang}/app`);
 		redirect(307, destination);
 	}

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1229,8 +1229,12 @@
 				"title": "Passwort zurücksetzen"
 			},
 			"signin": {
-				"description": "Melden Sie sich an oder erstellen Sie ein neues Konto.",
+				"description": "Melden Sie sich bei Ihrem Konto an.",
 				"title": "Anmelden"
+			},
+			"signup": {
+				"description": "Erstellen Sie ein neues Konto.",
+				"title": "Registrieren"
 			}
 		},
 		"emails": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1229,8 +1229,12 @@
 				"title": "Reset Password"
 			},
 			"signin": {
-				"description": "Access your account or create a new one.",
+				"description": "Sign in to your account.",
 				"title": "Sign In"
+			},
+			"signup": {
+				"description": "Create a new account to get started.",
+				"title": "Sign Up"
 			}
 		},
 		"emails": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1229,8 +1229,12 @@
 				"title": "Restablecer contraseña"
 			},
 			"signin": {
-				"description": "Accede a tu cuenta o crea una nueva.",
+				"description": "Accede a tu cuenta.",
 				"title": "Iniciar sesión"
+			},
+			"signup": {
+				"description": "Crea una cuenta nueva para empezar.",
+				"title": "Registrarse"
 			}
 		},
 		"emails": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1229,8 +1229,12 @@
 				"title": "Réinitialiser le mot de passe"
 			},
 			"signin": {
-				"description": "Connectez-vous à votre compte ou créez-en un nouveau.",
+				"description": "Connectez-vous à votre compte.",
 				"title": "Connexion"
+			},
+			"signup": {
+				"description": "Créez un nouveau compte pour commencer.",
+				"title": "Inscription"
 			}
 		},
 		"emails": {

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -172,11 +172,11 @@
 									<Button variant="ghost" size="sm" href={localizedHref('/signin')}>
 										<T keyName="nav.login" />
 									</Button>
-									<Button size="sm" href={localizedHref('/signin?tab=signup')}>
+									<Button size="sm" href={localizedHref('/signup')}>
 										<T keyName="nav.signup" />
 									</Button>
 								{:else}
-									<Button size="sm" href={localizedHref('/signin?tab=signup')}>
+									<Button size="sm" href={localizedHref('/signup')}>
 										<T keyName="nav.get_started" />
 									</Button>
 								{/if}
@@ -255,11 +255,11 @@
 							<Button variant="ghost" size="sm" href={localizedHref('/signin')} class="w-full">
 								<T keyName="nav.login" />
 							</Button>
-							<Button size="sm" href={localizedHref('/signin?tab=signup')} class="w-full">
+							<Button size="sm" href={localizedHref('/signup')} class="w-full">
 								<T keyName="nav.signup" />
 							</Button>
 						{:else}
-							<Button size="sm" href={localizedHref('/signin?tab=signup')} class="w-full">
+							<Button size="sm" href={localizedHref('/signup')} class="w-full">
 								<T keyName="nav.get_started" />
 							</Button>
 						{/if}

--- a/src/lib/components/ui/field/field-error.svelte
+++ b/src/lib/components/ui/field/field-error.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { slide } from 'svelte/transition';
 	import { cn, type WithElementRef } from '$lib/utils.js';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import type { Snippet } from 'svelte';
@@ -14,23 +15,10 @@
 		errors?: { message?: string }[];
 	} = $props();
 
-	const hasContent = $derived.by(() => {
-		// has slotted error
-		if (children) return true;
-
-		// no errors
-		if (!errors || errors.length === 0) return false;
-
-		// has an error but no message
-		if (errors.length === 1 && !errors[0]?.message) {
-			return false;
-		}
-
-		return true;
-	});
-
-	const isMultipleErrors = $derived(errors && errors.length > 1);
-	const singleErrorMessage = $derived(errors && errors.length === 1 && errors[0]?.message);
+	const errorMessages = $derived(
+		errors?.map((e) => e?.message).filter((m): m is string => !!m) ?? []
+	);
+	const hasContent = $derived(children || errorMessages.length > 0);
 </script>
 
 {#if hasContent}
@@ -38,19 +26,16 @@
 		bind:this={ref}
 		role="alert"
 		data-slot="field-error"
+		transition:slide={{ duration: 200 }}
 		class={cn('text-sm font-normal text-destructive', className)}
 		{...restProps}
 	>
 		{#if children}
 			{@render children()}
-		{:else if singleErrorMessage}
-			{singleErrorMessage}
-		{:else if isMultipleErrors}
-			<ul class="ml-4 flex list-disc flex-col gap-1">
-				{#each errors ?? [] as error, index (index)}
-					{#if error?.message}
-						<li>{error.message}</li>
-					{/if}
+		{:else}
+			<ul class={errorMessages.length > 1 ? 'ml-4 list-disc space-y-1' : 'list-none'}>
+				{#each errorMessages as message (message)}
+					<li transition:slide={{ duration: 150 }}>{message}</li>
 				{/each}
 			</ul>
 		{/if}

--- a/src/lib/schemas/auth.ts
+++ b/src/lib/schemas/auth.ts
@@ -3,11 +3,14 @@ import * as v from 'valibot';
 // Email validation schema (reusable across the app)
 export const emailSchema = v.pipe(v.string(), v.email());
 
-// URL params schema (for signin/signup tabs)
-export const authParamsSchema = v.object({
-	tab: v.optional(v.fallback(v.picklist(['signin', 'signup']), 'signin'), 'signin'),
+// URL params schema for auth pages (redirectTo only, no tab switching)
+export const redirectParamsSchema = v.object({
 	redirectTo: v.optional(v.fallback(v.string(), ''), '')
 });
 
+// Legacy alias — remove once all consumers are migrated
+export const authParamsSchema = redirectParamsSchema;
+
 // Types
-export type AuthParams = v.InferOutput<typeof authParamsSchema>;
+export type RedirectParams = v.InferOutput<typeof redirectParamsSchema>;
+export type AuthParams = RedirectParams;

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -14,6 +14,7 @@
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { forgotPasswordSchema } from './schema.js';
+	import { slide } from 'svelte/transition';
 	import { authFlow } from '$lib/hooks/auth-flow.svelte';
 	import { getAuthErrorKey } from '$lib/utils/auth-messages';
 	import { translateValidationErrors } from '$lib/utils/validation-i18n.js';
@@ -163,24 +164,22 @@
 								</p>
 							</div>
 							{#if formError}
-								<Field.Field>
-									<div
-										data-testid="forgot-password-form-error"
-										class="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-									>
-										<T keyName={formError} />
-									</div>
-								</Field.Field>
+								<div
+									data-testid="forgot-password-form-error"
+									transition:slide={{ duration: 200 }}
+									class="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+								>
+									<T keyName={formError} />
+								</div>
 							{/if}
 							{#if message}
-								<Field.Field>
-									<div
-										data-testid="forgot-password-success-message"
-										class="rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400"
-									>
-										<T keyName={message} />
-									</div>
-								</Field.Field>
+								<div
+									data-testid="forgot-password-success-message"
+									transition:slide={{ duration: 200 }}
+									class="rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400"
+								>
+									<T keyName={message} />
+								</div>
 							{/if}
 							<Field.Field>
 								<Field.Label for="email-{id}">

--- a/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
@@ -16,6 +16,7 @@
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { PASSWORD_MIN_LENGTH, resetPasswordSchema } from './schema.js';
 	import { page } from '$app/state';
+	import { slide } from 'svelte/transition';
 	import { getAuthErrorKey } from '$lib/utils/auth-messages';
 	import { translateValidationErrors } from '$lib/utils/validation-i18n.js';
 
@@ -182,27 +183,25 @@
 								</p>
 							</div>
 							{#if formError}
-								<Field.Field>
-									<div
-										data-testid="reset-password-form-error"
-										class="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-									>
-										<T keyName={formError} />
-									</div>
-								</Field.Field>
+								<div
+									data-testid="reset-password-form-error"
+									transition:slide={{ duration: 200 }}
+									class="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+								>
+									<T keyName={formError} />
+								</div>
 							{/if}
 							{#if message}
-								<Field.Field>
-									<div
-										data-testid="reset-password-success-message"
-										class="rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400"
-									>
-										<T keyName={message} />
-										<a href={resolve(localizedHref('/signin'))} class="underline">
-											<T keyName="auth.reset_password.sign_in_link" defaultValue="Sign in" />
-										</a>
-									</div>
-								</Field.Field>
+								<div
+									data-testid="reset-password-success-message"
+									transition:slide={{ duration: 200 }}
+									class="rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400"
+								>
+									<T keyName={message} />
+									<a href={resolve(localizedHref('/signin'))} class="underline">
+										<T keyName="auth.reset_password.sign_in_link" defaultValue="Sign in" />
+									</a>
+								</div>
 							{/if}
 							<Field.Field>
 								<Field.Label for="password-{id}">

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -44,7 +44,7 @@
 	const hasOAuthAuth = $derived(
 		Boolean(oauthProviders.data?.google || oauthProviders.data?.github)
 	);
-	const hasAlternativeAuth = $derived(hasOAuthAuth || true); // passkey always available on signin
+	const hasAlternativeAuth = true; // passkey always available on signin
 	const enabledProviderCount = $derived(
 		(oauthProviders.data?.google ? 1 : 0) + (oauthProviders.data?.github ? 1 : 0) + 1 // passkey
 	);

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -40,11 +40,8 @@
 		initialData: data.oauthProviders
 	}));
 
-	// Passkeys + OAuth
-	const hasOAuthAuth = $derived(
-		Boolean(oauthProviders.data?.google || oauthProviders.data?.github)
-	);
-	const hasAlternativeAuth = true; // passkey always available on signin
+	// Passkey always available on signin, so alternative auth is always shown
+	const hasAlternativeAuth = true;
 	const enabledProviderCount = $derived(
 		(oauthProviders.data?.google ? 1 : 0) + (oauthProviders.data?.github ? 1 : 0) + 1 // passkey
 	);

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	/* eslint-disable svelte/no-navigation-without-resolve -- Query-string-only hrefs don't need resolve() */
 	import { onMount } from 'svelte';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { resolve } from '$app/paths';
@@ -181,7 +180,10 @@
 				<T keyName="auth.signin.no_account" defaultValue="Don't have an account?" />
 				<a
 					bind:this={signUpLink}
-					href="?tab=signup{redirectTo ? `&redirectTo=${encodeURIComponent(redirectTo)}` : ''}"
+					href={resolve(
+						localizedHref('/signup') +
+							(redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : '')
+					)}
 					onkeydown={handleSignUpLinkKeydown}
 					class="underline underline-offset-4"
 				>

--- a/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	/* eslint-disable svelte/no-navigation-without-resolve -- Query-string-only hrefs don't need resolve() */
 	import { onMount } from 'svelte';
 	import { T, getTranslate } from '@tolgee/svelte';
+	import { resolve } from '$app/paths';
+	import { localizedHref } from '$lib/utils/i18n';
 	import { PASSWORD_MIN_LENGTH } from './schema.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Field from '$lib/components/ui/field/index.js';
@@ -167,7 +168,10 @@
 			<Field.Description class="text-center">
 				<T keyName="auth.signup.has_account" defaultValue="Already have an account?" />
 				<a
-					href="?tab=signin{redirectTo ? `&redirectTo=${encodeURIComponent(redirectTo)}` : ''}"
+					href={resolve(
+						localizedHref('/signin') +
+							(redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : '')
+					)}
 					class="underline underline-offset-4"
 				>
 					<T keyName="auth.signup.link_signin" defaultValue="Sign in" />

--- a/src/routes/[[lang]]/(auth)/signup/+page.server.ts
+++ b/src/routes/[[lang]]/(auth)/signup/+page.server.ts
@@ -1,0 +1,9 @@
+import type { PageServerLoad } from './$types';
+import { api } from '$lib/convex/_generated/api.js';
+import { createConvexHttpClient } from '@mmailaender/convex-better-auth-svelte/sveltekit';
+
+export const load = (async () => {
+	const client = createConvexHttpClient({});
+	const oauthProviders = await client.query(api.auth.getAvailableOAuthProviders, {});
+	return { oauthProviders };
+}) satisfies PageServerLoad;

--- a/src/routes/[[lang]]/(auth)/signup/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signup/+page.svelte
@@ -146,7 +146,7 @@
 
 		try {
 			let failed = false;
-			const finalDestination = params.redirectTo || localizedHref('/app');
+			const finalDestination = safeRedirectPath(params.redirectTo, localizedHref('/app'));
 			const callbackURL =
 				localizedHref('/email-verified') + `?redirectTo=${encodeURIComponent(finalDestination)}`;
 			await authClient.signUp.email(

--- a/src/routes/[[lang]]/(auth)/signup/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signup/+page.svelte
@@ -8,24 +8,24 @@
 	import * as Card from '$lib/components/ui/card/index.js';
 	import * as Field from '$lib/components/ui/field/index.js';
 	import { redirectParamsSchema } from '$lib/schemas/auth.js';
-	import { signInSchema } from './schema.js';
+	import { signUpSchema } from '../signin/schema.js';
 	import { localizedHref } from '$lib/utils/i18n';
 	import { resolve } from '$app/paths';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { authFlow } from '$lib/hooks/auth-flow.svelte';
 	import {
-		type LastAuthMethod,
 		type PendingOAuthProvider,
 		lastSuccessfulAuthMethod,
 		beginOAuth,
 		clearPendingOAuthProvider,
-		setLastSuccessfulAuthMethod,
-		clearLastSuccessfulAuthMethod
+		clearLastSuccessfulAuthMethod,
+		type LastAuthMethod
 	} from '$lib/hooks/last-auth-method.svelte';
 	import { getAuthErrorKey } from '$lib/utils/auth-messages';
 	import { safeRedirectPath } from '$lib/utils/url';
-	import SignInForm from './SignInForm.svelte';
+	import SignUpForm from '../signin/SignUpForm.svelte';
+	import VerificationStep from '../signin/VerificationStep.svelte';
 	import { useSearchParams } from 'runed/kit';
 
 	let { data } = $props();
@@ -40,34 +40,30 @@
 		initialData: data.oauthProviders
 	}));
 
-	// Passkeys + OAuth
 	const hasOAuthAuth = $derived(
 		Boolean(oauthProviders.data?.google || oauthProviders.data?.github)
-	);
-	const hasAlternativeAuth = $derived(hasOAuthAuth || true); // passkey always available on signin
-	const enabledProviderCount = $derived(
-		(oauthProviders.data?.google ? 1 : 0) + (oauthProviders.data?.github ? 1 : 0) + 1 // passkey
 	);
 
 	let isLoading = $state(false);
 	let formError = $state('');
-	let lastValidSignInSubmission = $state<string | null>(null);
-	let termsLink = $state<HTMLAnchorElement | null>(null);
+	let verificationStep = $state<{ email: string } | null>(null);
+	let lastValidSignUpSubmission = $state<string | null>(null);
 
 	const id = $props.id();
 
-	let signInData = $state({ email: '', password: '' });
-	let signInErrors = $state<Record<string, string[]>>({});
+	let signUpData = $state({ name: '', email: '', password: '' });
+	let signUpErrors = $state<Record<string, string[]>>({});
 
 	function isLastUsedAuthMethod(method: LastAuthMethod): boolean {
 		return lastSuccessfulAuthMethod.current === method;
 	}
 
-	const signInTotalSteps = 3;
-	const signInValidation = $derived.by(() => {
-		const result = v.safeParse(signInSchema, {
-			email: signInData.email,
-			_password: signInData.password
+	const signUpTotalSteps = 4;
+	const signUpValidation = $derived.by(() => {
+		const result = v.safeParse(signUpSchema, {
+			name: signUpData.name,
+			email: signUpData.email,
+			_password: signUpData.password
 		});
 		const invalidFields = new Set<string>(
 			result.success
@@ -77,46 +73,51 @@
 						.filter((key): key is string => typeof key === 'string')
 		);
 		return {
+			isNameValid: !invalidFields.has('name'),
 			isEmailValid: !invalidFields.has('email'),
 			isPasswordValid: !invalidFields.has('_password')
 		};
 	});
-	const signInSubmissionToken = $derived(`${signInData.email}\u0000${signInData.password}`);
-	const signInCompletedSteps = $derived(
-		(signInValidation.isEmailValid ? 1 : 0) +
-			(signInValidation.isPasswordValid ? 1 : 0) +
-			(lastValidSignInSubmission === signInSubmissionToken ? 1 : 0)
+	const signUpSubmissionToken = $derived(
+		`${signUpData.name}\u0000${signUpData.email}\u0000${signUpData.password}`
 	);
-	const signInProgress = $derived((signInCompletedSteps / signInTotalSteps) * 100);
+	const signUpCompletedSteps = $derived(
+		(signUpValidation.isNameValid ? 1 : 0) +
+			(signUpValidation.isEmailValid ? 1 : 0) +
+			(signUpValidation.isPasswordValid ? 1 : 0) +
+			(lastValidSignUpSubmission === signUpSubmissionToken ? 1 : 0)
+	);
+	const signUpProgress = $derived((signUpCompletedSteps / signUpTotalSteps) * 100);
 
 	// Initialize email from global state
 	$effect(() => {
 		if (authFlow.email) {
-			signInData.email = authFlow.email;
+			signUpData.email = authFlow.email;
 		}
 	});
 
 	// Sync email changes to global state
 	$effect(() => {
-		if (signInData.email) {
-			authFlow.email = signInData.email;
+		if (signUpData.email) {
+			authFlow.email = signUpData.email;
 		}
 	});
 
-	// Redirect when authenticated
+	// Redirect when authenticated (but not during verification step)
 	$effect(() => {
-		if (auth.isAuthenticated) {
+		if (auth.isAuthenticated && !verificationStep) {
 			const destination = safeRedirectPath(params.redirectTo, localizedHref('/app'));
 			window.location.href = destination;
 		}
 	});
 
-	function validateSignIn(): boolean {
+	function validateSignUp(): boolean {
 		const dataForValidation = {
-			email: signInData.email,
-			_password: signInData.password
+			name: signUpData.name,
+			email: signUpData.email,
+			_password: signUpData.password
 		};
-		const result = v.safeParse(signInSchema, dataForValidation);
+		const result = v.safeParse(signUpSchema, dataForValidation);
 		if (!result.success) {
 			const errors: Record<string, string[]> = {};
 			for (const issue of result.issues) {
@@ -125,52 +126,66 @@
 				if (!errors[fieldName]) errors[fieldName] = [];
 				errors[fieldName].push(issue.message);
 			}
-			signInErrors = errors;
+			signUpErrors = errors;
 			return false;
 		}
-		signInErrors = {};
+		signUpErrors = {};
 		return true;
 	}
 
-	async function handleSignIn(e: Event) {
+	async function handleSignUp(e: Event) {
 		e.preventDefault();
-		if (!validateSignIn()) {
-			lastValidSignInSubmission = null;
+		if (!validateSignUp()) {
+			lastValidSignUpSubmission = null;
 			return;
 		}
-		lastValidSignInSubmission = signInSubmissionToken;
+		lastValidSignUpSubmission = signUpSubmissionToken;
 
 		isLoading = true;
 		formError = '';
 
 		try {
 			let failed = false;
-			await authClient.signIn.email(
-				{ email: signInData.email, password: signInData.password },
+			const finalDestination = params.redirectTo || localizedHref('/app');
+			const callbackURL =
+				localizedHref('/email-verified') + `?redirectTo=${encodeURIComponent(finalDestination)}`;
+			await authClient.signUp.email(
 				{
+					email: signUpData.email,
+					password: signUpData.password,
+					name: signUpData.name,
+					callbackURL
+				},
+				{
+					onSuccess: () => {
+						haptic.trigger('success');
+						clearLastSuccessfulAuthMethod();
+						clearPendingOAuthProvider();
+						verificationStep = { email: signUpData.email };
+					},
 					onError: (ctx) => {
 						failed = true;
-						lastValidSignInSubmission = null;
+						lastValidSignUpSubmission = null;
 						haptic.trigger('error');
-						formError = getAuthErrorKey(ctx.error, 'auth.messages.invalid_credentials');
+						formError = getAuthErrorKey(ctx.error, 'auth.messages.signup_failed');
 					}
 				}
 			);
-			if (!failed) {
-				haptic.trigger('success');
-				clearLastSuccessfulAuthMethod();
-				clearPendingOAuthProvider();
-				window.location.href = safeRedirectPath(params.redirectTo, localizedHref('/app'));
-				return;
+			if (failed) {
+				lastValidSignUpSubmission = null;
 			}
 		} catch (error) {
-			console.error('[SignIn] Login error:', error);
-			haptic.trigger('error');
-			lastValidSignInSubmission = null;
-			formError = 'auth.messages.generic_error';
+			console.error('[SignUp] Registration error:', error);
+			lastValidSignUpSubmission = null;
+			formError = 'auth.messages.signup_failed';
 		} finally {
 			isLoading = false;
 		}
+	}
+
+	function cancelVerification() {
+		verificationStep = null;
+		formError = '';
 	}
 
 	async function handleOAuth(provider: PendingOAuthProvider) {
@@ -186,40 +201,19 @@
 			});
 		} catch (error) {
 			clearPendingOAuthProvider();
-			console.error(`[SignIn] OAuth ${provider} error:`, error);
+			console.error(`[SignUp] OAuth ${provider} error:`, error);
 			formError = 'auth.messages.oauth_failed';
-		} finally {
-			isLoading = false;
-		}
-	}
-
-	async function handlePasskeyLogin() {
-		haptic.trigger('light');
-		isLoading = true;
-		formError = '';
-
-		try {
-			const result = await authClient.signIn.passkey();
-			if (result.error) {
-				formError = getAuthErrorKey(result.error, 'auth.messages.passkey_failed');
-			} else {
-				setLastSuccessfulAuthMethod('passkey');
-				clearPendingOAuthProvider();
-			}
-		} catch (error) {
-			console.error('[SignIn] Passkey login error:', error);
-			formError = 'auth.messages.passkey_failed';
 		} finally {
 			isLoading = false;
 		}
 	}
 </script>
 
-<SEOHead title={$t('meta.auth.signin.title')} description={$t('meta.auth.signin.description')} />
+<SEOHead title={$t('meta.auth.signup.title')} description={$t('meta.auth.signup.description')} />
 
 <noscript>
 	<div class="fixed inset-x-0 top-0 z-50 bg-yellow-100 p-4 text-center text-yellow-800">
-		JavaScript is required for authentication. Please enable JavaScript to sign in.
+		JavaScript is required for authentication. Please enable JavaScript to sign up.
 	</div>
 </noscript>
 
@@ -227,23 +221,28 @@
 	<div class="flex w-full max-w-sm flex-col gap-6 md:max-w-3xl">
 		<Card.Root class="overflow-hidden p-0">
 			<Card.Content class="grid p-0 md:grid-cols-2">
-				<SignInForm
-					{id}
-					{signInData}
-					{signInErrors}
-					{formError}
-					{isLoading}
-					{signInProgress}
-					{hasAlternativeAuth}
-					{enabledProviderCount}
-					oauthProviders={oauthProviders.data}
-					redirectTo={params.redirectTo}
-					{termsLink}
-					{isLastUsedAuthMethod}
-					onSubmit={handleSignIn}
-					onOAuth={handleOAuth}
-					onPasskey={handlePasskeyLogin}
-				/>
+				{#if verificationStep}
+					<VerificationStep
+						email={verificationStep.email}
+						{formError}
+						onBack={cancelVerification}
+					/>
+				{:else}
+					<SignUpForm
+						{id}
+						{signUpData}
+						{signUpErrors}
+						{formError}
+						{isLoading}
+						{signUpProgress}
+						{hasOAuthAuth}
+						oauthProviders={oauthProviders.data}
+						redirectTo={params.redirectTo}
+						{isLastUsedAuthMethod}
+						onSubmit={handleSignUp}
+						onOAuth={handleOAuth}
+					/>
+				{/if}
 				<div class="relative hidden bg-muted md:block">
 					<img
 						src="/placeholder.svg"
@@ -256,10 +255,7 @@
 		</Card.Root>
 		<Field.Description class="px-6 text-center">
 			<T keyName="auth.terms.agreement" defaultValue="By clicking continue, you agree to our" />
-			<a
-				bind:this={termsLink}
-				href={resolve(localizedHref('/terms'))}
-				class="underline underline-offset-4"
+			<a href={resolve(localizedHref('/terms'))} class="underline underline-offset-4"
 				><T keyName="auth.terms.terms_of_service" defaultValue="Terms of Service" /></a
 			>
 			<T keyName="auth.terms.and" defaultValue="and" />

--- a/src/routes/[[lang]]/(marketing)/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/page.md.ts
@@ -67,7 +67,7 @@ export const marketingMarkdown: MarketingMarkdownDocument = {
 			links: [
 				{
 					label: 'Start building',
-					href: '/en/signin?tab=signup',
+					href: '/en/signup',
 					description: 'Create an account and enter the product flow'
 				}
 			]


### PR DESCRIPTION
Separate /signin and /signup into dedicated pages for proper SSR and
SEO instead of tab-based switching on a single page. Add slide
transitions to Field.Error and auth form success/error banners.