### PR TITLE
fix: Invalidate root layout on auth state mismatch from prerendered pages

### DIFF
--- a/src/lib/components/app/app-auth-provider.svelte
+++ b/src/lib/components/app/app-auth-provider.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { createSvelteAuthClient } from '@mmailaender/convex-better-auth-svelte/svelte';
+	import { invalidate } from '$app/navigation';
+	import { browser } from '$app/environment';
+	import { createSvelteAuthClient, useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 	import { authClient } from '$lib/auth-client';
 
 	let { children } = $props();
@@ -9,6 +11,23 @@
 		authClient,
 		getServerState() {
 			return page.data.authState;
+		}
+	});
+
+	const auth = useAuth();
+
+	// Sync server layout data when client auth state diverges.
+	// Prerendered pages bake authState.isAuthenticated: false at build time.
+	// When the client recovers a session from cookies, the server's root layout
+	// data (viewer, autumnState) remains stale. This invalidation triggers a
+	// re-run of the root +layout.server.ts with fresh cookies, so navigating
+	// to /app has the correct viewer data instead of null.
+	$effect(() => {
+		if (!browser || auth.isLoading) return;
+
+		const serverAuth = page.data.authState?.isAuthenticated ?? false;
+		if (auth.isAuthenticated !== serverAuth) {
+			invalidate('app:auth');
 		}
 	});
 </script>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -58,6 +58,11 @@ function getViewerFromJwt(token: string | undefined): JwtViewer | null {
 export const load: LayoutServerLoad = async (event) => {
 	// Enables targeted invalidation via invalidate('autumn:customer') to refetch only customer data
 	event.depends('autumn:customer');
+	// Enables targeted invalidation when client-side auth state diverges from server state.
+	// Prerendered pages bake authState.isAuthenticated: false at build time — when the client
+	// recovers a session from cookies, AppAuthProvider detects the mismatch and calls
+	// invalidate('app:auth') to re-run this load with fresh cookies.
+	event.depends('app:auth');
 
 	// Check if JWT token exists (set by handleAuth in hooks.server.ts)
 	const isAuthenticated = !!event.locals.token;


### PR DESCRIPTION
Prerendered marketing pages bake authState.isAuthenticated: false at
build time. When client-side auth recovers from cookies, SvelteKit
skips re-running the root +layout.server.ts (no tracked dependency
change), leaving viewer: null. The {#if user} guard in
AuthenticatedLayout then renders nothing — blank page.

Add event.depends('app:auth') to root layout and detect client/server
auth state divergence in AppAuthProvider via invalidate('app:auth').
Only fires once per page session when states disagree; zero overhead
for normal navigation.