### PR TITLE
fix(deploy): Use Convex preview deployments for CF Workers builds

### DIFF
--- a/.env-convex.schema
+++ b/.env-convex.schema
@@ -84,8 +84,8 @@ AUTH_E2E_TEST_SECRET=
 # Preview Dev (auto-seeded on preview deployments)
 # ====================================
 
-# Password for the auto-seeded preview admin (admin@preview.local)
-# Only set on preview Convex deployments by vercel-deploy.ts
+# Password for the auto-seeded preview admin (admin@preview.dev)
+# Only set on preview Convex deployments by deploy.ts
 # @optional @sensitive
 PREVIEW_ADMIN_PASSWORD=
 

--- a/.env.schema
+++ b/.env.schema
@@ -96,12 +96,17 @@ AUTH_E2E_TEST_SECRET=
 PUBLIC_SITE_URL=
 
 # ====================================
-# Vercel Build/Deploy
+# Build/Deploy
 # ====================================
 
-# Convex deploy key for automatic function deployment
+# Convex deploy key for production deployments
 # @sensitive @optional
 CONVEX_DEPLOY_KEY=
+
+# Convex preview deploy key for preview deployments
+# Generate from Convex dashboard > Preview Deploy Keys
+# @sensitive @optional
+CONVEX_PREVIEW_DEPLOY_KEY=
 
 # Preview bypass secret (maps to Vercel's VERCEL_AUTOMATION_BYPASS_SECRET in CI)
 # @sensitive @optional

--- a/.github/workflows/e2e-preview-cf.yml
+++ b/.github/workflows/e2e-preview-cf.yml
@@ -81,3 +81,14 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report/
+
+      - name: Report status to PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/statuses/${{ github.event.check_run.head_sha }} \
+            -f state=${{ job.status == 'success' && 'success' || 'failure' }} \
+            -f context="E2E Tests" \
+            -f description="E2E Tests (CF Preview)" \
+            -f target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,11 +1,11 @@
 /**
  * Platform-aware deployment script
  *
- * Supports Vercel, Cloudflare Pages, and unknown platforms.
+ * Supports Vercel, Cloudflare Workers/Pages, and unknown platforms.
  * Platform is auto-detected from environment variables.
  *
  * Handles:
- * - Platform detection (Vercel, Cloudflare Pages, unknown)
+ * - Platform detection (Vercel, Cloudflare Workers/Pages, unknown)
  * - Tolgee translation tagging and pulling (optional, skipped without TOLGEE_API_KEY)
  * - Convex environment variable validation (production and preview)
  * - Convex deployment
@@ -41,7 +41,7 @@ async function main(): Promise<void> {
 	}
 
 	// 3. Deploy Convex functions
-	const deployment = deployConvex();
+	const deployment = deployConvex(platform);
 
 	// 4. Preview: set SITE_URL, validate, seed admin
 	if (platform.isPreview) {

--- a/scripts/deploy/steps.ts
+++ b/scripts/deploy/steps.ts
@@ -85,12 +85,13 @@ export function validateConvexEnv(platform: PlatformContext, deployment?: Convex
  */
 export function deployConvex(platform: PlatformContext): ConvexDeployment {
 	const args = ['convex', 'deploy'];
-	const env: Record<string, string | undefined> = { ...process.env };
 
 	if (platform.isPreview) {
 		const previewKey = process.env.CONVEX_PREVIEW_DEPLOY_KEY;
 		if (previewKey) {
-			env.CONVEX_DEPLOY_KEY = previewKey;
+			// Set on process.env so all subsequent Convex CLI commands
+			// (env set, run) in setupPreviewEnv() also use the preview key
+			process.env.CONVEX_DEPLOY_KEY = previewKey;
 			console.log('Using Convex preview deploy key');
 		}
 		// CF Workers Builds isn't in Convex's auto-detection list for --preview-create,
@@ -101,7 +102,7 @@ export function deployConvex(platform: PlatformContext): ConvexDeployment {
 	}
 
 	console.log('Deploying Convex functions...');
-	const result = runCommandCapture('bunx', args, env);
+	const result = runCommandCapture('bunx', args);
 
 	if (result.stdout) console.log(result.stdout);
 	if (result.stderr) console.error(result.stderr);

--- a/scripts/deploy/steps.ts
+++ b/scripts/deploy/steps.ts
@@ -80,11 +80,28 @@ export function validateConvexEnv(platform: PlatformContext, deployment?: Convex
 }
 
 /**
- * Deploy Convex functions and parse the deployment URL from output
+ * Deploy Convex functions and parse the deployment URL from output.
+ * For preview builds, swaps to a preview deploy key if CONVEX_PREVIEW_DEPLOY_KEY is set.
  */
-export function deployConvex(): ConvexDeployment {
+export function deployConvex(platform: PlatformContext): ConvexDeployment {
+	const args = ['convex', 'deploy'];
+	const env: Record<string, string | undefined> = { ...process.env };
+
+	if (platform.isPreview) {
+		const previewKey = process.env.CONVEX_PREVIEW_DEPLOY_KEY;
+		if (previewKey) {
+			env.CONVEX_DEPLOY_KEY = previewKey;
+			console.log('Using Convex preview deploy key');
+		}
+		// CF Workers Builds isn't in Convex's auto-detection list for --preview-create,
+		// so pass the branch name explicitly
+		if (platform.gitRef) {
+			args.push('--preview-create', platform.gitRef);
+		}
+	}
+
 	console.log('Deploying Convex functions...');
-	const result = runCommandCapture('bunx', ['convex', 'deploy']);
+	const result = runCommandCapture('bunx', args, env);
 
 	if (result.stdout) console.log(result.stdout);
 	if (result.stderr) console.error(result.stderr);
@@ -246,7 +263,7 @@ export async function setupPreviewEnv(
 
 			if (seedResult.success) {
 				console.log(`${colors.green}=== Preview Admin Seeded ===${colors.reset}`);
-				console.log(`  Email:    admin@preview.local`);
+				console.log(`  Email:    admin@preview.dev`);
 				console.log(`  Password: (set via PREVIEW_ADMIN_PASSWORD)`);
 				console.log(`${colors.green}============================${colors.reset}`);
 				if (seedResult.stdout) console.log(`  Result: ${seedResult.stdout}`);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,7 +14,7 @@ export type CoercedEnvSchema = {
   
   /**
    * **CONVEX_DEPLOYMENT** 🔐 _sensitive_  
-   * Deployment used by `bunx convex dev`  
+   * Local dev deployment identifier, auto-set by `bunx convex dev`  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   CONVEX_DEPLOYMENT?: string;
@@ -35,7 +35,7 @@ export type CoercedEnvSchema = {
   
   /**
    * **VITE_TOLGEE_API_URL**  
-   * Tolgee Cloud Configuration (https://app.tolgee.io)  
+   * Tolgee Cloud API URL  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M24%2021V9h-2v14h8v-2zm-4-6v-4c0-1.103-.897-2-2-2h-6v14h2v-6h1.48l2.335%206h2.145l-2.333-6H18c1.103%200%202-.897%202-2m-6-4h4v4h-4zM8%2023H4c-1.103%200-2-.897-2-2V9h2v12h4V9h2v12c0%201.103-.897%202-2%202%22%2F%3E%3C%2Fsvg%3E)   
    */
   VITE_TOLGEE_API_URL: string;
@@ -64,14 +64,14 @@ export type CoercedEnvSchema = {
   
   /**
    * **AUTUMN_PROD_SECRET_KEY** 🔐 _sensitive_  
-   * Autumn Billing  
+   * Autumn billing production secret key  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   AUTUMN_PROD_SECRET_KEY?: string;
   
   /**
    * **PUBLIC_POSTHOG_API_KEY**  
-   * PostHog Analytics (https://posthog.com)  
+   * PostHog project API key (client-safe)  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   PUBLIC_POSTHOG_API_KEY?: string;
@@ -113,10 +113,18 @@ export type CoercedEnvSchema = {
   
   /**
    * **CONVEX_DEPLOY_KEY** 🔐 _sensitive_  
-   * Convex deploy key for automatic function deployment  
+   * Convex deploy key for production deployments  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   CONVEX_DEPLOY_KEY?: string;
+  
+  /**
+   * **CONVEX_PREVIEW_DEPLOY_KEY** 🔐 _sensitive_  
+   * Convex preview deploy key for preview deployments  
+   * Generate from Convex dashboard > Preview Deploy Keys  
+   * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
+   */
+  CONVEX_PREVIEW_DEPLOY_KEY?: string;
   
   /**
    * **PREVIEW_BYPASS_SECRET** 🔐 _sensitive_  
@@ -232,7 +240,7 @@ export type CoercedEnvSchema = {
   
   /**
    * **RESEND_API_KEY** 🔐 _sensitive_  
-   * SvelteKit-side copies of Resend/Auth email vars (for email preview server routes)  
+   * Resend API key for local email preview sending  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   RESEND_API_KEY?: string;


### PR DESCRIPTION
## Summary
- CF Workers preview builds were deploying Convex to **production** instead of creating isolated preview deployments
- Deploy script now swaps to `CONVEX_PREVIEW_DEPLOY_KEY` for preview builds and passes `--preview-create` with the branch name
- Fixes `admin@preview.local` → `admin@preview.dev` in deploy logs and schema docs
- Updates stale `vercel-deploy.ts` references → `deploy.ts`

## Setup required
1. Generate a preview deploy key in Convex dashboard (or copy existing `vercel-preview-deploy-key` value)
2. Add `CONVEX_PREVIEW_DEPLOY_KEY` env var in CF Workers Builds settings

## Test plan
- [ ] CF Workers Build creates a Convex preview deployment (not production)
- [ ] E2E config shows preview-specific Convex URL
- [ ] Preview admin login works with `admin@preview.dev`
- [ ] E2E tests pass on the isolated preview backend