### PR TITLE
style(ui): Add active:translate-y-px press effect to all text links

### DIFF
--- a/src/blocks/team/team-two.svelte
+++ b/src/blocks/team/team-two.svelte
@@ -94,7 +94,7 @@
 								<a
 									href={resolve(member.link)}
 									draggable={false}
-									class="inline-block text-sm tracking-wide no-drag group-hover:translate-y-0 group-hover:text-primary group-hover:opacity-100 hover:underline motion-safe:translate-y-8 motion-safe:opacity-0 motion-safe:transition-all motion-safe:duration-300"
+									class="inline-block text-sm tracking-wide no-drag group-hover:translate-y-0 group-hover:text-primary group-hover:opacity-100 hover:underline active:translate-y-px motion-safe:translate-y-8 motion-safe:opacity-0 motion-safe:transition-all motion-safe:duration-300"
 								>
 									<T keyName="team.linktree" />
 								</a>

--- a/src/lib/components/ErrorDisplay.svelte
+++ b/src/lib/components/ErrorDisplay.svelte
@@ -92,7 +92,10 @@
 			</InputGroup.Root>
 			<Empty.Description>
 				{translations.error_page.need_help}
-				<a href={resolve(homeHref)} class="text-primary underline-offset-4 hover:underline">
+				<a
+					href={resolve(homeHref)}
+					class="text-primary underline-offset-4 hover:underline active:translate-y-px"
+				>
 					{translations.error_page.back_home}
 				</a>
 			</Empty.Description>

--- a/src/lib/components/ui/breadcrumb/breadcrumb-link.svelte
+++ b/src/lib/components/ui/breadcrumb/breadcrumb-link.svelte
@@ -16,7 +16,7 @@
 
 	const attrs = $derived({
 		'data-slot': 'breadcrumb-link',
-		class: cn('hover:text-foreground transition-colors', className),
+		class: cn('hover:text-foreground transition-colors active:translate-y-px', className),
 		href,
 		...restProps
 	});

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -222,7 +222,7 @@
 								<a
 									href={resolve(localizedHref('/signin'))}
 									data-testid="forgot-password-back-link"
-									class="underline underline-offset-4"
+									class="underline underline-offset-4 active:translate-y-px"
 								>
 									<T keyName="auth.forgot_password.back_to_signin" defaultValue="Back to sign in" />
 								</a>
@@ -242,14 +242,20 @@
 		</Card.Root>
 		<Field.Description class="px-6 text-center">
 			<T keyName="auth.terms.agreement" defaultValue="By clicking continue, you agree to our" />
-			<a href={resolve(localizedHref('/terms'))} class="underline underline-offset-4"
+			<a
+				href={resolve(localizedHref('/terms'))}
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.terms.terms_of_service" defaultValue="Terms of Service" /></a
 			>
 			<T keyName="auth.terms.and" defaultValue="and" />
-			<a href={resolve(localizedHref('/privacy'))} class="underline underline-offset-4"
+			<a
+				href={resolve(localizedHref('/privacy'))}
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.terms.privacy_policy" defaultValue="Privacy Policy" /></a
 			>.
-			<a href={resolve(localizedHref('/'))} class="underline underline-offset-4"
+			<a
+				href={resolve(localizedHref('/'))}
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.back_to_home" defaultValue="Back to home" /></a
 			>
 		</Field.Description>

--- a/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
@@ -202,7 +202,10 @@
 									class="rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400"
 								>
 									<T keyName={message} />
-									<a href={resolve(localizedHref('/signin'))} class="underline">
+									<a
+										href={resolve(localizedHref('/signin'))}
+										class="underline active:translate-y-px"
+									>
 										<T keyName="auth.reset_password.sign_in_link" defaultValue="Sign in" />
 									</a>
 								</div>
@@ -266,7 +269,7 @@
 								<a
 									href={resolve(localizedHref('/signin'))}
 									data-testid="reset-password-back-link"
-									class="underline underline-offset-4"
+									class="underline underline-offset-4 active:translate-y-px"
 								>
 									<T keyName="auth.reset_password.back_to_signin" defaultValue="Back to sign in" />
 								</a>
@@ -286,14 +289,20 @@
 		</Card.Root>
 		<Field.Description class="px-6 text-center">
 			<T keyName="auth.terms.agreement" defaultValue="By clicking continue, you agree to our" />
-			<a href={resolve(localizedHref('/terms'))} class="underline underline-offset-4"
+			<a
+				href={resolve(localizedHref('/terms'))}
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.terms.terms_of_service" defaultValue="Terms of Service" /></a
 			>
 			<T keyName="auth.terms.and" defaultValue="and" />
-			<a href={resolve(localizedHref('/privacy'))} class="underline underline-offset-4"
+			<a
+				href={resolve(localizedHref('/privacy'))}
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.terms.privacy_policy" defaultValue="Privacy Policy" /></a
 			>.
-			<a href={resolve(localizedHref('/'))} class="underline underline-offset-4"
+			<a
+				href={resolve(localizedHref('/'))}
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.back_to_home" defaultValue="Back to home" /></a
 			>
 		</Field.Description>

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -255,14 +255,18 @@
 			<a
 				bind:this={termsLink}
 				href={resolve(localizedHref('/terms'))}
-				class="underline underline-offset-4"
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.terms.terms_of_service" defaultValue="Terms of Service" /></a
 			>
 			<T keyName="auth.terms.and" defaultValue="and" />
-			<a href={resolve(localizedHref('/privacy'))} class="underline underline-offset-4"
+			<a
+				href={resolve(localizedHref('/privacy'))}
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.terms.privacy_policy" defaultValue="Privacy Policy" /></a
 			>.
-			<a href={resolve(localizedHref('/'))} class="underline underline-offset-4"
+			<a
+				href={resolve(localizedHref('/'))}
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.back_to_home" defaultValue="Back to home" /></a
 			>
 		</Field.Description>

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -138,7 +138,7 @@
 						href={resolve(localizedHref('/forgot-password'))}
 						tabindex="-1"
 						onkeydown={handleForgotPasswordKeydown}
-						class="ms-auto text-sm text-muted-foreground underline-offset-2 hover:underline"
+						class="ms-auto text-sm text-muted-foreground underline-offset-2 hover:underline active:translate-y-px"
 					>
 						<T keyName="auth.signin.forgot_password" />
 					</a>
@@ -193,7 +193,7 @@
 							(redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : '')
 					)}
 					onkeydown={handleSignUpLinkKeydown}
-					class="underline underline-offset-4"
+					class="underline underline-offset-4 active:translate-y-px"
 				>
 					<T keyName="auth.signin.link_signup" defaultValue="Sign up" />
 				</a>

--- a/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
@@ -176,7 +176,7 @@
 						localizedHref('/signin') +
 							(redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : '')
 					)}
-					class="underline underline-offset-4"
+					class="underline underline-offset-4 active:translate-y-px"
 				>
 					<T keyName="auth.signup.link_signin" defaultValue="Sign in" />
 				</a>

--- a/src/routes/[[lang]]/(auth)/signup/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signup/+page.svelte
@@ -255,14 +255,20 @@
 		</Card.Root>
 		<Field.Description class="px-6 text-center">
 			<T keyName="auth.terms.agreement" defaultValue="By clicking continue, you agree to our" />
-			<a href={resolve(localizedHref('/terms'))} class="underline underline-offset-4"
+			<a
+				href={resolve(localizedHref('/terms'))}
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.terms.terms_of_service" defaultValue="Terms of Service" /></a
 			>
 			<T keyName="auth.terms.and" defaultValue="and" />
-			<a href={resolve(localizedHref('/privacy'))} class="underline underline-offset-4"
+			<a
+				href={resolve(localizedHref('/privacy'))}
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.terms.privacy_policy" defaultValue="Privacy Policy" /></a
 			>.
-			<a href={resolve(localizedHref('/'))} class="underline underline-offset-4"
+			<a
+				href={resolve(localizedHref('/'))}
+				class="underline underline-offset-4 active:translate-y-px"
 				><T keyName="auth.back_to_home" defaultValue="Back to home" /></a
 			>
 		</Field.Description>

--- a/src/routes/[[lang]]/admin/support/thread-details.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-details.svelte
@@ -208,7 +208,7 @@
 									.notificationEmail}?subject=Re: Your support request&body=Hi,%0A%0AThank you for reaching out!%0A%0A"
 								target="_blank"
 								rel="noopener noreferrer"
-								class="flex items-center gap-2 text-sm text-primary hover:underline"
+								class="flex items-center gap-2 text-sm text-primary hover:underline active:translate-y-px"
 							>
 								<span class="truncate">{thread.supportMetadata.notificationEmail}</span>
 								<ExternalLinkIcon class="size-3 shrink-0" />
@@ -225,7 +225,7 @@
 								href={thread.supportMetadata.pageUrl}
 								target="_blank"
 								rel="noopener noreferrer"
-								class="flex items-center gap-2 text-sm text-primary hover:underline"
+								class="flex items-center gap-2 text-sm text-primary hover:underline active:translate-y-px"
 							>
 								<span class="truncate">{thread.supportMetadata.pageUrl}</span>
 								<ExternalLinkIcon class="size-3 shrink-0" />


### PR DESCRIPTION
Auth pages, error display, breadcrumb, admin support, and team
block links were missing the press-down effect that buttons and
sidebar items already have.