### PR TITLE
fix(ci): Use .convex.cloud URL for backend readiness check

### DIFF
--- a/.github/workflows/e2e-preview-cf.yml
+++ b/.github/workflows/e2e-preview-cf.yml
@@ -68,16 +68,16 @@ jobs:
 
       - name: Wait for Convex backend readiness
         run: |
-          echo "Waiting for Convex backend at: ${PUBLIC_CONVEX_SITE_URL}"
+          echo "Waiting for Convex backend at: ${PUBLIC_CONVEX_URL}"
           for i in $(seq 1 12); do
-            if curl -sf "${PUBLIC_CONVEX_SITE_URL}" > /dev/null; then
+            if curl -sf "${PUBLIC_CONVEX_URL}" > /dev/null; then
               echo "Convex backend is ready (attempt $i)"
               exit 0
             fi
             echo "Not ready yet (attempt $i/12), waiting 5s..."
             sleep 5
           done
-          echo "::error::Convex backend not ready after 60s: ${PUBLIC_CONVEX_SITE_URL}"
+          echo "::error::Convex backend not ready after 60s: ${PUBLIC_CONVEX_URL}"
           exit 1
 
       - name: Log test configuration

--- a/.github/workflows/e2e-preview-cf.yml
+++ b/.github/workflows/e2e-preview-cf.yml
@@ -70,12 +70,12 @@ jobs:
         run: |
           echo "Waiting for Convex backend at: ${PUBLIC_CONVEX_URL}"
           for i in $(seq 1 12); do
-            if curl -sf "${PUBLIC_CONVEX_URL}" > /dev/null; then
+            if curl -sf --connect-timeout 5 --max-time 10 "${PUBLIC_CONVEX_URL}" > /dev/null; then
               echo "Convex backend is ready (attempt $i)"
               exit 0
             fi
             echo "Not ready yet (attempt $i/12), waiting 5s..."
-            sleep 5
+            [ "$i" -lt 12 ] && sleep 5
           done
           echo "::error::Convex backend not ready after 60s: ${PUBLIC_CONVEX_URL}"
           exit 1


### PR DESCRIPTION
The readiness check was curling the .convex.site (HTTP actions)
endpoint which always returns 404 at root. Switch to .convex.cloud
which returns 200, fixing E2E tests that always timed out.