### PR TITLE
fix: Varlock leak scanner false positive during dev

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -294,7 +294,7 @@ export default defineConfig(async ({ mode }) => {
 	}
 
 	plugins.push(
-		varlockVitePlugin({ ssrInjectMode: 'resolved-env' }),
+		varlockVitePlugin(mode === 'production' ? { ssrInjectMode: 'resolved-env' } : {}),
 		tailwindcss(),
 		sveltekit(),
 		devtoolsJson(),


### PR DESCRIPTION
## Summary
- Only use `resolved-env` ssrInjectMode for production builds, letting varlock default to `init-only` during dev
- Prevents false positive leak detection when `@sensitive` env vars get serialized into the SSR entry module

## Test plan
- [ ] Run `bun run dev` with a `@sensitive` env var set in `.env.local` — no leak error
- [ ] Run `bun run build` — production build still uses `resolved-env` for CF Workers

Resolves #307