### PR TITLE
fix(convex): Extract shared supportThreadFields to fix ReturnsValidationError

### DIFF
--- a/src/lib/convex/admin/support/queries.ts
+++ b/src/lib/convex/admin/support/queries.ts
@@ -8,6 +8,14 @@ import { parseBetterAuthUsers, betterAuthUserSchema } from '../types';
 import { isAnonymousUser } from '../../utils/anonymousUser';
 import { vStreamArgs } from '@convex-dev/agent/validators';
 import { listMessagesForThread } from '../../support/messageListing';
+import { supportThreadFields } from '../../support/supportThreadFields';
+
+/** Return validator for supportThreads documents (schema fields + system fields). */
+const vSupportMetadata = v.object({
+	_id: v.string(),
+	_creationTime: v.number(),
+	...supportThreadFields
+});
 
 /**
  * List threads with admin filters
@@ -41,39 +49,7 @@ export const listThreadsForAdmin = adminQuery({
 				title: v.optional(v.string()),
 				summary: v.optional(v.string()),
 				status: v.union(v.literal('active'), v.literal('archived')),
-				supportMetadata: v.object({
-					_id: v.string(),
-					_creationTime: v.number(),
-					threadId: v.string(),
-					userId: v.optional(v.string()),
-					status: v.union(v.literal('open'), v.literal('done')),
-					assignedTo: v.optional(v.string()),
-					isHandedOff: v.optional(v.boolean()),
-					awaitingAdminResponse: v.optional(v.boolean()),
-					priority: v.optional(v.union(v.literal('low'), v.literal('medium'), v.literal('high'))),
-					pageUrl: v.optional(v.string()),
-					notificationEmail: v.optional(v.string()),
-					notificationSentAt: v.optional(v.number()),
-					createdAt: v.number(),
-					updatedAt: v.number(),
-					// Denormalized search fields
-					searchText: v.optional(v.string()),
-					title: v.optional(v.string()),
-					summary: v.optional(v.string()),
-					lastMessage: v.optional(v.string()),
-					lastMessageAt: v.optional(v.number()),
-					lastMessageRole: v.optional(
-						v.union(
-							v.literal('user'),
-							v.literal('assistant'),
-							v.literal('tool'),
-							v.literal('system')
-						)
-					),
-					lastAgentName: v.optional(v.string()),
-					userName: v.optional(v.string()),
-					userEmail: v.optional(v.string())
-				}),
+				supportMetadata: vSupportMetadata,
 				lastMessage: v.optional(v.string()),
 				lastMessageAt: v.optional(v.number()),
 				userName: v.optional(v.string()),
@@ -270,34 +246,7 @@ export const getThreadForAdmin = adminQuery({
 		title: v.optional(v.string()),
 		summary: v.optional(v.string()),
 		status: v.union(v.literal('active'), v.literal('archived')),
-		supportMetadata: v.object({
-			_id: v.string(),
-			_creationTime: v.number(),
-			threadId: v.string(),
-			userId: v.optional(v.string()),
-			status: v.union(v.literal('open'), v.literal('done')),
-			assignedTo: v.optional(v.string()),
-			isHandedOff: v.optional(v.boolean()),
-			awaitingAdminResponse: v.optional(v.boolean()),
-			priority: v.optional(v.union(v.literal('low'), v.literal('medium'), v.literal('high'))),
-			pageUrl: v.optional(v.string()),
-			notificationEmail: v.optional(v.string()),
-			notificationSentAt: v.optional(v.number()),
-			createdAt: v.number(),
-			updatedAt: v.number(),
-			// Denormalized search fields
-			searchText: v.optional(v.string()),
-			title: v.optional(v.string()),
-			summary: v.optional(v.string()),
-			lastMessage: v.optional(v.string()),
-			lastMessageAt: v.optional(v.number()),
-			lastMessageRole: v.optional(
-				v.union(v.literal('user'), v.literal('assistant'), v.literal('tool'), v.literal('system'))
-			),
-			lastAgentName: v.optional(v.string()),
-			userName: v.optional(v.string()),
-			userEmail: v.optional(v.string())
-		}),
+		supportMetadata: vSupportMetadata,
 		assignedAdmin: v.optional(
 			v.object({
 				id: v.string(),

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -1,6 +1,7 @@
 import { defineSchema, defineTable } from 'convex/server';
 import { v } from 'convex/values';
 import { vEmailEvent } from '@convex-dev/resend';
+import { supportThreadFields } from './support/supportThreadFields';
 
 export default defineSchema({
 	// Note: Better Auth component manages its own tables (users, sessions, accounts, verifications)
@@ -65,37 +66,7 @@ export default defineSchema({
 	// Support feature registry.
 	// Source of truth for support thread membership, access, and denormalized list/search data.
 	// agent:threads remains generic conversation storage/runtime shared across features.
-	supportThreads: defineTable({
-		threadId: v.string(), // Reference to agent:threads
-		userId: v.optional(v.string()), // Denormalized for quick lookups
-		isWarm: v.optional(v.boolean()), // true = pre-warmed empty support thread awaiting first message
-		status: v.union(v.literal('open'), v.literal('done')),
-		isHandedOff: v.optional(v.boolean()), // true = human-only mode, undefined/false = AI responds
-		awaitingAdminResponse: v.optional(v.boolean()), // true = user waiting for reply, false = admin has responded
-		assignedTo: v.optional(v.string()), // Admin user ID (for tracking, not AI control)
-		priority: v.optional(v.union(v.literal('low'), v.literal('medium'), v.literal('high'))),
-		dueDate: v.optional(v.number()),
-		pageUrl: v.optional(v.string()), // URL where user started chat
-		createdAt: v.number(),
-		updatedAt: v.number(),
-
-		// Denormalized search fields (for server-side full-text search)
-		searchText: v.optional(v.string()), // Combined: title | summary | lastMessage | userName | userEmail
-		title: v.optional(v.string()), // From agent:threads
-		summary: v.optional(v.string()), // From agent:threads
-		lastMessage: v.optional(v.string()), // From agent:messages (truncated to 500 chars)
-		lastMessageAt: v.optional(v.number()), // Timestamp of the latest non-tool successful message
-		lastMessageRole: v.optional(
-			v.union(v.literal('user'), v.literal('assistant'), v.literal('tool'), v.literal('system'))
-		),
-		lastAgentName: v.optional(v.string()),
-		userName: v.optional(v.string()), // From user table
-		userEmail: v.optional(v.string()), // From user table
-
-		// Email notification settings
-		notificationEmail: v.optional(v.string()), // Email to notify on admin response
-		notificationSentAt: v.optional(v.number()) // Last notification timestamp (for 30-min cooldown)
-	})
+	supportThreads: defineTable(supportThreadFields)
 		.index('by_thread', ['threadId'])
 		.index('by_user', ['userId'])
 		.index('by_user_warm', ['userId', 'isWarm'])

--- a/src/lib/convex/support/supportThreadFields.ts
+++ b/src/lib/convex/support/supportThreadFields.ts
@@ -1,0 +1,39 @@
+import { v } from 'convex/values';
+
+/**
+ * Canonical field definitions for the supportThreads table.
+ *
+ * Used by both schema.ts (defineTable) and admin query return validators (v.object).
+ * Adding a field here automatically updates both — no validator drift.
+ */
+export const supportThreadFields = {
+	threadId: v.string(), // Reference to agent:threads
+	userId: v.optional(v.string()), // Denormalized for quick lookups
+	isWarm: v.optional(v.boolean()), // true = pre-warmed empty support thread awaiting first message
+	status: v.union(v.literal('open'), v.literal('done')),
+	isHandedOff: v.optional(v.boolean()), // true = human-only mode, undefined/false = AI responds
+	awaitingAdminResponse: v.optional(v.boolean()), // true = user waiting for reply, false = admin has responded
+	assignedTo: v.optional(v.string()), // Admin user ID (for tracking, not AI control)
+	priority: v.optional(v.union(v.literal('low'), v.literal('medium'), v.literal('high'))),
+	dueDate: v.optional(v.number()),
+	pageUrl: v.optional(v.string()), // URL where user started chat
+	createdAt: v.number(),
+	updatedAt: v.number(),
+
+	// Denormalized search fields (for server-side full-text search)
+	searchText: v.optional(v.string()), // Combined: title | summary | lastMessage | userName | userEmail
+	title: v.optional(v.string()), // From agent:threads
+	summary: v.optional(v.string()), // From agent:threads
+	lastMessage: v.optional(v.string()), // From agent:messages (truncated to 500 chars)
+	lastMessageAt: v.optional(v.number()), // Timestamp of the latest non-tool successful message
+	lastMessageRole: v.optional(
+		v.union(v.literal('user'), v.literal('assistant'), v.literal('tool'), v.literal('system'))
+	),
+	lastAgentName: v.optional(v.string()),
+	userName: v.optional(v.string()), // From user table
+	userEmail: v.optional(v.string()), // From user table
+
+	// Email notification settings
+	notificationEmail: v.optional(v.string()), // Email to notify on admin response
+	notificationSentAt: v.optional(v.number()) // Last notification timestamp (for 30-min cooldown)
+};


### PR DESCRIPTION
Both listThreadsForAdmin and getThreadForAdmin crashed in production with
ReturnsValidationError because the return validators omitted isWarm and
dueDate fields present in the supportThreads schema.

Extract a single canonical field definition (supportThreadFields) consumed
by both schema.ts and the admin query return validators, eliminating
validator drift by design.

Resolves: #315