### PR TITLE
fix(cf): Skip worktop cache for markdown requests

### DIFF
--- a/scripts/patch-cf-worker.test.ts
+++ b/scripts/patch-cf-worker.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { applyMarkdownPatch } from './patch-cf-worker';
 
 // Realistic worker snippet matching adapter-cloudflare@7.2.8 output
+// Includes both the worktop cache lookup AND the static-serving condition
 const WORKER_FIXTURE = `
+    let pragma = req.headers.get("cache-control") || "";
+    let res = !pragma.includes("no-cache") && await r2(req);
+    if (res) return res;
+    let { pathname, search } = new URL(req.url);
     let is_static_asset = false;
     const filename = stripped_pathname.slice(base_path.length + 1);
     if (filename) {
@@ -17,18 +22,37 @@ const WORKER_FIXTURE = `
     }
 `;
 
+// Fixture without the cache lookup (fallback path)
+const WORKER_FIXTURE_NO_CACHE = `
+    let is_static_asset = false;
+    if (is_static_asset || prerendered.has(pathname) || pathname === version_file || pathname.startsWith(immutable)) {
+      res = await env2.ASSETS.fetch(req);
+    }
+`;
+
 describe('patch-cf-worker', () => {
-	it('patches the static-serving condition', () => {
+	it('patches both cache lookup and static-serving condition', () => {
 		const result = applyMarkdownPatch(WORKER_FIXTURE);
 		expect(result).not.toBeNull();
 		expect(result).toContain('__wantsMarkdown');
 	});
 
-	it('wraps ALL disjuncts, not just the first two', () => {
+	it('skips worktop cache for markdown requests', () => {
+		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
+
+		// __wantsMarkdown detection should appear before the cache lookup
+		const mdIndex = result.indexOf('__wantsMarkdown');
+		const cacheIndex = result.indexOf('await r2(req)');
+		expect(mdIndex).toBeLessThan(cacheIndex);
+
+		// Cache lookup should be gated: !__wantsMarkdown && !pragma... && await r2(req)
+		expect(result).toContain('!__wantsMarkdown && !pragma.includes("no-cache") && await r2(req)');
+	});
+
+	it('wraps ALL static-serving disjuncts', () => {
 		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
 
 		// The patched condition must be: !__wantsMarkdown && (A || B || C || D)
-		// NOT: (!__wantsMarkdown && (A || B)) || C || D
 		expect(result).toContain(
 			'!__wantsMarkdown && (is_static_asset || prerendered.has(pathname) || pathname === version_file || pathname.startsWith(immutable))'
 		);
@@ -47,9 +71,14 @@ describe('patch-cf-worker', () => {
 	it('markdown requests fall through to server.respond', () => {
 		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
 
-		// Simulate: __wantsMarkdown is true → condition is false → hits else branch
-		// The patched if-condition starts with !__wantsMarkdown &&
-		// When __wantsMarkdown is true, the entire condition short-circuits to false
+		// When __wantsMarkdown is true, both cache and static-serving are skipped
 		expect(result).toMatch(/if\s*\(!__wantsMarkdown\s*&&\s*\(/);
+	});
+
+	it('falls back when cache pattern not found', () => {
+		const result = applyMarkdownPatch(WORKER_FIXTURE_NO_CACHE);
+		expect(result).not.toBeNull();
+		expect(result).toContain('__wantsMarkdown');
+		expect(result).toContain('!__wantsMarkdown && (is_static_asset');
 	});
 });

--- a/scripts/patch-cf-worker.test.ts
+++ b/scripts/patch-cf-worker.test.ts
@@ -49,13 +49,19 @@ describe('patch-cf-worker', () => {
 		expect(result).toContain('!__wantsMarkdown && !pragma.includes("no-cache") && await r2(req)');
 	});
 
-	it('wraps ALL static-serving disjuncts', () => {
+	it('wraps ALL static-serving disjuncts without extra parens', () => {
 		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
 
 		// The patched condition must be: !__wantsMarkdown && (A || B || C || D)
 		expect(result).toContain(
 			'!__wantsMarkdown && (is_static_asset || prerendered.has(pathname) || pathname === version_file || pathname.startsWith(immutable))'
 		);
+
+		// Verify correct paren nesting: if(!md && (...startsWith(immutable))) {
+		// Three closing parens is correct: startsWith() + wrapping group + if()
+		expect(result).toContain('pathname.startsWith(immutable))) {');
+		// But no quadruple parens (would indicate a regex bug)
+		expect(result).not.toContain('))))');
 	});
 
 	it('preserves the else branches unchanged', () => {

--- a/scripts/patch-cf-worker.ts
+++ b/scripts/patch-cf-worker.ts
@@ -1,13 +1,19 @@
 /**
  * Post-build patch for the Cloudflare Worker entry point.
  *
- * adapter-cloudflare's generated worker serves prerendered pages as static files
- * BEFORE calling server.respond(), which bypasses SvelteKit hooks. This breaks
- * the Accept: text/markdown content negotiation for marketing routes (used by
- * /llms.txt and AI agents).
+ * Two issues with adapter-cloudflare's generated worker:
  *
- * This script patches the worker to check the Accept header and fall through to
- * server.respond() for markdown requests, preserving same-URL content negotiation.
+ * 1. Prerendered pages are served as static files BEFORE calling server.respond(),
+ *    bypassing SvelteKit hooks. This breaks Accept: text/markdown negotiation.
+ *
+ * 2. The worktop cache layer ignores the Vary header (CF Cache API limitation),
+ *    so a cached HTML response is served for markdown requests on non-prerendered
+ *    pages like /en/pricing.
+ *
+ * This script patches the worker to:
+ * a) Detect markdown requests early (before cache lookup)
+ * b) Skip the worktop cache for markdown requests
+ * c) Skip static asset serving for markdown requests
  *
  * Runs as postbuild for all builds. Skips gracefully when no worker file exists
  * (e.g., Vercel via adapter-auto where server.respond() always runs).
@@ -22,6 +28,12 @@ import * as path from 'node:path';
 export const STATIC_SERVING_PATTERN =
 	/(if\s*\()(is_static_asset\s*\|\|[^)]+prerendered\.has\(pathname\)[^)]*)\)/;
 
+// Match the worktop cache lookup: `let res = !pragma.includes("no-cache") && await r2(req);`
+// We inject the __wantsMarkdown check here so markdown requests bypass the cache entirely.
+// CF Cache API ignores Vary headers, so cached HTML would be served for markdown requests.
+export const CACHE_LOOKUP_PATTERN =
+	/(let res = )(!pragma\.includes\("no-cache"\) && await \w+\(req\))/;
+
 /**
  * Apply the markdown passthrough patch to a worker source string.
  * Returns the patched source, or null if the pattern wasn't found.
@@ -31,10 +43,25 @@ export function applyMarkdownPatch(source: string): string | null {
 		return null;
 	}
 
-	const patched = source.replace(
-		STATIC_SERVING_PATTERN,
-		`const __wantsMarkdown = /\\btext\\/markdown\\b/i.test(req.headers.get("accept") || "");\n$1!__wantsMarkdown && ($2))`
-	);
+	// Step 1: Inject __wantsMarkdown detection before the cache lookup and skip cache
+	let patched = source;
+
+	if (CACHE_LOOKUP_PATTERN.test(patched)) {
+		patched = patched.replace(
+			CACHE_LOOKUP_PATTERN,
+			`const __wantsMarkdown = /\\btext\\/markdown\\b/i.test(req.headers.get("accept") || "");\n$1!__wantsMarkdown && $2`
+		);
+	} else {
+		// Fallback: inject before static serving (less ideal but still functional)
+		patched = patched.replace(
+			STATIC_SERVING_PATTERN,
+			`const __wantsMarkdown = /\\btext\\/markdown\\b/i.test(req.headers.get("accept") || "");\n$1!__wantsMarkdown && ($2))`
+		);
+		return patched === source ? null : patched;
+	}
+
+	// Step 2: Also skip static asset serving for markdown requests
+	patched = patched.replace(STATIC_SERVING_PATTERN, `$1!__wantsMarkdown && ($2))`);
 
 	return patched === source ? null : patched;
 }

--- a/scripts/patch-cf-worker.ts
+++ b/scripts/patch-cf-worker.ts
@@ -22,11 +22,10 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-// Match the entire if-condition that gates static asset / prerendered serving.
-// The condition includes: is_static_asset || prerendered.has(pathname) || pathname === version_file || pathname.startsWith(immutable)
-// We must wrap ALL disjuncts to avoid `(!md && (A||B)) || C` precedence bugs.
-export const STATIC_SERVING_PATTERN =
-	/(if\s*\()(is_static_asset\s*\|\|[^)]+prerendered\.has\(pathname\)[^)]*)\)/;
+// Match the entire if-condition body that gates static asset / prerendered serving.
+// The condition includes nested parens (e.g., prerendered.has(pathname), pathname.startsWith(immutable)),
+// so we match from `if (` up to the `) {` that closes the if-condition.
+export const STATIC_SERVING_PATTERN = /(if\s*\()(is_static_asset\b.+?\.startsWith\(immutable\))\)/;
 
 // Match the worktop cache lookup: `let res = !pragma.includes("no-cache") && await r2(req);`
 // We inject the __wantsMarkdown check here so markdown requests bypass the cache entirely.
@@ -52,7 +51,15 @@ export function applyMarkdownPatch(source: string): string | null {
 			`const __wantsMarkdown = /\\btext\\/markdown\\b/i.test(req.headers.get("accept") || "");\n$1!__wantsMarkdown && $2`
 		);
 	} else {
-		// Fallback: inject before static serving (less ideal but still functional)
+		// Warn if cache-like code exists but didn't match (pattern drift)
+		if (/await \w+\(req\)/.test(patched)) {
+			console.warn(
+				'[patch-cf-worker] WARNING: Detected a cache lookup but CACHE_LOOKUP_PATTERN did not match. ' +
+					'The worktop cache will NOT be bypassed for markdown requests. ' +
+					'Update CACHE_LOOKUP_PATTERN to match the new adapter output.'
+			);
+		}
+		// Fallback: inject before static serving (prerendered pages still fixed, cache bypass skipped)
 		patched = patched.replace(
 			STATIC_SERVING_PATTERN,
 			`const __wantsMarkdown = /\\btext\\/markdown\\b/i.test(req.headers.get("accept") || "");\n$1!__wantsMarkdown && ($2))`


### PR DESCRIPTION
CF Cache API ignores Vary headers, so cached HTML responses were served
for Accept: text/markdown requests on non-prerendered pages like
/en/pricing. Move __wantsMarkdown detection before the cache lookup
and gate both the worktop cache and static asset serving.

Resolves the only remaining E2E test failure.