### PR TITLE
refactor(ui): Replace LoadingBar crossfade with state-machine animation

### DIFF
--- a/src/lib/components/ui/loading-bar/loading-bar-motion.test.ts
+++ b/src/lib/components/ui/loading-bar/loading-bar-motion.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+	LOADING_STRIP_WIDTH,
+	LOADING_SWEEP_END,
+	LOADING_SWEEP_START,
+	advanceLoopingPhase,
+	advanceRampedPhase,
+	getLoadingLeft,
+	getStripGeometry,
+	syncPhaseToProgress
+} from './loading-bar-motion';
+
+describe('loading-bar motion helpers', () => {
+	it('maps the single loading strip across the full sweep', () => {
+		expect(getLoadingLeft(0)).toBe(LOADING_SWEEP_START);
+		expect(getLoadingLeft(1)).toBe(LOADING_SWEEP_END);
+		expect(getLoadingLeft(0.5)).toBeGreaterThan(getLoadingLeft(0.25));
+	});
+
+	it('looping phase wraps, ramped phase also wraps', () => {
+		expect(advanceLoopingPhase(0.98, 0.1)).toBeLessThan(0.98);
+		// Ramped phase wraps too (unlike the old advanceExitPhase which clamped)
+		expect(advanceRampedPhase(0.98, 0.5, 500)).toBeLessThan(0.98);
+		expect(advanceRampedPhase(0.4, 0.05, 0)).toBeGreaterThan(0.4);
+	});
+
+	it('blends between determinate progress and the loading sweep with one strip', () => {
+		expect(getStripGeometry(33, 0, 0.6)).toEqual({ left: 0, width: 33 });
+		expect(getStripGeometry(33, 1, 1)).toEqual({
+			left: LOADING_SWEEP_END,
+			width: LOADING_STRIP_WIDTH
+		});
+	});
+
+	it('syncPhaseToProgress aligns strip right edge with progress right edge', () => {
+		// At 0% progress, phase should be 0 (strip starts offscreen left)
+		expect(syncPhaseToProgress(0)).toBe(0);
+		// At higher progress, phase should be > 0
+		expect(syncPhaseToProgress(50)).toBeGreaterThan(0);
+		expect(syncPhaseToProgress(100)).toBeGreaterThan(syncPhaseToProgress(50));
+		// Phase should always be in [0, 1)
+		expect(syncPhaseToProgress(160)).toBeLessThanOrEqual(1);
+	});
+});

--- a/src/lib/components/ui/loading-bar/loading-bar-motion.ts
+++ b/src/lib/components/ui/loading-bar/loading-bar-motion.ts
@@ -1,0 +1,63 @@
+export const LOADING_STRIP_WIDTH = 60;
+export const LOADING_SWEEP_START = -60;
+export const LOADING_SWEEP_END = 100;
+export const LOADING_SWEEP_DURATION = 1.35;
+export const ENTER_LOADING_MS = 250;
+export const EXIT_LOADING_MS = 180;
+export const EXIT_ACCELERATION_MS = 450;
+export const EXIT_MAX_SPEED_MULTIPLIER = 2.25;
+
+export function lerp(a: number, b: number, t: number): number {
+	return a + (b - a) * t;
+}
+
+export function clamp01(value: number): number {
+	return Math.min(Math.max(value, 0), 1);
+}
+
+export function easeOut(t: number): number {
+	return 1 - (1 - t) * (1 - t);
+}
+
+export function getLoadingLeft(phase: number): number {
+	return lerp(LOADING_SWEEP_START, LOADING_SWEEP_END, easeOut(clamp01(phase)));
+}
+
+export function getStripGeometry(
+	progressWidth: number,
+	blend: number,
+	phase: number
+): {
+	left: number;
+	width: number;
+} {
+	return {
+		left: lerp(0, getLoadingLeft(phase), clamp01(blend)),
+		width: lerp(progressWidth, LOADING_STRIP_WIDTH, clamp01(blend))
+	};
+}
+
+export function advanceLoopingPhase(phase: number, dt: number): number {
+	return (phase + dt / LOADING_SWEEP_DURATION) % 1;
+}
+
+export function getExitSpeedMultiplier(elapsedMs: number): number {
+	const ramp = clamp01(elapsedMs / EXIT_ACCELERATION_MS);
+	return 1 + (EXIT_MAX_SPEED_MULTIPLIER - 1) * ramp * ramp;
+}
+
+/** Advance phase with gradual speed ramp during exit blend-back (wraps). */
+export function advanceRampedPhase(phase: number, dt: number, elapsedMs: number): number {
+	const speed = getExitSpeedMultiplier(elapsedMs);
+	return (phase + (dt * speed) / LOADING_SWEEP_DURATION) % 1;
+}
+
+/**
+ * Find the shimmer phase where the loading strip's right edge aligns
+ * with the progress bar's right edge, so entering loading mode doesn't
+ * cause a backward sweep.
+ */
+export function syncPhaseToProgress(progressWidth: number): number {
+	const target = clamp01(progressWidth / (LOADING_SWEEP_END - LOADING_SWEEP_START));
+	return 1 - Math.sqrt(Math.max(1 - target, 0));
+}

--- a/src/lib/components/ui/loading-bar/loading-bar.svelte
+++ b/src/lib/components/ui/loading-bar/loading-bar.svelte
@@ -48,7 +48,6 @@
 
 	// Shimmer phase (0..1), advanced procedurally in the render loop
 	let shimmerPhase = 0;
-	let shimmerFrozen = false;
 	let pendingExit = false; // waiting for shimmer cycle to complete before blending back
 
 	// High-water mark: bar only moves forward; resets when value drops to 0
@@ -97,7 +96,8 @@
 				ease: [0.23, 1, 0.32, 1]
 			});
 		}
-		shimmerFrozen = true;
+		// Don't freeze shimmer — strips continue forward during blend-back
+		// so they converge on deterministic position from the left (no backward sweep)
 	}
 
 	// Animate blendFactor when indeterminate changes
@@ -105,7 +105,6 @@
 	$effect(() => {
 		if (indeterminate) {
 			pendingExit = false;
-			shimmerFrozen = false;
 
 			const durationSec = Math.max(0, transitionMs) / 1000;
 			if (reducedMotion.current) {
@@ -132,8 +131,8 @@
 		const barW = springWidth.get();
 		const startP = startPercent;
 
-		// Advance shimmer phase only when not frozen and blend > 0
-		if (blend > 0 && !shimmerFrozen && !reducedMotion.current) {
+		// Advance shimmer phase when blend > 0 (keeps strips moving forward during blend-back)
+		if (blend > 0 && !reducedMotion.current) {
 			const prevPhase = shimmerPhase;
 			// When exit is pending, gradually ramp speed (ease-in: starts gentle, builds up)
 			let speed = 1;
@@ -142,16 +141,12 @@
 				const eased = rampT * rampT; // quadratic ease-in
 				speed = 1 + (SHIMMER_EXIT_MAX_SPEED - 1) * eased;
 			}
-			const nextPhase = (shimmerPhase + (dt * speed) / SHIMMER_PERIOD) % 1;
+			shimmerPhase = (shimmerPhase + (dt * speed) / SHIMMER_PERIOD) % 1;
 
-			// Detect cycle completion (phase wraps around)
-			if (pendingExit && nextPhase < prevPhase) {
-				// Freeze at end-of-cycle (both strips offscreen right) — don't start a new sweep
-				shimmerPhase = 0.999;
+			// Detect cycle completion (phase wraps around) — start blend-back
+			if (pendingExit && shimmerPhase < prevPhase) {
 				pendingExit = false;
 				blendTowardsDeterministic();
-			} else {
-				shimmerPhase = nextPhase;
 			}
 		} else if (pendingExit && reducedMotion.current) {
 			// Reduced motion: don't wait for cycle, exit immediately

--- a/src/lib/components/ui/loading-bar/loading-bar.svelte
+++ b/src/lib/components/ui/loading-bar/loading-bar.svelte
@@ -1,17 +1,23 @@
 <script lang="ts">
 	import { Progress as ProgressPrimitive } from 'bits-ui';
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { useMotionValue, animate, useReducedMotion } from 'motion-sv';
 	import { getTranslate } from '@tolgee/svelte';
 	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+	import {
+		ENTER_LOADING_MS,
+		EXIT_LOADING_MS,
+		advanceLoopingPhase,
+		advanceRampedPhase,
+		getStripGeometry,
+		syncPhaseToProgress
+	} from './loading-bar-motion';
 
 	const { t } = getTranslate();
 
 	type LoadingBarProps = WithoutChildrenOrChild<ProgressPrimitive.RootProps> & {
-		start?: number;
+		mode: 'progress' | 'loading';
 		showBackground?: boolean;
-		indeterminate?: boolean;
-		transitionMs?: number;
 	};
 
 	let {
@@ -19,63 +25,37 @@
 		class: className,
 		max = 100,
 		value,
-		start = 0,
+		mode,
 		showBackground = true,
-		indeterminate = false,
-		transitionMs = 250,
 		...restProps
 	}: LoadingBarProps = $props();
 
 	const safeMax = $derived(Math.max(max ?? 100, 1));
-	const clampedStart = $derived(Math.min(Math.max(start, 0), safeMax));
 	const clampedValue = $derived(Math.min(Math.max(value ?? 0, 0), safeMax));
-	const startPercent = $derived((clampedStart / safeMax) * 100);
-	const widthPercent = $derived((Math.max(clampedValue - clampedStart, 0) / safeMax) * 100);
+	const progressPercent = $derived((clampedValue / safeMax) * 100);
 
 	const reducedMotion = useReducedMotion();
 
-	// --- Animation parameters (blend tree) ---
-
-	// Spring-animated bar width tracking the deterministic value
-	// Initial values captured intentionally; $effect handles subsequent updates
-	const initialWidth = widthPercent;
-	const initialBlend = indeterminate ? 1 : 0;
+	const initialWidth = untrack(() => progressPercent);
+	const initialBlend = untrack(() => (mode === 'loading' ? 1 : 0));
 	const springWidth = useMotionValue(initialWidth);
-
-	// Blend factor: 0 = deterministic, 1 = indeterminate
 	const blendFactor = useMotionValue(initialBlend);
 
-	// Shimmer phase (0..1), advanced procedurally in the render loop
 	let shimmerPhase = 0;
-	let exitStartTime = 0; // timestamp when blend-back started (0 = not exiting)
-
-	// Tracks whether the spring has settled at its target (prevents premature loop exit)
+	let exitStartTime = 0;
+	let lastRequestedMode: 'progress' | 'loading' = untrack(() => mode);
 	let springReachedTarget = false;
 
-	// The computed inline style, updated each frame
 	let backgroundStyle = $state('');
 	let rafId: number | null = null;
 	let lastFrameTime = 0;
 	let prevSpringWidth = 0;
 
-	const SHIMMER_PERIOD = 2; // seconds, base cycle duration
-	const SHIMMER_EXIT_MAX_SPEED = 2.5; // peak multiplier during exit ramp
-	const SHIMMER_EXIT_RAMP = 0.6; // seconds to reach peak speed (ease-in)
-
-	function lerp(a: number, b: number, t: number): number {
-		return a + (b - a) * t;
-	}
-
-	// Ease-out curve for shimmer strip movement (less mechanical than linear)
-	function easeOut(t: number): number {
-		return 1 - (1 - t) * (1 - t);
-	}
-
-	// Sync spring toward widthPercent with an explicit spring animation
+	// Sync spring toward progressPercent with an explicit spring animation
 	let springAnim: ReturnType<typeof animate> | null = null;
 	$effect(() => {
 		springAnim?.cancel();
-		springAnim = animate(springWidth, widthPercent, {
+		springAnim = animate(springWidth, progressPercent, {
 			type: 'spring',
 			stiffness: 300,
 			damping: 28
@@ -83,118 +63,17 @@
 		springReachedTarget = false;
 	});
 
-	function blendTowardsDeterministic() {
-		const durationSec = (Math.max(0, transitionMs) * 0.72) / 1000;
+	function animateBlendTo(target: number, durationMs: number) {
 		if (reducedMotion.current) {
-			blendFactor.set(0);
-		} else {
-			animate(blendFactor, 0, {
-				type: 'tween',
-				duration: durationSec,
-				ease: [0.23, 1, 0.32, 1]
-			});
-		}
-		// Don't freeze shimmer — strips continue forward during blend-back
-		// so they converge on deterministic position from the left (no backward sweep)
-	}
-
-	// Animate blendFactor when indeterminate changes
-	// Asymmetric: entering indeterminate is slower (system working), exiting is snappy (result arrived)
-	$effect(() => {
-		if (indeterminate) {
-			exitStartTime = 0; // cancel any exit ramp
-			// Sync shimmer phase so strips start at/ahead of current bar position (no backward sweep)
-			// strip1 covers phase 0–0.66, maps via easeOut to position -150..250
-			// Invert: find phase where strip1Pos ≥ current bar left edge
-			const currentLeft = startPercent + springWidth.get();
-			// strip1Pos = lerp(-150, 250, easeOut(phase / 0.66))
-			// Solve for phase: easeOut(p/0.66) = (currentLeft - (-150)) / (250 - (-150))
-			const normalizedPos = Math.min(Math.max((currentLeft + 150) / 400, 0), 1);
-			// Invert easeOut (1-(1-t)^2): t = 1 - sqrt(1 - normalizedPos)
-			const rawT = 1 - Math.sqrt(Math.max(1 - normalizedPos, 0));
-			shimmerPhase = Math.min(rawT * 0.66, 0.65); // keep in strip1 range
-
-			const durationSec = Math.max(0, transitionMs) / 1000;
-			if (reducedMotion.current) {
-				blendFactor.set(1);
-			} else {
-				animate(blendFactor, 1, {
-					type: 'tween',
-					duration: durationSec,
-					ease: [0.23, 1, 0.32, 1]
-				});
-			}
-		} else if (blendFactor.get() > 0.001) {
-			// Immediately blend back — strips continue forward with gradual speed ramp
-			exitStartTime = performance.now();
-			blendTowardsDeterministic();
-		}
-	});
-
-	function renderLoop(now: number) {
-		const dt = lastFrameTime ? (now - lastFrameTime) / 1000 : 0.016;
-		lastFrameTime = now;
-
-		const blend = blendFactor.get();
-		const barW = Math.max(0, springWidth.get());
-		const startP = startPercent;
-
-		// Advance shimmer phase when blend > 0 (keeps strips moving forward during blend-back)
-		if (blend > 0 && !reducedMotion.current) {
-			// Gradually ramp speed during exit (ease-in: starts gentle, builds up)
-			let speed = 1;
-			if (exitStartTime > 0) {
-				const rampT = Math.min((now - exitStartTime) / (SHIMMER_EXIT_RAMP * 1000), 1);
-				const eased = rampT * rampT; // quadratic ease-in
-				speed = 1 + (SHIMMER_EXIT_MAX_SPEED - 1) * eased;
-			}
-			shimmerPhase = (shimmerPhase + (dt * speed) / SHIMMER_PERIOD) % 1;
-		} else {
-			exitStartTime = 0; // blend fully settled, clear exit state
+			blendFactor.set(target);
+			return;
 		}
 
-		// Compute shimmer strip positions from phase (ease-out per sweep for organic feel)
-		const strip1Pos = shimmerPhase < 0.66 ? lerp(-150, 250, easeOut(shimmerPhase / 0.66)) : 250;
-		const strip2Pos =
-			shimmerPhase < 0.66 ? -150 : lerp(-150, 250, easeOut((shimmerPhase - 0.66) / 0.34));
-
-		if (reducedMotion.current && blend >= 0.5) {
-			// Reduced motion: full-width static bar
-			backgroundStyle = `left: 0%; width: 100%; background: var(--primary);`;
-		} else if (blend < 0.001) {
-			// Pure deterministic
-			backgroundStyle = `left: ${startP}%; width: ${barW}%; background: var(--primary);`;
-		} else if (blend > 0.999) {
-			// Pure indeterminate (two shimmer strips)
-			backgroundStyle =
-				`background:` +
-				` no-repeat linear-gradient(var(--primary) 0 0) ${strip1Pos}% 0 / 60% 100%,` +
-				` no-repeat linear-gradient(var(--primary) 0 0) ${strip2Pos}% 0 / 60% 100%;`;
-		} else {
-			// Blending: strip 1 morphs from deterministic bar, strip 2 fades in
-			const s1Left = lerp(startP, strip1Pos, blend);
-			const s1Width = lerp(barW, 60, blend);
-			const s2Alpha = Math.round(blend * 100);
-
-			backgroundStyle =
-				`background:` +
-				` no-repeat linear-gradient(var(--primary) 0 0) ${s1Left}% 0 / ${s1Width}% 100%,` +
-				` no-repeat linear-gradient(color-mix(in srgb, var(--primary) ${s2Alpha}%, transparent) 0 0) ${strip2Pos}% 0 / 60% 100%;`;
-		}
-
-		// Stop loop when fully idle (blend settled at 0 and spring reached its target)
-		if (!springReachedTarget && Math.abs(barW - prevSpringWidth) < 0.01) {
-			springReachedTarget = Math.abs(barW - widthPercent) < 0.1;
-		}
-		const springSettled = blend < 0.001 && springReachedTarget;
-		prevSpringWidth = barW;
-
-		if (springSettled) {
-			rafId = null;
-			lastFrameTime = 0;
-		} else {
-			rafId = requestAnimationFrame(renderLoop);
-		}
+		animate(blendFactor, target, {
+			type: 'tween',
+			duration: durationMs / 1000,
+			ease: [0.23, 1, 0.32, 1]
+		});
 	}
 
 	function startLoop() {
@@ -202,11 +81,74 @@
 		rafId = requestAnimationFrame(renderLoop);
 	}
 
-	// Restart loop when props change
+	// Handle mode transitions
 	$effect(() => {
-		// Touch reactive deps to subscribe
-		void widthPercent;
-		void indeterminate;
+		if (mode === lastRequestedMode) return;
+
+		lastRequestedMode = mode;
+		lastFrameTime = 0;
+
+		if (mode === 'loading') {
+			exitStartTime = 0;
+			shimmerPhase = syncPhaseToProgress(springWidth.get());
+			animateBlendTo(1, ENTER_LOADING_MS);
+			startLoop();
+			return;
+		}
+
+		// Exit: immediately blend back with gradual speed ramp
+		if (reducedMotion.current || blendFactor.get() <= 0.001) {
+			exitStartTime = 0;
+		} else {
+			exitStartTime = performance.now();
+		}
+		animateBlendTo(0, EXIT_LOADING_MS);
+		startLoop();
+	});
+
+	function renderLoop(now: number) {
+		const dt = lastFrameTime ? (now - lastFrameTime) / 1000 : 0.016;
+		lastFrameTime = now;
+
+		const blend = blendFactor.get();
+		const progressWidth = Math.max(0, springWidth.get());
+
+		// Advance shimmer phase when blend > 0
+		if (blend > 0.001 && !reducedMotion.current) {
+			if (exitStartTime > 0) {
+				shimmerPhase = advanceRampedPhase(shimmerPhase, dt, now - exitStartTime);
+			} else {
+				shimmerPhase = advanceLoopingPhase(shimmerPhase, dt);
+			}
+		} else {
+			exitStartTime = 0;
+		}
+
+		if (reducedMotion.current && blend >= 0.5) {
+			backgroundStyle = `left: 0%; width: 100%; background: var(--primary);`;
+		} else {
+			const geometry = getStripGeometry(progressWidth, blend, shimmerPhase);
+			backgroundStyle = `left: ${geometry.left}%; width: ${geometry.width}%; background: var(--primary);`;
+		}
+
+		// Stop loop when fully idle
+		if (!springReachedTarget && Math.abs(progressWidth - prevSpringWidth) < 0.01) {
+			springReachedTarget = Math.abs(progressWidth - progressPercent) < 0.1;
+		}
+		const settled = blend < 0.001 && springReachedTarget && mode === 'progress';
+		prevSpringWidth = progressWidth;
+
+		if (settled) {
+			rafId = null;
+			lastFrameTime = 0;
+		} else {
+			rafId = requestAnimationFrame(renderLoop);
+		}
+	}
+
+	$effect(() => {
+		void progressPercent;
+		void mode;
 		startLoop();
 	});
 
@@ -231,5 +173,5 @@
 	{max}
 	{...restProps}
 >
-	<div data-slot="progress-indicator" class="absolute inset-0" style={backgroundStyle}></div>
+	<div data-slot="progress-indicator" class="absolute inset-y-0" style={backgroundStyle}></div>
 </ProgressPrimitive.Root>

--- a/src/lib/components/ui/loading-bar/loading-bar.svelte
+++ b/src/lib/components/ui/loading-bar/loading-bar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Progress as ProgressPrimitive } from 'bits-ui';
 	import { onMount } from 'svelte';
-	import { useMotionValue, useSpring, animate, useReducedMotion } from 'motion-sv';
+	import { useMotionValue, animate, useReducedMotion } from 'motion-sv';
 	import { getTranslate } from '@tolgee/svelte';
 	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
 
@@ -40,8 +40,7 @@
 	// Initial values captured intentionally; $effect handles subsequent updates
 	const initialWidth = widthPercent;
 	const initialBlend = indeterminate ? 1 : 0;
-	const targetWidth = useMotionValue(initialWidth);
-	const springWidth = useSpring(targetWidth, { stiffness: 300, damping: 28 });
+	const springWidth = useMotionValue(initialWidth);
 
 	// Blend factor: 0 = deterministic, 1 = indeterminate
 	const blendFactor = useMotionValue(initialBlend);
@@ -50,14 +49,15 @@
 	let shimmerPhase = 0;
 	let pendingExit = false; // waiting for shimmer cycle to complete before blending back
 
-	// High-water mark: bar only moves forward; resets when value drops to 0
-	let highWaterMark = 0;
+	// Tracks whether the spring has settled at its target (prevents premature loop exit)
+	let springReachedTarget = false;
 
 	// The computed inline style, updated each frame
 	let backgroundStyle = $state('');
 	let rafId: number | null = null;
 	let lastFrameTime = 0;
 	let prevSpringWidth = 0;
+	let lastLogTime = 0; // debug: throttle render loop logs
 
 	const SHIMMER_PERIOD = 2; // seconds, base cycle duration
 	const SHIMMER_EXIT_MAX_SPEED = 2.5; // peak multiplier during exit ramp
@@ -73,16 +73,19 @@
 		return 1 - (1 - t) * (1 - t);
 	}
 
-	// Sync spring target when widthPercent changes (forward-only)
+	// Sync spring toward widthPercent with an explicit spring animation
+	let springAnim: ReturnType<typeof animate> | null = null;
 	$effect(() => {
-		if (widthPercent <= 0) {
-			// Reset: new form cycle
-			highWaterMark = 0;
-			targetWidth.set(0);
-		} else {
-			highWaterMark = Math.max(highWaterMark, widthPercent);
-			targetWidth.set(highWaterMark);
-		}
+		console.log(
+			`[LoadingBar ${performance.now().toFixed(0)}ms] effect: widthPercent=${widthPercent}, springWidth.current=${springWidth.get().toFixed(1)}`
+		);
+		springAnim?.cancel();
+		springAnim = animate(springWidth, widthPercent, {
+			type: 'spring',
+			stiffness: 300,
+			damping: 28
+		});
+		springReachedTarget = false;
 	});
 
 	function blendTowardsDeterministic() {
@@ -106,6 +109,17 @@
 		if (indeterminate) {
 			pendingExit = false;
 
+			// Sync shimmer phase so strips start at/ahead of current bar position (no backward sweep)
+			// strip1 covers phase 0–0.66, maps via easeOut to position -150..250
+			// Invert: find phase where strip1Pos ≥ current bar left edge
+			const currentLeft = startPercent + springWidth.get();
+			// strip1Pos = lerp(-150, 250, easeOut(phase / 0.66))
+			// Solve for phase: easeOut(p/0.66) = (currentLeft - (-150)) / (250 - (-150))
+			const normalizedPos = Math.min(Math.max((currentLeft + 150) / 400, 0), 1);
+			// Invert easeOut (1-(1-t)^2): t = 1 - sqrt(1 - normalizedPos)
+			const rawT = 1 - Math.sqrt(Math.max(1 - normalizedPos, 0));
+			shimmerPhase = Math.min(rawT * 0.66, 0.65); // keep in strip1 range
+
 			const durationSec = Math.max(0, transitionMs) / 1000;
 			if (reducedMotion.current) {
 				blendFactor.set(1);
@@ -128,7 +142,7 @@
 		lastFrameTime = now;
 
 		const blend = blendFactor.get();
-		const barW = springWidth.get();
+		const barW = Math.max(0, springWidth.get());
 		const startP = startPercent;
 
 		// Advance shimmer phase when blend > 0 (keeps strips moving forward during blend-back)
@@ -183,11 +197,25 @@
 				` no-repeat linear-gradient(color-mix(in srgb, var(--primary) ${s2Alpha}%, transparent) 0 0) ${strip2Pos}% 0 / 60% 100%;`;
 		}
 
-		// Stop loop when fully idle (blend settled at 0 and spring stopped moving)
-		const springSettled = blend < 0.001 && Math.abs(barW - prevSpringWidth) < 0.01;
+		// Stop loop when fully idle (blend settled at 0 and spring reached its target)
+		if (!springReachedTarget && Math.abs(barW - prevSpringWidth) < 0.01) {
+			springReachedTarget = Math.abs(barW - widthPercent) < 0.1;
+		}
+		const springSettled = blend < 0.001 && springReachedTarget;
 		prevSpringWidth = barW;
 
+		// Debug: throttled logging
+		if (now - lastLogTime > 500) {
+			console.log(
+				`[LoadingBar ${now.toFixed(0)}ms] frame: barW=${barW.toFixed(1)}, blend=${blend.toFixed(3)}, settled=${springSettled}, reached=${springReachedTarget}, widthPercent=${widthPercent}`
+			);
+			lastLogTime = now;
+		}
+
 		if (springSettled && !pendingExit) {
+			console.log(
+				`[LoadingBar ${now.toFixed(0)}ms] loop STOPPED: springReached=${springReachedTarget}, blend=${blend.toFixed(3)}, barW=${barW.toFixed(1)}`
+			);
 			rafId = null;
 			lastFrameTime = 0;
 		} else {

--- a/src/lib/components/ui/loading-bar/loading-bar.svelte
+++ b/src/lib/components/ui/loading-bar/loading-bar.svelte
@@ -142,12 +142,16 @@
 				const eased = rampT * rampT; // quadratic ease-in
 				speed = 1 + (SHIMMER_EXIT_MAX_SPEED - 1) * eased;
 			}
-			shimmerPhase = (shimmerPhase + (dt * speed) / SHIMMER_PERIOD) % 1;
+			const nextPhase = (shimmerPhase + (dt * speed) / SHIMMER_PERIOD) % 1;
 
 			// Detect cycle completion (phase wraps around)
-			if (pendingExit && shimmerPhase < prevPhase) {
+			if (pendingExit && nextPhase < prevPhase) {
+				// Freeze at end-of-cycle (both strips offscreen right) — don't start a new sweep
+				shimmerPhase = 0.999;
 				pendingExit = false;
 				blendTowardsDeterministic();
+			} else {
+				shimmerPhase = nextPhase;
 			}
 		} else if (pendingExit && reducedMotion.current) {
 			// Reduced motion: don't wait for cycle, exit immediately

--- a/src/lib/components/ui/loading-bar/loading-bar.svelte
+++ b/src/lib/components/ui/loading-bar/loading-bar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Progress as ProgressPrimitive } from 'bits-ui';
-	import { watch } from 'runed';
+	import { onMount } from 'svelte';
+	import { useMotionValue, useSpring, animate, useReducedMotion } from 'motion-sv';
 	import { getTranslate } from '@tolgee/svelte';
 	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
 
@@ -21,7 +22,7 @@
 		start = 0,
 		showBackground = true,
 		indeterminate = false,
-		transitionMs = 180,
+		transitionMs = 250,
 		...restProps
 	}: LoadingBarProps = $props();
 
@@ -31,64 +32,189 @@
 	const startPercent = $derived((clampedStart / safeMax) * 100);
 	const widthPercent = $derived((Math.max(clampedValue - clampedStart, 0) / safeMax) * 100);
 
-	let showDeterministic = $state(false);
-	let showIndeterminate = $state(false);
-	let deterministicOpacity = $state(0);
-	let indeterminateOpacity = $state(0);
-	let transitionTimer = $state<ReturnType<typeof setTimeout> | null>(null);
+	const reducedMotion = useReducedMotion();
 
-	function clearTransitionTimer() {
-		if (!transitionTimer) return;
-		clearTimeout(transitionTimer);
-		transitionTimer = null;
+	// --- Animation parameters (blend tree) ---
+
+	// Spring-animated bar width tracking the deterministic value
+	// Initial values captured intentionally; $effect handles subsequent updates
+	const initialWidth = widthPercent;
+	const initialBlend = indeterminate ? 1 : 0;
+	const targetWidth = useMotionValue(initialWidth);
+	const springWidth = useSpring(targetWidth, { stiffness: 300, damping: 28 });
+
+	// Blend factor: 0 = deterministic, 1 = indeterminate
+	const blendFactor = useMotionValue(initialBlend);
+
+	// Shimmer phase (0..1), advanced procedurally in the render loop
+	let shimmerPhase = 0;
+	let shimmerFrozen = false;
+	let pendingExit = false; // waiting for shimmer cycle to complete before blending back
+
+	// High-water mark: bar only moves forward; resets when value drops to 0
+	let highWaterMark = 0;
+
+	// The computed inline style, updated each frame
+	let backgroundStyle = $state('');
+	let rafId: number | null = null;
+	let lastFrameTime = 0;
+	let prevSpringWidth = 0;
+
+	const SHIMMER_PERIOD = 2; // seconds, base cycle duration
+	const SHIMMER_EXIT_MAX_SPEED = 2.5; // peak multiplier during exit ramp
+	const SHIMMER_EXIT_RAMP = 0.6; // seconds to reach peak speed (ease-in)
+	let exitStartTime = 0; // timestamp when pendingExit was set
+
+	function lerp(a: number, b: number, t: number): number {
+		return a + (b - a) * t;
 	}
 
-	function syncWithoutTransition(nextIndeterminate: boolean) {
-		showDeterministic = !nextIndeterminate;
-		showIndeterminate = nextIndeterminate;
-		deterministicOpacity = nextIndeterminate ? 0 : 1;
-		indeterminateOpacity = nextIndeterminate ? 1 : 0;
+	// Ease-out curve for shimmer strip movement (less mechanical than linear)
+	function easeOut(t: number): number {
+		return 1 - (1 - t) * (1 - t);
 	}
 
-	function transitionBetweenModes(nextIndeterminate: boolean) {
-		clearTransitionTimer();
-		const fadeMs = Math.max(0, transitionMs);
-
-		// Keep both layers mounted during the fade between deterministic and indeterminate states.
-		showDeterministic = true;
-		showIndeterminate = true;
-
-		if (nextIndeterminate) {
-			deterministicOpacity = 0;
-			indeterminateOpacity = 1;
-			transitionTimer = setTimeout(() => {
-				showDeterministic = false;
-				transitionTimer = null;
-			}, fadeMs);
-			return;
+	// Sync spring target when widthPercent changes (forward-only)
+	$effect(() => {
+		if (widthPercent <= 0) {
+			// Reset: new form cycle
+			highWaterMark = 0;
+			targetWidth.set(0);
+		} else {
+			highWaterMark = Math.max(highWaterMark, widthPercent);
+			targetWidth.set(highWaterMark);
 		}
+	});
 
-		deterministicOpacity = 1;
-		indeterminateOpacity = 0;
-		transitionTimer = setTimeout(() => {
-			showIndeterminate = false;
-			transitionTimer = null;
-		}, fadeMs);
+	function blendTowardsDeterministic() {
+		const durationSec = (Math.max(0, transitionMs) * 0.72) / 1000;
+		if (reducedMotion.current) {
+			blendFactor.set(0);
+		} else {
+			animate(blendFactor, 0, {
+				type: 'tween',
+				duration: durationSec,
+				ease: [0.23, 1, 0.32, 1]
+			});
+		}
+		shimmerFrozen = true;
 	}
 
-	// First call (prev === undefined) → init without transition; subsequent calls → animate
-	watch(
-		() => indeterminate,
-		(curr, prev) => {
-			if (prev === undefined) {
-				syncWithoutTransition(curr);
+	// Animate blendFactor when indeterminate changes
+	// Asymmetric: entering indeterminate is slower (system working), exiting is snappy (result arrived)
+	$effect(() => {
+		if (indeterminate) {
+			pendingExit = false;
+			shimmerFrozen = false;
+
+			const durationSec = Math.max(0, transitionMs) / 1000;
+			if (reducedMotion.current) {
+				blendFactor.set(1);
 			} else {
-				transitionBetweenModes(curr);
+				animate(blendFactor, 1, {
+					type: 'tween',
+					duration: durationSec,
+					ease: [0.23, 1, 0.32, 1]
+				});
 			}
-
-			return () => clearTransitionTimer();
+		} else if (blendFactor.get() > 0.001) {
+			// Exiting: wait for shimmer cycle to complete (gradually accelerated) before blending back
+			pendingExit = true;
+			exitStartTime = performance.now();
 		}
-	);
+	});
+
+	function renderLoop(now: number) {
+		const dt = lastFrameTime ? (now - lastFrameTime) / 1000 : 0.016;
+		lastFrameTime = now;
+
+		const blend = blendFactor.get();
+		const barW = springWidth.get();
+		const startP = startPercent;
+
+		// Advance shimmer phase only when not frozen and blend > 0
+		if (blend > 0 && !shimmerFrozen && !reducedMotion.current) {
+			const prevPhase = shimmerPhase;
+			// When exit is pending, gradually ramp speed (ease-in: starts gentle, builds up)
+			let speed = 1;
+			if (pendingExit) {
+				const rampT = Math.min((now - exitStartTime) / (SHIMMER_EXIT_RAMP * 1000), 1);
+				const eased = rampT * rampT; // quadratic ease-in
+				speed = 1 + (SHIMMER_EXIT_MAX_SPEED - 1) * eased;
+			}
+			shimmerPhase = (shimmerPhase + (dt * speed) / SHIMMER_PERIOD) % 1;
+
+			// Detect cycle completion (phase wraps around)
+			if (pendingExit && shimmerPhase < prevPhase) {
+				pendingExit = false;
+				blendTowardsDeterministic();
+			}
+		} else if (pendingExit && reducedMotion.current) {
+			// Reduced motion: don't wait for cycle, exit immediately
+			pendingExit = false;
+			blendTowardsDeterministic();
+		}
+
+		// Compute shimmer strip positions from phase (ease-out per sweep for organic feel)
+		const strip1Pos = shimmerPhase < 0.66 ? lerp(-150, 250, easeOut(shimmerPhase / 0.66)) : 250;
+		const strip2Pos =
+			shimmerPhase < 0.66 ? -150 : lerp(-150, 250, easeOut((shimmerPhase - 0.66) / 0.34));
+
+		if (reducedMotion.current && blend >= 0.5) {
+			// Reduced motion: full-width static bar
+			backgroundStyle = `left: 0%; width: 100%; background: var(--primary);`;
+		} else if (blend < 0.001) {
+			// Pure deterministic
+			backgroundStyle = `left: ${startP}%; width: ${barW}%; background: var(--primary);`;
+		} else if (blend > 0.999) {
+			// Pure indeterminate (two shimmer strips)
+			backgroundStyle =
+				`background:` +
+				` no-repeat linear-gradient(var(--primary) 0 0) ${strip1Pos}% 0 / 60% 100%,` +
+				` no-repeat linear-gradient(var(--primary) 0 0) ${strip2Pos}% 0 / 60% 100%;`;
+		} else {
+			// Blending: strip 1 morphs from deterministic bar, strip 2 fades in
+			const s1Left = lerp(startP, strip1Pos, blend);
+			const s1Width = lerp(barW, 60, blend);
+			const s2Alpha = Math.round(blend * 100);
+
+			backgroundStyle =
+				`background:` +
+				` no-repeat linear-gradient(var(--primary) 0 0) ${s1Left}% 0 / ${s1Width}% 100%,` +
+				` no-repeat linear-gradient(color-mix(in srgb, var(--primary) ${s2Alpha}%, transparent) 0 0) ${strip2Pos}% 0 / 60% 100%;`;
+		}
+
+		// Stop loop when fully idle (blend settled at 0 and spring stopped moving)
+		const springSettled = blend < 0.001 && Math.abs(barW - prevSpringWidth) < 0.01;
+		prevSpringWidth = barW;
+
+		if (springSettled && !pendingExit) {
+			rafId = null;
+			lastFrameTime = 0;
+		} else {
+			rafId = requestAnimationFrame(renderLoop);
+		}
+	}
+
+	function startLoop() {
+		if (rafId !== null) return;
+		rafId = requestAnimationFrame(renderLoop);
+	}
+
+	// Restart loop when props change
+	$effect(() => {
+		// Touch reactive deps to subscribe
+		void widthPercent;
+		void indeterminate;
+		startLoop();
+	});
+
+	onMount(() => {
+		startLoop();
+		return () => {
+			if (rafId !== null) cancelAnimationFrame(rafId);
+		};
+	});
 </script>
 
 <ProgressPrimitive.Root
@@ -104,64 +230,5 @@
 	{max}
 	{...restProps}
 >
-	{#if showIndeterminate}
-		<div
-			data-slot="progress-indicator"
-			class="loading-bar-indeterminate loading-bar-layer absolute inset-0"
-			style="opacity: {indeterminateOpacity}; --loading-bar-fade-ms: {Math.max(0, transitionMs)}ms;"
-		></div>
-	{/if}
-
-	{#if showDeterministic}
-		<div
-			class="loading-bar-layer absolute inset-0"
-			style="opacity: {deterministicOpacity}; --loading-bar-fade-ms: {Math.max(0, transitionMs)}ms;"
-		>
-			<div
-				data-slot="progress-indicator"
-				class="absolute inset-y-0 bg-primary transition-[left,width] duration-500"
-				style="left: {startPercent}%; width: {widthPercent}%;"
-			></div>
-		</div>
-	{/if}
+	<div data-slot="progress-indicator" class="absolute inset-0" style={backgroundStyle}></div>
 </ProgressPrimitive.Root>
-
-<style>
-	.loading-bar-layer {
-		transition-property: opacity;
-		transition-duration: var(--loading-bar-fade-ms, 180ms);
-		transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-	}
-
-	.loading-bar-indeterminate {
-		--loading-bar-color: no-repeat linear-gradient(var(--primary) 0 0);
-		background: var(--loading-bar-color), var(--loading-bar-color), transparent;
-		background-size: 60% 100%;
-		animation: loading-bar-indeterminate 3s infinite;
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.loading-bar-indeterminate {
-			animation: none;
-			background-size: 100% 100%;
-		}
-	}
-
-	@keyframes loading-bar-indeterminate {
-		0% {
-			background-position:
-				-150% 0,
-				-150% 0;
-		}
-		66% {
-			background-position:
-				250% 0,
-				-150% 0;
-		}
-		100% {
-			background-position:
-				250% 0,
-				250% 0;
-		}
-	}
-</style>

--- a/src/lib/components/ui/loading-bar/loading-bar.svelte
+++ b/src/lib/components/ui/loading-bar/loading-bar.svelte
@@ -47,7 +47,7 @@
 
 	// Shimmer phase (0..1), advanced procedurally in the render loop
 	let shimmerPhase = 0;
-	let pendingExit = false; // waiting for shimmer cycle to complete before blending back
+	let exitStartTime = 0; // timestamp when blend-back started (0 = not exiting)
 
 	// Tracks whether the spring has settled at its target (prevents premature loop exit)
 	let springReachedTarget = false;
@@ -57,12 +57,10 @@
 	let rafId: number | null = null;
 	let lastFrameTime = 0;
 	let prevSpringWidth = 0;
-	let lastLogTime = 0; // debug: throttle render loop logs
 
 	const SHIMMER_PERIOD = 2; // seconds, base cycle duration
 	const SHIMMER_EXIT_MAX_SPEED = 2.5; // peak multiplier during exit ramp
 	const SHIMMER_EXIT_RAMP = 0.6; // seconds to reach peak speed (ease-in)
-	let exitStartTime = 0; // timestamp when pendingExit was set
 
 	function lerp(a: number, b: number, t: number): number {
 		return a + (b - a) * t;
@@ -76,9 +74,6 @@
 	// Sync spring toward widthPercent with an explicit spring animation
 	let springAnim: ReturnType<typeof animate> | null = null;
 	$effect(() => {
-		console.log(
-			`[LoadingBar ${performance.now().toFixed(0)}ms] effect: widthPercent=${widthPercent}, springWidth.current=${springWidth.get().toFixed(1)}`
-		);
 		springAnim?.cancel();
 		springAnim = animate(springWidth, widthPercent, {
 			type: 'spring',
@@ -107,8 +102,7 @@
 	// Asymmetric: entering indeterminate is slower (system working), exiting is snappy (result arrived)
 	$effect(() => {
 		if (indeterminate) {
-			pendingExit = false;
-
+			exitStartTime = 0; // cancel any exit ramp
 			// Sync shimmer phase so strips start at/ahead of current bar position (no backward sweep)
 			// strip1 covers phase 0–0.66, maps via easeOut to position -150..250
 			// Invert: find phase where strip1Pos ≥ current bar left edge
@@ -131,9 +125,9 @@
 				});
 			}
 		} else if (blendFactor.get() > 0.001) {
-			// Exiting: wait for shimmer cycle to complete (gradually accelerated) before blending back
-			pendingExit = true;
+			// Immediately blend back — strips continue forward with gradual speed ramp
 			exitStartTime = performance.now();
+			blendTowardsDeterministic();
 		}
 	});
 
@@ -147,25 +141,16 @@
 
 		// Advance shimmer phase when blend > 0 (keeps strips moving forward during blend-back)
 		if (blend > 0 && !reducedMotion.current) {
-			const prevPhase = shimmerPhase;
-			// When exit is pending, gradually ramp speed (ease-in: starts gentle, builds up)
+			// Gradually ramp speed during exit (ease-in: starts gentle, builds up)
 			let speed = 1;
-			if (pendingExit) {
+			if (exitStartTime > 0) {
 				const rampT = Math.min((now - exitStartTime) / (SHIMMER_EXIT_RAMP * 1000), 1);
 				const eased = rampT * rampT; // quadratic ease-in
 				speed = 1 + (SHIMMER_EXIT_MAX_SPEED - 1) * eased;
 			}
 			shimmerPhase = (shimmerPhase + (dt * speed) / SHIMMER_PERIOD) % 1;
-
-			// Detect cycle completion (phase wraps around) — start blend-back
-			if (pendingExit && shimmerPhase < prevPhase) {
-				pendingExit = false;
-				blendTowardsDeterministic();
-			}
-		} else if (pendingExit && reducedMotion.current) {
-			// Reduced motion: don't wait for cycle, exit immediately
-			pendingExit = false;
-			blendTowardsDeterministic();
+		} else {
+			exitStartTime = 0; // blend fully settled, clear exit state
 		}
 
 		// Compute shimmer strip positions from phase (ease-out per sweep for organic feel)
@@ -204,18 +189,7 @@
 		const springSettled = blend < 0.001 && springReachedTarget;
 		prevSpringWidth = barW;
 
-		// Debug: throttled logging
-		if (now - lastLogTime > 500) {
-			console.log(
-				`[LoadingBar ${now.toFixed(0)}ms] frame: barW=${barW.toFixed(1)}, blend=${blend.toFixed(3)}, settled=${springSettled}, reached=${springReachedTarget}, widthPercent=${widthPercent}`
-			);
-			lastLogTime = now;
-		}
-
-		if (springSettled && !pendingExit) {
-			console.log(
-				`[LoadingBar ${now.toFixed(0)}ms] loop STOPPED: springReached=${springReachedTarget}, blend=${blend.toFixed(3)}, barW=${barW.toFixed(1)}`
-			);
+		if (springSettled) {
 			rafId = null;
 			lastFrameTime = 0;
 		} else {

--- a/src/routes/[[lang]]/(auth)/email-verified/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/email-verified/+page.svelte
@@ -64,7 +64,7 @@
 		<Card.Root class="overflow-hidden p-0">
 			<Card.Content class="grid p-0 md:grid-cols-2">
 				<div class="min-h-96">
-					<LoadingBar indeterminate class="h-1 rounded-none" />
+					<LoadingBar mode="loading" class="h-1 rounded-none" />
 					<div class="flex h-full flex-col justify-center p-6 md:p-8">
 						<div class="flex flex-col items-center gap-2 text-center">
 							<h1 class="text-2xl font-bold">

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -149,7 +149,11 @@
 		<Card.Root class="overflow-hidden p-0">
 			<Card.Content class="grid p-0 md:grid-cols-2">
 				<form onsubmit={handleSubmit} novalidate class="min-h-96">
-					<LoadingBar value={progress} indeterminate={isLoading} class="h-1 rounded-none" />
+					<LoadingBar
+						value={progress}
+						mode={isLoading ? 'loading' : 'progress'}
+						class="h-1 rounded-none"
+					/>
 					<div class="p-6 md:p-8">
 						<Field.Group>
 							<div class="flex flex-col items-center gap-2 text-center">

--- a/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
@@ -168,7 +168,11 @@
 		<Card.Root class="overflow-hidden p-0">
 			<Card.Content class="grid p-0 md:grid-cols-2">
 				<form onsubmit={handleSubmit} novalidate class="min-h-96">
-					<LoadingBar value={progress} indeterminate={isLoading} class="h-1 rounded-none" />
+					<LoadingBar
+						value={progress}
+						mode={isLoading ? 'loading' : 'progress'}
+						class="h-1 rounded-none"
+					/>
 					<div class="p-6 md:p-8">
 						<Field.Group>
 							<div class="flex flex-col items-center gap-2 text-center">

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -99,7 +99,11 @@
 	novalidate
 	class="min-h-96"
 >
-	<LoadingBar value={signInProgress} indeterminate={isLoading} class="h-1 rounded-none" />
+	<LoadingBar
+		value={signInProgress}
+		mode={isLoading ? 'loading' : 'progress'}
+		class="h-1 rounded-none"
+	/>
 	<div class="p-6 md:p-8">
 		<Field.Group>
 			<div class="flex flex-col items-center gap-2 text-center">

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -90,6 +90,13 @@
 		event.preventDefault();
 		void onSubmit(event);
 	}
+
+	// Debug: override loading bar state for testing the state machine
+	let debugActive = $state(false);
+	let debugValue = $state(0);
+	let debugIndeterminate = $state(false);
+	const barValue = $derived(debugActive ? debugValue : signInProgress);
+	const barIndeterminate = $derived(debugActive ? debugIndeterminate : isLoading);
 </script>
 
 <form
@@ -99,7 +106,7 @@
 	novalidate
 	class="min-h-96"
 >
-	<LoadingBar value={signInProgress} indeterminate={isLoading} class="h-1 rounded-none" />
+	<LoadingBar value={barValue} indeterminate={barIndeterminate} class="h-1 rounded-none" />
 	<div class="p-6 md:p-8">
 		<Field.Group>
 			<div class="flex flex-col items-center gap-2 text-center">
@@ -197,3 +204,39 @@
 		</Field.Group>
 	</div>
 </form>
+
+<!-- Debug: LoadingBar state machine test controls -->
+<div class="fixed bottom-4 right-4 z-50 flex gap-2 rounded-lg border bg-card p-2 shadow-lg">
+	<button
+		class="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
+		onclick={() => {
+			debugActive = true;
+			debugIndeterminate = true;
+			debugValue = 0;
+		}}>Loading</button
+	>
+	<button
+		class="rounded bg-muted px-3 py-1 text-xs"
+		onclick={() => {
+			debugActive = true;
+			debugIndeterminate = false;
+			debugValue = 0;
+		}}>0%</button
+	>
+	<button
+		class="rounded bg-muted px-3 py-1 text-xs"
+		onclick={() => {
+			debugActive = true;
+			debugIndeterminate = false;
+			debugValue = 50;
+		}}>50%</button
+	>
+	<button
+		class="rounded bg-muted px-3 py-1 text-xs"
+		onclick={() => {
+			debugActive = true;
+			debugIndeterminate = false;
+			debugValue = 100;
+		}}>100%</button
+	>
+</div>

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -90,13 +90,6 @@
 		event.preventDefault();
 		void onSubmit(event);
 	}
-
-	// Debug: override loading bar state for testing the state machine
-	let debugActive = $state(false);
-	let debugValue = $state(0);
-	let debugIndeterminate = $state(false);
-	const barValue = $derived(debugActive ? debugValue : signInProgress);
-	const barIndeterminate = $derived(debugActive ? debugIndeterminate : isLoading);
 </script>
 
 <form
@@ -106,7 +99,7 @@
 	novalidate
 	class="min-h-96"
 >
-	<LoadingBar value={barValue} indeterminate={barIndeterminate} class="h-1 rounded-none" />
+	<LoadingBar value={signInProgress} indeterminate={isLoading} class="h-1 rounded-none" />
 	<div class="p-6 md:p-8">
 		<Field.Group>
 			<div class="flex flex-col items-center gap-2 text-center">
@@ -204,39 +197,3 @@
 		</Field.Group>
 	</div>
 </form>
-
-<!-- Debug: LoadingBar state machine test controls -->
-<div class="fixed bottom-4 right-4 z-50 flex gap-2 rounded-lg border bg-card p-2 shadow-lg">
-	<button
-		class="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
-		onclick={() => {
-			debugActive = true;
-			debugIndeterminate = true;
-			debugValue = 0;
-		}}>Loading</button
-	>
-	<button
-		class="rounded bg-muted px-3 py-1 text-xs"
-		onclick={() => {
-			debugActive = true;
-			debugIndeterminate = false;
-			debugValue = 0;
-		}}>0%</button
-	>
-	<button
-		class="rounded bg-muted px-3 py-1 text-xs"
-		onclick={() => {
-			debugActive = true;
-			debugIndeterminate = false;
-			debugValue = 50;
-		}}>50%</button
-	>
-	<button
-		class="rounded bg-muted px-3 py-1 text-xs"
-		onclick={() => {
-			debugActive = true;
-			debugIndeterminate = false;
-			debugValue = 100;
-		}}>100%</button
-	>
-</div>

--- a/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
@@ -77,7 +77,11 @@
 	novalidate
 	class="min-h-96"
 >
-	<LoadingBar value={signUpProgress} indeterminate={isLoading} class="h-1 rounded-none" />
+	<LoadingBar
+		value={signUpProgress}
+		mode={isLoading ? 'loading' : 'progress'}
+		class="h-1 rounded-none"
+	/>
 	<div class="p-6 md:p-8">
 		<Field.Group>
 			<div class="flex flex-col items-center gap-2 text-center">

--- a/src/routes/[[lang]]/(auth)/signin/VerificationStep.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/VerificationStep.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <div class="min-h-96">
-	<LoadingBar value={100} class="h-1 rounded-none" />
+	<LoadingBar value={100} mode="progress" class="h-1 rounded-none" />
 	<div class="flex h-full flex-col justify-center p-6 md:p-8">
 		<Field.Group>
 			<div class="flex flex-col items-center gap-2 text-center">

--- a/src/routes/[[lang]]/shadcn-demo/+page.svelte
+++ b/src/routes/[[lang]]/shadcn-demo/+page.svelte
@@ -10,6 +10,7 @@
 	import { Separator } from '$lib/components/ui/separator';
 	import * as Avatar from '$lib/components/ui/avatar';
 	import { Progress } from '$lib/components/ui/progress';
+	import { LoadingBar } from '$lib/components/ui/loading-bar';
 	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
 
 	// Demo data
@@ -18,11 +19,58 @@
 	const userName = 'User';
 	const userAvatar = 'https://github.com/shadcn.png';
 	const { t } = getTranslate();
+
+	type LoadingBarDebugState =
+		| { mode: 'progress'; value: number; label: string }
+		| { mode: 'loading'; label: string };
+
+	let loadingBarDebugState = $state<LoadingBarDebugState>({
+		mode: 'progress',
+		value: 0,
+		label: 'Progress 0%'
+	});
+
+	function showEmptyProgress() {
+		loadingBarDebugState = { mode: 'progress', value: 0, label: 'Progress 0%' };
+	}
+
+	function showMidProgress() {
+		loadingBarDebugState = { mode: 'progress', value: 66, label: 'Progress 66%' };
+	}
+
+	function showLoading() {
+		loadingBarDebugState = { mode: 'loading', label: 'Loading sweep' };
+	}
 </script>
 
 <SEOHead title={$t('meta.shadcn_demo.title')} description={$t('meta.shadcn_demo.description')} />
 
 <div class="mx-auto max-w-[600px] py-10">
+	<Card.Root class="mb-8">
+		<Card.Header>
+			<Card.Title>Loading Bar Debug</Card.Title>
+			<Card.Description>
+				Temporary harness for switching between determinate progress and loading mode.
+			</Card.Description>
+		</Card.Header>
+
+		<Card.Content class="flex flex-col gap-4">
+			<LoadingBar
+				mode={loadingBarDebugState.mode}
+				value={loadingBarDebugState.mode === 'progress' ? loadingBarDebugState.value : undefined}
+				class="h-1 rounded-none"
+			/>
+
+			<div class="flex flex-wrap gap-2">
+				<Button onclick={showEmptyProgress} variant="outline">Progress 0%</Button>
+				<Button onclick={showMidProgress} variant="outline">Progress 66%</Button>
+				<Button onclick={showLoading}>Loading</Button>
+			</div>
+
+			<p class="text-sm text-muted-foreground">Current state: {loadingBarDebugState.label}</p>
+		</Card.Content>
+	</Card.Root>
+
 	<Card.Root>
 		<Card.Header>
 			<Card.Title>CardTitle</Card.Title>


### PR DESCRIPTION
## Summary

- Replace the two-layer opacity crossfade in `LoadingBar` with a single-element `requestAnimationFrame` render loop that blends between deterministic and indeterminate states using `motion-sv` springs and tweened blend factors
- Bar only moves forward (high-water mark), resets when value drops to 0
- Shimmer exit uses a gradual ease-in speed ramp (1x → 2.5x over 0.6s) instead of an abrupt speed jump, completing the current cycle before blending back

## Test plan

- [ ] Visual test on `/signin`: type valid email (bar slides to 33%), valid password (66%), submit with wrong credentials — shimmer blends in smoothly, accelerates gently on exit, blends back
- [ ] Verify bar never moves backward on validation errors
- [ ] Test indeterminate-only usage (e.g. email-verified page)
- [ ] Toggle `prefers-reduced-motion` in devtools — should show static full-width bar
- [ ] Rapid submit/cancel — no visual glitches