### PR TITLE
docs(readme): Name the stack in the intro for SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![E2E Tests (CF)](https://github.com/stickerdaniel/saas-starter/actions/workflows/e2e-preview-cf.yml/badge.svg)](https://github.com/stickerdaniel/saas-starter/actions/workflows/e2e-preview-cf.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-%233fb950)](https://opensource.org/licenses/MIT)
 
-A free, open-source SaaS foundation you can deploy for $0. Ships with auth, billing, admin, AI chat, email, i18n, and more — all implemented end-to-end so you (and your AI agents) have real patterns to build on.
+A free, open-source SaaS template built with SvelteKit, Convex, Better Auth, Tolgee, and Tailwind. Auth, billing, admin, AI chat, email, and i18n are all implemented end-to-end so you and your AI agents have real patterns to build on. Deploy on Cloudflare Workers or Vercel for $0.
 
 > See a live demo of the user-facing side at **[saas.daniel.sticker.name](https://saas.daniel.sticker.name)**. Admin features like the admin panel, support dashboard, and user management are not accessible there. To explore everything, follow the steps below.
 


### PR DESCRIPTION
## Summary
- Pulls SvelteKit, Convex, Better Auth, Tolgee, and Tailwind into the README opening paragraph so the first-paragraph snippet matches the keywords people actually search for.
- Adds Cloudflare Workers and Vercel deploy targets explicitly.
- Paired with a GitHub repo description + topics refresh (already applied via `gh repo edit`).

## Test plan
- [x] `bun scripts/static-checks.ts README.md` passes
- [ ] Visual check on GitHub PR diff render