### PR TITLE
refactor(worktree): group worktrees in <repo>.worktrees/ sibling dir

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,11 @@ btca ask -r svelte -r convex -q "How do I integrate Convex with SvelteKit?"
 
 When starting work that needs its own branch/PR, always create a worktree first with `bun run worktree <type/short-description>` (e.g. `feature/dark-mode`, `fix/422-password-reset`, `chore/upgrade-svelte-5`, `hotfix/rate-limit-bypass`, `docs/api-reference`).
 
+Worktrees live in a sibling directory next to the main repo at `<repo>.worktrees/<folder-name>/`. The folder name flattens branch slashes to dashes: `feat/dark-mode` creates `saas-starter.worktrees/feat-dark-mode/`. The git branch name keeps its original slashes; only the on-disk folder name is flattened. Edge case: branches like `feat/sentry` and `feat-sentry` map to the same folder — the script catches this as a loud error before touching git state.
+
 NEVER use the `EnterWorktree` tool. Always use `bun run worktree` instead and add the worktree path before all consecutive actions. You must do this, the cwd is reset after each action and theres currently no better way to do this.
 
-**Before committing:** Always check `git branch` first. If you're in a worktree, the branch already exists and was created by `bun run worktree` (which runs `gt create` internally). Use `git commit` to add commits, not `gt create`. Only use `gt create` when you need a new stacked branch on top of the current one.
+**Before committing:** Always check `git branch` first. If you're in a worktree, the branch already exists and was created by `bun run worktree` (which runs `git worktree add -b` and then `gt track` + `gt sync` when Graphite is installed). Use `git commit` to add commits, not `gt create`. Only use `gt create` when you need a new stacked branch on top of the current one.
 
 ## Development Commands
 

--- a/scripts/create-worktree.ts
+++ b/scripts/create-worktree.ts
@@ -9,7 +9,7 @@
 
 import { spawnSync } from 'child_process';
 import { chmodSync, existsSync, copyFileSync, mkdirSync, readdirSync, statSync } from 'fs';
-import { dirname, join } from 'path';
+import { join } from 'path';
 import { parseArgs } from 'util';
 
 // ANSI colors for terminal output
@@ -83,15 +83,25 @@ function runCommandInherit(command: string, args: string[], cwd?: string): boole
 }
 
 /**
- * Get root worktree path (where .git directory is)
+ * Get main repo path (where .git directory is).
+ * Uses `git worktree list --porcelain` so this returns the main repo root
+ * even when invoked from inside an auxiliary worktree.
  */
 function getRootWorktree(): string {
-	const result = runCommand('git', ['rev-parse', '--show-toplevel'], { silent: true });
-	if (!result.success) {
+	const result = runCommand('git', ['worktree', 'list', '--porcelain'], { silent: true });
+	if (!result.success || !result.stdout) {
 		console.error(`${colors.red}Error: Not in a git repository${colors.reset}`);
 		process.exit(1);
 	}
-	return result.stdout;
+	// First line of --porcelain output is always "worktree <path>" for the
+	// main worktree, regardless of which worktree the script is invoked from.
+	const firstLine = result.stdout.split('\n')[0];
+	const mainRepoPath = firstLine.replace(/^worktree /, '');
+	if (!mainRepoPath) {
+		console.error(`${colors.red}Error: Could not determine main repo path${colors.reset}`);
+		process.exit(1);
+	}
+	return mainRepoPath;
 }
 
 /**
@@ -295,8 +305,14 @@ function main(): void {
 	const rootPath = getRootWorktree();
 	console.log(`Root worktree: ${rootPath}`);
 
-	// Determine target worktree path
-	const worktreePath = join(dirname(rootPath), branchName);
+	// Determine target worktree path.
+	// Worktrees live in <repo>.worktrees/ (sibling of main repo) with slashes
+	// flattened to dashes. The git branch name keeps its original slashes;
+	// only the on-disk folder name is flattened.
+	const worktreesDir = `${rootPath}.worktrees`;
+	const folderName = branchName.replace(/\//g, '-');
+	const worktreePath = join(worktreesDir, folderName);
+	mkdirSync(worktreesDir, { recursive: true });
 	console.log(`Target worktree: ${worktreePath}`);
 	console.log('');
 
@@ -304,6 +320,25 @@ function main(): void {
 	if (existsSync(worktreePath)) {
 		console.error(
 			`${colors.red}Error: Worktree directory already exists: ${worktreePath}${colors.reset}`
+		);
+		console.log('');
+		// Explain the flattening rule unconditionally. The collision can come
+		// from either direction (new branch has /, or existing branch had /),
+		// and the user can't tell which from the error alone.
+		console.log(
+			`${colors.yellow}Note: worktree folder names flatten slashes to dashes.${colors.reset}`
+		);
+		console.log(
+			`${colors.yellow}Branch "${branchName}" maps to folder "${folderName}".${colors.reset}`
+		);
+		console.log(
+			`${colors.yellow}This can collide when a sibling branch exists on the other side of the mapping${colors.reset}`
+		);
+		console.log(
+			`${colors.yellow}(e.g. "feat/sentry" and "feat-sentry" both map to "feat-sentry").${colors.reset}`
+		);
+		console.log(
+			`${colors.yellow}Run "git worktree list" to see which branch currently owns this folder.${colors.reset}`
 		);
 		console.log('');
 		console.log('Options:');


### PR DESCRIPTION
Replace sibling-flat layout with a dedicated <repo>.worktrees/ directory
next to the main repo. Branch slashes are flattened to dashes in the
folder name only; the git branch name is unchanged.

- getRootWorktree() now uses git worktree list --porcelain so the main
  repo path is resolved correctly when invoked from an auxiliary worktree
- New worktrees land at saas-starter.worktrees/feat-foo/ instead of
  the parent dir (which accumulated feat/, fix/, docs/ stub dirs)
- Collision error message unconditionally explains the slash-to-dash
  mapping in both directions with a concrete example
- AGENTS.md: add layout note, correct gt create claim (script uses
  git worktree add -b + gt track/sync, not gt create)