### PR TITLE
fix(chat): Prevent reasoning accordion from reopening after user closes during streaming

### DIFF
--- a/src/lib/chat/ui/ChatContext.svelte.ts
+++ b/src/lib/chat/ui/ChatContext.svelte.ts
@@ -57,8 +57,8 @@ export class ChatUIContext {
 	/** Tracks messages that have been auto-opened (for auto-close logic) */
 	autoOpenedMessages = $state(new SvelteSet<string>());
 
-	/** Tracks reasoning blocks the user has manually toggled (user owns the state) */
-	userDismissedMessages = $state(new SvelteSet<string>());
+	/** Tracks reasoning blocks the user has manually toggled (auto-sync should not override) */
+	userToggledMessages = $state(new SvelteSet<string>());
 
 	/** Processed messages with display fields (set by ChatMessages) */
 	displayMessages = $state<DisplayMessage[]>([]);
@@ -155,28 +155,28 @@ export class ChatUIContext {
 	}
 
 	/**
-	 * Mark a reasoning block as user-dismissed (user manually toggled it)
+	 * Mark a reasoning block as user-toggled (auto-sync should not override)
 	 */
-	markUserDismissed(messageId: string): void {
-		this.userDismissedMessages.add(messageId);
+	markUserToggled(messageId: string): void {
+		this.userToggledMessages.add(messageId);
 	}
 
 	/**
-	 * Check if a reasoning block was user-dismissed
+	 * Check if a reasoning block was user-toggled
 	 */
-	wasUserDismissed(messageId: string): boolean {
-		return this.userDismissedMessages.has(messageId);
+	wasUserToggled(messageId: string): boolean {
+		return this.userToggledMessages.has(messageId);
 	}
 
 	/**
-	 * Clear user-dismissed tracking for a reasoning block
+	 * Clear user-toggled tracking for a reasoning block
 	 */
-	clearUserDismissed(messageId: string): void {
-		this.userDismissedMessages.delete(messageId);
+	clearUserToggled(messageId: string): void {
+		this.userToggledMessages.delete(messageId);
 	}
 
-	getUserDismissedKeys(): Iterable<string> {
-		return this.userDismissedMessages.keys();
+	getUserToggledKeys(): Iterable<string> {
+		return this.userToggledMessages.keys();
 	}
 
 	/**

--- a/src/lib/chat/ui/ChatContext.svelte.ts
+++ b/src/lib/chat/ui/ChatContext.svelte.ts
@@ -57,6 +57,9 @@ export class ChatUIContext {
 	/** Tracks messages that have been auto-opened (for auto-close logic) */
 	autoOpenedMessages = $state(new SvelteSet<string>());
 
+	/** Tracks reasoning blocks the user has manually toggled (user owns the state) */
+	userDismissedMessages = $state(new SvelteSet<string>());
+
 	/** Processed messages with display fields (set by ChatMessages) */
 	displayMessages = $state<DisplayMessage[]>([]);
 
@@ -149,6 +152,31 @@ export class ChatUIContext {
 
 	getAutoOpenedKeys(): Iterable<string> {
 		return this.autoOpenedMessages.keys();
+	}
+
+	/**
+	 * Mark a reasoning block as user-dismissed (user manually toggled it)
+	 */
+	markUserDismissed(messageId: string): void {
+		this.userDismissedMessages.add(messageId);
+	}
+
+	/**
+	 * Check if a reasoning block was user-dismissed
+	 */
+	wasUserDismissed(messageId: string): boolean {
+		return this.userDismissedMessages.has(messageId);
+	}
+
+	/**
+	 * Clear user-dismissed tracking for a reasoning block
+	 */
+	clearUserDismissed(messageId: string): void {
+		this.userDismissedMessages.delete(messageId);
+	}
+
+	getUserDismissedKeys(): Iterable<string> {
+		return this.userDismissedMessages.keys();
 	}
 
 	/**

--- a/src/lib/chat/ui/ChatMessage.svelte
+++ b/src/lib/chat/ui/ChatMessage.svelte
@@ -57,7 +57,9 @@
 	}
 
 	function handleReasoningPartOpenChange(partKey: string, open: boolean) {
-		ctx.setReasoningOpen(`${message.id}:${partKey}`, open);
+		const fullKey = `${message.id}:${partKey}`;
+		ctx.setReasoningOpen(fullKey, open);
+		ctx.markUserDismissed(fullKey);
 	}
 
 	// Fallback: single reasoning open state for messages without parts
@@ -127,6 +129,7 @@
 
 	function handleReasoningOpenChange(open: boolean) {
 		ctx.setReasoningOpen(message.id, open);
+		ctx.markUserDismissed(message.id);
 	}
 </script>
 

--- a/src/lib/chat/ui/ChatMessage.svelte
+++ b/src/lib/chat/ui/ChatMessage.svelte
@@ -59,7 +59,7 @@
 	function handleReasoningPartOpenChange(partKey: string, open: boolean) {
 		const fullKey = `${message.id}:${partKey}`;
 		ctx.setReasoningOpen(fullKey, open);
-		ctx.markUserDismissed(fullKey);
+		ctx.markUserToggled(fullKey);
 	}
 
 	// Fallback: single reasoning open state for messages without parts
@@ -129,7 +129,7 @@
 
 	function handleReasoningOpenChange(open: boolean) {
 		ctx.setReasoningOpen(message.id, open);
-		ctx.markUserDismissed(message.id);
+		ctx.markUserToggled(message.id);
 	}
 </script>
 

--- a/src/lib/chat/ui/reasoning-accordion-sync.test.ts
+++ b/src/lib/chat/ui/reasoning-accordion-sync.test.ts
@@ -5,9 +5,14 @@ import {
 	type ReasoningAccordionController
 } from './reasoning-accordion-sync.js';
 
-function createController(initiallyOpen: string[] = [], initiallyAutoOpened: string[] = []) {
+function createController(
+	initiallyOpen: string[] = [],
+	initiallyAutoOpened: string[] = [],
+	initiallyUserDismissed: string[] = []
+) {
 	const openState = new Set(initiallyOpen);
 	const autoOpened = new Set(initiallyAutoOpened);
+	const userDismissed = new Set(initiallyUserDismissed);
 
 	const controller: ReasoningAccordionController = {
 		isReasoningOpen: (messageId) => openState.has(messageId),
@@ -25,10 +30,15 @@ function createController(initiallyOpen: string[] = [], initiallyAutoOpened: str
 		clearAutoOpened: (messageId) => {
 			autoOpened.delete(messageId);
 		},
-		getAutoOpenedKeys: () => autoOpened.values()
+		getAutoOpenedKeys: () => autoOpened.values(),
+		wasUserDismissed: (messageId) => userDismissed.has(messageId),
+		clearUserDismissed: (messageId) => {
+			userDismissed.delete(messageId);
+		},
+		getUserDismissedKeys: () => userDismissed.values()
 	};
 
-	return { controller, openState, autoOpened };
+	return { controller, openState, autoOpened, userDismissed };
 }
 
 function createDisplayMessage(overrides: Partial<DisplayMessage> = {}): DisplayMessage {
@@ -204,5 +214,138 @@ describe('syncReasoningAccordionState', () => {
 
 		expect(openState.has('msg-1:reasoning-ghost')).toBe(false);
 		expect(autoOpened.has('msg-1:reasoning-ghost')).toBe(false);
+	});
+
+	it('does not reopen a reasoning block the user closed during streaming', () => {
+		// Step 1: auto-open during streaming
+		const { controller, openState } = createController();
+		const streamingMsg = createDisplayMessage({
+			parts: [{ type: 'reasoning', text: 'Thinking', streamPartId: 'reason-1' }]
+		});
+
+		syncReasoningAccordionState([streamingMsg], controller);
+		expect(openState.has('msg-1:reasoning-reason-1')).toBe(true);
+
+		// Step 2: simulate user close (setReasoningOpen + markUserDismissed from ChatMessage handler)
+		// Recreate controller with the post-user-close state: closed, auto-opened, user-dismissed
+		const { controller: c2, openState: os2 } = createController(
+			[],
+			['msg-1:reasoning-reason-1'],
+			['msg-1:reasoning-reason-1']
+		);
+
+		// Step 3: next stream update — should NOT reopen
+		syncReasoningAccordionState([streamingMsg], c2);
+		expect(os2.has('msg-1:reasoning-reason-1')).toBe(false);
+	});
+
+	it('respects user reopen during streaming — does not auto-close on completion', () => {
+		// User closed then reopened — userDismissed is set, accordion is open
+		const { controller, openState, autoOpened, userDismissed } = createController(
+			['msg-1:reasoning-reason-1'],
+			['msg-1:reasoning-reason-1'],
+			['msg-1:reasoning-reason-1']
+		);
+
+		// Streaming ends: reasoning is no longer the active part
+		syncReasoningAccordionState(
+			[
+				createDisplayMessage({
+					status: 'success',
+					parts: [
+						{ type: 'reasoning', text: 'Done', streamPartId: 'reason-1' },
+						{ type: 'text', text: 'Response' }
+					]
+				})
+			],
+			controller
+		);
+
+		// User-dismissed blocks should not be auto-closed
+		expect(openState.has('msg-1:reasoning-reason-1')).toBe(true);
+		// But tracking flags should be cleaned up
+		expect(autoOpened.has('msg-1:reasoning-reason-1')).toBe(false);
+		expect(userDismissed.has('msg-1:reasoning-reason-1')).toBe(false);
+	});
+
+	it('does not reopen a legacy fallback the user closed during streaming', () => {
+		// Step 1: auto-open legacy message
+		const { controller, openState } = createController();
+		syncReasoningAccordionState(
+			[
+				createDisplayMessage({
+					id: 'msg-legacy',
+					parts: undefined,
+					displayReasoning: 'Thinking...',
+					displayText: ''
+				})
+			],
+			controller
+		);
+		expect(openState.has('msg-legacy')).toBe(true);
+
+		// Step 2: user closes, simulate with dismissed state
+		const { controller: c2, openState: os2 } = createController([], ['msg-legacy'], ['msg-legacy']);
+
+		// Step 3: next sync — should NOT reopen
+		syncReasoningAccordionState(
+			[
+				createDisplayMessage({
+					id: 'msg-legacy',
+					parts: undefined,
+					displayReasoning: 'Thinking more...',
+					displayText: ''
+				})
+			],
+			c2
+		);
+		expect(os2.has('msg-legacy')).toBe(false);
+	});
+
+	it('opens a new reasoning block even after user closed a previous one', () => {
+		// reason-1 was auto-opened then user-dismissed
+		const { controller, openState } = createController(
+			[],
+			['msg-1:reasoning-reason-1'],
+			['msg-1:reasoning-reason-1']
+		);
+
+		// New streaming message with reason-1 (done) + tool + reason-2 (active)
+		syncReasoningAccordionState(
+			[
+				createDisplayMessage({
+					parts: [
+						{ type: 'reasoning', text: 'First', streamPartId: 'reason-1' },
+						{ type: 'tool-getWeather', toolCallId: 'tool-1', state: 'output-available' },
+						{ type: 'reasoning', text: 'Second', streamPartId: 'reason-2' }
+					]
+				})
+			],
+			controller
+		);
+
+		// reason-1 should stay as user left it (closed), reason-2 should auto-open
+		expect(openState.has('msg-1:reasoning-reason-1')).toBe(false);
+		expect(openState.has('msg-1:reasoning-reason-2')).toBe(true);
+	});
+
+	it('removes stale userDismissed keys when reasoning parts disappear', () => {
+		const { controller, userDismissed } = createController(
+			[],
+			['msg-1:reasoning-ghost'],
+			['msg-1:reasoning-ghost']
+		);
+
+		syncReasoningAccordionState(
+			[
+				createDisplayMessage({
+					status: 'success',
+					parts: [{ type: 'reasoning', text: 'Current', streamPartId: 'reason-1' }]
+				})
+			],
+			controller
+		);
+
+		expect(userDismissed.has('msg-1:reasoning-ghost')).toBe(false);
 	});
 });

--- a/src/lib/chat/ui/reasoning-accordion-sync.test.ts
+++ b/src/lib/chat/ui/reasoning-accordion-sync.test.ts
@@ -8,11 +8,11 @@ import {
 function createController(
 	initiallyOpen: string[] = [],
 	initiallyAutoOpened: string[] = [],
-	initiallyUserDismissed: string[] = []
+	initiallyUserToggled: string[] = []
 ) {
 	const openState = new Set(initiallyOpen);
 	const autoOpened = new Set(initiallyAutoOpened);
-	const userDismissed = new Set(initiallyUserDismissed);
+	const userToggled = new Set(initiallyUserToggled);
 
 	const controller: ReasoningAccordionController = {
 		isReasoningOpen: (messageId) => openState.has(messageId),
@@ -31,14 +31,14 @@ function createController(
 			autoOpened.delete(messageId);
 		},
 		getAutoOpenedKeys: () => autoOpened.values(),
-		wasUserDismissed: (messageId) => userDismissed.has(messageId),
-		clearUserDismissed: (messageId) => {
-			userDismissed.delete(messageId);
+		wasUserToggled: (messageId) => userToggled.has(messageId),
+		clearUserToggled: (messageId) => {
+			userToggled.delete(messageId);
 		},
-		getUserDismissedKeys: () => userDismissed.values()
+		getUserToggledKeys: () => userToggled.values()
 	};
 
-	return { controller, openState, autoOpened, userDismissed };
+	return { controller, openState, autoOpened, userToggled };
 }
 
 function createDisplayMessage(overrides: Partial<DisplayMessage> = {}): DisplayMessage {
@@ -226,7 +226,7 @@ describe('syncReasoningAccordionState', () => {
 		syncReasoningAccordionState([streamingMsg], controller);
 		expect(openState.has('msg-1:reasoning-reason-1')).toBe(true);
 
-		// Step 2: simulate user close (setReasoningOpen + markUserDismissed from ChatMessage handler)
+		// Step 2: simulate user close (setReasoningOpen + markUserToggled from ChatMessage handler)
 		// Recreate controller with the post-user-close state: closed, auto-opened, user-dismissed
 		const { controller: c2, openState: os2 } = createController(
 			[],
@@ -240,8 +240,8 @@ describe('syncReasoningAccordionState', () => {
 	});
 
 	it('respects user reopen during streaming — does not auto-close on completion', () => {
-		// User closed then reopened — userDismissed is set, accordion is open
-		const { controller, openState, autoOpened, userDismissed } = createController(
+		// User closed then reopened — userToggled is set, accordion is open
+		const { controller, openState, autoOpened, userToggled } = createController(
 			['msg-1:reasoning-reason-1'],
 			['msg-1:reasoning-reason-1'],
 			['msg-1:reasoning-reason-1']
@@ -265,7 +265,7 @@ describe('syncReasoningAccordionState', () => {
 		expect(openState.has('msg-1:reasoning-reason-1')).toBe(true);
 		// But tracking flags should be cleaned up
 		expect(autoOpened.has('msg-1:reasoning-reason-1')).toBe(false);
-		expect(userDismissed.has('msg-1:reasoning-reason-1')).toBe(false);
+		expect(userToggled.has('msg-1:reasoning-reason-1')).toBe(false);
 	});
 
 	it('does not reopen a legacy fallback the user closed during streaming', () => {
@@ -329,8 +329,8 @@ describe('syncReasoningAccordionState', () => {
 		expect(openState.has('msg-1:reasoning-reason-2')).toBe(true);
 	});
 
-	it('removes stale userDismissed keys when reasoning parts disappear', () => {
-		const { controller, userDismissed } = createController(
+	it('removes stale userToggled keys when reasoning parts disappear', () => {
+		const { controller, userToggled } = createController(
 			[],
 			['msg-1:reasoning-ghost'],
 			['msg-1:reasoning-ghost']
@@ -346,6 +346,6 @@ describe('syncReasoningAccordionState', () => {
 			controller
 		);
 
-		expect(userDismissed.has('msg-1:reasoning-ghost')).toBe(false);
+		expect(userToggled.has('msg-1:reasoning-ghost')).toBe(false);
 	});
 });

--- a/src/lib/chat/ui/reasoning-accordion-sync.ts
+++ b/src/lib/chat/ui/reasoning-accordion-sync.ts
@@ -8,6 +8,9 @@ export interface ReasoningAccordionController {
 	markAutoOpened(messageId: string): void;
 	clearAutoOpened(messageId: string): void;
 	getAutoOpenedKeys(): Iterable<string>;
+	wasUserDismissed(messageId: string): boolean;
+	clearUserDismissed(messageId: string): void;
+	getUserDismissedKeys(): Iterable<string>;
 }
 
 export function syncReasoningAccordionState(
@@ -29,13 +32,18 @@ export function syncReasoningAccordionState(
 				validReasoningKeys.add(partKey);
 
 				if (index === activeReasoningIndex) {
-					if (!controller.isReasoningOpen(partKey)) {
-						controller.setReasoningOpen(partKey, true);
-						controller.markAutoOpened(partKey);
+					if (!controller.wasUserDismissed(partKey)) {
+						if (!controller.isReasoningOpen(partKey)) {
+							controller.setReasoningOpen(partKey, true);
+							controller.markAutoOpened(partKey);
+						}
 					}
 				} else if (controller.wasAutoOpened(partKey)) {
-					controller.setReasoningOpen(partKey, false);
+					if (!controller.wasUserDismissed(partKey)) {
+						controller.setReasoningOpen(partKey, false);
+					}
 					controller.clearAutoOpened(partKey);
+					controller.clearUserDismissed(partKey);
 				}
 			});
 			return;
@@ -46,12 +54,19 @@ export function syncReasoningAccordionState(
 
 		if (hasReasoning && !hasResponse) {
 			validReasoningKeys.add(message.id);
-			controller.setReasoningOpen(message.id, true);
-			controller.markAutoOpened(message.id);
+			if (!controller.wasUserDismissed(message.id)) {
+				if (!controller.isReasoningOpen(message.id) && !controller.wasAutoOpened(message.id)) {
+					controller.setReasoningOpen(message.id, true);
+					controller.markAutoOpened(message.id);
+				}
+			}
 		} else if (hasResponse && controller.wasAutoOpened(message.id)) {
 			validReasoningKeys.add(message.id);
-			controller.setReasoningOpen(message.id, false);
+			if (!controller.wasUserDismissed(message.id)) {
+				controller.setReasoningOpen(message.id, false);
+			}
 			controller.clearAutoOpened(message.id);
+			controller.clearUserDismissed(message.id);
 		}
 	});
 
@@ -59,5 +74,10 @@ export function syncReasoningAccordionState(
 		if (validReasoningKeys.has(autoOpenedKey)) continue;
 		controller.setReasoningOpen(autoOpenedKey, false);
 		controller.clearAutoOpened(autoOpenedKey);
+	}
+
+	for (const dismissedKey of controller.getUserDismissedKeys()) {
+		if (validReasoningKeys.has(dismissedKey)) continue;
+		controller.clearUserDismissed(dismissedKey);
 	}
 }

--- a/src/lib/chat/ui/reasoning-accordion-sync.ts
+++ b/src/lib/chat/ui/reasoning-accordion-sync.ts
@@ -8,9 +8,9 @@ export interface ReasoningAccordionController {
 	markAutoOpened(messageId: string): void;
 	clearAutoOpened(messageId: string): void;
 	getAutoOpenedKeys(): Iterable<string>;
-	wasUserDismissed(messageId: string): boolean;
-	clearUserDismissed(messageId: string): void;
-	getUserDismissedKeys(): Iterable<string>;
+	wasUserToggled(messageId: string): boolean;
+	clearUserToggled(messageId: string): void;
+	getUserToggledKeys(): Iterable<string>;
 }
 
 export function syncReasoningAccordionState(
@@ -32,18 +32,18 @@ export function syncReasoningAccordionState(
 				validReasoningKeys.add(partKey);
 
 				if (index === activeReasoningIndex) {
-					if (!controller.wasUserDismissed(partKey)) {
+					if (!controller.wasUserToggled(partKey)) {
 						if (!controller.isReasoningOpen(partKey)) {
 							controller.setReasoningOpen(partKey, true);
 							controller.markAutoOpened(partKey);
 						}
 					}
 				} else if (controller.wasAutoOpened(partKey)) {
-					if (!controller.wasUserDismissed(partKey)) {
+					if (!controller.wasUserToggled(partKey)) {
 						controller.setReasoningOpen(partKey, false);
 					}
 					controller.clearAutoOpened(partKey);
-					controller.clearUserDismissed(partKey);
+					controller.clearUserToggled(partKey);
 				}
 			});
 			return;
@@ -54,19 +54,19 @@ export function syncReasoningAccordionState(
 
 		if (hasReasoning && !hasResponse) {
 			validReasoningKeys.add(message.id);
-			if (!controller.wasUserDismissed(message.id)) {
-				if (!controller.isReasoningOpen(message.id) && !controller.wasAutoOpened(message.id)) {
+			if (!controller.wasUserToggled(message.id)) {
+				if (!controller.isReasoningOpen(message.id)) {
 					controller.setReasoningOpen(message.id, true);
 					controller.markAutoOpened(message.id);
 				}
 			}
 		} else if (hasResponse && controller.wasAutoOpened(message.id)) {
 			validReasoningKeys.add(message.id);
-			if (!controller.wasUserDismissed(message.id)) {
+			if (!controller.wasUserToggled(message.id)) {
 				controller.setReasoningOpen(message.id, false);
 			}
 			controller.clearAutoOpened(message.id);
-			controller.clearUserDismissed(message.id);
+			controller.clearUserToggled(message.id);
 		}
 	});
 
@@ -76,8 +76,8 @@ export function syncReasoningAccordionState(
 		controller.clearAutoOpened(autoOpenedKey);
 	}
 
-	for (const dismissedKey of controller.getUserDismissedKeys()) {
-		if (validReasoningKeys.has(dismissedKey)) continue;
-		controller.clearUserDismissed(dismissedKey);
+	for (const toggledKey of controller.getUserToggledKeys()) {
+		if (validReasoningKeys.has(toggledKey)) continue;
+		controller.clearUserToggled(toggledKey);
 	}
 }


### PR DESCRIPTION
Add explicit user-dismissed tracking so the sync function respects
manual toggles. Any user interaction hands full control of that
reasoning block to the user until the block's lifecycle ends.