### PR TITLE
chore: Reposition tagline toward open source and free hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![E2E Tests (CF)](https://github.com/stickerdaniel/saas-starter/actions/workflows/e2e-preview-cf.yml/badge.svg)](https://github.com/stickerdaniel/saas-starter/actions/workflows/e2e-preview-cf.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-%233fb950)](https://opensource.org/licenses/MIT)
 
-Agents write better code when they have good examples to work from. This starter ships with auth, billing, admin, AI chat, email, i18n, and more, all implemented end-to-end so your agents have real patterns to reference when building new features. It also includes the DX tools and guardrails to make sure what ships stays secure, performant, and maintainable.
+A free, open-source SaaS foundation you can deploy for $0. Ships with auth, billing, admin, AI chat, email, i18n, and more — all implemented end-to-end so you (and your AI agents) have real patterns to build on.
 
 > See a live demo of the user-facing side at **[saas.daniel.sticker.name](https://saas.daniel.sticker.name)**. Admin features like the admin panel, support dashboard, and user management are not accessible there. To explore everything, follow the steps below.
 

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1372,7 +1372,7 @@
 		"companies_text": "Vertrauen der besten Teams",
 		"cta": "Jetzt starten",
 		"cta_demo": "Demo anfordern",
-		"description": "Erwecke dein SaaS zum Leben in Minuten, nicht in Monaten. Open-Source Template mit einem Tech-Stack, der dich schnell shippen lässt.",
+		"description": "Die kostenlose SaaS-Grundlage. Open Source, sofort einsatzbereit.",
 		"section_label": "Start",
 		"tagline": "Mit Produktfokus\nschneller zum Ziel",
 		"title": "SaaS-Starter-Vorlage"
@@ -1530,7 +1530,7 @@
 			}
 		},
 		"home": {
-			"description": "SaaS-Starter für SvelteKit mit Auth, Billing, E-Mail und Analytics.",
+			"description": "Kostenloser Open-Source SaaS-Starter mit SvelteKit. Auth, Billing, E-Mail und Analytics inklusive. Kostenlos auf Free-Tiers hosten.",
 			"title": "Schneller entwickeln und veröffentlichen"
 		},
 		"impressum": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1372,7 +1372,7 @@
 		"companies_text": "Powering the best teams",
 		"cta": "Start Building",
 		"cta_demo": "Request a demo",
-		"description": "SaaS starter with SvelteKit, auth, billing, and analytics.",
+		"description": "The free SaaS foundation. Open source, ready to deploy.",
 		"section_label": "Home",
 		"tagline": "Focus on your product.\nShip faster.",
 		"title": "SaaS Starter Template"
@@ -1530,7 +1530,7 @@
 			}
 		},
 		"home": {
-			"description": "SaaS starter for SvelteKit with auth, billing, email, and analytics.",
+			"description": "Free, open-source SaaS starter built with SvelteKit. Auth, billing, email, and analytics included. Host on free tiers.",
 			"title": "Build & Ship Your Product Faster"
 		},
 		"impressum": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1372,7 +1372,7 @@
 		"companies_text": "Impulsando a los mejores equipos",
 		"cta": "Comenzar ahora",
 		"cta_demo": "Solicitar una demo",
-		"description": "Dale vida a tu SaaS en minutos, no en meses. Plantilla open-source cargada con la tecnología que te hace lanzar rápido.",
+		"description": "La base SaaS gratuita. Open source, lista para desplegar.",
 		"section_label": "Inicio",
 		"tagline": "Foco en tu producto.\nLanzamiento más rápido.",
 		"title": "Plantilla SaaS Starter"
@@ -1530,7 +1530,7 @@
 			}
 		},
 		"home": {
-			"description": "Starter SaaS para SvelteKit con auth, pagos, email y analítica.",
+			"description": "Starter SaaS gratuito y open source con SvelteKit. Auth, pagos, email y analítica incluidos. Aloja gratis con planes gratuitos.",
 			"title": "Construye y lanza tu producto más rápido"
 		},
 		"impressum": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1372,7 +1372,7 @@
 		"companies_text": "Propulsant les meilleures équipes",
 		"cta": "Commencer maintenant",
 		"cta_demo": "Demander une démo",
-		"description": "Donne vie à ton SaaS en quelques minutes, pas en mois. Template open-source bourré de tech qui te fait shipper direct.",
+		"description": "La fondation SaaS gratuite. Open source, prête à déployer.",
 		"section_label": "Accueil",
 		"tagline": "Focus sur ton produit.\nLancement plus rapide.",
 		"title": "Modèle SaaS Starter"
@@ -1530,7 +1530,7 @@
 			}
 		},
 		"home": {
-			"description": "Starter SaaS pour SvelteKit avec auth, paiements, email et analytics.",
+			"description": "Starter SaaS gratuit et open source avec SvelteKit. Auth, paiements, email et analytics inclus. Hébergez gratuitement.",
 			"title": "Construisez et lancez votre produit plus rapidement"
 		},
 		"impressum": {

--- a/src/routes/[[lang]]/(marketing)/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/page.md.ts
@@ -3,7 +3,7 @@ import type { MarketingMarkdownDocument } from '$lib/markdown/types';
 export const marketingMarkdown: MarketingMarkdownDocument = {
 	title: 'Build & Ship Your Product Faster',
 	description:
-		'An open-source SaaS starter for teams who want to launch with a modern SvelteKit stack instead of assembling the foundation from scratch.',
+		'The free SaaS foundation. An open-source SvelteKit starter with auth, billing, email, and analytics. Deploy on free tiers, own every line.',
 	sections: [
 		{
 			heading: 'What this starter is',


### PR DESCRIPTION
Update hero descriptions, SEO meta, agent-facing markdown, and
README to lead with "free" and "open source" instead of feature
enumeration.