### PR TITLE
fix(ui): Prevent layout jump when field errors swap

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,7 +14,7 @@ export type CoercedEnvSchema = {
   
   /**
    * **CONVEX_DEPLOYMENT** 🔐 _sensitive_  
-   * Local dev deployment identifier, auto-set by `bunx convex dev`  
+   * Deployment used by `bunx convex dev`  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   CONVEX_DEPLOYMENT?: string;

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -112,7 +112,7 @@
 						{...props}
 					>
 						<Avatar.Root class="size-8 rounded-lg after:rounded-lg">
-							<Avatar.Image src={user.avatar} alt={user.name} />
+							<Avatar.Image src={user.avatar} alt={user.name} class="rounded-lg" />
 							<Avatar.Fallback class="rounded-lg">{initials}</Avatar.Fallback>
 						</Avatar.Root>
 						<div class="grid flex-1 text-left text-sm leading-tight">
@@ -132,7 +132,7 @@
 				<DropdownMenu.Label class="p-0 font-normal">
 					<div class="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
 						<Avatar.Root class="size-8 rounded-lg after:rounded-lg">
-							<Avatar.Image src={user.avatar} alt={user.name} />
+							<Avatar.Image src={user.avatar} alt={user.name} class="rounded-lg" />
 							<Avatar.Fallback class="rounded-lg">{initials}</Avatar.Fallback>
 						</Avatar.Root>
 						<div class="grid flex-1 text-left text-sm leading-tight">

--- a/src/lib/components/ui/field/field-error.svelte
+++ b/src/lib/components/ui/field/field-error.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { slide } from 'svelte/transition';
+	import { slide, fade } from 'svelte/transition';
 	import { cn, type WithElementRef } from '$lib/utils.js';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import type { Snippet } from 'svelte';
@@ -33,11 +33,22 @@
 		{#if children}
 			{@render children()}
 		{:else}
-			<ul class={errorMessages.length > 1 ? 'ml-4 list-disc space-y-1' : 'list-none'}>
-				{#each errorMessages as message (message)}
-					<li transition:slide={{ duration: 150 }}>{message}</li>
-				{/each}
-			</ul>
+			<div class="grid">
+				{#key errorMessages.join('\x00')}
+					<ul
+						class={cn(
+							'col-start-1 row-start-1',
+							errorMessages.length > 1 ? 'ml-4 list-disc space-y-1' : 'list-none'
+						)}
+						in:fade={{ duration: 150, delay: 100 }}
+						out:fade={{ duration: 100 }}
+					>
+						{#each errorMessages as message (message)}
+							<li>{message}</li>
+						{/each}
+					</ul>
+				{/key}
+			</div>
 		{/if}
 	</div>
 {/if}

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -138,7 +138,6 @@
 		lastValidSignInSubmission = signInSubmissionToken;
 
 		isLoading = true;
-		formError = '';
 
 		try {
 			let failed = false;

--- a/src/routes/[[lang]]/(auth)/signup/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signup/+page.svelte
@@ -160,6 +160,7 @@
 						haptic.trigger('success');
 						clearLastSuccessfulAuthMethod();
 						clearPendingOAuthProvider();
+						formError = '';
 						verificationStep = { email: signUpData.email };
 					},
 					onError: (ctx) => {

--- a/src/routes/[[lang]]/(auth)/signup/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signup/+page.svelte
@@ -142,7 +142,6 @@
 		lastValidSignUpSubmission = signUpSubmissionToken;
 
 		isLoading = true;
-		formError = '';
 
 		try {
 			let failed = false;


### PR DESCRIPTION
Use CSS Grid stacking + fade transitions instead of per-item
slide transitions so old/new error messages overlap during
the crossover instead of collapsing then expanding.