### PR TITLE
feat(chat): Add per-thread draft preservation to admin support and AI chat

### DIFF
--- a/src/lib/chat/core/ChatDraftManager.svelte.ts
+++ b/src/lib/chat/core/ChatDraftManager.svelte.ts
@@ -1,0 +1,33 @@
+import { PersistedState } from 'runed';
+
+/**
+ * Manages per-thread draft text persistence via localStorage.
+ *
+ * Each chat surface instantiates its own manager with a unique storage key
+ * to avoid collisions (e.g. 'drafts:ai-chat', 'drafts:admin-support').
+ */
+export class ChatDraftManager {
+	readonly drafts: PersistedState<Record<string, string>>;
+
+	constructor(storageKey: string) {
+		this.drafts = new PersistedState<Record<string, string>>(storageKey, {});
+	}
+
+	getDraft(threadId: string | null): string {
+		return threadId ? (this.drafts.current[threadId] ?? '') : '';
+	}
+
+	setDraft(threadId: string | null, text: string): void {
+		if (!threadId) return;
+		if (text.trim()) {
+			this.drafts.current[threadId] = text;
+		} else {
+			delete this.drafts.current[threadId];
+		}
+	}
+
+	clearDraft(threadId: string | null): void {
+		if (!threadId) return;
+		delete this.drafts.current[threadId];
+	}
+}

--- a/src/lib/chat/core/index.ts
+++ b/src/lib/chat/core/index.ts
@@ -65,3 +65,6 @@ export {
 export type { ChatCoreAPI, ChatCoreOptions, CreateThreadResult } from './ChatCore.svelte.js';
 
 export { ChatCore, createChatCore } from './ChatCore.svelte.js';
+
+// Draft persistence
+export { ChatDraftManager } from './ChatDraftManager.svelte.js';

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -83,7 +83,8 @@ export {
 	updateProgress,
 	FileUploadManager,
 	ChatCore,
-	createChatCore
+	createChatCore,
+	ChatDraftManager
 } from './core/index.js';
 
 // UI exports

--- a/src/routes/[[lang]]/admin/support/+page.svelte
+++ b/src/routes/[[lang]]/admin/support/+page.svelte
@@ -19,9 +19,13 @@
 	import ThreadDetails from './thread-details.svelte';
 	import { adminSupportUI } from '$lib/hooks/admin-support-ui.svelte';
 	import { adminCache } from '$lib/hooks/admin-cache.svelte';
+	import { ChatDraftManager } from '$lib/chat';
 	import { browser } from '$app/environment';
 
 	const { t } = getTranslate();
+
+	// Draft persistence — lives outside {#key threadId} so drafts survive thread switches
+	const draftManager = new ChatDraftManager('drafts:admin-support');
 
 	// Filter state schema (thread managed separately to avoid reload on selection)
 	const filterSchema = v.object({
@@ -168,7 +172,7 @@
 			<Pane defaultSize={50} minSize={30}>
 				{#if threadId}
 					{#key threadId}
-						<ThreadChat {threadId} initialThread={selectedThread} />
+						<ThreadChat {threadId} initialThread={selectedThread} {draftManager} />
 					{/key}
 				{:else}
 					<div
@@ -224,7 +228,7 @@
 			<Pane defaultSize={70} minSize={50}>
 				{#if threadId}
 					{#key threadId}
-						<ThreadChat {threadId} initialThread={selectedThread} />
+						<ThreadChat {threadId} initialThread={selectedThread} {draftManager} />
 					{/key}
 				{:else}
 					<div
@@ -260,7 +264,12 @@
 			<SlidingPanel open={!!threadId} class="bg-background">
 				{#if threadId}
 					{#key threadId}
-						<ThreadChat {threadId} initialThread={selectedThread} onBackClick={clearThread} />
+						<ThreadChat
+							{threadId}
+							initialThread={selectedThread}
+							onBackClick={clearThread}
+							{draftManager}
+						/>
 					{/key}
 				{/if}
 			</SlidingPanel>

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -7,6 +7,7 @@
 	import ChatInput from '$lib/chat/ui/ChatInput.svelte';
 	import { ChatUIContext, type UploadConfig } from '$lib/chat/ui/ChatContext.svelte';
 	import { ChatCore } from '$lib/chat/core/ChatCore.svelte';
+	import type { ChatDraftManager } from '$lib/chat/core/ChatDraftManager.svelte';
 	import { createOptimisticUpdate, type ListMessagesArgs } from '$lib/chat/core/optimistic';
 	import { Button } from '$lib/components/ui/button';
 	import { Skeleton } from '$lib/components/ui/skeleton';
@@ -25,7 +26,8 @@
 	let {
 		threadId,
 		initialThread,
-		onBackClick
+		onBackClick,
+		draftManager
 	}: {
 		threadId: string;
 		initialThread?: {
@@ -35,6 +37,7 @@
 			lastMessageAt?: number;
 		};
 		onBackClick?: () => void;
+		draftManager?: ChatDraftManager;
 	} = $props();
 
 	const media = useMedia();
@@ -66,6 +69,22 @@
 
 	// Create ChatUIContext with upload support (userAlignment 'left' for admin view)
 	const chatUIContext = new ChatUIContext(chatCore, client, uploadConfig, 'left');
+
+	// Draft persistence — load saved draft on mount, save continuously
+	let sending = $state(false);
+
+	// Load saved draft on mount (threadId is constant per {#key} instance)
+	if (draftManager) {
+		const draft = draftManager.getDraft(threadId);
+		if (draft) chatUIContext.setInputValue(draft);
+	}
+
+	$effect(() => {
+		if (!draftManager) return;
+		// Don't persist the empty string caused by clearInput() during send
+		if (sending && !chatUIContext.inputValue.trim()) return;
+		draftManager.setDraft(threadId, chatUIContext.inputValue);
+	});
 
 	// Query thread details to show header info
 	const threadQuery = useQuery(api.admin.support.queries.getThreadForAdmin, () => ({
@@ -243,6 +262,7 @@
 				};
 
 				// Fire-and-forget: no blocking, optimistic update provides instant feedback
+				sending = true;
 				try {
 					await client.mutation(
 						api.admin.support.mutations.sendAdminReply,
@@ -265,11 +285,16 @@
 						}
 					);
 
-					// Clear attachments after successful send
+					// Clear attachments and draft after successful send
 					chatUIContext.clearAttachments();
+					draftManager?.clearDraft(threadId);
 				} catch (error) {
 					console.error('[Admin sendAdminReply] Error:', error);
+					// Restore prompt so user can retry and $effect re-persists draft
+					chatUIContext.setInputValue(prompt);
 					toast.error($t('admin.support.chat.error.send_failed'));
+				} finally {
+					sending = false;
 				}
 			}}
 		/>

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { useConvexClient } from 'convex-svelte';
 	import { toast } from 'svelte-sonner';
+	import { watch } from 'runed';
 	import { api } from '$lib/convex/_generated/api';
 	import ChatRoot from '$lib/chat/ui/ChatRoot.svelte';
 	import ChatMessages from '$lib/chat/ui/ChatMessages.svelte';
@@ -8,6 +9,7 @@
 	import { PromptSuggestion } from '$lib/components/prompt-kit/prompt-suggestion';
 	import { ChatUIContext, type UploadConfig } from '$lib/chat/ui/ChatContext.svelte';
 	import { ChatCore } from '$lib/chat/core/ChatCore.svelte';
+	import { ChatDraftManager } from '$lib/chat/core/ChatDraftManager.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import LockIcon from '@lucide/svelte/icons/lock';
 	import { T, getTranslate } from '@tolgee/svelte';
@@ -69,6 +71,28 @@
 	});
 
 	const chatUIContext = new ChatUIContext(chatCore, client, uploadConfig, 'right');
+
+	// Draft persistence across thread switches and page refreshes
+	const draftManager = new ChatDraftManager('drafts:ai-chat');
+	let sending = $state(false);
+
+	// Save draft on leave, restore on enter
+	watch(
+		() => threadId,
+		(current, previous) => {
+			if (previous && chatUIContext.inputValue.trim()) {
+				draftManager.setDraft(previous, chatUIContext.inputValue);
+			}
+			chatUIContext.setInputValue(draftManager.getDraft(current));
+		}
+	);
+
+	// Continuous save for refresh persistence
+	$effect(() => {
+		// Don't persist the empty string caused by clearInput() during send
+		if (sending && !chatUIContext.inputValue.trim()) return;
+		draftManager.setDraft(threadId, chatUIContext.inputValue);
+	});
 
 	// Auto-focus input when thread changes
 	let chatContainer: HTMLDivElement | undefined = $state();
@@ -196,17 +220,21 @@
 				isRateLimited={!hasMessagesAvailable}
 				onSend={async (prompt) => {
 					if (!hasMessagesAvailable || !prompt?.trim()) return;
-
+					sending = true;
 					try {
 						await chatCore.sendMessage(client, prompt, {
 							fileIds: chatUIContext.uploadedFileIds,
 							attachments: chatUIContext.attachments
 						});
 						chatUIContext.clearAttachments();
+						draftManager.clearDraft(threadId);
 						onMessageSent?.();
 					} catch (error) {
 						console.error('[AI Chat sendMessage] Error:', error);
+						chatUIContext.setInputValue(prompt);
 						toast.error($t('chat.messages.send_failed'));
+					} finally {
+						sending = false;
 					}
 				}}
 			/>


### PR DESCRIPTION
Extract reusable ChatDraftManager from existing support widget pattern.
Drafts persist to localStorage across thread switches and page refreshes.
Includes send-failure recovery (prompt restored to input on error).