### PR TITLE
fix(chat): Fix draft persistence loop and silent delete failure

### DIFF
--- a/src/lib/chat/core/ChatDraftManager.svelte.ts
+++ b/src/lib/chat/core/ChatDraftManager.svelte.ts
@@ -22,12 +22,16 @@ export class ChatDraftManager {
 		if (text.trim()) {
 			this.drafts.current[threadId] = text;
 		} else {
-			delete this.drafts.current[threadId];
+			// Rest spread instead of delete: PersistedState's Proxy has no deleteProperty trap,
+			// so `delete` silently skips localStorage serialization
+			const { [threadId]: _, ...rest } = this.drafts.current;
+			this.drafts.current = rest;
 		}
 	}
 
 	clearDraft(threadId: string | null): void {
 		if (!threadId) return;
-		delete this.drafts.current[threadId];
+		const { [threadId]: _, ...rest } = this.drafts.current;
+		this.drafts.current = rest;
 	}
 }

--- a/src/lib/chat/core/ChatDraftManager.test.ts
+++ b/src/lib/chat/core/ChatDraftManager.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Provide a proper Web Storage API for PersistedState
+const storage = new Map<string, string>();
+const localStorageMock: Storage = {
+	getItem: (key: string) => storage.get(key) ?? null,
+	setItem: (key: string, value: string) => storage.set(key, value),
+	removeItem: (key: string) => storage.delete(key),
+	clear: () => storage.clear(),
+	get length() {
+		return storage.size;
+	},
+	key: (index: number) => [...storage.keys()][index] ?? null
+};
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
+
+// Mock esm-env so runed's PersistedState uses the window/localStorage above
+vi.mock('esm-env', () => ({ BROWSER: true, DEV: true }));
+
+import { ChatDraftManager } from './ChatDraftManager.svelte';
+
+describe('ChatDraftManager', () => {
+	let manager: ChatDraftManager;
+
+	beforeEach(() => {
+		storage.clear();
+		manager = new ChatDraftManager('test-drafts-' + Math.random());
+	});
+
+	it('stores and retrieves a draft', () => {
+		manager.setDraft('thread-1', 'hello world');
+		expect(manager.getDraft('thread-1')).toBe('hello world');
+	});
+
+	it('returns empty string for unknown thread', () => {
+		expect(manager.getDraft('nonexistent')).toBe('');
+	});
+
+	it('returns empty string for null threadId', () => {
+		expect(manager.getDraft(null)).toBe('');
+	});
+
+	it('removes key when setDraft is called with empty string', () => {
+		manager.setDraft('thread-1', 'draft text');
+		manager.setDraft('thread-1', '');
+		expect(manager.getDraft('thread-1')).toBe('');
+		expect('thread-1' in manager.drafts.current).toBe(false);
+	});
+
+	it('removes key when setDraft is called with whitespace-only string', () => {
+		manager.setDraft('thread-1', 'draft text');
+		manager.setDraft('thread-1', '   ');
+		expect(manager.getDraft('thread-1')).toBe('');
+		expect('thread-1' in manager.drafts.current).toBe(false);
+	});
+
+	it('clearDraft removes the key', () => {
+		manager.setDraft('thread-1', 'draft text');
+		manager.clearDraft('thread-1');
+		expect(manager.getDraft('thread-1')).toBe('');
+		expect('thread-1' in manager.drafts.current).toBe(false);
+	});
+
+	it('clearDraft is a no-op for null threadId', () => {
+		manager.setDraft('thread-1', 'draft text');
+		manager.clearDraft(null);
+		expect(manager.getDraft('thread-1')).toBe('draft text');
+	});
+
+	it('setDraft is a no-op for null threadId', () => {
+		manager.setDraft(null, 'should not store');
+		expect(Object.keys(manager.drafts.current)).toHaveLength(0);
+	});
+
+	it('preserves other drafts when clearing one', () => {
+		manager.setDraft('thread-1', 'draft 1');
+		manager.setDraft('thread-2', 'draft 2');
+		manager.clearDraft('thread-1');
+		expect(manager.getDraft('thread-1')).toBe('');
+		expect(manager.getDraft('thread-2')).toBe('draft 2');
+	});
+});

--- a/src/lib/chat/core/ChatDraftManager.test.ts
+++ b/src/lib/chat/core/ChatDraftManager.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Provide a proper Web Storage API for PersistedState
+// Mock esm-env so runed's PersistedState uses the window/localStorage
+vi.mock('esm-env', () => ({ BROWSER: true, DEV: true }));
+
+// Provide a proper Web Storage API (jsdom's localStorage lacks standard methods)
 const storage = new Map<string, string>();
 const localStorageMock: Storage = {
 	getItem: (key: string) => storage.get(key) ?? null,
@@ -12,15 +15,19 @@ const localStorageMock: Storage = {
 	},
 	key: (index: number) => [...storage.keys()][index] ?? null
 };
-Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
-
-// Mock esm-env so runed's PersistedState uses the window/localStorage above
-vi.mock('esm-env', () => ({ BROWSER: true, DEV: true }));
 
 import { ChatDraftManager } from './ChatDraftManager.svelte';
 
 describe('ChatDraftManager', () => {
 	let manager: ChatDraftManager;
+
+	beforeAll(() => {
+		vi.stubGlobal('localStorage', localStorageMock);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
 
 	beforeEach(() => {
 		storage.clear();

--- a/src/lib/components/customer-support/support-thread-context.svelte.ts
+++ b/src/lib/components/customer-support/support-thread-context.svelte.ts
@@ -1,4 +1,5 @@
-import { Context, PersistedState } from 'runed';
+import { Context } from 'runed';
+import { ChatDraftManager } from '$lib/chat/core/ChatDraftManager.svelte';
 import type { ConvexClient } from 'convex/browser';
 import type { UIMessagePart, UIDataTypes, UITools } from 'ai';
 import { isToolOrDynamicToolUIPart } from 'ai';
@@ -85,34 +86,19 @@ export class SupportThreadContext {
 	// Rate limit state
 	rateLimitedUntil = $state<number | null>(null);
 
-	// Draft storage - persists input text per thread to localStorage
-	readonly drafts = new PersistedState<Record<string, string>>('support-drafts', {});
+	// Draft storage — delegates to ChatDraftManager (single source of delete-safe logic)
+	private readonly draftManager = new ChatDraftManager('support-drafts');
 
-	/**
-	 * Get draft text for a thread
-	 */
 	getDraft(threadId: string | null): string {
-		return threadId ? (this.drafts.current[threadId] ?? '') : '';
+		return this.draftManager.getDraft(threadId);
 	}
 
-	/**
-	 * Save draft text for a thread
-	 */
 	setDraft(threadId: string | null, text: string): void {
-		if (!threadId) return;
-		if (text.trim()) {
-			this.drafts.current[threadId] = text;
-		} else {
-			delete this.drafts.current[threadId];
-		}
+		this.draftManager.setDraft(threadId, text);
 	}
 
-	/**
-	 * Clear draft for a thread (e.g., after sending)
-	 */
 	clearDraft(threadId: string | null): void {
-		if (!threadId) return;
-		delete this.drafts.current[threadId];
+		this.draftManager.clearDraft(threadId);
 	}
 
 	/**

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { useConvexClient, useQuery } from 'convex-svelte';
 	import { toast } from 'svelte-sonner';
+	import { watch } from 'runed';
 	import { api } from '$lib/convex/_generated/api';
 	import ChatRoot from '$lib/chat/ui/ChatRoot.svelte';
 	import ChatMessages from '$lib/chat/ui/ChatMessages.svelte';
@@ -79,12 +80,16 @@
 		if (draft) chatUIContext.setInputValue(draft);
 	}
 
-	$effect(() => {
-		if (!draftManager) return;
-		// Don't persist the empty string caused by clearInput() during send
-		if (sending && !chatUIContext.inputValue.trim()) return;
-		draftManager.setDraft(threadId, chatUIContext.inputValue);
-	});
+	// Continuous save — watch untracks the callback, avoiding a reactive loop
+	// with PersistedState's Proxy set trap
+	watch(
+		() => [chatUIContext.inputValue, threadId, sending, draftManager] as const,
+		([value, id, isSending, dm]) => {
+			if (!dm) return;
+			if (isSending && !value.trim()) return;
+			dm.setDraft(id, value);
+		}
+	);
 
 	// Query thread details to show header info
 	const threadQuery = useQuery(api.admin.support.queries.getThreadForAdmin, () => ({

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -87,12 +87,15 @@
 		}
 	);
 
-	// Continuous save for refresh persistence
-	$effect(() => {
-		// Don't persist the empty string caused by clearInput() during send
-		if (sending && !chatUIContext.inputValue.trim()) return;
-		draftManager.setDraft(threadId, chatUIContext.inputValue);
-	});
+	// Continuous save for refresh persistence — watch untracks the callback,
+	// avoiding a reactive loop with PersistedState's Proxy set trap
+	watch(
+		() => [chatUIContext.inputValue, threadId, sending] as const,
+		([value, id, isSending]) => {
+			if (isSending && !value.trim()) return;
+			draftManager.setDraft(id, value);
+		}
+	);
 
 	// Auto-focus input when thread changes
 	let chatContainer: HTMLDivElement | undefined = $state();


### PR DESCRIPTION
## Summary

- Replace `$effect` with runed `watch` in AI chat and admin support thread-chat draft autosave to break the reactive read-write loop with PersistedState's Proxy `set` trap (`effect_update_depth_exceeded` on page load)
- Replace `delete` operator with rest spread in `ChatDraftManager` since PersistedState's Proxy has no `deleteProperty` trap (cleared drafts silently reappeared after refresh)
- Deduplicate `SupportThreadContext` draft logic by composing `ChatDraftManager` instead of reimplementing the same methods
- Add unit tests for `ChatDraftManager` covering the delete-persistence regression

Resolves #323

## Test plan

- [x] Unit tests pass (`bun run test:unit`) — 9 tests covering set/get/clear/delete-persistence
- [x] Tests correctly fail against the old code (verified with git stash round-trip)
- [ ] AI Chat: navigate to thread, type draft, switch threads, switch back — draft restored
- [ ] AI Chat: type draft, clear it, refresh — draft stays cleared
- [ ] Admin support: same manual checks
- [ ] Customer support widget: type draft, clear, refresh — draft stays cleared