### PR TITLE
fix(billing): Surface checkout and portal errors

### DIFF
--- a/e2e/upgrade-checkout-failure.spec.ts
+++ b/e2e/upgrade-checkout-failure.spec.ts
@@ -68,7 +68,14 @@ test('pricing checkout failure surfaces an error toast instead of failing silent
 	// Pin the locale to English. `/pricing` without a prefix is redirected by
 	// src/hooks.server.ts based on Accept-Language, which would randomize the
 	// toast copy on non-English machines.
-	await page.goto('/en/pricing');
+	//
+	// The cache-buster query param avoids a CF Cache API quirk on preview
+	// deployments: CF Cache ignores the Vary: Accept header, so an earlier
+	// request for `/en/pricing` with Accept: text/markdown (exercised by
+	// e2e/public-agent-surface.spec.ts) can poison the cache and return the
+	// markdown body to a subsequent HTML request. Unique `cb` per run forces
+	// a fresh origin fetch.
+	await page.goto(`/en/pricing?cb=${Date.now()}`);
 
 	// Wait for the network to settle so client-side hydration has run and
 	// useAuth()/useCustomer() have resolved. Without this, handleCheckout
@@ -90,8 +97,8 @@ test('pricing checkout failure surfaces an error toast instead of failing silent
 	});
 	await expect(toast).toBeVisible({ timeout: 10000 });
 
-	// No navigation to a checkout URL occurred.
-	await expect(page).toHaveURL(/\/en\/pricing$/);
+	// No navigation to a checkout URL occurred (cache-buster query param kept).
+	await expect(page).toHaveURL(/\/en\/pricing\?/);
 
 	// Button returned to idle state (no longer disabled by isLoading).
 	await expect(checkoutButton).toBeEnabled();

--- a/e2e/upgrade-checkout-failure.spec.ts
+++ b/e2e/upgrade-checkout-failure.spec.ts
@@ -21,7 +21,11 @@ import { test, expect } from '@playwright/test';
 test('pricing checkout failure surfaces an error toast instead of failing silently', async ({
 	page
 }) => {
-	await page.routeWebSocket(/convex\.cloud/, (ws) => {
+	// Match Convex's WS path (`<origin>/api/<version>/sync`) on any origin.
+	// Pinning to `convex.cloud` would miss local embedded-backend runs where
+	// PUBLIC_CONVEX_URL resolves to http://localhost:PORT via
+	// e2e/utils/convex-url.ts + .convex/.backend-url.
+	await page.routeWebSocket(/\/api\/[^/]+\/sync/, (ws) => {
 		const server = ws.connectToServer();
 
 		ws.onMessage((raw) => {
@@ -78,10 +82,11 @@ test('pricing checkout failure surfaces an error toast instead of failing silent
 
 	await checkoutButton.click();
 
-	// Sonner renders toasts with data-sonner-toast. Assert on the English
-	// billing.checkout_failed copy.
+	// Sonner renders toasts with data-sonner-toast. Match on a stable
+	// substring of the billing.checkout_failed copy so minor Tolgee tweaks
+	// don't break the regression guard.
 	const toast = page.locator('[data-sonner-toast]').filter({
-		hasText: 'Checkout failed. Please try again.'
+		hasText: /Checkout failed/i
 	});
 	await expect(toast).toBeVisible({ timeout: 10000 });
 

--- a/e2e/upgrade-checkout-failure.spec.ts
+++ b/e2e/upgrade-checkout-failure.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+
+// Regression guard for #317: the Upgrade/Checkout button must surface an error
+// toast when the underlying Autumn checkout action fails, instead of silently
+// returning the button to idle with no feedback.
+//
+// Runs in the default `chromium` project using the authenticated user storage
+// state prepared by globalSetup. Pricing page chosen because the Pro checkout
+// button renders unconditionally for non-pro users — fresh test users always
+// match that state (unlike `/app/community-chat` where the upgrade CTA is
+// quota-gated).
+//
+// The reactive Convex client ships actions over WebSocket (see
+// node_modules/convex/dist/esm/browser/sync/client.js `actionInternal` — which
+// calls `webSocketManager.sendMessage`), not HTTP POST. We intercept the
+// Convex WS connection with `page.routeWebSocket`, forward everything through
+// unchanged, and synthesize a failed `ActionResponse` only for the checkout
+// action. This keeps the rest of the page (customer sync, auth token refresh,
+// etc.) working normally.
+
+test('pricing checkout failure surfaces an error toast instead of failing silently', async ({
+	page
+}) => {
+	await page.routeWebSocket(/convex\.cloud/, (ws) => {
+		const server = ws.connectToServer();
+
+		ws.onMessage((raw) => {
+			if (typeof raw !== 'string') {
+				server.send(raw);
+				return;
+			}
+			let parsed: { type?: string; udfPath?: string; requestId?: number } | null = null;
+			try {
+				parsed = JSON.parse(raw);
+			} catch {
+				/* not JSON — forward verbatim */
+			}
+			if (
+				parsed &&
+				parsed.type === 'Action' &&
+				typeof parsed.udfPath === 'string' &&
+				parsed.udfPath.includes('checkout') &&
+				typeof parsed.requestId === 'number'
+			) {
+				ws.send(
+					JSON.stringify({
+						type: 'ActionResponse',
+						requestId: parsed.requestId,
+						success: false,
+						result: 'forced failure for E2E',
+						logLines: []
+					})
+				);
+				return;
+			}
+			server.send(raw);
+		});
+
+		server.onMessage((raw) => {
+			ws.send(raw);
+		});
+	});
+
+	// Pin the locale to English. `/pricing` without a prefix is redirected by
+	// src/hooks.server.ts based on Accept-Language, which would randomize the
+	// toast copy on non-English machines.
+	await page.goto('/en/pricing');
+
+	// Wait for the network to settle so client-side hydration has run and
+	// useAuth()/useCustomer() have resolved. Without this, handleCheckout
+	// sees isAuthenticated=false and redirects to /signin instead of firing
+	// the checkout action.
+	await page.waitForLoadState('networkidle');
+
+	const checkoutButton = page.getByTestId('pricing-checkout-pro');
+	await expect(checkoutButton).toBeVisible();
+	await expect(checkoutButton).toBeEnabled();
+
+	await checkoutButton.click();
+
+	// Sonner renders toasts with data-sonner-toast. Assert on the English
+	// billing.checkout_failed copy.
+	const toast = page.locator('[data-sonner-toast]').filter({
+		hasText: 'Checkout failed. Please try again.'
+	});
+	await expect(toast).toBeVisible({ timeout: 10000 });
+
+	// No navigation to a checkout URL occurred.
+	await expect(page).toHaveURL(/\/en\/pricing$/);
+
+	// Button returned to idle state (no longer disabled by isLoading).
+	await expect(checkoutButton).toBeEnabled();
+});

--- a/src/blocks/pricing/pricing-three.svelte
+++ b/src/blocks/pricing/pricing-three.svelte
@@ -14,9 +14,11 @@
 	import { useSearchParams } from 'runed/kit';
 	import { pricingParamsSchema } from '$lib/schemas/pricing-params';
 	import { T, getTranslate } from '@tolgee/svelte';
+	import { toast } from 'svelte-sonner';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
+	import { haptic } from '$lib/hooks/use-haptic.svelte';
 
 	const { customer, checkout, openBillingPortal } = useCustomer();
 	const upgradeOperation = useAutumnOperation(checkout);
@@ -75,6 +77,19 @@
 
 		if (result?.url) {
 			window.location.href = result.url;
+		} else if (upgradeOperation.error) {
+			haptic.trigger('error');
+			toast.error($t('billing.checkout_failed'));
+			console.error('Checkout failed:', upgradeOperation.error);
+		}
+	}
+
+	async function handleManageBilling() {
+		await portalOperation.execute({});
+		if (portalOperation.error) {
+			haptic.trigger('error');
+			toast.error($t('billing.portal_failed'));
+			console.error('Billing portal failed:', portalOperation.error);
 		}
 	}
 
@@ -168,9 +183,10 @@
 
 					{#if isPro}
 						<Button
+							data-testid="pricing-manage-pro"
 							variant="outline"
 							class="mt-4 w-full"
-							onclick={() => portalOperation.execute({})}
+							onclick={handleManageBilling}
 							disabled={portalOperation.isLoading}
 						>
 							{#if portalOperation.isLoading}
@@ -181,6 +197,7 @@
 						</Button>
 					{:else}
 						<Button
+							data-testid="pricing-checkout-pro"
 							class="mt-4 w-full"
 							onclick={() => handleCheckout('pro')}
 							disabled={upgradeOperation.isLoading}

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -16,6 +16,8 @@
 			"external_services": "Externe Dienste",
 			"hosting_deployment": "Hosting & Deployment",
 			"no_framework_activity": "Es wurden noch keine Framework-Aktionen aufgezeichnet.",
+			"playground": "QA-Spielplatz",
+			"playground_description": "Öffnet den deterministischen Demo-Spielplatz und setzt das Admin-v2-Showcase auf einen bekannten Ausgangszustand zurück.",
 			"recent_framework_activity": "Letzte Framework-Aktivität",
 			"resource_overview": "Ressourcenübersicht",
 			"resource_records": "{count} Einträge",
@@ -73,21 +75,25 @@
 		},
 		"resources": {
 			"actions": {
-				"create": "Create",
-				"create_resource": "Create {resource}",
-				"delete": "Delete",
-				"edit": "Edit",
-				"force_delete": "Force Delete",
+				"associate": "Zuordnen",
+				"attach": "Anhängen",
+				"create": "Erstellen",
+				"create_resource": "{resource} erstellen",
+				"delete": "Löschen",
+				"detach": "Trennen",
+				"dissociate": "Trennen",
+				"edit": "Bearbeiten",
+				"force_delete": "Endgültig löschen",
 				"preview": "Vorschau",
-				"replicate": "Replicate",
-				"restore": "Restore",
+				"replicate": "Duplizieren",
+				"restore": "Wiederherstellen",
 				"select_exactly_one": "Bitte wählen Sie genau einen Datensatz aus.",
 				"status_completed": "Abgeschlossen",
 				"status_failed": "Fehlgeschlagen",
 				"status_pending": "Ausstehend",
 				"status_running": "Laufend",
 				"update_resource": "{resource} aktualisieren",
-				"view": "View"
+				"view": "Ansehen"
 			},
 			"actions_column": "Aktionen",
 			"activity": {
@@ -300,6 +306,65 @@
 				"copied_tooltip": "Kopiert!",
 				"tooltip": "In Zwischenablage kopieren"
 			},
+			"demo_assets": {
+				"actions": {
+					"delete_description": "Demo-Asset „{name}“ löschen? Hochgeladene Dateien werden ebenfalls entfernt.",
+					"delete_title": "Demo-Asset löschen",
+					"seed_data": "Demo-Assets befüllen"
+				},
+				"dashboard_description": "Medien- und Rich-Field-Showcase für Uploads, Markdown, Code und JSON.",
+				"empty_description": "Erstellen Sie ein Demo-Asset oder befüllen Sie die Showcase-Daten, um die Rich-Field-Darstellung zu prüfen.",
+				"empty_title": "Keine Demo-Assets",
+				"fields": {
+					"attachment": "Anhang",
+					"attachment_help": "Laden Sie eine herunterladbare Datei hoch, um den generischen Datei-Lebenszyklus zu prüfen.",
+					"code_snippet": "Code-Snippet",
+					"content_summary": "Inhaltsübersicht",
+					"content_summary_help": "Berechnete Vorschau des aktuellen Markdown-Inhalts und der Upload-Abdeckung.",
+					"coverage": "Abdeckung",
+					"hero_image": "Hero-Bild",
+					"hero_image_help": "Laden Sie ein Bild hoch, um Vorschau-Darstellung und Asset-Speicherung zu prüfen.",
+					"markdown_body": "Markdown-Inhalt",
+					"name": "Name",
+					"price": "Preis (USD)",
+					"published_at": "Veröffentlicht am",
+					"release_date": "Release-Datum",
+					"settings_json": "Settings-JSON",
+					"slug": "Slug",
+					"slug_help": "Nur Kleinbuchstaben, Zahlen und Bindestriche."
+				},
+				"groups": {
+					"content": "Inhalt",
+					"media": "Medien"
+				},
+				"metrics": {
+					"total": "Assets gesamt",
+					"total_desc": "Alle Demo-Asset-Einträge",
+					"with_attachments": "Mit Anhängen",
+					"with_attachments_desc": "Assets mit herunterladbarer Datei",
+					"with_images": "Mit Bildern",
+					"with_images_desc": "Assets mit Hero-Bild"
+				},
+				"plural_label": "Demo-Assets",
+				"search_placeholder": "Demo-Assets durchsuchen...",
+				"singular_label": "Demo-Asset",
+				"toasts": {
+					"deleted": "Demo-Asset gelöscht",
+					"seeded": "Demo-Assets befüllt"
+				},
+				"validation": {
+					"invalid_json": "Settings-JSON muss gültiges JSON sein.",
+					"invalid_price": "Der Preis muss null oder größer sein.",
+					"invalid_published_at": "„Veröffentlicht am“ muss ein gültiges Datum mit Uhrzeit sein.",
+					"invalid_release_date": "Das Release-Datum muss ein gültiges Datum sein.",
+					"invalid_slug": "Der Slug darf nur Kleinbuchstaben, Zahlen und Bindestriche enthalten."
+				},
+				"values": {
+					"coverage_missing": "Uploads fehlen",
+					"coverage_partial": "Teilweise bereit",
+					"coverage_ready": "Bereit"
+				}
+			},
 			"detail_missing_description": "Dieser Eintrag existiert nicht mehr oder ist für die aktuelle Admin-Sitzung nicht sichtbar.",
 			"detail_missing_title": "Eintrag nicht gefunden",
 			"email_events": {
@@ -351,10 +416,12 @@
 				"characters_count": "{count} / {limit}",
 				"fix_errors": "Bitte korrigiere die markierten Felder.",
 				"hide_content": "Inhalt ausblenden",
+				"image_required": "Bitte laden Sie eine Bilddatei hoch.",
 				"invalid": "Invalid field value",
 				"key_placeholder": "Schlüssel",
 				"local_override_notice": "Sie haben dieses Feld lokal geändert. Eingehende Live-Updates überschreiben es nicht.",
 				"markdown_placeholder": "## Markdown-Inhalt",
+				"max_file_size": "Die Datei überschreitet die maximale Größe von {size} MB.",
 				"maxlength_exceeded": "Maximale Zeichenanzahl von {limit} überschritten",
 				"no_relation_options": "No options available",
 				"no_suggestions": "Keine Vorschläge",
@@ -365,6 +432,8 @@
 				"suggestions_input": "Tippen, um Vorschläge zu suchen",
 				"suggestions_loading": "Vorschläge werden geladen…",
 				"upload": "Datei hochladen",
+				"upload_ready": "Upload abgeschlossen",
+				"uploading_progress": "Wird hochgeladen… {progress}%",
 				"value_placeholder": "Wert"
 			},
 			"framework_activity": {
@@ -418,6 +487,7 @@
 				"event": "Ereignis",
 				"identity": "Identität",
 				"main": "Hauptbereich",
+				"media": "Medien",
 				"metadata": "Metadaten",
 				"notifications": "Benachrichtigungen",
 				"other": "Weitere",
@@ -510,21 +580,84 @@
 				"empty": "Keine Daten zum Anzeigen.",
 				"loading": "Laden..."
 			},
+			"project_members": {
+				"associate_project_description": "Diesen Pivot-Eintrag einem Demo-Projekt zuordnen.",
+				"associate_project_empty_description": "Demo-Daten laden oder die Suche verfeinern, um ein Projekt zu finden.",
+				"associate_project_empty_title": "Keine Projekte verfügbar",
+				"associate_project_search_placeholder": "Projekte durchsuchen...",
+				"associate_user_description": "Diesen Pivot-Eintrag einem verwalteten Benutzer zuordnen.",
+				"associate_user_empty_description": "Die Suche verfeinern, um einen verwalteten Benutzer zu finden.",
+				"associate_user_empty_title": "Keine verwalteten Benutzer verfügbar",
+				"associate_user_search_placeholder": "Verwaltete Benutzer durchsuchen...",
+				"dashboard_description": "Pivot-artige Mitgliedschaftseinträge zum Prüfen von Zuordnen- und Trennen-Workflows.",
+				"delete_description": "Diesen Projektmitglied-Eintrag mit der Rolle {role} löschen?",
+				"delete_title": "Projektmitglied löschen",
+				"dissociate_project_description": "{name} von diesem Projektmitglied-Eintrag trennen?",
+				"dissociate_project_title": "Projekt trennen",
+				"dissociate_user_description": "{name} von diesem Projektmitglied-Eintrag trennen?",
+				"dissociate_user_title": "Benutzer trennen",
+				"empty_description": "Ein Demo-Projektmitglied erstellen oder die Suche anpassen, um Pivot-Einträge zu sehen.",
+				"empty_title": "Keine Projektmitglieder",
+				"fields": {
+					"allocation_percent": "Auslastung",
+					"allocation_percent_help": "Prozentualer Aufwand dieses Mitglieds für das zugeordnete Projekt.",
+					"joined_at": "Beigetreten am",
+					"project": "Projekt",
+					"role": "Rolle",
+					"user": "Verwalteter Benutzer",
+					"user_email": "Benutzer-E-Mail"
+				},
+				"groups": {
+					"assignment": "Zuordnung",
+					"membership": "Mitgliedschaft"
+				},
+				"metrics": {
+					"total": "Mitglieder gesamt",
+					"total_desc": "Alle Pivot-Einträge",
+					"with_project": "Verknüpfte Projekte",
+					"with_project_desc": "Einträge mit Projektzuordnung",
+					"with_user": "Verknüpfte Benutzer",
+					"with_user_desc": "Einträge mit Benutzerzuordnung"
+				},
+				"options": {
+					"role_contributor": "Mitwirkend",
+					"role_lead": "Lead",
+					"role_reviewer": "Reviewer"
+				},
+				"plural_label": "Demo-Projektmitglieder",
+				"search_placeholder": "Demo-Projektmitglieder durchsuchen...",
+				"singular_label": "Demo-Projektmitglied",
+				"toasts": {
+					"deleted": "Projektmitglied gelöscht",
+					"project_associated": "Projekt zugeordnet",
+					"project_dissociated": "Projekt getrennt",
+					"user_associated": "Verwalteter Benutzer zugeordnet",
+					"user_dissociated": "Verwalteter Benutzer getrennt"
+				},
+				"validation": {
+					"invalid_allocation_percent": "Die Auslastung muss zwischen 0 und 100 liegen."
+				},
+				"values": {
+					"unassigned": "Nicht zugewiesen"
+				}
+			},
 			"projects": {
 				"actions": {
 					"archive": "Archive",
-					"attach_tag": "Attach Tag",
+					"attach_tag": "Tag anhängen",
 					"export_csv": "CSV exportieren",
-					"feature": "Mark Featured",
+					"feature": "Als hervorgehoben markieren",
+					"force_delete": "Endgültig löschen",
 					"purge": "Endgültig löschen",
 					"purge_cancel_btn": "Abbrechen",
 					"purge_confirm": "Die ausgewählten Projekte und alle zugehörigen Daten werden dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
 					"purge_confirm_btn": "Ja, löschen",
 					"restore_archived": "Archivierte Projekte wiederherstellen",
+					"restore_trashed": "Papierkorb-Projekte wiederherstellen",
 					"seed_data": "Testdaten anlegen"
 				},
 				"dashboard_description": "Parity-Spielwiese für reichere admin-v2-Ressourcenabläufe.",
-				"empty_active_description": "Archiviere Projekte oder lege Demodaten an, um die Linse für aktive Projekte zu prüfen.",
+				"empty_active_description": "Stelle ein Papierkorb-Projekt wieder her oder lege Demodaten an, um die Linse für aktive Projekte zu prüfen.",
 				"empty_active_title": "Keine aktiven Projekte",
 				"empty_archived_description": "Archiviere ein Projekt oder lege Demodaten an, um archivierte Wiederherstellungsabläufe zu prüfen.",
 				"empty_archived_title": "Keine archivierten Projekte",
@@ -532,6 +665,8 @@
 				"empty_featured_description": "Markiere ein Projekt als hervorgehoben oder lege Demodaten an, um die Linse für hervorgehobene Projekte zu prüfen.",
 				"empty_featured_title": "Keine hervorgehobenen Projekte",
 				"empty_title": "Keine Projekte gefunden",
+				"empty_trashed_description": "Verschiebe ein Projekt in den Papierkorb oder lege Demodaten an, um Wiederherstellungsabläufe zu prüfen.",
+				"empty_trashed_title": "Keine Papierkorb-Projekte",
 				"fields": {
 					"brand_color": "Markenfarbe",
 					"brand_color_help": "Primäre Akzentfarbe für Vorschauen und die Operator-QA.",
@@ -539,11 +674,12 @@
 					"budget": "Budget",
 					"code_snippet": "Code-Snippet",
 					"cover_image": "Cover-Bild-URL",
-					"description": "Description",
+					"deleted_at": "Gelöscht am",
+					"description": "Beschreibung",
 					"description_help": "Unterstützt Markdown-Formatierung.",
-					"featured": "Featured",
+					"featured": "Hervorgehoben",
 					"name": "Name",
-					"owner_email": "Owner Email",
+					"owner_email": "Owner-E-Mail",
 					"owner_email_placeholder": "inhaber@beispiel.de",
 					"settings_json": "Einstellungen JSON",
 					"slug": "Slug",
@@ -558,13 +694,15 @@
 					"featured_only": "Featured Only",
 					"owner_1": "Eigentümer 1",
 					"owner_2": "Eigentümer 2",
-					"regular_only": "Regular Only",
-					"status": "Status"
+					"regular_only": "Nur reguläre",
+					"status": "Status",
+					"trashed": "Papierkorb"
 				},
 				"lenses": {
-					"active": "Active Projects",
+					"active": "Aktive Projekte",
 					"archived": "Archived Projects",
-					"featured": "Featured Projects"
+					"featured": "Hervorgehobene Projekte",
+					"trashed": "Papierkorb-Projekte"
 				},
 				"metrics": {
 					"active": "Aktive Projekte",
@@ -582,17 +720,19 @@
 					"total_desc": "Alle registrierten Projekte",
 					"total_subtitle": "Projektportfolio"
 				},
-				"nav_title": "Demo Projects",
+				"nav_title": "Demo-Projekte",
 				"options": {
-					"status_active": "Active",
+					"status_active": "Aktiv",
 					"status_archived": "Archived",
-					"status_draft": "Draft"
+					"status_draft": "Entwurf",
+					"status_trashed": "Papierkorb"
 				},
 				"plural_label": "Demo-Projekte",
 				"search_placeholder": "Demo-Projekte durchsuchen...",
 				"search_placeholder_active": "Aktive Projekte durchsuchen...",
 				"search_placeholder_archived": "Archivierte Projekte durchsuchen...",
 				"search_placeholder_featured": "Hervorgehobene Projekte durchsuchen...",
+				"search_placeholder_trashed": "Papierkorb-Projekte durchsuchen...",
 				"singular_label": "Demo-Projekt",
 				"validation": {
 					"invalid_brand_color": "Die Markenfarbe muss ein gültiger Hex-Farbwert sein.",
@@ -602,6 +742,12 @@
 			"queued_actions": {
 				"cancel_job": "Abbrechen",
 				"enqueued": "Aktion zur Hintergrundverarbeitung eingereiht",
+				"fields": {
+					"action": "Aktion",
+					"status": "Status",
+					"summary": "Zusammenfassung",
+					"updated": "Aktualisiert"
+				},
 				"no_active_jobs": "Keine aktiven Hintergrundaufgaben",
 				"panel_title": "Hintergrundaufgaben",
 				"progress": "{processed} von {total} verarbeitet",
@@ -617,10 +763,19 @@
 				"actor_user_description": "Verwalteter Benutzer, der aus dem Akteur dieses Framework-Eintrags aufgelöst wurde.",
 				"admin_actor": "Admin-Akteur",
 				"admin_actor_description": "Admin-Benutzer, der mit diesem Audit- oder Notizeintrag verknüpft ist.",
+				"associated_project": "Zugeordnetes Projekt",
+				"associated_project_description": "Demo-Projekt, das aktuell mit diesem Pivot-Eintrag verknüpft ist.",
+				"associated_user": "Zugeordneter Benutzer",
+				"associated_user_description": "Verwalteter Benutzer, der aktuell mit diesem Pivot-Eintrag verknüpft ist.",
+				"duplicates_allowed": "Duplikate sind für diese Relation erlaubt. Wenn derselbe Datensatz erneut gewählt wird, entsteht eine weitere Zuordnung statt einer Ersetzung.",
 				"internal_notes": "Interne Notizen",
 				"internal_notes_description": "Von Operatoren verfasste Notizen, die mit diesem verwalteten Benutzer verknüpft sind.",
 				"managed_user": "Verwalteter Benutzer",
 				"managed_user_description": "Verwalteter Benutzer, der mit diesem Benachrichtigungsempfänger verknüpft ist.",
+				"project_tags": "Projekt-Tags",
+				"project_tags_description": "Wiederverwendbare Demo-Tags, die über den generischen Relations-Workflow mit diesem Projekt verbunden sind.",
+				"project_tasks": "Projektaufgaben",
+				"project_tasks_description": "Einklappbare Aufgaben-Relation zum QAen von Inline-Erstellung, Zeilenaktionen und kontextbezogenen Task-Workflows.",
 				"related_record": "Verknüpfter Datensatz",
 				"related_record_description": "Framework-Datensatz, auf den dieser Aktivitätseintrag verweist.",
 				"related_record_unavailable": "Der verknüpfte Datensatz ist derzeit nicht verfügbar.",
@@ -637,40 +792,85 @@
 			},
 			"selected": "{selected} of {total} selected",
 			"tags": {
+				"attach_description": "Hängen Sie ein vorhandenes Demo-Tag an dieses Projekt an.",
+				"attach_empty_description": "Erstellen Sie ein neues Tag oder verfeinern Sie die Suche, um anhängbare Tags zu finden.",
+				"attach_empty_title": "Keine anhängbaren Tags",
+				"attach_search_placeholder": "Anhängbare Tags suchen...",
+				"dashboard_description": "Wiederverwendbare Demo-Tags für QA von Relations-Anhängen und -Trennungen.",
+				"delete_description": "Tag „{name}“ löschen? An Projekte angehängte Tags können nicht gelöscht werden.",
+				"delete_title": "Demo-Tag löschen",
+				"empty_description": "Keine Demo-Tags entsprechen der aktuellen Suche.",
+				"empty_relation_description": "Hängen Sie ein vorhandenes Tag an oder erstellen Sie von diesem Panel aus ein neues.",
+				"empty_relation_title": "Keine Tags angehängt",
+				"empty_title": "Keine Demo-Tags",
 				"fields": {
-					"color": "Color",
-					"name": "Name"
+					"color": "Farbe",
+					"name": "Name",
+					"usage_count": "Nutzungsanzahl"
 				},
 				"metrics": {
 					"total": "Tags gesamt",
 					"total_desc": "Alle verfügbaren Tags",
 					"total_subtitle": "Tag-Bibliothek"
 				},
-				"nav_title": "Demo Tags"
+				"nav_title": "Demo-Tags",
+				"plural_label": "Demo-Tags",
+				"search_placeholder": "Demo-Tags suchen...",
+				"singular_label": "Demo-Tag",
+				"toasts": {
+					"attached": "Tag angehängt",
+					"detached": "Tag getrennt"
+				},
+				"validation": {
+					"invalid_color": "Die Tag-Farbe muss eine gültige Hex-Farbe sein."
+				}
 			},
 			"tasks": {
 				"actions": {
 					"assign_to_me": "Mir zuweisen",
-					"mark_done": "Mark Done",
-					"mark_in_progress": "Mark In Progress",
-					"queued_bulk_process": "Massen-Hintergrundverarbeitung",
-					"quick_done": "Schnell erledigen"
+					"inline_create": "Aufgabe inline anlegen",
+					"mark_done": "Als erledigt markieren",
+					"mark_in_progress": "In Bearbeitung setzen",
+					"queued_bulk_process": "Massenaktualisierung in Warteschlange",
+					"quick_done": "Schnell erledigen",
+					"seed_data": "Demo-Aufgaben erzeugen",
+					"update_status": "Status aktualisieren"
 				},
+				"dashboard_description": "Showcase-Aufgaben für Aktionsformulare, Warteschlangen-Jobs, Preview-Route und Inline-Erstellung.",
+				"delete_description": "{title} dauerhaft aus der Demo-Aufgabenfläche entfernen?",
+				"delete_title": "Demo-Aufgabe löschen",
+				"empty_completed_description": "Keine abgeschlossenen Demo-Aufgaben entsprechen der aktuellen Suche.",
+				"empty_completed_title": "Keine abgeschlossenen Demo-Aufgaben",
+				"empty_description": "Keine Demo-Aufgaben entsprechen der aktuellen Suche.",
+				"empty_due_description": "Derzeit sind keine bevorstehenden Demo-Aufgaben bald fällig.",
+				"empty_due_title": "Keine bald fälligen Aufgaben",
+				"empty_relation_description": "Erstelle eine Aufgabe direkt in der Projektansicht oder öffne die vollständige Aufgabenressource.",
+				"empty_relation_title": "Noch keine verknüpften Aufgaben",
+				"empty_title": "Keine Demo-Aufgaben",
 				"fields": {
-					"assignee_email": "Assignee Email",
-					"estimate_hours": "Estimate Hours",
-					"priority": "Priority",
-					"project": "Project",
+					"assignee_email": "Zugewiesene E-Mail",
+					"due_at": "Fällig am",
+					"estimate_hours": "Geschätzte Stunden",
+					"note": "Operator-Notiz",
+					"priority": "Priorität",
+					"project": "Projekt",
 					"status": "Status",
-					"title": "Title"
+					"title": "Titel",
+					"workload": "Auslastung"
 				},
 				"filters": {
-					"priority": "Priority",
+					"all_priorities": "Alle Prioritäten",
+					"all_statuses": "Alle Status",
+					"priority": "Priorität",
 					"status": "Status"
 				},
+				"groups": {
+					"delivery": "Lieferung",
+					"schedule": "Planung"
+				},
 				"lenses": {
-					"completed": "Completed Tasks",
-					"due": "Due Tasks"
+					"completed": "Abgeschlossene Aufgaben",
+					"due": "Fällige Aufgaben"
 				},
 				"metrics": {
 					"completion_rate": "Fertigstellungsrate",
@@ -690,16 +890,35 @@
 					"status_trend": "Status-Trend",
 					"todo": "Zu erledigen",
 					"todo_desc": "Aufgaben, die noch nicht begonnen wurden",
-					"todo_subtitle": "Backlog-Elemente"
+					"todo_subtitle": "Backlog-Elemente",
+					"total": "Aufgaben gesamt",
+					"total_desc": "Alle Demo-Aufgaben im Showcase"
 				},
-				"nav_title": "Demo Tasks",
+				"nav_title": "Demo-Aufgaben",
 				"options": {
-					"done": "Done",
-					"high": "High",
-					"in_progress": "In Progress",
-					"low": "Low",
-					"medium": "Medium",
-					"todo": "Todo"
+					"done": "Erledigt",
+					"high": "Hoch",
+					"in_progress": "In Bearbeitung",
+					"low": "Niedrig",
+					"medium": "Mittel",
+					"todo": "Zu erledigen"
+				},
+				"plural_label": "Demo-Aufgaben",
+				"search_placeholder": "Demo-Aufgaben durchsuchen...",
+				"search_placeholder_completed": "Abgeschlossene Aufgaben durchsuchen...",
+				"search_placeholder_due": "Fällige Aufgaben durchsuchen...",
+				"singular_label": "Demo-Aufgabe",
+				"toasts": {
+					"bulk_started": "Massenaktualisierung der Aufgaben wurde gestartet"
+				},
+				"tools": {
+					"open_project": "Projekt öffnen",
+					"review_due": "Fällige Aufgaben prüfen"
+				},
+				"values": {
+					"workload_heavy": "Hoch",
+					"workload_light": "Leicht",
+					"workload_medium": "Mittel"
 				}
 			},
 			"toasts": {
@@ -722,6 +941,7 @@
 				"enabled": "Enabled",
 				"masked": "••••••••",
 				"no": "No",
+				"none": "Keine",
 				"pairs_count": "{count} Paare",
 				"selected_count": "{count} ausgewählt",
 				"yes": "Yes"
@@ -820,6 +1040,87 @@
 			"type_admin": "Admin",
 			"type_custom": "Benutzerdefiniert"
 		},
+		"showcase": {
+			"badges": {
+				"baseline_incomplete": "Reset nötig",
+				"baseline_ready": "Baseline bereit",
+				"demo_available": "Demo vorhanden",
+				"managed_by_reset": "Per Reset verwaltet",
+				"reference_surface": "Referenzoberfläche",
+				"tool_only": "Nur Tool"
+			},
+			"controls": {
+				"clear_demo_data": "Demo-Daten leeren",
+				"clear_help": "Entfernt die reset-verwalteten Showcase-Daten und alle laufenden Showcase-Jobs. Verwenden Sie dies, um Empty States zu prüfen.",
+				"description": "Diese Steuerelemente betreffen nur den deterministischen Admin-v2-Showcase-Datensatz. Bestehende Support- oder Einstellungsdaten bleiben unberührt.",
+				"queue_help": "{count} Showcase-Hintergrundjobs sind derzeit aktiv.",
+				"reset_baseline": "Auf Baseline zurücksetzen",
+				"reset_help": "Starten Sie die manuelle QA immer mit der bekannten Baseline. Dabei werden Projekte, Tags, Mitglieder, Assets und Tasks neu angelegt.",
+				"title": "Datensteuerung"
+			},
+			"description": "Ein zentraler Ort, um jede Nova-ähnliche Admin-v2-Funktionsfamilie mit deterministischen Daten und klaren Routen manuell zu prüfen.",
+			"features": {
+				"audit": "Audit-Verläufe",
+				"auth_managed": "Auth-verwaltete Ressourcen",
+				"batch_actions": "Batch-Aktionen",
+				"crud": "Generisches CRUD",
+				"derived": "Abgeleitete Ressourcen",
+				"file_fields": "Datei- und Bildfelder",
+				"filters": "Filter",
+				"lenses": "Erstklassige Lenses",
+				"metrics": "Metriken",
+				"pivot_fields": "Pivot-Metadaten",
+				"preview": "Vorschaurouten",
+				"queued_actions": "Queue-Aktionen",
+				"relations": "Relations-Workflows",
+				"replicate": "Duplizieren",
+				"rich_fields": "Markdown, Code und JSON",
+				"row_actions": "Zeilenaktionen",
+				"soft_delete": "Soft Delete und Wiederherstellung"
+			},
+			"flow": {
+				"step_1": "Setzen Sie das Showcase auf den Baseline-Datensatz zurück.",
+				"step_2": "Prüfen Sie, dass die Ressourcenkarten unten die erwarteten Seed-Zahlen anzeigen.",
+				"step_3": "Verwenden Sie die Feature-Matrix, um direkt zur gewünschten Oberfläche zu springen.",
+				"step_4": "Nutzen Sie die Tool-Links nur für Workflows, die bewusst außerhalb des generischen Frameworks bleiben."
+			},
+			"links": {
+				"archived_lens": "Archiv-Lens",
+				"trashed_lens": "Papierkorb-Lens"
+			},
+			"non_demo": {
+				"dashboard_description": "Das Dashboard bleibt eine zusammengesetzte Operator-Oberfläche. Das Showcase verlinkt hinein, aber das Dashboard selbst ist keine generische Ressourcendemo.",
+				"dashboard_title": "Dashboard-Komposition",
+				"settings_description": "Einstellungen bleiben ein kuratiertes Admin-Tool. Die generische Ressourcenseite dafür ist Benachrichtigungsempfänger.",
+				"settings_title": "Kuratiere Einstellungen",
+				"support_description": "Support verwendet bewusst einen benutzerdefinierten Multi-Panel-Workflow und wird nicht in eine generische Ressource gepresst.",
+				"support_title": "Support-Workflow",
+				"users_description": "Die alte Benutzertabelle existiert noch, aber die Auth-Managed-Parität wird auf Verwaltete Benutzer geprüft.",
+				"users_title": "Legacy-Benutzertabelle"
+			},
+			"sections": {
+				"feature_matrix": "Feature-Abdeckung",
+				"no_dedicated_demo": "Keine eigene generische Demo",
+				"no_dedicated_demo_desc": "Diese Oberflächen sind weiterhin wichtig, bleiben aber bewusst bespoke oder legacy.",
+				"recommended_flow": "Empfohlener QA-Ablauf",
+				"resources": "Demo-Oberflächen"
+			},
+			"summary": {
+				"baseline_state": "Baseline-Status",
+				"baseline_state_desc": "Ob die reset-verwalteten Showcase-Ressourcen wieder auf ihrer Seed-Baseline sind.",
+				"relation_records": "Relations-Datensätze",
+				"relation_records_desc": "Tags und Projektmitgliedschaften zum Prüfen von Attach/Detach- und Pivot-Workflows.",
+				"seeded_resources": "Seed-Ressourcen",
+				"seeded_resources_desc": "Aktuell vorhandene, per Reset verwaltete Showcase-Ressourcen.",
+				"uploads": "Assets mit Uploads",
+				"uploads_desc": "Demo-Assets, die derzeit Datei- oder Bild-Uploads enthalten."
+			},
+			"title": "Admin-v2-Showcase",
+			"toasts": {
+				"clear_complete": "Die Admin-v2-Showcase-Daten wurden geleert.",
+				"reset_complete": "Das Admin-v2-Showcase wurde auf den Baseline-Datensatz zurückgesetzt."
+			}
+		},
 		"sidebar": {
 			"back_to_app": "Zurück zur App",
 			"dashboard": "Dashboard",
@@ -830,6 +1131,7 @@
 				"security": "Sicherheit"
 			},
 			"settings": "Einstellungen",
+			"showcase": "Showcase",
 			"support": "Support",
 			"users": "Benutzer"
 		},
@@ -1372,7 +1674,7 @@
 		"companies_text": "Vertrauen der besten Teams",
 		"cta": "Jetzt starten",
 		"cta_demo": "Demo anfordern",
-		"description": "Die kostenlose SaaS-Grundlage. Open Source, sofort einsatzbereit.",
+		"description": "Erwecke dein SaaS zum Leben in Minuten, nicht in Monaten. Open-Source Template mit einem Tech-Stack, der dich schnell shippen lässt.",
 		"section_label": "Start",
 		"tagline": "Mit Produktfokus\nschneller zum Ziel",
 		"title": "SaaS-Starter-Vorlage"
@@ -1470,6 +1772,10 @@
 				"description": "Konfigurieren Sie Admin-Benachrichtigungen und Einstellungen.",
 				"title": "Admin-Einstellungen"
 			},
+			"showcase": {
+				"description": "Prüfen Sie den vollständigen Admin-v2-Demo-Spielplatz mit rücksetzbaren Baseline-Daten manuell.",
+				"title": "Admin-v2-Showcase"
+			},
 			"support": {
 				"description": "Prüfen und beantworten Sie Support-Anfragen von Nutzern.",
 				"title": "Support-Postfach"
@@ -1530,7 +1836,7 @@
 			}
 		},
 		"home": {
-			"description": "Kostenloser Open-Source SaaS-Starter mit SvelteKit. Auth, Billing, E-Mail und Analytics inklusive. Kostenlos auf Free-Tiers hosten.",
+			"description": "SaaS-Starter für SvelteKit mit Auth, Billing, E-Mail und Analytics.",
 			"title": "Schneller entwickeln und veröffentlichen"
 		},
 		"impressum": {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1545,6 +1545,10 @@
 			}
 		}
 	},
+	"billing": {
+		"checkout_failed": "Bezahlvorgang fehlgeschlagen. Bitte versuchen Sie es erneut.",
+		"portal_failed": "Abrechnungsportal konnte nicht geöffnet werden. Bitte versuchen Sie es erneut."
+	},
 	"chat": {
 		"action": {
 			"talk_to_human": "Mit Experte sprechen"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -16,6 +16,8 @@
 			"external_services": "External Services",
 			"hosting_deployment": "Hosting & deployment",
 			"no_framework_activity": "No framework actions have been recorded yet.",
+			"playground": "QA Playground",
+			"playground_description": "Open the deterministic demo playground and reset the admin-v2 showcase to a known baseline.",
 			"recent_framework_activity": "Recent Framework Activity",
 			"resource_overview": "Resource Overview",
 			"resource_records": "{count} records",
@@ -73,9 +75,13 @@
 		},
 		"resources": {
 			"actions": {
+				"associate": "Associate",
+				"attach": "Attach",
 				"create": "Create",
 				"create_resource": "Create {resource}",
 				"delete": "Delete",
+				"detach": "Detach",
+				"dissociate": "Dissociate",
 				"edit": "Edit",
 				"force_delete": "Force Delete",
 				"preview": "Preview",
@@ -300,6 +306,65 @@
 				"copied_tooltip": "Copied!",
 				"tooltip": "Copy to clipboard"
 			},
+			"demo_assets": {
+				"actions": {
+					"delete_description": "Delete the demo asset “{name}”? Uploaded files will be removed as well.",
+					"delete_title": "Delete Demo Asset",
+					"seed_data": "Seed Demo Assets"
+				},
+				"dashboard_description": "Media and rich-field showcase for uploads, markdown, code, and JSON.",
+				"empty_description": "Create a demo asset or seed the showcase data to verify rich field rendering.",
+				"empty_title": "No demo assets",
+				"fields": {
+					"attachment": "Attachment",
+					"attachment_help": "Upload a downloadable file to verify generic file lifecycle handling.",
+					"code_snippet": "Code Snippet",
+					"content_summary": "Content Summary",
+					"content_summary_help": "Computed preview of the current markdown and upload coverage.",
+					"coverage": "Coverage",
+					"hero_image": "Hero Image",
+					"hero_image_help": "Upload an image to verify preview rendering and asset persistence.",
+					"markdown_body": "Markdown Body",
+					"name": "Name",
+					"price": "Price (USD)",
+					"published_at": "Published At",
+					"release_date": "Release Date",
+					"settings_json": "Settings JSON",
+					"slug": "Slug",
+					"slug_help": "Lowercase letters, numbers, and hyphens only."
+				},
+				"groups": {
+					"content": "Content",
+					"media": "Media"
+				},
+				"metrics": {
+					"total": "Total Assets",
+					"total_desc": "All demo asset records",
+					"with_attachments": "With Attachments",
+					"with_attachments_desc": "Assets that include a downloadable file",
+					"with_images": "With Images",
+					"with_images_desc": "Assets that include a hero image"
+				},
+				"plural_label": "Demo Assets",
+				"search_placeholder": "Search demo assets...",
+				"singular_label": "Demo Asset",
+				"toasts": {
+					"deleted": "Demo asset deleted",
+					"seeded": "Demo assets seeded"
+				},
+				"validation": {
+					"invalid_json": "Settings JSON must be valid JSON.",
+					"invalid_price": "Price must be zero or greater.",
+					"invalid_published_at": "Published at must be a valid date and time.",
+					"invalid_release_date": "Release date must be a valid date.",
+					"invalid_slug": "Slug must use lowercase letters, numbers, and hyphens."
+				},
+				"values": {
+					"coverage_missing": "Missing uploads",
+					"coverage_partial": "Partially ready",
+					"coverage_ready": "Ready"
+				}
+			},
 			"detail_missing_description": "This record no longer exists or is not visible to the current admin session.",
 			"detail_missing_title": "Record not found",
 			"email_events": {
@@ -351,10 +416,12 @@
 				"characters_count": "{count} / {limit}",
 				"fix_errors": "Please fix the highlighted fields.",
 				"hide_content": "Hide content",
+				"image_required": "Please upload an image file.",
 				"invalid": "Invalid field value",
 				"key_placeholder": "Key",
 				"local_override_notice": "You changed this field locally. Incoming live updates will not overwrite it.",
 				"markdown_placeholder": "## Markdown content",
+				"max_file_size": "File exceeds the maximum size of {size} MB.",
 				"maxlength_exceeded": "Exceeds maximum length of {limit} characters",
 				"no_relation_options": "No options available",
 				"no_suggestions": "No suggestions",
@@ -365,6 +432,8 @@
 				"suggestions_input": "Type to search suggestions",
 				"suggestions_loading": "Loading suggestions…",
 				"upload": "Upload file",
+				"upload_ready": "Upload complete",
+				"uploading_progress": "Uploading… {progress}%",
 				"value_placeholder": "Value"
 			},
 			"framework_activity": {
@@ -418,6 +487,7 @@
 				"event": "Event",
 				"identity": "Identity",
 				"main": "Main",
+				"media": "Media",
 				"metadata": "Metadata",
 				"notifications": "Notifications",
 				"other": "Other",
@@ -510,21 +580,85 @@
 				"empty": "Nothing to show here.",
 				"loading": "Loading..."
 			},
+			"project_members": {
+				"associate_project_description": "Associate this pivot record with a demo project.",
+				"associate_project_empty_description": "Seed demo data or refine the search to find a project to associate.",
+				"associate_project_empty_title": "No projects available",
+				"associate_project_search_placeholder": "Search projects...",
+				"associate_user_description": "Associate this pivot record with a managed user.",
+				"associate_user_empty_description": "Refine the search to find a managed user to associate.",
+				"associate_user_empty_title": "No managed users available",
+				"associate_user_search_placeholder": "Search managed users...",
+				"dashboard_description": "Pivot-style membership records used to verify associate and dissociate workflows.",
+				"delete_description": "Delete this project member record with role {role}?",
+				"delete_title": "Delete Project Member",
+				"dissociate_project_description": "Remove {name} from this project member record?",
+				"dissociate_project_title": "Dissociate Project",
+				"dissociate_user_description": "Remove {name} from this project member record?",
+				"dissociate_user_title": "Dissociate User",
+				"empty_description": "Create a demo project member or adjust the search to view pivot records.",
+				"empty_title": "No project members",
+				"fields": {
+					"allocation_percent": "Allocation",
+					"allocation_percent_help": "Percentage of this member's effort allocated to the associated project.",
+					"joined_at": "Joined At",
+					"project": "Project",
+					"role": "Role",
+					"user": "Managed User",
+					"user_email": "User Email"
+				},
+				"groups": {
+					"assignment": "Assignment",
+					"membership": "Membership"
+				},
+				"metrics": {
+					"total": "Total Members",
+					"total_desc": "All pivot records",
+					"with_project": "Linked Projects",
+					"with_project_desc": "Records already associated with a project",
+					"with_user": "Linked Users",
+					"with_user_desc": "Records already associated with a managed user"
+				},
+				"options": {
+					"role_contributor": "Contributor",
+					"role_lead": "Lead",
+					"role_reviewer": "Reviewer"
+				},
+				"plural_label": "Demo Project Members",
+				"search_placeholder": "Search demo project members...",
+				"singular_label": "Demo Project Member",
+				"toasts": {
+					"deleted": "Project member deleted",
+					"project_associated": "Project associated",
+					"project_dissociated": "Project dissociated",
+					"user_associated": "Managed user associated",
+					"user_dissociated": "Managed user dissociated"
+				},
+				"validation": {
+					"invalid_allocation_percent": "Allocation must be between 0 and 100."
+				},
+				"values": {
+					"unassigned": "Unassigned"
+				}
+			},
 			"projects": {
 				"actions": {
 					"archive": "Archive",
 					"attach_tag": "Attach Tag",
 					"export_csv": "Export CSV",
 					"feature": "Mark Featured",
+					"force_delete": "Force Delete",
 					"purge": "Purge",
 					"purge_cancel_btn": "Cancel",
 					"purge_confirm": "This will permanently delete the selected projects and all related data. This action cannot be undone.",
 					"purge_confirm_btn": "Yes, Purge",
 					"restore_archived": "Restore Archived Projects",
-					"seed_data": "Seed Data"
+					"restore_trashed": "Restore Trashed Projects",
+					"seed_data": "Seed Data",
+					"soft_delete": "Move to Trash"
 				},
 				"dashboard_description": "Parity playground for richer admin-v2 resource workflows.",
-				"empty_active_description": "Archive or seed projects to verify the active-project lens.",
+				"empty_active_description": "Restore a trashed project or seed projects to verify the active-project lens.",
 				"empty_active_title": "No active projects",
 				"empty_archived_description": "Archive a project or seed demo data to verify archived recovery flows.",
 				"empty_archived_title": "No archived projects",
@@ -532,6 +666,8 @@
 				"empty_featured_description": "Mark a project as featured or seed demo data to verify featured-project flows.",
 				"empty_featured_title": "No featured projects",
 				"empty_title": "No projects found",
+				"empty_trashed_description": "Move a project to trash or seed demo data to verify trashed recovery flows.",
+				"empty_trashed_title": "No trashed projects",
 				"fields": {
 					"brand_color": "Brand Color",
 					"brand_color_help": "Primary accent color used across previews and operator QA.",
@@ -539,6 +675,7 @@
 					"budget": "Budget",
 					"code_snippet": "Code Snippet",
 					"cover_image": "Cover Image URL",
+					"deleted_at": "Deleted At",
 					"description": "Description",
 					"description_help": "Supports Markdown formatting.",
 					"featured": "Featured",
@@ -559,12 +696,14 @@
 					"owner_1": "Owner 1",
 					"owner_2": "Owner 2",
 					"regular_only": "Regular Only",
-					"status": "Status"
+					"status": "Status",
+					"trashed": "Trashed"
 				},
 				"lenses": {
 					"active": "Active Projects",
 					"archived": "Archived Projects",
-					"featured": "Featured Projects"
+					"featured": "Featured Projects",
+					"trashed": "Trashed Projects"
 				},
 				"metrics": {
 					"active": "Active Projects",
@@ -586,13 +725,15 @@
 				"options": {
 					"status_active": "Active",
 					"status_archived": "Archived",
-					"status_draft": "Draft"
+					"status_draft": "Draft",
+					"status_trashed": "Trashed"
 				},
 				"plural_label": "Demo Projects",
 				"search_placeholder": "Search demo projects...",
 				"search_placeholder_active": "Search active projects...",
 				"search_placeholder_archived": "Search archived projects...",
 				"search_placeholder_featured": "Search featured projects...",
+				"search_placeholder_trashed": "Search trashed projects...",
 				"singular_label": "Demo Project",
 				"validation": {
 					"invalid_brand_color": "Brand color must be a valid hex color.",
@@ -602,6 +743,12 @@
 			"queued_actions": {
 				"cancel_job": "Cancel",
 				"enqueued": "Action queued for background processing",
+				"fields": {
+					"action": "Action",
+					"status": "Status",
+					"summary": "Summary",
+					"updated": "Updated"
+				},
 				"no_active_jobs": "No active background jobs",
 				"panel_title": "Background Jobs",
 				"progress": "{processed} of {total} processed",
@@ -617,10 +764,19 @@
 				"actor_user_description": "Managed user resolved from the actor attached to this framework event.",
 				"admin_actor": "Admin Actor",
 				"admin_actor_description": "Admin user associated with this audit or note entry.",
+				"associated_project": "Associated Project",
+				"associated_project_description": "Demo project currently linked to this pivot record.",
+				"associated_user": "Associated User",
+				"associated_user_description": "Managed user currently linked to this pivot record.",
+				"duplicates_allowed": "Duplicates are allowed for this relation. Reusing the same record will create another assignment instead of replacing the existing one.",
 				"internal_notes": "Internal Notes",
 				"internal_notes_description": "Operator-authored notes connected to this managed user.",
 				"managed_user": "Managed User",
 				"managed_user_description": "Managed user linked to this notification recipient.",
+				"project_tags": "Project Tags",
+				"project_tags_description": "Reusable demo tags attached to this project through the generic relation workflow.",
+				"project_tasks": "Project Tasks",
+				"project_tasks_description": "Collapsible task relation used to QA inline create, row actions, and contextual task workflows.",
 				"related_record": "Related Record",
 				"related_record_description": "Framework record referenced by this activity entry.",
 				"related_record_unavailable": "The related record is not currently available.",
@@ -637,36 +793,81 @@
 			},
 			"selected": "{selected} of {total} selected",
 			"tags": {
+				"attach_description": "Attach an existing demo tag to this project.",
+				"attach_empty_description": "Create a new tag or refine the search to find attachable tags.",
+				"attach_empty_title": "No attachable tags",
+				"attach_search_placeholder": "Search attachable tags...",
+				"dashboard_description": "Reusable demo tags for relation attach and detach QA.",
+				"delete_description": "Delete the tag “{name}”? Tags attached to projects cannot be deleted.",
+				"delete_title": "Delete Demo Tag",
+				"empty_description": "No demo tags match the current search.",
+				"empty_relation_description": "Attach an existing tag or create a new one from this panel.",
+				"empty_relation_title": "No tags attached",
+				"empty_title": "No demo tags",
 				"fields": {
 					"color": "Color",
-					"name": "Name"
+					"name": "Name",
+					"usage_count": "Usage Count"
 				},
 				"metrics": {
 					"total": "Total Tags",
 					"total_desc": "All available tags",
 					"total_subtitle": "Tag library"
 				},
-				"nav_title": "Demo Tags"
+				"nav_title": "Demo Tags",
+				"plural_label": "Demo Tags",
+				"search_placeholder": "Search demo tags...",
+				"singular_label": "Demo Tag",
+				"toasts": {
+					"attached": "Tag attached",
+					"detached": "Tag detached"
+				},
+				"validation": {
+					"invalid_color": "Tag color must be a valid hex color."
+				}
 			},
 			"tasks": {
 				"actions": {
 					"assign_to_me": "Assign to Me",
+					"inline_create": "Add Task Inline",
 					"mark_done": "Mark Done",
 					"mark_in_progress": "Mark In Progress",
 					"queued_bulk_process": "Queued Bulk Process",
-					"quick_done": "Quick Done"
+					"quick_done": "Quick Done",
+					"seed_data": "Seed Demo Tasks",
+					"update_status": "Update Status"
 				},
+				"dashboard_description": "Action-form, queued-job, preview-route, and inline-create showcase tasks.",
+				"delete_description": "Permanently remove {title} from the demo task surface?",
+				"delete_title": "Delete Demo Task",
+				"empty_completed_description": "No completed demo tasks match the current search.",
+				"empty_completed_title": "No completed demo tasks",
+				"empty_description": "No demo tasks match the current search.",
+				"empty_due_description": "No upcoming demo tasks are due soon.",
+				"empty_due_title": "No tasks due soon",
+				"empty_relation_description": "Create a task inline from the project detail page or open the full task resource.",
+				"empty_relation_title": "No tasks linked yet",
+				"empty_title": "No demo tasks",
 				"fields": {
 					"assignee_email": "Assignee Email",
+					"due_at": "Due At",
 					"estimate_hours": "Estimate Hours",
+					"note": "Operator Note",
 					"priority": "Priority",
 					"project": "Project",
 					"status": "Status",
-					"title": "Title"
+					"title": "Title",
+					"workload": "Workload"
 				},
 				"filters": {
+					"all_priorities": "All priorities",
+					"all_statuses": "All statuses",
 					"priority": "Priority",
 					"status": "Status"
+				},
+				"groups": {
+					"delivery": "Delivery",
+					"schedule": "Schedule"
 				},
 				"lenses": {
 					"completed": "Completed Tasks",
@@ -690,7 +891,9 @@
 					"status_trend": "Status Trend",
 					"todo": "Todo",
 					"todo_desc": "Tasks awaiting start",
-					"todo_subtitle": "Backlog items"
+					"todo_subtitle": "Backlog items",
+					"total": "Total Tasks",
+					"total_desc": "All demo tasks in the showcase set"
 				},
 				"nav_title": "Demo Tasks",
 				"options": {
@@ -700,6 +903,23 @@
 					"low": "Low",
 					"medium": "Medium",
 					"todo": "Todo"
+				},
+				"plural_label": "Demo Tasks",
+				"search_placeholder": "Search demo tasks...",
+				"search_placeholder_completed": "Search completed tasks...",
+				"search_placeholder_due": "Search due tasks...",
+				"singular_label": "Demo Task",
+				"toasts": {
+					"bulk_started": "Queued bulk task update started"
+				},
+				"tools": {
+					"open_project": "Open Project",
+					"review_due": "Review Due Tasks"
+				},
+				"values": {
+					"workload_heavy": "Heavy",
+					"workload_light": "Light",
+					"workload_medium": "Medium"
 				}
 			},
 			"toasts": {
@@ -722,6 +942,7 @@
 				"enabled": "Enabled",
 				"masked": "••••••••",
 				"no": "No",
+				"none": "None",
 				"pairs_count": "{count} pairs",
 				"selected_count": "{count} selected",
 				"yes": "Yes"
@@ -820,6 +1041,87 @@
 			"type_admin": "Admin",
 			"type_custom": "Custom"
 		},
+		"showcase": {
+			"badges": {
+				"baseline_incomplete": "Needs reset",
+				"baseline_ready": "Baseline ready",
+				"demo_available": "Demo available",
+				"managed_by_reset": "Reset-managed",
+				"reference_surface": "Reference surface",
+				"tool_only": "Tool only"
+			},
+			"controls": {
+				"clear_demo_data": "Clear demo data",
+				"clear_help": "This removes the reset-managed showcase data and any queued showcase jobs. Use it to verify empty states.",
+				"description": "These controls only touch the deterministic admin-v2 showcase dataset. They do not modify bespoke support/settings data.",
+				"queue_help": "{count} queued showcase jobs are currently active.",
+				"reset_baseline": "Reset to baseline",
+				"reset_help": "Start manual QA by resetting to the known baseline. This reseeds projects, tags, members, assets, and tasks.",
+				"title": "Data Controls"
+			},
+			"description": "One place to manually QA every Nova-like admin-v2 feature family against deterministic data and explicit route coverage.",
+			"features": {
+				"audit": "Audit trails",
+				"auth_managed": "Auth-managed resources",
+				"batch_actions": "Batch actions",
+				"crud": "Generic CRUD",
+				"derived": "Derived resources",
+				"file_fields": "File and image fields",
+				"filters": "Filters",
+				"lenses": "First-class lenses",
+				"metrics": "Metrics",
+				"pivot_fields": "Pivot metadata",
+				"preview": "Preview routes",
+				"queued_actions": "Queued actions",
+				"relations": "Relation workflows",
+				"replicate": "Replicate",
+				"rich_fields": "Markdown, code, and JSON",
+				"row_actions": "Row actions",
+				"soft_delete": "Soft delete and restore"
+			},
+			"flow": {
+				"step_1": "Reset the showcase to the baseline dataset.",
+				"step_2": "Verify the resource cards below all show the expected seeded counts.",
+				"step_3": "Use the feature matrix to jump to the exact surface you want to inspect.",
+				"step_4": "Use the bespoke tool links only for workflows that intentionally stay outside the generic framework."
+			},
+			"links": {
+				"archived_lens": "Archived Lens",
+				"trashed_lens": "Trashed Lens"
+			},
+			"non_demo": {
+				"dashboard_description": "The dashboard remains a composed operator surface. The playground links into it, but the dashboard itself is not a generic resource demo.",
+				"dashboard_title": "Dashboard composition",
+				"settings_description": "Settings stays a curated admin tool. Notification Recipients is the generic resource-backed slice to QA instead.",
+				"settings_title": "Settings curation",
+				"support_description": "Support uses a custom multi-pane operator workflow and intentionally does not collapse into a generic resource.",
+				"support_title": "Support workflow",
+				"users_description": "The legacy users table still exists, but auth-managed parity is verified on Managed Users.",
+				"users_title": "Legacy users table"
+			},
+			"sections": {
+				"feature_matrix": "Feature Coverage",
+				"no_dedicated_demo": "No Dedicated Generic Demo",
+				"no_dedicated_demo_desc": "These surfaces are still important, but they stay bespoke or legacy by design.",
+				"recommended_flow": "Recommended QA Flow",
+				"resources": "Demo Surfaces"
+			},
+			"summary": {
+				"baseline_state": "Baseline State",
+				"baseline_state_desc": "Whether the reset-managed showcase resources are back at their seeded baseline.",
+				"relation_records": "Relation Records",
+				"relation_records_desc": "Tags and project-membership rows proving attach/detach and pivot workflows.",
+				"seeded_resources": "Seeded Resources",
+				"seeded_resources_desc": "Reset-managed showcase resources currently present.",
+				"uploads": "Assets With Uploads",
+				"uploads_desc": "Demo assets currently storing file or image uploads."
+			},
+			"title": "Admin-v2 Showcase",
+			"toasts": {
+				"clear_complete": "Cleared the admin-v2 showcase data.",
+				"reset_complete": "Reset the admin-v2 showcase to the baseline dataset."
+			}
+		},
 		"sidebar": {
 			"back_to_app": "Back to App",
 			"dashboard": "Dashboard",
@@ -830,6 +1132,7 @@
 				"security": "Security"
 			},
 			"settings": "Settings",
+			"showcase": "Showcase",
 			"support": "Support",
 			"users": "Users"
 		},
@@ -1372,7 +1675,7 @@
 		"companies_text": "Powering the best teams",
 		"cta": "Start Building",
 		"cta_demo": "Request a demo",
-		"description": "The free SaaS foundation. Open source, ready to deploy.",
+		"description": "SaaS starter with SvelteKit, auth, billing, and analytics.",
 		"section_label": "Home",
 		"tagline": "Focus on your product.\nShip faster.",
 		"title": "SaaS Starter Template"
@@ -1470,6 +1773,10 @@
 				"description": "Configure admin notification recipients and preferences.",
 				"title": "Admin Settings"
 			},
+			"showcase": {
+				"description": "Manually QA the complete admin-v2 demo playground and resettable baseline data.",
+				"title": "Admin-v2 Showcase"
+			},
 			"support": {
 				"description": "Review and respond to customer support threads.",
 				"title": "Support Inbox"
@@ -1530,7 +1837,7 @@
 			}
 		},
 		"home": {
-			"description": "Free, open-source SaaS starter built with SvelteKit. Auth, billing, email, and analytics included. Host on free tiers.",
+			"description": "SaaS starter for SvelteKit with auth, billing, email, and analytics.",
 			"title": "Build & Ship Your Product Faster"
 		},
 		"impressum": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1546,6 +1546,10 @@
 			}
 		}
 	},
+	"billing": {
+		"checkout_failed": "Checkout failed. Please try again.",
+		"portal_failed": "Could not open billing portal. Please try again."
+	},
 	"chat": {
 		"action": {
 			"talk_to_human": "Talk to a human"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1545,6 +1545,10 @@
 			}
 		}
 	},
+	"billing": {
+		"checkout_failed": "Error en el pago. Por favor, inténtalo de nuevo.",
+		"portal_failed": "No se pudo abrir el portal de facturación. Por favor, inténtalo de nuevo."
+	},
 	"chat": {
 		"action": {
 			"talk_to_human": "Hablar con una persona"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -16,6 +16,8 @@
 			"external_services": "Servicios Externos",
 			"hosting_deployment": "Hosting y despliegue",
 			"no_framework_activity": "Todavía no se han registrado acciones del framework.",
+			"playground": "Playground QA",
+			"playground_description": "Abre el playground de demostración determinista y restablece el showcase admin-v2 a una línea base conocida.",
 			"recent_framework_activity": "Actividad reciente del framework",
 			"resource_overview": "Resumen de Recursos",
 			"resource_records": "{count} registros",
@@ -73,21 +75,25 @@
 		},
 		"resources": {
 			"actions": {
-				"create": "Create",
-				"create_resource": "Create {resource}",
-				"delete": "Delete",
-				"edit": "Edit",
-				"force_delete": "Force Delete",
+				"associate": "Asociar",
+				"attach": "Adjuntar",
+				"create": "Crear",
+				"create_resource": "Crear {resource}",
+				"delete": "Eliminar",
+				"detach": "Desvincular",
+				"dissociate": "Desasociar",
+				"edit": "Editar",
+				"force_delete": "Eliminar definitivamente",
 				"preview": "Vista previa",
-				"replicate": "Replicate",
-				"restore": "Restore",
+				"replicate": "Duplicar",
+				"restore": "Restaurar",
 				"select_exactly_one": "Seleccione exactamente un registro.",
 				"status_completed": "Completado",
 				"status_failed": "Fallido",
 				"status_pending": "Pendiente",
 				"status_running": "Ejecutando",
 				"update_resource": "Actualizar {resource}",
-				"view": "View"
+				"view": "Ver"
 			},
 			"actions_column": "Acciones",
 			"activity": {
@@ -300,6 +306,65 @@
 				"copied_tooltip": "¡Copiado!",
 				"tooltip": "Copiar al portapapeles"
 			},
+			"demo_assets": {
+				"actions": {
+					"delete_description": "¿Eliminar el recurso de demostración “{name}”? Los archivos subidos también se eliminarán.",
+					"delete_title": "Eliminar recurso de demostración",
+					"seed_data": "Sembrar recursos de demostración"
+				},
+				"dashboard_description": "Showcase de medios y campos enriquecidos para cargas, markdown, código y JSON.",
+				"empty_description": "Crea un recurso de demostración o siembra los datos del showcase para verificar el renderizado de campos enriquecidos.",
+				"empty_title": "No hay recursos de demostración",
+				"fields": {
+					"attachment": "Adjunto",
+					"attachment_help": "Sube un archivo descargable para verificar el flujo genérico de archivos.",
+					"code_snippet": "Fragmento de código",
+					"content_summary": "Resumen del contenido",
+					"content_summary_help": "Vista previa calculada del markdown actual y de la cobertura de cargas.",
+					"coverage": "Cobertura",
+					"hero_image": "Imagen principal",
+					"hero_image_help": "Sube una imagen para verificar la vista previa y la persistencia del recurso.",
+					"markdown_body": "Contenido Markdown",
+					"name": "Nombre",
+					"price": "Precio (USD)",
+					"published_at": "Publicado el",
+					"release_date": "Fecha de lanzamiento",
+					"settings_json": "JSON de configuración",
+					"slug": "Slug",
+					"slug_help": "Solo letras minúsculas, números y guiones."
+				},
+				"groups": {
+					"content": "Contenido",
+					"media": "Medios"
+				},
+				"metrics": {
+					"total": "Recursos totales",
+					"total_desc": "Todos los registros de recursos de demostración",
+					"with_attachments": "Con adjuntos",
+					"with_attachments_desc": "Recursos que incluyen un archivo descargable",
+					"with_images": "Con imágenes",
+					"with_images_desc": "Recursos que incluyen una imagen principal"
+				},
+				"plural_label": "Recursos de demostración",
+				"search_placeholder": "Buscar recursos de demostración...",
+				"singular_label": "Recurso de demostración",
+				"toasts": {
+					"deleted": "Recurso de demostración eliminado",
+					"seeded": "Recursos de demostración sembrados"
+				},
+				"validation": {
+					"invalid_json": "El JSON de configuración debe ser válido.",
+					"invalid_price": "El precio debe ser cero o mayor.",
+					"invalid_published_at": "La fecha y hora de publicación deben ser válidas.",
+					"invalid_release_date": "La fecha de lanzamiento debe ser válida.",
+					"invalid_slug": "El slug debe usar letras minúsculas, números y guiones."
+				},
+				"values": {
+					"coverage_missing": "Faltan cargas",
+					"coverage_partial": "Parcialmente listo",
+					"coverage_ready": "Listo"
+				}
+			},
 			"detail_missing_description": "Este registro ya no existe o no es visible para la sesión de administración actual.",
 			"detail_missing_title": "Registro no encontrado",
 			"email_events": {
@@ -351,10 +416,12 @@
 				"characters_count": "{count} / {limit}",
 				"fix_errors": "Corrige los campos resaltados.",
 				"hide_content": "Ocultar contenido",
+				"image_required": "Sube un archivo de imagen.",
 				"invalid": "Invalid field value",
 				"key_placeholder": "Clave",
 				"local_override_notice": "Has cambiado este campo localmente. Las actualizaciones en vivo entrantes no lo sobrescribirán.",
 				"markdown_placeholder": "## Contenido Markdown",
+				"max_file_size": "El archivo supera el tamaño máximo de {size} MB.",
 				"maxlength_exceeded": "Excede la longitud máxima de {limit} caracteres",
 				"no_relation_options": "No options available",
 				"no_suggestions": "Sin sugerencias",
@@ -365,6 +432,8 @@
 				"suggestions_input": "Escriba para buscar sugerencias",
 				"suggestions_loading": "Cargando sugerencias…",
 				"upload": "Subir archivo",
+				"upload_ready": "Carga completada",
+				"uploading_progress": "Subiendo… {progress}%",
 				"value_placeholder": "Valor"
 			},
 			"framework_activity": {
@@ -418,6 +487,7 @@
 				"event": "Evento",
 				"identity": "Identidad",
 				"main": "Principal",
+				"media": "Medios",
 				"metadata": "Metadatos",
 				"notifications": "Notificaciones",
 				"other": "Otros",
@@ -510,21 +580,84 @@
 				"empty": "No hay datos para mostrar.",
 				"loading": "Cargando..."
 			},
+			"project_members": {
+				"associate_project_description": "Asocia este registro pivote con un proyecto de demostración.",
+				"associate_project_empty_description": "Carga datos de demostración o ajusta la búsqueda para encontrar un proyecto.",
+				"associate_project_empty_title": "No hay proyectos disponibles",
+				"associate_project_search_placeholder": "Buscar proyectos...",
+				"associate_user_description": "Asocia este registro pivote con un usuario gestionado.",
+				"associate_user_empty_description": "Ajusta la búsqueda para encontrar un usuario gestionado.",
+				"associate_user_empty_title": "No hay usuarios gestionados disponibles",
+				"associate_user_search_placeholder": "Buscar usuarios gestionados...",
+				"dashboard_description": "Registros de membresía tipo pivote para verificar flujos de asociación y desasociación.",
+				"delete_description": "¿Eliminar este registro de miembro del proyecto con el rol {role}?",
+				"delete_title": "Eliminar miembro del proyecto",
+				"dissociate_project_description": "¿Quitar {name} de este registro de miembro del proyecto?",
+				"dissociate_project_title": "Desasociar proyecto",
+				"dissociate_user_description": "¿Quitar {name} de este registro de miembro del proyecto?",
+				"dissociate_user_title": "Desasociar usuario",
+				"empty_description": "Crea un miembro de proyecto de demostración o ajusta la búsqueda para ver registros pivote.",
+				"empty_title": "No hay miembros del proyecto",
+				"fields": {
+					"allocation_percent": "Asignación",
+					"allocation_percent_help": "Porcentaje del esfuerzo de este miembro asignado al proyecto asociado.",
+					"joined_at": "Se unió el",
+					"project": "Proyecto",
+					"role": "Rol",
+					"user": "Usuario gestionado",
+					"user_email": "Correo del usuario"
+				},
+				"groups": {
+					"assignment": "Asignación",
+					"membership": "Membresía"
+				},
+				"metrics": {
+					"total": "Miembros totales",
+					"total_desc": "Todos los registros pivote",
+					"with_project": "Con proyecto",
+					"with_project_desc": "Registros ya asociados a un proyecto",
+					"with_user": "Con usuario",
+					"with_user_desc": "Registros ya asociados a un usuario gestionado"
+				},
+				"options": {
+					"role_contributor": "Colaborador",
+					"role_lead": "Líder",
+					"role_reviewer": "Revisor"
+				},
+				"plural_label": "Miembros de proyecto de demostración",
+				"search_placeholder": "Buscar miembros del proyecto de demostración...",
+				"singular_label": "Miembro de proyecto de demostración",
+				"toasts": {
+					"deleted": "Miembro del proyecto eliminado",
+					"project_associated": "Proyecto asociado",
+					"project_dissociated": "Proyecto desasociado",
+					"user_associated": "Usuario gestionado asociado",
+					"user_dissociated": "Usuario gestionado desasociado"
+				},
+				"validation": {
+					"invalid_allocation_percent": "La asignación debe estar entre 0 y 100."
+				},
+				"values": {
+					"unassigned": "Sin asignar"
+				}
+			},
 			"projects": {
 				"actions": {
 					"archive": "Archive",
-					"attach_tag": "Attach Tag",
+					"attach_tag": "Adjuntar etiqueta",
 					"export_csv": "Exportar CSV",
-					"feature": "Mark Featured",
+					"feature": "Marcar como destacado",
+					"force_delete": "Eliminar permanentemente",
 					"purge": "Purgar",
 					"purge_cancel_btn": "Cancelar",
 					"purge_confirm": "Esto eliminará permanentemente los proyectos seleccionados y todos los datos relacionados. Esta acción no se puede deshacer.",
 					"purge_confirm_btn": "Sí, purgar",
 					"restore_archived": "Restaurar proyectos archivados",
+					"restore_trashed": "Restaurar proyectos en papelera",
 					"seed_data": "Generar datos"
 				},
 				"dashboard_description": "Entorno de paridad para flujos de recursos admin-v2 más ricos.",
-				"empty_active_description": "Archiva proyectos o genera datos de demostración para verificar la lente de proyectos activos.",
+				"empty_active_description": "Restaura un proyecto en papelera o genera datos de demostración para verificar la lente de proyectos activos.",
 				"empty_active_title": "No hay proyectos activos",
 				"empty_archived_description": "Archiva un proyecto o genera datos de demostración para verificar los flujos de recuperación archivados.",
 				"empty_archived_title": "No hay proyectos archivados",
@@ -532,6 +665,8 @@
 				"empty_featured_description": "Marca un proyecto como destacado o genera datos de demostración para verificar la lente de destacados.",
 				"empty_featured_title": "No hay proyectos destacados",
 				"empty_title": "No se encontraron proyectos",
+				"empty_trashed_description": "Envía un proyecto a la papelera o genera datos de demostración para verificar los flujos de recuperación.",
+				"empty_trashed_title": "No hay proyectos en papelera",
 				"fields": {
 					"brand_color": "Color de marca",
 					"brand_color_help": "Color de acento principal usado en vistas previas y QA operativa.",
@@ -539,11 +674,12 @@
 					"budget": "Budget",
 					"code_snippet": "Fragmento de código",
 					"cover_image": "URL de imagen de portada",
-					"description": "Description",
+					"deleted_at": "Eliminado el",
+					"description": "Descripción",
 					"description_help": "Admite formato Markdown.",
-					"featured": "Featured",
-					"name": "Name",
-					"owner_email": "Owner Email",
+					"featured": "Destacado",
+					"name": "Nombre",
+					"owner_email": "Correo del responsable",
 					"owner_email_placeholder": "propietario@ejemplo.com",
 					"settings_json": "Configuración JSON",
 					"slug": "Slug",
@@ -558,13 +694,15 @@
 					"featured_only": "Featured Only",
 					"owner_1": "Propietario 1",
 					"owner_2": "Propietario 2",
-					"regular_only": "Regular Only",
-					"status": "Status"
+					"regular_only": "Solo normales",
+					"status": "Estado",
+					"trashed": "Papelera"
 				},
 				"lenses": {
-					"active": "Active Projects",
+					"active": "Proyectos activos",
 					"archived": "Archived Projects",
-					"featured": "Featured Projects"
+					"featured": "Proyectos destacados",
+					"trashed": "Proyectos en papelera"
 				},
 				"metrics": {
 					"active": "Proyectos activos",
@@ -582,17 +720,19 @@
 					"total_desc": "Todos los proyectos registrados",
 					"total_subtitle": "Portafolio de proyectos"
 				},
-				"nav_title": "Demo Projects",
+				"nav_title": "Proyectos de demostración",
 				"options": {
-					"status_active": "Active",
+					"status_active": "Activo",
 					"status_archived": "Archived",
-					"status_draft": "Draft"
+					"status_draft": "Borrador",
+					"status_trashed": "Papelera"
 				},
 				"plural_label": "Proyectos de demostración",
 				"search_placeholder": "Buscar proyectos de demostración...",
 				"search_placeholder_active": "Buscar proyectos activos...",
 				"search_placeholder_archived": "Buscar proyectos archivados...",
 				"search_placeholder_featured": "Buscar proyectos destacados...",
+				"search_placeholder_trashed": "Buscar proyectos en papelera...",
 				"singular_label": "Proyecto de demostración",
 				"validation": {
 					"invalid_brand_color": "El color de marca debe ser un color hexadecimal válido.",
@@ -602,6 +742,12 @@
 			"queued_actions": {
 				"cancel_job": "Cancelar",
 				"enqueued": "Acción en cola para procesamiento en segundo plano",
+				"fields": {
+					"action": "Acción",
+					"status": "Estado",
+					"summary": "Resumen",
+					"updated": "Actualizado"
+				},
 				"no_active_jobs": "No hay tareas activas",
 				"panel_title": "Tareas en segundo plano",
 				"progress": "{processed} de {total} procesados",
@@ -617,10 +763,19 @@
 				"actor_user_description": "Usuario gestionado resuelto a partir del actor vinculado a este evento del framework.",
 				"admin_actor": "Actor administrador",
 				"admin_actor_description": "Usuario administrador asociado con esta auditoría o nota.",
+				"associated_project": "Proyecto asociado",
+				"associated_project_description": "Proyecto de demostración vinculado actualmente a este registro pivote.",
+				"associated_user": "Usuario asociado",
+				"associated_user_description": "Usuario gestionado vinculado actualmente a este registro pivote.",
+				"duplicates_allowed": "Se permiten duplicados para esta relación. Reutilizar el mismo registro creará otra asignación en lugar de reemplazar la existente.",
 				"internal_notes": "Notas internas",
 				"internal_notes_description": "Notas escritas por operadores conectadas a este usuario gestionado.",
 				"managed_user": "Usuario gestionado",
 				"managed_user_description": "Usuario gestionado vinculado a este destinatario de notificaciones.",
+				"project_tags": "Etiquetas del proyecto",
+				"project_tags_description": "Etiquetas demo reutilizables adjuntas a este proyecto mediante el flujo genérico de relaciones.",
+				"project_tasks": "Tareas del proyecto",
+				"project_tasks_description": "Relación de tareas colapsable para validar creación inline, acciones de fila y flujos de tareas contextuales.",
 				"related_record": "Registro relacionado",
 				"related_record_description": "Registro del framework referenciado por esta entrada de actividad.",
 				"related_record_unavailable": "El registro relacionado no está disponible actualmente.",
@@ -637,40 +792,85 @@
 			},
 			"selected": "{selected} of {total} selected",
 			"tags": {
+				"attach_description": "Adjunta una etiqueta demo existente a este proyecto.",
+				"attach_empty_description": "Crea una etiqueta nueva o ajusta la búsqueda para encontrar etiquetas adjuntables.",
+				"attach_empty_title": "No hay etiquetas adjuntables",
+				"attach_search_placeholder": "Buscar etiquetas adjuntables...",
+				"dashboard_description": "Etiquetas demo reutilizables para QA de adjuntar y desvincular relaciones.",
+				"delete_description": "¿Eliminar la etiqueta “{name}”? Las etiquetas adjuntas a proyectos no se pueden eliminar.",
+				"delete_title": "Eliminar etiqueta demo",
+				"empty_description": "No hay etiquetas demo que coincidan con la búsqueda actual.",
+				"empty_relation_description": "Adjunta una etiqueta existente o crea una nueva desde este panel.",
+				"empty_relation_title": "No hay etiquetas adjuntas",
+				"empty_title": "No hay etiquetas demo",
 				"fields": {
 					"color": "Color",
-					"name": "Name"
+					"name": "Nombre",
+					"usage_count": "Recuento de uso"
 				},
 				"metrics": {
 					"total": "Etiquetas totales",
 					"total_desc": "Todas las etiquetas disponibles",
 					"total_subtitle": "Biblioteca de etiquetas"
 				},
-				"nav_title": "Demo Tags"
+				"nav_title": "Etiquetas demo",
+				"plural_label": "Etiquetas demo",
+				"search_placeholder": "Buscar etiquetas demo...",
+				"singular_label": "Etiqueta demo",
+				"toasts": {
+					"attached": "Etiqueta adjuntada",
+					"detached": "Etiqueta desvinculada"
+				},
+				"validation": {
+					"invalid_color": "El color de la etiqueta debe ser un color hex válido."
+				}
 			},
 			"tasks": {
 				"actions": {
 					"assign_to_me": "Asignarme",
-					"mark_done": "Mark Done",
-					"mark_in_progress": "Mark In Progress",
-					"queued_bulk_process": "Procesamiento masivo en cola",
-					"quick_done": "Marcar listo"
+					"inline_create": "Crear tarea en línea",
+					"mark_done": "Marcar como hecha",
+					"mark_in_progress": "Marcar en progreso",
+					"queued_bulk_process": "Proceso masivo en cola",
+					"quick_done": "Hecha rápida",
+					"seed_data": "Sembrar tareas demo",
+					"update_status": "Actualizar estado"
 				},
+				"dashboard_description": "Tareas de demostración para formularios de acción, trabajos en cola, ruta de vista previa y creación inline.",
+				"delete_description": "¿Eliminar permanentemente {title} de la superficie demo de tareas?",
+				"delete_title": "Eliminar tarea demo",
+				"empty_completed_description": "Ninguna tarea demo completada coincide con la búsqueda actual.",
+				"empty_completed_title": "No hay tareas demo completadas",
+				"empty_description": "Ninguna tarea demo coincide con la búsqueda actual.",
+				"empty_due_description": "No hay tareas demo próximas con vencimiento cercano.",
+				"empty_due_title": "No hay tareas próximas",
+				"empty_relation_description": "Crea una tarea en línea desde la página del proyecto o abre el recurso completo de tareas.",
+				"empty_relation_title": "Todavía no hay tareas vinculadas",
+				"empty_title": "No hay tareas demo",
 				"fields": {
-					"assignee_email": "Assignee Email",
-					"estimate_hours": "Estimate Hours",
-					"priority": "Priority",
-					"project": "Project",
-					"status": "Status",
-					"title": "Title"
+					"assignee_email": "Correo del responsable",
+					"due_at": "Vence el",
+					"estimate_hours": "Horas estimadas",
+					"note": "Nota del operador",
+					"priority": "Prioridad",
+					"project": "Proyecto",
+					"status": "Estado",
+					"title": "Título",
+					"workload": "Carga"
 				},
 				"filters": {
-					"priority": "Priority",
-					"status": "Status"
+					"all_priorities": "Todas las prioridades",
+					"all_statuses": "Todos los estados",
+					"priority": "Prioridad",
+					"status": "Estado"
+				},
+				"groups": {
+					"delivery": "Entrega",
+					"schedule": "Planificación"
 				},
 				"lenses": {
-					"completed": "Completed Tasks",
-					"due": "Due Tasks"
+					"completed": "Tareas completadas",
+					"due": "Tareas por vencer"
 				},
 				"metrics": {
 					"completion_rate": "Tasa de finalización",
@@ -690,16 +890,35 @@
 					"status_trend": "Tendencia de estado",
 					"todo": "Pendiente",
 					"todo_desc": "Tareas pendientes de inicio",
-					"todo_subtitle": "Elementos del backlog"
+					"todo_subtitle": "Elementos del backlog",
+					"total": "Tareas totales",
+					"total_desc": "Todas las tareas demo del escaparate"
 				},
-				"nav_title": "Demo Tasks",
+				"nav_title": "Tareas demo",
 				"options": {
-					"done": "Done",
-					"high": "High",
-					"in_progress": "In Progress",
-					"low": "Low",
-					"medium": "Medium",
-					"todo": "Todo"
+					"done": "Hecho",
+					"high": "Alta",
+					"in_progress": "En progreso",
+					"low": "Baja",
+					"medium": "Media",
+					"todo": "Pendiente"
+				},
+				"plural_label": "Tareas demo",
+				"search_placeholder": "Buscar tareas demo...",
+				"search_placeholder_completed": "Buscar tareas completadas...",
+				"search_placeholder_due": "Buscar tareas por vencer...",
+				"singular_label": "Tarea demo",
+				"toasts": {
+					"bulk_started": "Se inició la actualización masiva de tareas en cola"
+				},
+				"tools": {
+					"open_project": "Abrir proyecto",
+					"review_due": "Revisar tareas por vencer"
+				},
+				"values": {
+					"workload_heavy": "Alta",
+					"workload_light": "Ligera",
+					"workload_medium": "Media"
 				}
 			},
 			"toasts": {
@@ -722,6 +941,7 @@
 				"enabled": "Enabled",
 				"masked": "••••••••",
 				"no": "No",
+				"none": "Ninguno",
 				"pairs_count": "{count} pares",
 				"selected_count": "{count} seleccionados",
 				"yes": "Yes"
@@ -820,6 +1040,87 @@
 			"type_admin": "Admin",
 			"type_custom": "Personalizado"
 		},
+		"showcase": {
+			"badges": {
+				"baseline_incomplete": "Necesita reinicio",
+				"baseline_ready": "Línea base lista",
+				"demo_available": "Demo disponible",
+				"managed_by_reset": "Gestionado por reinicio",
+				"reference_surface": "Superficie de referencia",
+				"tool_only": "Solo herramienta"
+			},
+			"controls": {
+				"clear_demo_data": "Vaciar datos demo",
+				"clear_help": "Elimina los datos del showcase gestionados por reinicio y cualquier trabajo en cola del showcase. Úsalo para verificar estados vacíos.",
+				"description": "Estos controles solo afectan al conjunto de datos determinista del showcase admin-v2. No modifican datos personalizados de soporte o configuración.",
+				"queue_help": "Hay {count} trabajos en cola del showcase activos.",
+				"reset_baseline": "Restablecer a la línea base",
+				"reset_help": "Empieza la QA manual desde la línea base conocida. Esto vuelve a sembrar proyectos, etiquetas, miembros, assets y tareas.",
+				"title": "Controles de datos"
+			},
+			"description": "Un único lugar para revisar manualmente cada familia de funciones admin-v2 tipo Nova con datos deterministas y cobertura de rutas explícita.",
+			"features": {
+				"audit": "Trazas de auditoría",
+				"auth_managed": "Recursos gestionados por auth",
+				"batch_actions": "Acciones por lote",
+				"crud": "CRUD genérico",
+				"derived": "Recursos derivados",
+				"file_fields": "Campos de archivo e imagen",
+				"filters": "Filtros",
+				"lenses": "Lentes de primera clase",
+				"metrics": "Métricas",
+				"pivot_fields": "Metadatos pivot",
+				"preview": "Rutas de vista previa",
+				"queued_actions": "Acciones en cola",
+				"relations": "Flujos relacionales",
+				"replicate": "Replicar",
+				"rich_fields": "Markdown, código y JSON",
+				"row_actions": "Acciones por fila",
+				"soft_delete": "Borrado suave y restauración"
+			},
+			"flow": {
+				"step_1": "Restablece el showcase al conjunto de datos base.",
+				"step_2": "Verifica que las tarjetas de recursos muestren los conteos sembrados esperados.",
+				"step_3": "Usa la matriz de funciones para saltar directamente a la superficie que quieres inspeccionar.",
+				"step_4": "Usa los enlaces de herramientas personalizadas solo para flujos que permanecen intencionalmente fuera del framework genérico."
+			},
+			"links": {
+				"archived_lens": "Lente archivada",
+				"trashed_lens": "Lente papelera"
+			},
+			"non_demo": {
+				"dashboard_description": "El dashboard sigue siendo una superficie compuesta para operadores. El playground enlaza a él, pero el dashboard no es una demo genérica de recursos.",
+				"dashboard_title": "Composición del dashboard",
+				"settings_description": "Configuración sigue siendo una herramienta curada. La parte genérica a revisar es Destinatarios de Notificaciones.",
+				"settings_title": "Curación de configuración",
+				"support_description": "Soporte usa un flujo personalizado de múltiples paneles y no se fuerza dentro de un recurso genérico.",
+				"support_title": "Flujo de soporte",
+				"users_description": "La tabla de usuarios heredada todavía existe, pero la paridad auth-managed se verifica en Usuarios Gestionados.",
+				"users_title": "Tabla heredada de usuarios"
+			},
+			"sections": {
+				"feature_matrix": "Cobertura de funciones",
+				"no_dedicated_demo": "Sin demo genérica dedicada",
+				"no_dedicated_demo_desc": "Estas superficies siguen siendo importantes, pero permanecen personalizadas o heredadas por diseño.",
+				"recommended_flow": "Flujo QA recomendado",
+				"resources": "Superficies demo"
+			},
+			"summary": {
+				"baseline_state": "Estado de la línea base",
+				"baseline_state_desc": "Si los recursos del showcase gestionados por reinicio ya volvieron a su línea base sembrada.",
+				"relation_records": "Registros relacionales",
+				"relation_records_desc": "Etiquetas y filas de miembros de proyecto que prueban attach/detach y flujos pivot.",
+				"seeded_resources": "Recursos sembrados",
+				"seeded_resources_desc": "Recursos del showcase gestionados por reinicio presentes actualmente.",
+				"uploads": "Assets con uploads",
+				"uploads_desc": "Assets demo que actualmente almacenan archivos o imágenes subidas."
+			},
+			"title": "Showcase admin-v2",
+			"toasts": {
+				"clear_complete": "Se vaciaron los datos del showcase admin-v2.",
+				"reset_complete": "El showcase admin-v2 se restableció a la línea base."
+			}
+		},
 		"sidebar": {
 			"back_to_app": "Volver a la App",
 			"dashboard": "Panel",
@@ -830,6 +1131,7 @@
 				"security": "Seguridad"
 			},
 			"settings": "Configuración",
+			"showcase": "Showcase",
 			"support": "Soporte",
 			"users": "Usuarios"
 		},
@@ -1372,7 +1674,7 @@
 		"companies_text": "Impulsando a los mejores equipos",
 		"cta": "Comenzar ahora",
 		"cta_demo": "Solicitar una demo",
-		"description": "La base SaaS gratuita. Open source, lista para desplegar.",
+		"description": "Dale vida a tu SaaS en minutos, no en meses. Plantilla open-source cargada con la tecnología que te hace lanzar rápido.",
 		"section_label": "Inicio",
 		"tagline": "Foco en tu producto.\nLanzamiento más rápido.",
 		"title": "Plantilla SaaS Starter"
@@ -1470,6 +1772,10 @@
 				"description": "Configura destinatarios y preferencias de notificaciones de admin.",
 				"title": "Ajustes de Admin"
 			},
+			"showcase": {
+				"description": "Revisa manualmente el playground completo de admin-v2 con datos base restablecibles.",
+				"title": "Showcase admin-v2"
+			},
 			"support": {
 				"description": "Revisa y responde conversaciones de soporte de clientes.",
 				"title": "Bandeja de Soporte"
@@ -1530,7 +1836,7 @@
 			}
 		},
 		"home": {
-			"description": "Starter SaaS gratuito y open source con SvelteKit. Auth, pagos, email y analítica incluidos. Aloja gratis con planes gratuitos.",
+			"description": "Starter SaaS para SvelteKit con auth, pagos, email y analítica.",
 			"title": "Construye y lanza tu producto más rápido"
 		},
 		"impressum": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -16,6 +16,8 @@
 			"external_services": "Services Externes",
 			"hosting_deployment": "Hébergement & déploiement",
 			"no_framework_activity": "Aucune action du framework n’a encore été enregistrée.",
+			"playground": "Playground QA",
+			"playground_description": "Ouvre le playground de démonstration déterministe et réinitialise le showcase admin-v2 vers une base connue.",
 			"recent_framework_activity": "Activité récente du framework",
 			"resource_overview": "Vue des Ressources",
 			"resource_records": "{count} enregistrements",
@@ -73,21 +75,25 @@
 		},
 		"resources": {
 			"actions": {
-				"create": "Create",
-				"create_resource": "Create {resource}",
-				"delete": "Delete",
-				"edit": "Edit",
-				"force_delete": "Force Delete",
+				"associate": "Associer",
+				"attach": "Attacher",
+				"create": "Créer",
+				"create_resource": "Créer {resource}",
+				"delete": "Supprimer",
+				"detach": "Détacher",
+				"dissociate": "Dissocier",
+				"edit": "Modifier",
+				"force_delete": "Supprimer définitivement",
 				"preview": "Aperçu",
-				"replicate": "Replicate",
-				"restore": "Restore",
+				"replicate": "Dupliquer",
+				"restore": "Restaurer",
 				"select_exactly_one": "Veuillez sélectionner exactement un enregistrement.",
 				"status_completed": "Terminé",
 				"status_failed": "Échoué",
 				"status_pending": "En attente",
 				"status_running": "En cours",
 				"update_resource": "Mettre à jour {resource}",
-				"view": "View"
+				"view": "Voir"
 			},
 			"actions_column": "Actions",
 			"activity": {
@@ -300,6 +306,65 @@
 				"copied_tooltip": "Copié !",
 				"tooltip": "Copier dans le presse-papiers"
 			},
+			"demo_assets": {
+				"actions": {
+					"delete_description": "Supprimer la ressource de démonstration « {name} » ? Les fichiers téléversés seront également supprimés.",
+					"delete_title": "Supprimer la ressource de démonstration",
+					"seed_data": "Initialiser les ressources de démonstration"
+				},
+				"dashboard_description": "Showcase médias et champs enrichis pour les téléversements, le markdown, le code et le JSON.",
+				"empty_description": "Créez une ressource de démonstration ou initialisez les données du showcase pour vérifier le rendu des champs enrichis.",
+				"empty_title": "Aucune ressource de démonstration",
+				"fields": {
+					"attachment": "Pièce jointe",
+					"attachment_help": "Téléversez un fichier téléchargeable pour vérifier le cycle de vie générique des fichiers.",
+					"code_snippet": "Extrait de code",
+					"content_summary": "Résumé du contenu",
+					"content_summary_help": "Aperçu calculé du markdown actuel et de la couverture des téléversements.",
+					"coverage": "Couverture",
+					"hero_image": "Image principale",
+					"hero_image_help": "Téléversez une image pour vérifier l’aperçu et la persistance de la ressource.",
+					"markdown_body": "Contenu Markdown",
+					"name": "Nom",
+					"price": "Prix (USD)",
+					"published_at": "Publié le",
+					"release_date": "Date de sortie",
+					"settings_json": "JSON de configuration",
+					"slug": "Slug",
+					"slug_help": "Lettres minuscules, chiffres et tirets uniquement."
+				},
+				"groups": {
+					"content": "Contenu",
+					"media": "Médias"
+				},
+				"metrics": {
+					"total": "Total des ressources",
+					"total_desc": "Tous les enregistrements de ressources de démonstration",
+					"with_attachments": "Avec pièces jointes",
+					"with_attachments_desc": "Ressources incluant un fichier téléchargeable",
+					"with_images": "Avec images",
+					"with_images_desc": "Ressources incluant une image principale"
+				},
+				"plural_label": "Ressources de démonstration",
+				"search_placeholder": "Rechercher des ressources de démonstration...",
+				"singular_label": "Ressource de démonstration",
+				"toasts": {
+					"deleted": "Ressource de démonstration supprimée",
+					"seeded": "Ressources de démonstration initialisées"
+				},
+				"validation": {
+					"invalid_json": "Le JSON de configuration doit être valide.",
+					"invalid_price": "Le prix doit être supérieur ou égal à zéro.",
+					"invalid_published_at": "La date et l’heure de publication doivent être valides.",
+					"invalid_release_date": "La date de sortie doit être valide.",
+					"invalid_slug": "Le slug doit utiliser uniquement des lettres minuscules, des chiffres et des tirets."
+				},
+				"values": {
+					"coverage_missing": "Téléversements manquants",
+					"coverage_partial": "Partiellement prêt",
+					"coverage_ready": "Prêt"
+				}
+			},
 			"detail_missing_description": "Cet enregistrement n’existe plus ou n’est pas visible pour la session admin actuelle.",
 			"detail_missing_title": "Enregistrement introuvable",
 			"email_events": {
@@ -351,10 +416,12 @@
 				"characters_count": "{count} / {limit}",
 				"fix_errors": "Veuillez corriger les champs en surbrillance.",
 				"hide_content": "Masquer le contenu",
+				"image_required": "Veuillez téléverser un fichier image.",
 				"invalid": "Invalid field value",
 				"key_placeholder": "Clé",
 				"local_override_notice": "Vous avez modifié ce champ localement. Les mises à jour en direct entrantes ne l’écraseront pas.",
 				"markdown_placeholder": "## Contenu Markdown",
+				"max_file_size": "Le fichier dépasse la taille maximale de {size} Mo.",
 				"maxlength_exceeded": "Dépasse la longueur maximale de {limit} caractères",
 				"no_relation_options": "No options available",
 				"no_suggestions": "Aucune suggestion",
@@ -365,6 +432,8 @@
 				"suggestions_input": "Tapez pour rechercher des suggestions",
 				"suggestions_loading": "Chargement des suggestions…",
 				"upload": "Téléverser un fichier",
+				"upload_ready": "Téléversement terminé",
+				"uploading_progress": "Téléversement… {progress}%",
 				"value_placeholder": "Valeur"
 			},
 			"framework_activity": {
@@ -418,6 +487,7 @@
 				"event": "Événement",
 				"identity": "Identité",
 				"main": "Principal",
+				"media": "Médias",
 				"metadata": "Métadonnées",
 				"notifications": "Notifications",
 				"other": "Autres",
@@ -510,21 +580,84 @@
 				"empty": "Rien à afficher ici.",
 				"loading": "Chargement..."
 			},
+			"project_members": {
+				"associate_project_description": "Associer cet enregistrement pivot à un projet de démonstration.",
+				"associate_project_empty_description": "Chargez les données de démonstration ou affinez la recherche pour trouver un projet.",
+				"associate_project_empty_title": "Aucun projet disponible",
+				"associate_project_search_placeholder": "Rechercher des projets...",
+				"associate_user_description": "Associer cet enregistrement pivot à un utilisateur géré.",
+				"associate_user_empty_description": "Affinez la recherche pour trouver un utilisateur géré.",
+				"associate_user_empty_title": "Aucun utilisateur géré disponible",
+				"associate_user_search_placeholder": "Rechercher des utilisateurs gérés...",
+				"dashboard_description": "Enregistrements d’adhésion de type pivot pour vérifier les workflows d’association et de dissociation.",
+				"delete_description": "Supprimer cet enregistrement de membre du projet avec le rôle {role} ?",
+				"delete_title": "Supprimer le membre du projet",
+				"dissociate_project_description": "Retirer {name} de cet enregistrement de membre du projet ?",
+				"dissociate_project_title": "Dissocier le projet",
+				"dissociate_user_description": "Retirer {name} de cet enregistrement de membre du projet ?",
+				"dissociate_user_title": "Dissocier l’utilisateur",
+				"empty_description": "Créez un membre de projet de démonstration ou ajustez la recherche pour afficher les enregistrements pivot.",
+				"empty_title": "Aucun membre du projet",
+				"fields": {
+					"allocation_percent": "Allocation",
+					"allocation_percent_help": "Pourcentage de l’effort de ce membre alloué au projet associé.",
+					"joined_at": "A rejoint le",
+					"project": "Projet",
+					"role": "Rôle",
+					"user": "Utilisateur géré",
+					"user_email": "E-mail de l’utilisateur"
+				},
+				"groups": {
+					"assignment": "Affectation",
+					"membership": "Adhésion"
+				},
+				"metrics": {
+					"total": "Membres au total",
+					"total_desc": "Tous les enregistrements pivot",
+					"with_project": "Avec projet",
+					"with_project_desc": "Enregistrements déjà associés à un projet",
+					"with_user": "Avec utilisateur",
+					"with_user_desc": "Enregistrements déjà associés à un utilisateur géré"
+				},
+				"options": {
+					"role_contributor": "Contributeur",
+					"role_lead": "Responsable",
+					"role_reviewer": "Relecteur"
+				},
+				"plural_label": "Membres de projet de démonstration",
+				"search_placeholder": "Rechercher des membres de projet de démonstration...",
+				"singular_label": "Membre de projet de démonstration",
+				"toasts": {
+					"deleted": "Membre du projet supprimé",
+					"project_associated": "Projet associé",
+					"project_dissociated": "Projet dissocié",
+					"user_associated": "Utilisateur géré associé",
+					"user_dissociated": "Utilisateur géré dissocié"
+				},
+				"validation": {
+					"invalid_allocation_percent": "L’allocation doit être comprise entre 0 et 100."
+				},
+				"values": {
+					"unassigned": "Non attribué"
+				}
+			},
 			"projects": {
 				"actions": {
 					"archive": "Archive",
-					"attach_tag": "Attach Tag",
+					"attach_tag": "Attacher une étiquette",
 					"export_csv": "Exporter CSV",
-					"feature": "Mark Featured",
+					"feature": "Marquer en vedette",
+					"force_delete": "Supprimer définitivement",
 					"purge": "Purger",
 					"purge_cancel_btn": "Annuler",
 					"purge_confirm": "Cela supprimera définitivement les projets sélectionnés et toutes les données associées. Cette action est irréversible.",
 					"purge_confirm_btn": "Oui, purger",
 					"restore_archived": "Restaurer les projets archivés",
+					"restore_trashed": "Restaurer les projets de la corbeille",
 					"seed_data": "Générer des données"
 				},
 				"dashboard_description": "Terrain de parité pour des workflows de ressources admin-v2 plus riches.",
-				"empty_active_description": "Archivez des projets ou générez des données de démonstration pour vérifier la vue des projets actifs.",
+				"empty_active_description": "Restaurez un projet de la corbeille ou générez des données de démonstration pour vérifier la vue des projets actifs.",
 				"empty_active_title": "Aucun projet actif",
 				"empty_archived_description": "Archivez un projet ou générez des données de démonstration pour vérifier les flux de récupération archivés.",
 				"empty_archived_title": "Aucun projet archivé",
@@ -532,6 +665,8 @@
 				"empty_featured_description": "Mettez un projet en avant ou générez des données de démonstration pour vérifier la vue des projets en vedette.",
 				"empty_featured_title": "Aucun projet en vedette",
 				"empty_title": "Aucun projet trouvé",
+				"empty_trashed_description": "Envoyez un projet dans la corbeille ou générez des données de démonstration pour vérifier les flux de restauration.",
+				"empty_trashed_title": "Aucun projet dans la corbeille",
 				"fields": {
 					"brand_color": "Couleur de marque",
 					"brand_color_help": "Couleur d’accent principale utilisée pour les aperçus et la QA opérateur.",
@@ -539,11 +674,12 @@
 					"budget": "Budget",
 					"code_snippet": "Extrait de code",
 					"cover_image": "URL de l'image de couverture",
+					"deleted_at": "Supprimé le",
 					"description": "Description",
 					"description_help": "Prend en charge le formatage Markdown.",
-					"featured": "Featured",
-					"name": "Name",
-					"owner_email": "Owner Email",
+					"featured": "En vedette",
+					"name": "Nom",
+					"owner_email": "E-mail du responsable",
 					"owner_email_placeholder": "proprietaire@exemple.fr",
 					"settings_json": "Paramètres JSON",
 					"slug": "Slug",
@@ -558,13 +694,15 @@
 					"featured_only": "Featured Only",
 					"owner_1": "Propriétaire 1",
 					"owner_2": "Propriétaire 2",
-					"regular_only": "Regular Only",
-					"status": "Status"
+					"regular_only": "Seulement réguliers",
+					"status": "Statut",
+					"trashed": "Corbeille"
 				},
 				"lenses": {
-					"active": "Active Projects",
+					"active": "Projets actifs",
 					"archived": "Archived Projects",
-					"featured": "Featured Projects"
+					"featured": "Projets en vedette",
+					"trashed": "Projets de la corbeille"
 				},
 				"metrics": {
 					"active": "Projets actifs",
@@ -582,17 +720,19 @@
 					"total_desc": "Tous les projets enregistrés",
 					"total_subtitle": "Portefeuille de projets"
 				},
-				"nav_title": "Demo Projects",
+				"nav_title": "Projets de démonstration",
 				"options": {
-					"status_active": "Active",
+					"status_active": "Actif",
 					"status_archived": "Archived",
-					"status_draft": "Draft"
+					"status_draft": "Brouillon",
+					"status_trashed": "Corbeille"
 				},
 				"plural_label": "Projets de démonstration",
 				"search_placeholder": "Rechercher des projets de démonstration...",
 				"search_placeholder_active": "Rechercher des projets actifs...",
 				"search_placeholder_archived": "Rechercher des projets archivés...",
 				"search_placeholder_featured": "Rechercher des projets en vedette...",
+				"search_placeholder_trashed": "Rechercher des projets de la corbeille...",
 				"singular_label": "Projet de démonstration",
 				"validation": {
 					"invalid_brand_color": "La couleur de marque doit être une couleur hexadécimale valide.",
@@ -602,6 +742,12 @@
 			"queued_actions": {
 				"cancel_job": "Annuler",
 				"enqueued": "Action mise en file d'attente pour traitement en arrière-plan",
+				"fields": {
+					"action": "Action",
+					"status": "Statut",
+					"summary": "Résumé",
+					"updated": "Mis à jour"
+				},
 				"no_active_jobs": "Aucune tâche active",
 				"panel_title": "Tâches en arrière-plan",
 				"progress": "{processed} sur {total} traités",
@@ -617,10 +763,19 @@
 				"actor_user_description": "Utilisateur géré résolu à partir de l’acteur attaché à cet événement du framework.",
 				"admin_actor": "Acteur admin",
 				"admin_actor_description": "Utilisateur admin associé à cette entrée d’audit ou de note.",
+				"associated_project": "Projet associé",
+				"associated_project_description": "Projet de démonstration actuellement lié à cet enregistrement pivot.",
+				"associated_user": "Utilisateur associé",
+				"associated_user_description": "Utilisateur géré actuellement lié à cet enregistrement pivot.",
+				"duplicates_allowed": "Les doublons sont autorisés pour cette relation. Réutiliser le même enregistrement créera une attribution supplémentaire au lieu de remplacer l’existante.",
 				"internal_notes": "Notes internes",
 				"internal_notes_description": "Notes rédigées par les opérateurs et liées à cet utilisateur géré.",
 				"managed_user": "Utilisateur géré",
 				"managed_user_description": "Utilisateur géré lié à ce destinataire de notifications.",
+				"project_tags": "Tags du projet",
+				"project_tags_description": "Tags de démonstration réutilisables attachés à ce projet via le flux générique de relations.",
+				"project_tasks": "Tâches du projet",
+				"project_tasks_description": "Relation de tâches repliable pour valider la création inline, les actions de ligne et les flux contextuels autour des tâches.",
 				"related_record": "Enregistrement associé",
 				"related_record_description": "Enregistrement du framework référencé par cette entrée d’activité.",
 				"related_record_unavailable": "L’enregistrement associé n’est pas disponible actuellement.",
@@ -637,40 +792,85 @@
 			},
 			"selected": "{selected} of {total} selected",
 			"tags": {
+				"attach_description": "Attachez un tag de démonstration existant à ce projet.",
+				"attach_empty_description": "Créez un nouveau tag ou affinez la recherche pour trouver des tags attachables.",
+				"attach_empty_title": "Aucun tag attachable",
+				"attach_search_placeholder": "Rechercher des tags attachables...",
+				"dashboard_description": "Tags de démonstration réutilisables pour la QA des flux d’attache et de détache des relations.",
+				"delete_description": "Supprimer le tag « {name} » ? Les tags attachés à des projets ne peuvent pas être supprimés.",
+				"delete_title": "Supprimer le tag de démonstration",
+				"empty_description": "Aucun tag de démonstration ne correspond à la recherche actuelle.",
+				"empty_relation_description": "Attachez un tag existant ou créez-en un nouveau depuis ce panneau.",
+				"empty_relation_title": "Aucun tag attaché",
+				"empty_title": "Aucun tag de démonstration",
 				"fields": {
-					"color": "Color",
-					"name": "Name"
+					"color": "Couleur",
+					"name": "Nom",
+					"usage_count": "Nombre d’utilisations"
 				},
 				"metrics": {
 					"total": "Étiquettes au total",
 					"total_desc": "Toutes les étiquettes disponibles",
 					"total_subtitle": "Bibliothèque d'étiquettes"
 				},
-				"nav_title": "Demo Tags"
+				"nav_title": "Tags de démonstration",
+				"plural_label": "Tags de démonstration",
+				"search_placeholder": "Rechercher des tags de démonstration...",
+				"singular_label": "Tag de démonstration",
+				"toasts": {
+					"attached": "Tag attaché",
+					"detached": "Tag détaché"
+				},
+				"validation": {
+					"invalid_color": "La couleur du tag doit être une couleur hexadécimale valide."
+				}
 			},
 			"tasks": {
 				"actions": {
-					"assign_to_me": "M'assigner",
-					"mark_done": "Mark Done",
-					"mark_in_progress": "Mark In Progress",
-					"queued_bulk_process": "Traitement en masse en file d'attente",
-					"quick_done": "Terminé rapide"
+					"assign_to_me": "M’assigner",
+					"inline_create": "Créer la tâche en ligne",
+					"mark_done": "Marquer comme terminée",
+					"mark_in_progress": "Passer en cours",
+					"queued_bulk_process": "Traitement groupé en file",
+					"quick_done": "Terminer rapidement",
+					"seed_data": "Créer les tâches de démo",
+					"update_status": "Mettre à jour le statut"
 				},
+				"dashboard_description": "Tâches vitrine pour les formulaires d’action, les jobs en file, la route de prévisualisation et la création inline.",
+				"delete_description": "Supprimer définitivement {title} de la surface de démo des tâches ?",
+				"delete_title": "Supprimer la tâche de démo",
+				"empty_completed_description": "Aucune tâche de démo terminée ne correspond à la recherche actuelle.",
+				"empty_completed_title": "Aucune tâche de démo terminée",
+				"empty_description": "Aucune tâche de démo ne correspond à la recherche actuelle.",
+				"empty_due_description": "Aucune tâche de démo à venir n’est bientôt due.",
+				"empty_due_title": "Aucune tâche bientôt due",
+				"empty_relation_description": "Créez une tâche en ligne depuis la page du projet ou ouvrez la ressource complète des tâches.",
+				"empty_relation_title": "Aucune tâche liée pour le moment",
+				"empty_title": "Aucune tâche de démo",
 				"fields": {
-					"assignee_email": "Assignee Email",
-					"estimate_hours": "Estimate Hours",
-					"priority": "Priority",
-					"project": "Project",
-					"status": "Status",
-					"title": "Title"
+					"assignee_email": "E-mail du responsable",
+					"due_at": "Échéance",
+					"estimate_hours": "Heures estimées",
+					"note": "Note opérateur",
+					"priority": "Priorité",
+					"project": "Projet",
+					"status": "Statut",
+					"title": "Titre",
+					"workload": "Charge"
 				},
 				"filters": {
-					"priority": "Priority",
-					"status": "Status"
+					"all_priorities": "Toutes les priorités",
+					"all_statuses": "Tous les statuts",
+					"priority": "Priorité",
+					"status": "Statut"
+				},
+				"groups": {
+					"delivery": "Livraison",
+					"schedule": "Planification"
 				},
 				"lenses": {
-					"completed": "Completed Tasks",
-					"due": "Due Tasks"
+					"completed": "Tâches terminées",
+					"due": "Tâches à échéance proche"
 				},
 				"metrics": {
 					"completion_rate": "Taux d'achèvement",
@@ -690,16 +890,35 @@
 					"status_trend": "Tendance du statut",
 					"todo": "À faire",
 					"todo_desc": "Tâches en attente de démarrage",
-					"todo_subtitle": "Éléments du backlog"
+					"todo_subtitle": "Éléments du backlog",
+					"total": "Tâches totales",
+					"total_desc": "Toutes les tâches de démo de la vitrine"
 				},
-				"nav_title": "Demo Tasks",
+				"nav_title": "Tâches de démo",
 				"options": {
-					"done": "Done",
-					"high": "High",
-					"in_progress": "In Progress",
-					"low": "Low",
-					"medium": "Medium",
-					"todo": "Todo"
+					"done": "Terminé",
+					"high": "Haute",
+					"in_progress": "En cours",
+					"low": "Basse",
+					"medium": "Moyenne",
+					"todo": "À faire"
+				},
+				"plural_label": "Tâches de démo",
+				"search_placeholder": "Rechercher des tâches de démo...",
+				"search_placeholder_completed": "Rechercher les tâches terminées...",
+				"search_placeholder_due": "Rechercher les tâches à échéance proche...",
+				"singular_label": "Tâche de démo",
+				"toasts": {
+					"bulk_started": "La mise à jour groupée des tâches a démarré"
+				},
+				"tools": {
+					"open_project": "Ouvrir le projet",
+					"review_due": "Vérifier les tâches dues"
+				},
+				"values": {
+					"workload_heavy": "Élevée",
+					"workload_light": "Légère",
+					"workload_medium": "Moyenne"
 				}
 			},
 			"toasts": {
@@ -722,6 +941,7 @@
 				"enabled": "Enabled",
 				"masked": "••••••••",
 				"no": "No",
+				"none": "Aucun",
 				"pairs_count": "{count} paires",
 				"selected_count": "{count} sélectionnés",
 				"yes": "Yes"
@@ -820,6 +1040,87 @@
 			"type_admin": "Admin",
 			"type_custom": "Personnalisé"
 		},
+		"showcase": {
+			"badges": {
+				"baseline_incomplete": "Réinitialisation requise",
+				"baseline_ready": "Base prête",
+				"demo_available": "Démo disponible",
+				"managed_by_reset": "Géré par réinitialisation",
+				"reference_surface": "Surface de référence",
+				"tool_only": "Outil uniquement"
+			},
+			"controls": {
+				"clear_demo_data": "Vider les données démo",
+				"clear_help": "Supprime les données showcase gérées par réinitialisation ainsi que les tâches showcase en file d’attente. Utilisez-le pour vérifier les états vides.",
+				"description": "Ces contrôles ne touchent qu’au jeu de données déterministe du showcase admin-v2. Ils ne modifient pas les données personnalisées de support ou de paramètres.",
+				"queue_help": "{count} tâches showcase en file d’attente sont actuellement actives.",
+				"reset_baseline": "Réinitialiser la base",
+				"reset_help": "Commencez la QA manuelle à partir de la base connue. Cela réamorce projets, tags, membres, assets et tâches.",
+				"title": "Contrôles des données"
+			},
+			"description": "Un seul endroit pour vérifier manuellement chaque famille de fonctionnalités admin-v2 de style Nova avec des données déterministes et une couverture explicite des routes.",
+			"features": {
+				"audit": "Pistes d’audit",
+				"auth_managed": "Ressources gérées par auth",
+				"batch_actions": "Actions en lot",
+				"crud": "CRUD générique",
+				"derived": "Ressources dérivées",
+				"file_fields": "Champs fichier et image",
+				"filters": "Filtres",
+				"lenses": "Lenses de première classe",
+				"metrics": "Métriques",
+				"pivot_fields": "Métadonnées pivot",
+				"preview": "Routes de prévisualisation",
+				"queued_actions": "Actions en file d’attente",
+				"relations": "Workflows de relation",
+				"replicate": "Dupliquer",
+				"rich_fields": "Markdown, code et JSON",
+				"row_actions": "Actions de ligne",
+				"soft_delete": "Suppression douce et restauration"
+			},
+			"flow": {
+				"step_1": "Réinitialisez le showcase vers le jeu de données de base.",
+				"step_2": "Vérifiez que les cartes de ressources ci-dessous affichent les comptes attendus.",
+				"step_3": "Utilisez la matrice des fonctionnalités pour ouvrir directement la surface à inspecter.",
+				"step_4": "N’utilisez les liens vers les outils personnalisés que pour les workflows qui restent volontairement hors du framework générique."
+			},
+			"links": {
+				"archived_lens": "Lens archivée",
+				"trashed_lens": "Lens corbeille"
+			},
+			"non_demo": {
+				"dashboard_description": "Le dashboard reste une surface opérateur composée. Le playground y mène, mais le dashboard lui-même n’est pas une démo de ressource générique.",
+				"dashboard_title": "Composition du dashboard",
+				"settings_description": "Les paramètres restent un outil admin curé. La partie générique à vérifier est Destinataires des Notifications.",
+				"settings_title": "Curation des paramètres",
+				"support_description": "Le support utilise un workflow opérateur multi-panneaux personnalisé et ne doit pas être forcé dans une ressource générique.",
+				"support_title": "Workflow support",
+				"users_description": "L’ancienne table utilisateurs existe encore, mais la parité auth-managed se vérifie sur Utilisateurs gérés.",
+				"users_title": "Table utilisateurs historique"
+			},
+			"sections": {
+				"feature_matrix": "Couverture des fonctionnalités",
+				"no_dedicated_demo": "Pas de démo générique dédiée",
+				"no_dedicated_demo_desc": "Ces surfaces restent importantes, mais elles demeurent volontairement spécifiques ou héritées.",
+				"recommended_flow": "Flux QA recommandé",
+				"resources": "Surfaces de démo"
+			},
+			"summary": {
+				"baseline_state": "État de base",
+				"baseline_state_desc": "Indique si les ressources showcase gérées par réinitialisation sont revenues à leur état initial.",
+				"relation_records": "Enregistrements relationnels",
+				"relation_records_desc": "Tags et lignes de membres de projet pour valider attach/detach et les workflows pivot.",
+				"seeded_resources": "Ressources amorcées",
+				"seeded_resources_desc": "Ressources showcase gérées par réinitialisation actuellement présentes.",
+				"uploads": "Assets avec uploads",
+				"uploads_desc": "Assets de démonstration qui stockent actuellement des fichiers ou images téléversés."
+			},
+			"title": "Showcase admin-v2",
+			"toasts": {
+				"clear_complete": "Les données du showcase admin-v2 ont été vidées.",
+				"reset_complete": "Le showcase admin-v2 a été réinitialisé sur le jeu de données de base."
+			}
+		},
 		"sidebar": {
 			"back_to_app": "Retour à l'App",
 			"dashboard": "Tableau de bord",
@@ -830,6 +1131,7 @@
 				"security": "Sécurité"
 			},
 			"settings": "Paramètres",
+			"showcase": "Showcase",
 			"support": "Support",
 			"users": "Utilisateurs"
 		},
@@ -1372,7 +1674,7 @@
 		"companies_text": "Propulsant les meilleures équipes",
 		"cta": "Commencer maintenant",
 		"cta_demo": "Demander une démo",
-		"description": "La fondation SaaS gratuite. Open source, prête à déployer.",
+		"description": "Donne vie à ton SaaS en quelques minutes, pas en mois. Template open-source bourré de tech qui te fait shipper direct.",
 		"section_label": "Accueil",
 		"tagline": "Focus sur ton produit.\nLancement plus rapide.",
 		"title": "Modèle SaaS Starter"
@@ -1470,6 +1772,10 @@
 				"description": "Configurez les destinataires et préférences de notifications admin.",
 				"title": "Paramètres Admin"
 			},
+			"showcase": {
+				"description": "Vérifiez manuellement le playground complet admin-v2 avec des données de base réinitialisables.",
+				"title": "Showcase admin-v2"
+			},
 			"support": {
 				"description": "Consultez et répondez aux conversations de support client.",
 				"title": "Boîte de support"
@@ -1530,7 +1836,7 @@
 			}
 		},
 		"home": {
-			"description": "Starter SaaS gratuit et open source avec SvelteKit. Auth, paiements, email et analytics inclus. Hébergez gratuitement.",
+			"description": "Starter SaaS pour SvelteKit avec auth, paiements, email et analytics.",
 			"title": "Construisez et lancez votre produit plus rapidement"
 		},
 		"impressum": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1545,6 +1545,10 @@
 			}
 		}
 	},
+	"billing": {
+		"checkout_failed": "Échec du paiement. Veuillez réessayer.",
+		"portal_failed": "Impossible d'ouvrir le portail de facturation. Veuillez réessayer."
+	},
 	"chat": {
 		"action": {
 			"talk_to_human": "Parler à un humain"

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -57,12 +57,21 @@
 		});
 		if (result?.url) {
 			window.location.href = result.url;
+		} else if (upgradeOperation.error) {
+			haptic.trigger('error');
+			toast.error($t('billing.checkout_failed'));
+			console.error('Checkout failed:', upgradeOperation.error);
 		}
 	}
 
 	async function handleBilling() {
 		haptic.trigger('light');
 		await portalOperation.execute({});
+		if (portalOperation.error) {
+			haptic.trigger('error');
+			toast.error($t('billing.portal_failed'));
+			console.error('Billing portal failed:', portalOperation.error);
+		}
 	}
 
 	async function signOut() {

--- a/src/routes/[[lang]]/app/ai-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/+page.svelte
@@ -7,6 +7,7 @@
 	import { api } from '$lib/convex/_generated/api';
 	import { useCustomer, useAutumnOperation } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
 	import { getTranslate } from '@tolgee/svelte';
+	import { toast } from 'svelte-sonner';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import ThreadChat from './thread-chat.svelte';
 
@@ -71,6 +72,10 @@
 		});
 		if (result?.url) {
 			window.location.href = result.url;
+		} else if (upgradeOperation.error) {
+			haptic.trigger('error');
+			toast.error($t('billing.checkout_failed'));
+			console.error('Checkout failed:', upgradeOperation.error);
 		}
 	}
 </script>

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -174,6 +174,10 @@
 		});
 		if (result?.url) {
 			window.location.href = result.url;
+		} else if (upgradeOperation.error) {
+			haptic.trigger('error');
+			toast.error($t('billing.checkout_failed'));
+			console.error('Checkout failed:', upgradeOperation.error);
 		}
 	}
 </script>


### PR DESCRIPTION
Resolves #317.

## Summary

- `useAutumnOperation.execute()` catches errors onto `.error` and returns `null`. Every call site in the repo only checked `result?.url` and ignored `.error`, so a failed `autumn.checkout` or `openBillingPortal` left the button in its idle state with no feedback.
- Wrap all six call sites (ai-chat, community-chat, nav-user `handleUpgrade` + `handleBilling`, pricing-three `handleCheckout` + new `handleManageBilling`) to surface a `toast.error` + `haptic.trigger('error')` when the operation fails.
- Extract the pricing Manage button's inline `() => portalOperation.execute({})` into a named `handleManageBilling()` so it gets the same error path.
- Add `billing.checkout_failed` and `billing.portal_failed` keys in all four locales; pushed to Tolgee Cloud with tag ` + "`feature-317-checkout-errors`" + `.
- Add `data-testid="pricing-checkout-pro"` and `data-testid="pricing-manage-pro"` for the E2E.

## Regression guard

`e2e/upgrade-checkout-failure.spec.ts` — Playwright `page.routeWebSocket` intercepts the Convex WS, forwards every message through, and synthesizes a failed `ActionResponse` only for `autumn:checkout`. Asserts the toast becomes visible, URL stays at `/en/pricing`, and the button returns to idle.

This is the first spec in `e2e/` to use WebSocket routing — the reactive Convex client ships actions over WS, so HTTP interception doesn't work. Spec is pinned to `/en/pricing` because `hooks.server.ts` would otherwise redirect `/pricing` based on `Accept-Language` and localize the toast copy.

## Test plan

- [x] `bun run i18n:push` — keys uploaded with tag `feature-317-checkout-errors`
- [x] `bun scripts/static-checks.ts` on all changed files — 0 errors
- [x] `bun run test:e2e -- upgrade-checkout-failure.spec.ts` — 2/2 passed
- [ ] Manual: DevTools → Network → Block the `autumn:checkout` WS message on `/en/pricing` upgrade + user-menu upgrade; repeat with `autumn:billingPortal` blocked for user-menu Billing + pricing Manage button
- [ ] CI E2E on preview

## Commits

1. `chore(i18n): Pull latest translations from Tolgee Cloud` — required by repo workflow before touching `src/i18n/*.json`; 1,380 lines of unrelated Tolgee Cloud drift kept in its own commit for reviewability.
2. `fix(billing): Surface checkout and portal errors` — the actual fix.