### PR TITLE
fix(ui): Add z-index stacking to ChatInput wrappers

### DIFF
--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -260,7 +260,7 @@
 
 				<!-- Input area -->
 				<ChatInput
-					class="mx-4 -translate-y-4 p-0"
+					class="relative z-20 mx-4 -translate-y-4 p-0"
 					{suggestions}
 					placeholder={$t('support.widget.input.placeholder')}
 					placeholderNoSuggestions={$t('support.widget.input.placeholder_no_suggestions')}

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -225,7 +225,7 @@
 		</div>
 
 		<ChatInput
-			class="mx-4 -translate-y-4"
+			class="relative z-20 mx-4 -translate-y-4"
 			placeholder={$t('admin.support.chat.placeholder')}
 			showFileButton={true}
 			onSend={async (prompt) => {


### PR DESCRIPTION
Prevent ProgressiveBlur overlay from rendering above the chat input
in the support widget and admin support views.