### PR TITLE
refactor(ui): Rewrite LoadingBar with M3 CSS indeterminate animation

### DIFF
--- a/src/lib/components/ui/loading-bar/loading-bar-motion.test.ts
+++ b/src/lib/components/ui/loading-bar/loading-bar-motion.test.ts
@@ -1,44 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import {
-	LOADING_STRIP_WIDTH,
-	LOADING_SWEEP_END,
-	LOADING_SWEEP_START,
-	advanceLoopingPhase,
-	advanceRampedPhase,
-	getLoadingLeft,
-	getStripGeometry,
-	syncPhaseToProgress
-} from './loading-bar-motion';
+import { clamp01, lerp } from './loading-bar-motion';
 
 describe('loading-bar motion helpers', () => {
-	it('maps the single loading strip across the full sweep', () => {
-		expect(getLoadingLeft(0)).toBe(LOADING_SWEEP_START);
-		expect(getLoadingLeft(1)).toBe(LOADING_SWEEP_END);
-		expect(getLoadingLeft(0.5)).toBeGreaterThan(getLoadingLeft(0.25));
+	it('lerp interpolates between two values', () => {
+		expect(lerp(0, 100, 0)).toBe(0);
+		expect(lerp(0, 100, 0.5)).toBe(50);
+		expect(lerp(0, 100, 1)).toBe(100);
 	});
 
-	it('looping phase wraps, ramped phase also wraps', () => {
-		expect(advanceLoopingPhase(0.98, 0.1)).toBeLessThan(0.98);
-		// Ramped phase wraps too (unlike the old advanceExitPhase which clamped)
-		expect(advanceRampedPhase(0.98, 0.5, 500)).toBeLessThan(0.98);
-		expect(advanceRampedPhase(0.4, 0.05, 0)).toBeGreaterThan(0.4);
-	});
-
-	it('blends between determinate progress and the loading sweep with one strip', () => {
-		expect(getStripGeometry(33, 0, 0.6)).toEqual({ left: 0, width: 33 });
-		expect(getStripGeometry(33, 1, 1)).toEqual({
-			left: LOADING_SWEEP_END,
-			width: LOADING_STRIP_WIDTH
-		});
-	});
-
-	it('syncPhaseToProgress aligns strip right edge with progress right edge', () => {
-		// At 0% progress, phase should be 0 (strip starts offscreen left)
-		expect(syncPhaseToProgress(0)).toBe(0);
-		// At higher progress, phase should be > 0
-		expect(syncPhaseToProgress(50)).toBeGreaterThan(0);
-		expect(syncPhaseToProgress(100)).toBeGreaterThan(syncPhaseToProgress(50));
-		// Phase should always be in [0, 1)
-		expect(syncPhaseToProgress(160)).toBeLessThan(1);
+	it('clamp01 clamps values to [0, 1]', () => {
+		expect(clamp01(-0.5)).toBe(0);
+		expect(clamp01(0.5)).toBe(0.5);
+		expect(clamp01(1.5)).toBe(1);
 	});
 });

--- a/src/lib/components/ui/loading-bar/loading-bar-motion.ts
+++ b/src/lib/components/ui/loading-bar/loading-bar-motion.ts
@@ -1,64 +1,7 @@
-export const LOADING_STRIP_WIDTH = 60;
-export const LOADING_SWEEP_START = -60;
-export const LOADING_SWEEP_END = 100;
-export const LOADING_SWEEP_DURATION = 1.35;
-export const ENTER_LOADING_MS = 250;
-export const EXIT_LOADING_MS = 180;
-export const EXIT_ACCELERATION_MS = 450;
-export const EXIT_MAX_SPEED_MULTIPLIER = 2.25;
-
 export function lerp(a: number, b: number, t: number): number {
 	return a + (b - a) * t;
 }
 
 export function clamp01(value: number): number {
 	return Math.min(Math.max(value, 0), 1);
-}
-
-export function easeOut(t: number): number {
-	return 1 - (1 - t) * (1 - t);
-}
-
-export function getLoadingLeft(phase: number): number {
-	return lerp(LOADING_SWEEP_START, LOADING_SWEEP_END, easeOut(clamp01(phase)));
-}
-
-export function getStripGeometry(
-	progressWidth: number,
-	blend: number,
-	phase: number
-): {
-	left: number;
-	width: number;
-} {
-	return {
-		left: lerp(0, getLoadingLeft(phase), clamp01(blend)),
-		width: lerp(progressWidth, LOADING_STRIP_WIDTH, clamp01(blend))
-	};
-}
-
-export function advanceLoopingPhase(phase: number, dt: number): number {
-	return (phase + dt / LOADING_SWEEP_DURATION) % 1;
-}
-
-export function getExitSpeedMultiplier(elapsedMs: number): number {
-	const ramp = clamp01(elapsedMs / EXIT_ACCELERATION_MS);
-	return 1 + (EXIT_MAX_SPEED_MULTIPLIER - 1) * ramp * ramp;
-}
-
-/** Advance phase with gradual speed ramp during exit blend-back (wraps). */
-export function advanceRampedPhase(phase: number, dt: number, elapsedMs: number): number {
-	const speed = getExitSpeedMultiplier(elapsedMs);
-	return (phase + (dt * speed) / LOADING_SWEEP_DURATION) % 1;
-}
-
-/**
- * Find the shimmer phase where the loading strip's right edge aligns
- * with the progress bar's right edge, so entering loading mode doesn't
- * cause a backward sweep.
- */
-export function syncPhaseToProgress(progressWidth: number): number {
-	const target = clamp01(progressWidth / (LOADING_SWEEP_END - LOADING_SWEEP_START));
-	const phase = 1 - Math.sqrt(Math.max(1 - target, 0));
-	return Math.min(phase, 0.999); // keep in [0, 1) to avoid wrap discontinuity
 }

--- a/src/lib/components/ui/loading-bar/loading-bar.svelte
+++ b/src/lib/components/ui/loading-bar/loading-bar.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
 	import { Progress as ProgressPrimitive } from 'bits-ui';
 	import { onMount, untrack } from 'svelte';
-	import { useMotionValue, animate, useReducedMotion } from 'motion-sv';
+	import { useMotionValue, animate } from 'motion-sv';
 	import { getTranslate } from '@tolgee/svelte';
 	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
-
-	const ENTER_LOADING_MS = 250;
-	const EXIT_LOADING_MS = 180;
 
 	const { t } = getTranslate();
 
@@ -29,8 +26,6 @@
 	const clampedValue = $derived(Math.min(Math.max(value ?? 0, 0), safeMax));
 	const progressPercent = $derived((clampedValue / safeMax) * 100);
 
-	const reducedMotion = useReducedMotion();
-
 	const initialWidth = untrack(() => progressPercent);
 	const springWidth = useMotionValue(initialWidth);
 
@@ -40,7 +35,6 @@
 
 	let progressStyle = $state(`width: ${initialWidth}%; background: var(--primary);`);
 	let rafId: number | null = null;
-	let lastFrameTime = 0;
 	let prevSpringWidth = 0;
 
 	// Sync spring toward progressPercent — tween at boundaries to prevent overshoot
@@ -86,15 +80,9 @@
 		startLoop();
 	});
 
-	function renderLoop(now: number) {
-		lastFrameTime = now;
+	function renderLoop() {
 		const progressWidth = Math.max(0, springWidth.get());
-
-		if (reducedMotion.current && isLoading) {
-			progressStyle = `width: 100%; background: var(--primary);`;
-		} else {
-			progressStyle = `width: ${progressWidth}%; background: var(--primary);`;
-		}
+		progressStyle = `width: ${progressWidth}%; background: var(--primary);`;
 
 		// Stop loop when spring has settled
 		if (!springReachedTarget && Math.abs(progressWidth - prevSpringWidth) < 0.01) {
@@ -104,7 +92,6 @@
 
 		if (springReachedTarget && !isLoading) {
 			rafId = null;
-			lastFrameTime = 0;
 		} else {
 			rafId = requestAnimationFrame(renderLoop);
 		}

--- a/src/lib/components/ui/loading-bar/loading-bar.svelte
+++ b/src/lib/components/ui/loading-bar/loading-bar.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { Progress as ProgressPrimitive } from 'bits-ui';
 	import { onMount, untrack } from 'svelte';
-	import { useMotionValue, animate } from 'motion-sv';
+	import { useMotionValue, animate, useReducedMotion } from 'motion-sv';
 	import { getTranslate } from '@tolgee/svelte';
 	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
 
 	const { t } = getTranslate();
+	const reducedMotion = useReducedMotion();
 
 	type LoadingBarProps = WithoutChildrenOrChild<ProgressPrimitive.RootProps> & {
 		mode: 'progress' | 'loading';
@@ -41,6 +42,12 @@
 	let springAnim: ReturnType<typeof animate> | null = null;
 	$effect(() => {
 		springAnim?.stop();
+		if (reducedMotion.current) {
+			springWidth.set(progressPercent);
+			springReachedTarget = true;
+			progressStyle = `width: ${progressPercent}%; background: var(--primary);`;
+			return;
+		}
 		const atBoundary = progressPercent <= 0 || progressPercent >= 100;
 		if (atBoundary) {
 			springAnim = animate(springWidth, progressPercent, {
@@ -56,7 +63,7 @@
 			});
 		}
 		springReachedTarget = false;
-		startLoop();
+		if (!isLoading) startLoop();
 		return () => springAnim?.stop();
 	});
 
@@ -72,6 +79,10 @@
 
 		if (mode === 'loading') {
 			isLoading = true;
+			if (rafId !== null) {
+				cancelAnimationFrame(rafId);
+				rafId = null;
+			}
 			return;
 		}
 
@@ -98,7 +109,7 @@
 	}
 
 	onMount(() => {
-		startLoop();
+		if (!isLoading) startLoop();
 		return () => {
 			if (rafId !== null) cancelAnimationFrame(rafId);
 		};

--- a/src/lib/components/ui/loading-bar/loading-bar.svelte
+++ b/src/lib/components/ui/loading-bar/loading-bar.svelte
@@ -4,14 +4,9 @@
 	import { useMotionValue, animate, useReducedMotion } from 'motion-sv';
 	import { getTranslate } from '@tolgee/svelte';
 	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
-	import {
-		ENTER_LOADING_MS,
-		EXIT_LOADING_MS,
-		advanceLoopingPhase,
-		advanceRampedPhase,
-		getStripGeometry,
-		syncPhaseToProgress
-	} from './loading-bar-motion';
+
+	const ENTER_LOADING_MS = 250;
+	const EXIT_LOADING_MS = 180;
 
 	const { t } = getTranslate();
 
@@ -37,49 +32,39 @@
 	const reducedMotion = useReducedMotion();
 
 	const initialWidth = untrack(() => progressPercent);
-	const initialBlend = untrack(() => (mode === 'loading' ? 1 : 0));
 	const springWidth = useMotionValue(initialWidth);
-	const blendFactor = useMotionValue(initialBlend);
 
-	let shimmerPhase = 0;
-	let exitStartTime = 0;
+	let isLoading = $state(untrack(() => mode === 'loading'));
 	let lastRequestedMode: 'progress' | 'loading' = untrack(() => mode);
 	let springReachedTarget = false;
 
-	// Initialize with deterministic geometry to avoid flash before first rAF frame
-	const initialGeometry = getStripGeometry(initialWidth, initialBlend, 0);
-	let backgroundStyle = $state(
-		`left: ${initialGeometry.left}%; width: ${initialGeometry.width}%; background: var(--primary);`
-	);
+	let progressStyle = $state(`width: ${initialWidth}%; background: var(--primary);`);
 	let rafId: number | null = null;
 	let lastFrameTime = 0;
 	let prevSpringWidth = 0;
 
-	// Sync spring toward progressPercent with an explicit spring animation
+	// Sync spring toward progressPercent — tween at boundaries to prevent overshoot
 	let springAnim: ReturnType<typeof animate> | null = null;
 	$effect(() => {
-		springAnim?.cancel();
-		springAnim = animate(springWidth, progressPercent, {
-			type: 'spring',
-			stiffness: 300,
-			damping: 28
-		});
-		springReachedTarget = false;
-		return () => springAnim?.cancel();
-	});
-
-	function animateBlendTo(target: number, durationMs: number) {
-		if (reducedMotion.current) {
-			blendFactor.set(target);
-			return;
+		springAnim?.stop();
+		const atBoundary = progressPercent <= 0 || progressPercent >= 100;
+		if (atBoundary) {
+			springAnim = animate(springWidth, progressPercent, {
+				type: 'tween',
+				duration: 0.2,
+				ease: [0.23, 1, 0.32, 1]
+			});
+		} else {
+			springAnim = animate(springWidth, progressPercent, {
+				type: 'spring',
+				stiffness: 300,
+				damping: 28
+			});
 		}
-
-		animate(blendFactor, target, {
-			type: 'tween',
-			duration: durationMs / 1000,
-			ease: [0.23, 1, 0.32, 1]
-		});
-	}
+		springReachedTarget = false;
+		startLoop();
+		return () => springAnim?.stop();
+	});
 
 	function startLoop() {
 		if (rafId !== null) return;
@@ -89,76 +74,41 @@
 	// Handle mode transitions
 	$effect(() => {
 		if (mode === lastRequestedMode) return;
-
 		lastRequestedMode = mode;
-		lastFrameTime = 0;
 
 		if (mode === 'loading') {
-			exitStartTime = 0;
-			shimmerPhase = syncPhaseToProgress(springWidth.get());
-			animateBlendTo(1, ENTER_LOADING_MS);
-			startLoop();
+			isLoading = true;
 			return;
 		}
 
-		// Exit: immediately blend back with gradual speed ramp
-		if (reducedMotion.current || blendFactor.get() <= 0.001) {
-			exitStartTime = 0;
-		} else {
-			exitStartTime = performance.now();
-		}
-		animateBlendTo(0, EXIT_LOADING_MS);
+		// Exit loading: CSS animations stop, progress bar takes over
+		isLoading = false;
 		startLoop();
 	});
 
 	function renderLoop(now: number) {
-		const dt = lastFrameTime ? (now - lastFrameTime) / 1000 : 0.016;
 		lastFrameTime = now;
-
-		const blend = blendFactor.get();
 		const progressWidth = Math.max(0, springWidth.get());
 
-		// Advance shimmer phase when blend > 0
-		if (blend > 0.001 && !reducedMotion.current) {
-			if (exitStartTime > 0) {
-				shimmerPhase = advanceRampedPhase(shimmerPhase, dt, now - exitStartTime);
-			} else {
-				shimmerPhase = advanceLoopingPhase(shimmerPhase, dt);
-			}
+		if (reducedMotion.current && isLoading) {
+			progressStyle = `width: 100%; background: var(--primary);`;
 		} else {
-			exitStartTime = 0;
+			progressStyle = `width: ${progressWidth}%; background: var(--primary);`;
 		}
 
-		if (reducedMotion.current && blend >= 0.5) {
-			backgroundStyle = `left: 0%; width: 100%; background: var(--primary);`;
-		} else {
-			const geometry = getStripGeometry(progressWidth, blend, shimmerPhase);
-			backgroundStyle = `left: ${geometry.left}%; width: ${geometry.width}%; background: var(--primary);`;
-		}
-
-		// Stop loop when fully idle
+		// Stop loop when spring has settled
 		if (!springReachedTarget && Math.abs(progressWidth - prevSpringWidth) < 0.01) {
 			springReachedTarget = Math.abs(progressWidth - progressPercent) < 0.1;
 		}
-		// Reduced motion: static bar, no animation needed — stop immediately
-		const reducedMotionSettled = reducedMotion.current && mode === 'loading';
-		const settled =
-			reducedMotionSettled || (blend < 0.001 && springReachedTarget && mode === 'progress');
 		prevSpringWidth = progressWidth;
 
-		if (settled) {
+		if (springReachedTarget && !isLoading) {
 			rafId = null;
 			lastFrameTime = 0;
 		} else {
 			rafId = requestAnimationFrame(renderLoop);
 		}
 	}
-
-	$effect(() => {
-		void progressPercent;
-		void mode;
-		startLoop();
-	});
 
 	onMount(() => {
 		startLoop();
@@ -181,5 +131,148 @@
 	{max}
 	{...restProps}
 >
-	<div data-slot="progress-indicator" class="absolute inset-y-0" style={backgroundStyle}></div>
+	<!-- Progress bar (always present, shown when not loading) -->
+	<div
+		data-slot="progress-indicator"
+		class={cn('absolute inset-y-0 transition-opacity', isLoading ? 'opacity-0' : 'opacity-100')}
+		style={progressStyle}
+	></div>
+
+	<!-- M3 indeterminate bars (CSS-animated, shown when loading) -->
+	<div class={cn('absolute inset-0 transition-opacity', isLoading ? 'opacity-100' : 'opacity-0')}>
+		<div class="loading-bar primary-bar">
+			<div class="loading-bar-inner"></div>
+		</div>
+		<div class="loading-bar secondary-bar">
+			<div class="loading-bar-inner"></div>
+		</div>
+	</div>
 </ProgressPrimitive.Root>
+
+<style>
+	/* M3 indeterminate linear progress — exact keyframes from material-web source */
+	.loading-bar,
+	.loading-bar-inner {
+		position: absolute;
+	}
+
+	.loading-bar {
+		width: 100%;
+		height: 100%;
+		transform-origin: left center;
+	}
+
+	.loading-bar-inner {
+		inset: 0;
+		background: var(--primary);
+	}
+
+	.primary-bar {
+		inset-inline-start: -145.167%;
+		animation: primary-translate 2s linear infinite;
+	}
+
+	.primary-bar > .loading-bar-inner {
+		animation: primary-scale 2s linear infinite;
+	}
+
+	.secondary-bar {
+		inset-inline-start: -54.8889%;
+		animation: secondary-translate 2s linear infinite;
+	}
+
+	.secondary-bar > .loading-bar-inner {
+		animation: secondary-scale 2s linear infinite;
+	}
+
+	@keyframes primary-translate {
+		0% {
+			transform: translateX(0);
+		}
+		20% {
+			animation-timing-function: cubic-bezier(0.5, 0, 0.701732, 0.495819);
+			transform: translateX(0);
+		}
+		59.15% {
+			animation-timing-function: cubic-bezier(0.302435, 0.381352, 0.55, 0.956352);
+			transform: translateX(83.6714%);
+		}
+		100% {
+			transform: translateX(200.611%);
+		}
+	}
+
+	@keyframes primary-scale {
+		0% {
+			transform: scaleX(0.08);
+		}
+		36.65% {
+			animation-timing-function: cubic-bezier(0.334731, 0.12482, 0.785844, 1);
+			transform: scaleX(0.08);
+		}
+		69.15% {
+			animation-timing-function: cubic-bezier(0.06, 0.11, 0.6, 1);
+			transform: scaleX(0.661479);
+		}
+		100% {
+			transform: scaleX(0.08);
+		}
+	}
+
+	@keyframes secondary-translate {
+		0% {
+			animation-timing-function: cubic-bezier(0.15, 0, 0.515058, 0.409685);
+			transform: translateX(0);
+		}
+		25% {
+			animation-timing-function: cubic-bezier(0.31033, 0.284058, 0.8, 0.733712);
+			transform: translateX(37.6519%);
+		}
+		48.35% {
+			animation-timing-function: cubic-bezier(0.4, 0.627035, 0.6, 0.902026);
+			transform: translateX(84.3862%);
+		}
+		100% {
+			transform: translateX(160.278%);
+		}
+	}
+
+	@keyframes secondary-scale {
+		0% {
+			animation-timing-function: cubic-bezier(0.205028, 0.057051, 0.57661, 0.453971);
+			transform: scaleX(0.08);
+		}
+		19.15% {
+			animation-timing-function: cubic-bezier(0.152313, 0.196432, 0.648374, 1.00432);
+			transform: scaleX(0.457104);
+		}
+		44.15% {
+			animation-timing-function: cubic-bezier(0.257759, -0.003163, 0.211762, 1.38179);
+			transform: scaleX(0.72796);
+		}
+		100% {
+			transform: scaleX(0.08);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.primary-bar,
+		.primary-bar > .loading-bar-inner,
+		.secondary-bar,
+		.secondary-bar > .loading-bar-inner {
+			animation: none;
+		}
+
+		.primary-bar {
+			inset-inline-start: 0;
+		}
+
+		.primary-bar > .loading-bar-inner {
+			transform: scaleX(1);
+		}
+
+		.secondary-bar {
+			display: none;
+		}
+	}
+</style>

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -209,7 +209,7 @@
 
 {#if import.meta.env.DEV}
 	<!-- Debug: LoadingBar state machine test controls -->
-	<div class="fixed bottom-4 right-4 z-50 flex gap-2 rounded-lg border bg-card p-2 shadow-lg">
+	<div class="fixed right-4 bottom-4 z-50 flex gap-2 rounded-lg border bg-card p-2 shadow-lg">
 		<button
 			class="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
 			onclick={() => {

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -207,38 +207,40 @@
 	</div>
 </form>
 
-<!-- Debug: LoadingBar state machine test controls -->
-<div class="fixed bottom-4 right-4 z-50 flex gap-2 rounded-lg border bg-card p-2 shadow-lg">
-	<button
-		class="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
-		onclick={() => {
-			debugActive = true;
-			debugIndeterminate = true;
-			debugValue = 0;
-		}}>Loading</button
-	>
-	<button
-		class="rounded bg-muted px-3 py-1 text-xs"
-		onclick={() => {
-			debugActive = true;
-			debugIndeterminate = false;
-			debugValue = 0;
-		}}>0%</button
-	>
-	<button
-		class="rounded bg-muted px-3 py-1 text-xs"
-		onclick={() => {
-			debugActive = true;
-			debugIndeterminate = false;
-			debugValue = 50;
-		}}>50%</button
-	>
-	<button
-		class="rounded bg-muted px-3 py-1 text-xs"
-		onclick={() => {
-			debugActive = true;
-			debugIndeterminate = false;
-			debugValue = 100;
-		}}>100%</button
-	>
-</div>
+{#if import.meta.env.DEV}
+	<!-- Debug: LoadingBar state machine test controls -->
+	<div class="fixed bottom-4 right-4 z-50 flex gap-2 rounded-lg border bg-card p-2 shadow-lg">
+		<button
+			class="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
+			onclick={() => {
+				debugActive = true;
+				debugIndeterminate = true;
+				debugValue = 0;
+			}}>Loading</button
+		>
+		<button
+			class="rounded bg-muted px-3 py-1 text-xs"
+			onclick={() => {
+				debugActive = true;
+				debugIndeterminate = false;
+				debugValue = 0;
+			}}>0%</button
+		>
+		<button
+			class="rounded bg-muted px-3 py-1 text-xs"
+			onclick={() => {
+				debugActive = true;
+				debugIndeterminate = false;
+				debugValue = 50;
+			}}>50%</button
+		>
+		<button
+			class="rounded bg-muted px-3 py-1 text-xs"
+			onclick={() => {
+				debugActive = true;
+				debugIndeterminate = false;
+				debugValue = 100;
+			}}>100%</button
+		>
+	</div>
+{/if}

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -90,6 +90,15 @@
 		event.preventDefault();
 		void onSubmit(event);
 	}
+
+	// Debug: override loading bar state for testing the state machine
+	let debugActive = $state(false);
+	let debugValue = $state(0);
+	let debugIndeterminate = $state(false);
+	const barMode = $derived(
+		debugActive ? (debugIndeterminate ? 'loading' : 'progress') : isLoading ? 'loading' : 'progress'
+	);
+	const barValue = $derived(debugActive ? debugValue : signInProgress);
 </script>
 
 <form
@@ -99,11 +108,7 @@
 	novalidate
 	class="min-h-96"
 >
-	<LoadingBar
-		value={signInProgress}
-		mode={isLoading ? 'loading' : 'progress'}
-		class="h-1 rounded-none"
-	/>
+	<LoadingBar value={barValue} mode={barMode} class="h-1 rounded-none" />
 	<div class="p-6 md:p-8">
 		<Field.Group>
 			<div class="flex flex-col items-center gap-2 text-center">
@@ -201,3 +206,39 @@
 		</Field.Group>
 	</div>
 </form>
+
+<!-- Debug: LoadingBar state machine test controls -->
+<div class="fixed bottom-4 right-4 z-50 flex gap-2 rounded-lg border bg-card p-2 shadow-lg">
+	<button
+		class="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
+		onclick={() => {
+			debugActive = true;
+			debugIndeterminate = true;
+			debugValue = 0;
+		}}>Loading</button
+	>
+	<button
+		class="rounded bg-muted px-3 py-1 text-xs"
+		onclick={() => {
+			debugActive = true;
+			debugIndeterminate = false;
+			debugValue = 0;
+		}}>0%</button
+	>
+	<button
+		class="rounded bg-muted px-3 py-1 text-xs"
+		onclick={() => {
+			debugActive = true;
+			debugIndeterminate = false;
+			debugValue = 50;
+		}}>50%</button
+	>
+	<button
+		class="rounded bg-muted px-3 py-1 text-xs"
+		onclick={() => {
+			debugActive = true;
+			debugIndeterminate = false;
+			debugValue = 100;
+		}}>100%</button
+	>
+</div>


### PR DESCRIPTION
refactor(ui): Rewrite LoadingBar with M3 CSS indeterminate animation

Replace RAF-based shimmer with native CSS keyframe animations from the
Material Design 3 linear progress component. Two bars (primary +
secondary) animate via translateX/scaleX with per-segment cubic beziers,
matching the official material-web implementation exactly.

- Loading mode: pure CSS animations (2s linear infinite cycle)
- Progress mode: spring animation with boundary-safe tweens (0%/100%)
- Mode transitions: opacity crossfade between loading and progress
- Fix cancel() → stop() on motion-sv animations (cancel reverts value)
- Add debug buttons to SignInForm for testing state machine

style(ui): Remove unused imports and variables from LoadingBar