### PR TITLE
fix(env): Replace $env/dynamic/public with $env/static/public

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -124,6 +124,11 @@ export default defineConfig(
 						{
 							name: '$lib/utils/utils.js',
 							message: 'Import from $lib/utils.js instead (canonical location).'
+						},
+						{
+							name: '$env/dynamic/public',
+							message:
+								'Use $env/static/public instead. All PUBLIC_* vars are known at build time in this project.'
 						}
 					]
 				}

--- a/src/lib/analytics/posthog.ts
+++ b/src/lib/analytics/posthog.ts
@@ -1,4 +1,8 @@
-import { env } from '$env/dynamic/public';
+import {
+	PUBLIC_POSTHOG_API_KEY,
+	PUBLIC_POSTHOG_HOST,
+	PUBLIC_POSTHOG_PROXY_HOST
+} from '$env/static/public';
 
 const READY_EVENT = 'posthog:ready';
 const ADBLOCK_DETECT_TIMEOUT_MS = 3000;
@@ -37,18 +41,16 @@ export async function initPosthog(): Promise<PostHogClient | null> {
 	if (initPromise) return initPromise;
 
 	initPromise = (async () => {
-		const apiKey = env.PUBLIC_POSTHOG_API_KEY;
-		const host = env.PUBLIC_POSTHOG_HOST;
-
-		if (!apiKey || !host) return null;
+		if (!PUBLIC_POSTHOG_API_KEY || !PUBLIC_POSTHOG_HOST) return null;
 
 		try {
 			const posthog = (await import('posthog-js')).default;
-			const proxyHost = env.PUBLIC_POSTHOG_PROXY_HOST;
-			const isBlocked = await detectAdBlock(host);
-			const apiHost = isBlocked ? proxyHost || host : host;
+			const isBlocked = await detectAdBlock(PUBLIC_POSTHOG_HOST);
+			const apiHost = isBlocked
+				? PUBLIC_POSTHOG_PROXY_HOST || PUBLIC_POSTHOG_HOST
+				: PUBLIC_POSTHOG_HOST;
 
-			posthog.init(apiKey, {
+			posthog.init(PUBLIC_POSTHOG_API_KEY, {
 				api_host: apiHost,
 				ui_host: 'https://eu.posthog.com',
 				person_profiles: 'identified_only'

--- a/src/lib/components/app/app-posthog-bootstrap.svelte
+++ b/src/lib/components/app/app-posthog-bootstrap.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { env } from '$env/dynamic/public';
+	import { PUBLIC_POSTHOG_API_KEY, PUBLIC_POSTHOG_HOST } from '$env/static/public';
 	import { initPosthog } from '$lib/analytics/posthog';
 
 	onMount(function onMountPosthogInit() {
-		const PUBLIC_POSTHOG_API_KEY = env.PUBLIC_POSTHOG_API_KEY;
-		const PUBLIC_POSTHOG_HOST = env.PUBLIC_POSTHOG_HOST;
 		if (!PUBLIC_POSTHOG_API_KEY || !PUBLIC_POSTHOG_HOST) return;
 
 		let initialized = false;

--- a/src/lib/utils/snapdom-config.ts
+++ b/src/lib/utils/snapdom-config.ts
@@ -11,7 +11,7 @@
  */
 
 import { dev } from '$app/environment';
-import { env } from '$env/dynamic/public';
+import { PUBLIC_SNAPDOM_PROXY_URL } from '$env/static/public';
 
 /**
  * Get the CORS proxy URL for snapDOM
@@ -30,7 +30,7 @@ export function getSnapDOMProxyUrl(): string | undefined {
 
 	// Production: Use custom Cloudflare Worker proxy if provided
 	// Falls back to no proxy if not configured (external images may fail with CORS)
-	return env.PUBLIC_SNAPDOM_PROXY_URL || undefined;
+	return PUBLIC_SNAPDOM_PROXY_URL || undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Migrate PostHog and snapdom from `$env/dynamic/public` to `$env/static/public` — enables dead-code elimination (optional integrations stripped when unconfigured), build-time validation, and avoids `/_app/env.js` waterfall on prerendered pages
- Add ESLint `no-restricted-imports` rule to prevent `$env/dynamic/public` from being reintroduced

## Test plan

- [x] `bun scripts/static-checks.ts` passes on all changed files
- [x] `bun run build` succeeds (static imports compile)
- [x] `grep -r '$env/dynamic/public' src/` returns zero matches
- [ ] Verify PostHog initializes correctly on preview deploy (when keys are set)

Resolves #303