### PR TITLE
refactor(dev): Always use local Convex backend for `bun run dev`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,13 +42,13 @@ NEVER use the `EnterWorktree` tool. Always use `bun run worktree` instead and ad
 
 - `bun run build` - Build for production
 - `bun run dev` - Start Vite with an embedded local Convex backend (default)
-- `bun run dev:cloud` - Start Vite + cloud Convex backend (requires `CONVEX_DEPLOYMENT` in `.env.local`)
+- `bun run dev:cloud` - Start Vite + cloud Convex backend
 
 NEVER use `bun run dev` to start the development server, its already running in a separate terminal.
 
 Local dev notes (`bun run dev`):
 
-- Auto-detected: runs local backend unless `CONVEX_DEPLOYMENT` is set in `.env.local`.
+- Always runs the local embedded backend (ignores `CONVEX_DEPLOYMENT` in `.env.local`).
 - Seeds a verified local admin automatically after startup.
 - Local seeded admin credentials: `admin@local.dev` / `LocalDevAdmin123!`
 - Convex backend env vars are loaded from `.env.convex.local` (optional services like email, OAuth, billing, AI).
@@ -80,7 +80,7 @@ Local dev notes (`bun run dev`):
 
 **Running functions (cloud vs local):**
 
-- **Cloud:** `bun convex run module:functionName '{"arg": "value"}'` — requires `CONVEX_DEPLOYMENT` in `.env.local`
+- **Cloud:** `bun convex run module:functionName '{"arg": "value"}'`
 - **Local dev:** Use the HTTP API directly (the Convex MCP and CLI don't support local backends):
   ```bash
   # Admin key and port are printed in dev server startup logs

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ I'd recommend the local embedded backend for day-to-day work. Each git worktree 
 bunx convex init                              # creates a Convex project
 ```
 
-Add `CONVEX_DEPLOYMENT` to `.env.local` (printed by `convex init`), then:
+`convex init` prints a `CONVEX_DEPLOYMENT` value — add it to `.env.local`. `bun run dev` still uses the local embedded backend; the variable is only needed for `dev:cloud` and the Convex CLI.
 
 ```bash
 bun run dev:cloud                             # frontend + cloud Convex backend

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -169,8 +169,8 @@ export default defineConfig(async ({ mode }) => {
 	const loadedEnv = loadEnv(mode, cwd, '');
 	// Local Convex backend only during `bun run dev` (not CI, builds, postinstall, or scripts).
 	// build:emails uses createServer() which re-enters this config -- lifecycle check prevents that.
-	const useLocalConvex =
-		process.env.npm_lifecycle_event === 'dev' && !loadedEnv.CONVEX_DEPLOYMENT && !process.env.CI;
+	// dev:cloud runs via dev:frontend (lifecycle = "dev:frontend"), so it's excluded naturally.
+	const useLocalConvex = process.env.npm_lifecycle_event === 'dev' && !process.env.CI;
 	const plugins: PluginOption[] = [];
 
 	if (useLocalConvex) {


### PR DESCRIPTION
Remove CONVEX_DEPLOYMENT check from local dev detection so the CLI
works without commenting/uncommenting .env.local. dev:cloud uses a
different lifecycle event (dev:frontend) so it's excluded naturally.