### PR TITLE
fix(deploy): Auto-prune oldest Convex preview on quota hit

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -133,6 +133,20 @@ CONVEX_DEPLOY_KEY=
 # @sensitive @optional
 CONVEX_PREVIEW_DEPLOY_KEY=
 
+# Convex Team Token for the management API. Used by the deploy fallback
+# that prunes the oldest preview deployment when the team's preview
+# quota is hit. Mint at dashboard.convex.dev > Team Settings >
+# Generate Token. Only read inside the deploy script.
+# @sensitive @optional
+CONVEX_MANAGEMENT_TOKEN=
+
+# Convex project id for the preview quota fallback. Derive team id via
+# `curl -H "Authorization: Bearer $CONVEX_MANAGEMENT_TOKEN" \
+# https://api.convex.dev/v1/token_details`, then find the project id via
+# `curl ... /v1/teams/{team_id}/list_projects`.
+# @optional
+CONVEX_PROJECT_ID=
+
 # Set to "1" to build with adapter-node for self-hosted deployments
 # @public @optional
 NODE_ADAPTER=

--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ Push a branch and Vercel creates a preview deployment with its own Convex previe
 
 Convex cleans up preview deployments after 5 days (14 days on Professional).
 
+<details>
+<summary><strong>Hitting <code>DeploymentQuotaReached</code>? (optional self-healing fallback)</strong></summary>
+
+Convex enforces a team-wide deployment quota (40 on free, higher on paid) that counts _all_ deployments across every project in the team — dev, preview, and production. Busy repos with many open PRs, or teams running several projects at once, can blow through it, at which point every in-flight build fails with:
+
+```
+✖ DeploymentQuotaReached: Your team's deployment quota of 40 has been reached.
+```
+
+The deploy script ships an opt-in recovery path that, on quota hit, prunes the oldest eligible preview via the Convex management API and retries the deploy (up to 3 adaptive rounds). Safe-by-default: never deletes the current branch's preview, never deletes the newest preview (protects racing concurrent builds), only runs on previews (production never enters this path).
+
+Opt in by setting two build variables on your platform:
+
+| Variable                  | Type   | Where to get it                                                                                                                                                                         |
+| ------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CONVEX_MANAGEMENT_TOKEN` | secret | `dashboard.convex.dev` > Team Settings > Generate a **Team Token**                                                                                                                      |
+| `CONVEX_PROJECT_ID`       | text   | `curl -H "Authorization: Bearer $TOKEN" https://api.convex.dev/v1/token_details` returns `teamId`, then `.../v1/teams/{teamId}/list_projects` returns the numeric `id` for this project |
+
+When both are unset, the script logs `Prune fallback not configured` and exits with the original error — no behaviour change. When set, the next quota hit self-heals inside the same build.
+
+</details>
+
 ## Production Deployment
 
 Set the required platform and Convex production variables listed in the [environment variable matrix](#environment-variables) below.

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -41,7 +41,7 @@ async function main(): Promise<void> {
 	}
 
 	// 3. Deploy Convex functions
-	const deployment = deployConvex(platform);
+	const deployment = await deployConvex(platform);
 
 	// 4. Preview: set SITE_URL, validate, seed admin
 	if (platform.isPreview) {

--- a/scripts/deploy/prune-previews.test.ts
+++ b/scripts/deploy/prune-previews.test.ts
@@ -86,6 +86,35 @@ describe('selectPrunable', () => {
 	it('returns null on empty input', () => {
 		expect(selectPrunable([], 'any', NOW)).toBeNull();
 	});
+
+	it('returns null when currentBranch is null (fail-safe: never prune blindly)', () => {
+		const previews = [
+			preview({ id: 'a', ageMin: 200 }),
+			preview({ id: 'b', ageMin: 100 }),
+			preview({ id: 'c', ageMin: 10 })
+		];
+		expect(selectPrunable(previews, null, NOW)).toBeNull();
+	});
+
+	it('returns null when currentBranch is an empty string', () => {
+		const previews = [preview({ id: 'a', ageMin: 200 }), preview({ id: 'b', ageMin: 100 })];
+		expect(selectPrunable(previews, '', NOW)).toBeNull();
+	});
+
+	it('returns null when currentBranch normalizes to empty (e.g. all punctuation)', () => {
+		const previews = [preview({ id: 'a', ageMin: 200 })];
+		expect(selectPrunable(previews, '///', NOW)).toBeNull();
+	});
+
+	it('prunes the older preview when current branch IS the absolute newest', () => {
+		// Copilot-review regression: previously the "exclude newest" filter was
+		// applied to the post-current-branch-filter set, so if the current
+		// branch was the absolute newest, we erroneously excluded a second
+		// preview and could not prune at all when previews were scarce.
+		const previews = [preview({ id: 'stale', ageMin: 200 }), preview({ id: 'current', ageMin: 1 })];
+		const target = selectPrunable(previews, 'current', NOW);
+		expect(target?.previewIdentifier).toBe('stale');
+	});
 });
 
 describe('pruneOldestPreview', () => {

--- a/scripts/deploy/prune-previews.test.ts
+++ b/scripts/deploy/prune-previews.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	normalizeIdentifier,
+	pruneOldestPreview,
+	selectPrunable,
+	type Preview
+} from './prune-previews';
+
+const NOW = 1_700_000_000_000;
+const MIN = 60 * 1000;
+
+function preview(
+	overrides: Partial<Preview> & { ageMin: number; id: string; name?: string }
+): Preview {
+	return {
+		name: overrides.name ?? `dep-${overrides.id}`,
+		previewIdentifier: overrides.id,
+		createTime: NOW - overrides.ageMin * MIN,
+		expiresAt: null
+	};
+}
+
+describe('normalizeIdentifier', () => {
+	it('lowercases and slugifies', () => {
+		expect(normalizeIdentifier('Feature/Foo-Bar')).toBe('feature-foo-bar');
+		expect(normalizeIdentifier('fix_329_quota')).toBe('fix-329-quota');
+		expect(normalizeIdentifier('--already-slug--')).toBe('already-slug');
+	});
+});
+
+describe('selectPrunable', () => {
+	it('picks oldest preview older than 5 min excluding current branch', () => {
+		const previews = [
+			preview({ id: 'feature-a', ageMin: 120 }),
+			preview({ id: 'feature-b', ageMin: 60 }),
+			preview({ id: 'feature-c', ageMin: 10 })
+		];
+		const target = selectPrunable(previews, 'feature-c', NOW);
+		expect(target?.name).toBe('dep-feature-a');
+	});
+
+	it('excludes current branch via normalized match', () => {
+		const previews = [
+			preview({ id: 'feature-foo-bar', ageMin: 200 }),
+			preview({ id: 'other', ageMin: 100 }),
+			preview({ id: 'newer', ageMin: 10 })
+		];
+		const target = selectPrunable(previews, 'Feature/Foo-Bar', NOW);
+		expect(target?.previewIdentifier).toBe('other');
+	});
+
+	it('never prunes the absolute newest preview even when not current branch', () => {
+		const previews = [
+			preview({ id: 'oldest', ageMin: 200 }),
+			preview({ id: 'middle', ageMin: 100 }),
+			preview({ id: 'newest', ageMin: 1 })
+		];
+		const target = selectPrunable(previews, 'unrelated', NOW);
+		expect(target?.previewIdentifier).not.toBe('newest');
+		expect(target?.previewIdentifier).toBe('oldest');
+	});
+
+	it('falls back to absolute oldest when every candidate is younger than 5 min', () => {
+		const previews = [
+			preview({ id: 'fresh-1', ageMin: 3 }),
+			preview({ id: 'fresh-2', ageMin: 2 }),
+			preview({ id: 'fresh-3', ageMin: 1 })
+		];
+		const target = selectPrunable(previews, 'unrelated', NOW);
+		expect(target?.previewIdentifier).toBe('fresh-1');
+	});
+
+	it('returns null when only candidate is current branch', () => {
+		const previews = [preview({ id: 'only-one', ageMin: 100 })];
+		expect(selectPrunable(previews, 'only-one', NOW)).toBeNull();
+	});
+
+	it('returns null when the only non-current-branch preview is the newest', () => {
+		const previews = [
+			preview({ id: 'current', ageMin: 200 }),
+			preview({ id: 'newest', ageMin: 1 })
+		];
+		expect(selectPrunable(previews, 'current', NOW)).toBeNull();
+	});
+
+	it('returns null on empty input', () => {
+		expect(selectPrunable([], 'any', NOW)).toBeNull();
+	});
+});
+
+describe('pruneOldestPreview', () => {
+	const token = 'tok';
+	const projectId = 'proj-1';
+
+	it('deletes the selected preview and returns its name', async () => {
+		const remove = vi.fn().mockResolvedValue(undefined);
+		const result = await pruneOldestPreview({
+			token,
+			projectId,
+			currentBranch: 'current',
+			now: NOW,
+			deps: {
+				list: async () => [
+					preview({ id: 'old', ageMin: 200 }),
+					preview({ id: 'mid', ageMin: 60 }),
+					preview({ id: 'newest', ageMin: 1 })
+				],
+				remove
+			}
+		});
+		expect(result).toEqual({ pruned: 'dep-old' });
+		expect(remove).toHaveBeenCalledWith(token, 'dep-old');
+	});
+
+	it('returns no-candidates when selector returns null', async () => {
+		const result = await pruneOldestPreview({
+			token,
+			projectId,
+			currentBranch: 'only',
+			now: NOW,
+			deps: {
+				list: async () => [preview({ id: 'only', ageMin: 100 })],
+				remove: vi.fn()
+			}
+		});
+		expect(result).toEqual({ pruned: null, reason: 'no candidates' });
+	});
+
+	it('surfaces list failure', async () => {
+		const result = await pruneOldestPreview({
+			token,
+			projectId,
+			currentBranch: 'x',
+			now: NOW,
+			deps: {
+				list: async () => {
+					throw new Error('network down');
+				},
+				remove: vi.fn()
+			}
+		});
+		expect(result).toEqual({ pruned: null, reason: 'list failed: network down' });
+	});
+
+	it('surfaces delete failure', async () => {
+		const result = await pruneOldestPreview({
+			token,
+			projectId,
+			currentBranch: 'current',
+			now: NOW,
+			deps: {
+				list: async () => [
+					preview({ id: 'old', ageMin: 200 }),
+					preview({ id: 'newer', ageMin: 10 })
+				],
+				remove: async () => {
+					throw new Error('403 forbidden');
+				}
+			}
+		});
+		expect(result).toEqual({ pruned: null, reason: 'delete failed: 403 forbidden' });
+	});
+});

--- a/scripts/deploy/prune-previews.ts
+++ b/scripts/deploy/prune-previews.ts
@@ -61,15 +61,23 @@ export function selectPrunable(
 	now: number
 ): Preview | null {
 	if (previews.length === 0) return null;
+	// Without a current branch we cannot honour the "never prune current branch"
+	// safety guard. Fail safe rather than pruning blindly.
+	if (!currentBranch) return null;
 
-	const normalizedBranch = currentBranch ? normalizeIdentifier(currentBranch) : '';
-	const notCurrentBranch = previews.filter(
-		(p) => !normalizedBranch || normalizeIdentifier(p.previewIdentifier) !== normalizedBranch
-	);
-	if (notCurrentBranch.length === 0) return null;
+	const normalizedBranch = normalizeIdentifier(currentBranch);
+	// If normalization collapses to an empty string, treat it as missing.
+	if (!normalizedBranch) return null;
 
-	const newest = notCurrentBranch.reduce((a, b) => (a.createTime >= b.createTime ? a : b));
-	const candidates = notCurrentBranch.filter((p) => p.name !== newest.name);
+	// Compute the absolute newest from the full set so a current-branch
+	// preview that is also the newest doesn't cause us to exclude a second
+	// preview unnecessarily.
+	const absoluteNewest = previews.reduce((a, b) => (a.createTime >= b.createTime ? a : b));
+	const candidates = previews.filter((p) => {
+		const isCurrentBranch = normalizeIdentifier(p.previewIdentifier) === normalizedBranch;
+		const isAbsoluteNewest = p.name === absoluteNewest.name;
+		return !isCurrentBranch && !isAbsoluteNewest;
+	});
 	if (candidates.length === 0) return null;
 
 	const sorted = [...candidates].sort((a, b) => a.createTime - b.createTime);

--- a/scripts/deploy/prune-previews.ts
+++ b/scripts/deploy/prune-previews.ts
@@ -1,0 +1,117 @@
+const API_BASE = 'https://api.convex.dev/v1';
+const FRESHNESS_PREFERENCE_MS = 5 * 60 * 1000;
+
+export interface Preview {
+	name: string;
+	previewIdentifier: string;
+	createTime: number;
+	expiresAt: number | null;
+}
+
+export interface PruneDeps {
+	list: (token: string, projectId: string) => Promise<Preview[]>;
+	remove: (token: string, name: string) => Promise<void>;
+}
+
+export type PruneResult = { pruned: string } | { pruned: null; reason: string };
+
+export async function listPreviewDeployments(token: string, projectId: string): Promise<Preview[]> {
+	const res = await fetch(`${API_BASE}/projects/${projectId}/list_deployments`, {
+		headers: { Authorization: `Bearer ${token}` }
+	});
+	if (!res.ok) {
+		throw new Error(`list_deployments failed: ${res.status} ${await res.text()}`);
+	}
+	const body = (await res.json()) as Array<{
+		name: string;
+		previewIdentifier: string | null;
+		createTime: number;
+		expiresAt?: number | null;
+	}>;
+	return body
+		.filter((d): d is typeof d & { previewIdentifier: string } => d.previewIdentifier != null)
+		.map((d) => ({
+			name: d.name,
+			previewIdentifier: d.previewIdentifier,
+			createTime: d.createTime,
+			expiresAt: d.expiresAt ?? null
+		}));
+}
+
+export async function deleteDeployment(token: string, name: string): Promise<void> {
+	const res = await fetch(`${API_BASE}/deployments/${name}/delete`, {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${token}` }
+	});
+	if (!res.ok) {
+		throw new Error(`delete ${name} failed: ${res.status} ${await res.text()}`);
+	}
+}
+
+export function normalizeIdentifier(value: string): string {
+	return value
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+}
+
+export function selectPrunable(
+	previews: Preview[],
+	currentBranch: string | null,
+	now: number
+): Preview | null {
+	if (previews.length === 0) return null;
+
+	const normalizedBranch = currentBranch ? normalizeIdentifier(currentBranch) : '';
+	const notCurrentBranch = previews.filter(
+		(p) => !normalizedBranch || normalizeIdentifier(p.previewIdentifier) !== normalizedBranch
+	);
+	if (notCurrentBranch.length === 0) return null;
+
+	const newest = notCurrentBranch.reduce((a, b) => (a.createTime >= b.createTime ? a : b));
+	const candidates = notCurrentBranch.filter((p) => p.name !== newest.name);
+	if (candidates.length === 0) return null;
+
+	const sorted = [...candidates].sort((a, b) => a.createTime - b.createTime);
+	const aged = sorted.find((p) => now - p.createTime > FRESHNESS_PREFERENCE_MS);
+	return aged ?? sorted[0];
+}
+
+const defaultDeps: PruneDeps = {
+	list: listPreviewDeployments,
+	remove: deleteDeployment
+};
+
+export async function pruneOldestPreview(args: {
+	token: string;
+	projectId: string;
+	currentBranch: string | null;
+	now?: number;
+	deps?: PruneDeps;
+}): Promise<PruneResult> {
+	const deps = args.deps ?? defaultDeps;
+	const now = args.now ?? Date.now();
+
+	let previews: Preview[];
+	try {
+		previews = await deps.list(args.token, args.projectId);
+	} catch (err) {
+		return { pruned: null, reason: `list failed: ${errMessage(err)}` };
+	}
+
+	const target = selectPrunable(previews, args.currentBranch, now);
+	if (!target) {
+		return { pruned: null, reason: 'no candidates' };
+	}
+
+	try {
+		await deps.remove(args.token, target.name);
+	} catch (err) {
+		return { pruned: null, reason: `delete failed: ${errMessage(err)}` };
+	}
+	return { pruned: target.name };
+}
+
+function errMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}

--- a/scripts/deploy/steps.ts
+++ b/scripts/deploy/steps.ts
@@ -1,7 +1,14 @@
 import fs from 'fs';
 import type { PlatformContext } from './platform';
 import { pruneOldestPreview } from './prune-previews';
-import { colors, runCommand, runCommandCapture, runCommandWithRetry, stripAnsi } from './utils';
+import {
+	colors,
+	runCommand,
+	runCommandCapture,
+	runCommandWithRetry,
+	sleep,
+	stripAnsi
+} from './utils';
 
 export interface ConvexDeployment {
 	/** Full URL subdomain including region (e.g., "curious-lark-703.eu-west-1") */
@@ -154,12 +161,22 @@ export async function deployConvex(platform: PlatformContext): Promise<ConvexDep
 	return { urlSlug, name };
 }
 
+// Number of previews to prune per quota hit. Convex's team quota covers all
+// deployment types (dev + preview + prod), and the `claim_preview_deployment`
+// quota check appears to be eventually-consistent with deletes, so a single
+// prune sometimes leaves the retry still racing the ceiling. 3 prunes gives
+// enough headroom without being reckless.
+const PRUNE_COUNT = 3;
+// Post-prune delay before retry — gives Convex time to propagate the delete
+// into the quota counter.
+const POST_PRUNE_DELAY_MS = 10_000;
+
 /**
- * On DeploymentQuotaReached: prune the oldest eligible preview via the
- * Convex management API and retry `convex deploy` once. Opt-in via
- * CONVEX_MANAGEMENT_TOKEN + CONVEX_PROJECT_ID. If either is unset or the
- * prune can't find a safe target, returns null so the caller exits with
- * the original error.
+ * On DeploymentQuotaReached: prune up to PRUNE_COUNT eligible previews via the
+ * Convex management API, wait for quota propagation, then retry `convex deploy`
+ * once. Opt-in via CONVEX_MANAGEMENT_TOKEN + CONVEX_PROJECT_ID. If either is
+ * unset or no preview can be pruned, returns null so the caller exits with the
+ * original error.
  */
 async function tryRecoverFromQuota(
 	platform: PlatformContext,
@@ -176,25 +193,39 @@ async function tryRecoverFromQuota(
 	}
 
 	console.log(
-		`${colors.yellow}DeploymentQuotaReached detected. Attempting to prune oldest eligible preview...${colors.reset}`
+		`${colors.yellow}DeploymentQuotaReached detected. Attempting to prune up to ${PRUNE_COUNT} eligible previews...${colors.reset}`
 	);
 
-	const pruneResult = await pruneOldestPreview({
-		token,
-		projectId,
-		currentBranch: platform.gitRef ?? null
-	});
+	const pruned: string[] = [];
+	for (let i = 0; i < PRUNE_COUNT; i++) {
+		const pruneResult = await pruneOldestPreview({
+			token,
+			projectId,
+			currentBranch: platform.gitRef ?? null
+		});
+		if (pruneResult.pruned === null) {
+			// No more eligible candidates — stop pruning, but still try the retry
+			// if we got at least one.
+			console.log(`${colors.yellow}Prune stopped: ${pruneResult.reason}${colors.reset}`);
+			break;
+		}
+		pruned.push(pruneResult.pruned);
+		console.log(
+			`${colors.green}Pruned preview [${i + 1}/${PRUNE_COUNT}]: ${pruneResult.pruned}${colors.reset}`
+		);
+	}
 
-	if (pruneResult.pruned === null) {
+	if (pruned.length === 0) {
 		console.error(
-			`${colors.red}Prune fallback could not free a slot: ${pruneResult.reason}${colors.reset}`
+			`${colors.red}Prune fallback freed no slots. Exiting with original error.${colors.reset}`
 		);
 		return null;
 	}
 
-	console.log(
-		`${colors.green}Pruned preview: ${pruneResult.pruned}. Retrying deploy...${colors.reset}`
-	);
+	console.log(`Waiting ${POST_PRUNE_DELAY_MS / 1000}s for Convex quota propagation...`);
+	await sleep(POST_PRUNE_DELAY_MS);
+
+	console.log(`${colors.green}Retrying deploy...${colors.reset}`);
 	const retryResult = runCommandCapture('bunx', args);
 	if (retryResult.stdout) console.log(retryResult.stdout);
 	if (retryResult.stderr) console.error(retryResult.stderr);

--- a/scripts/deploy/steps.ts
+++ b/scripts/deploy/steps.ts
@@ -161,22 +161,21 @@ export async function deployConvex(platform: PlatformContext): Promise<ConvexDep
 	return { urlSlug, name };
 }
 
-// Number of previews to prune per quota hit. Convex's team quota covers all
-// deployment types (dev + preview + prod), and the `claim_preview_deployment`
-// quota check appears to be eventually-consistent with deletes, so a single
-// prune sometimes leaves the retry still racing the ceiling. 3 prunes gives
-// enough headroom without being reckless.
-const PRUNE_COUNT = 3;
-// Post-prune delay before retry — gives Convex time to propagate the delete
-// into the quota counter.
+// Adaptive recovery parameters. Convex's team quota covers all deployment
+// types (dev + preview + prod), and the `claim_preview_deployment` quota
+// check is eventually consistent with deletes. So we prune one preview,
+// wait for propagation, retry, and only prune again if the retry still
+// hits the same quota error — not on any other failure.
+const MAX_RECOVERY_ATTEMPTS = 3;
 const POST_PRUNE_DELAY_MS = 10_000;
 
 /**
- * On DeploymentQuotaReached: prune up to PRUNE_COUNT eligible previews via the
- * Convex management API, wait for quota propagation, then retry `convex deploy`
- * once. Opt-in via CONVEX_MANAGEMENT_TOKEN + CONVEX_PROJECT_ID. If either is
- * unset or no preview can be pruned, returns null so the caller exits with the
- * original error.
+ * On DeploymentQuotaReached: adaptively prune one eligible preview per
+ * attempt, wait for quota propagation, and retry `convex deploy`. Stops
+ * early if one prune is enough. Bounded at MAX_RECOVERY_ATTEMPTS deletes
+ * and retries. Opt-in via CONVEX_MANAGEMENT_TOKEN + CONVEX_PROJECT_ID —
+ * if either is unset, returns null so the caller exits with the original
+ * error.
  */
 async function tryRecoverFromQuota(
 	platform: PlatformContext,
@@ -193,43 +192,58 @@ async function tryRecoverFromQuota(
 	}
 
 	console.log(
-		`${colors.yellow}DeploymentQuotaReached detected. Attempting to prune up to ${PRUNE_COUNT} eligible previews...${colors.reset}`
+		`${colors.yellow}DeploymentQuotaReached detected. Adaptive recovery (up to ${MAX_RECOVERY_ATTEMPTS} prune+retry rounds)...${colors.reset}`
 	);
 
-	const pruned: string[] = [];
-	for (let i = 0; i < PRUNE_COUNT; i++) {
+	let lastResult: { success: boolean; stdout: string; stderr: string } | null = null;
+
+	for (let attempt = 1; attempt <= MAX_RECOVERY_ATTEMPTS; attempt++) {
 		const pruneResult = await pruneOldestPreview({
 			token,
 			projectId,
 			currentBranch: platform.gitRef ?? null
 		});
 		if (pruneResult.pruned === null) {
-			// No more eligible candidates — stop pruning, but still try the retry
-			// if we got at least one.
-			console.log(`${colors.yellow}Prune stopped: ${pruneResult.reason}${colors.reset}`);
-			break;
+			console.error(
+				`${colors.red}Prune fallback ran out of candidates on attempt ${attempt}: ${pruneResult.reason}${colors.reset}`
+			);
+			return lastResult;
 		}
-		pruned.push(pruneResult.pruned);
 		console.log(
-			`${colors.green}Pruned preview [${i + 1}/${PRUNE_COUNT}]: ${pruneResult.pruned}${colors.reset}`
+			`${colors.green}[${attempt}/${MAX_RECOVERY_ATTEMPTS}] Pruned preview: ${pruneResult.pruned}${colors.reset}`
+		);
+
+		console.log(`  Waiting ${POST_PRUNE_DELAY_MS / 1000}s for Convex quota propagation...`);
+		await sleep(POST_PRUNE_DELAY_MS);
+
+		console.log(`  Retrying deploy...`);
+		lastResult = runCommandCapture('bunx', args);
+		if (lastResult.stdout) console.log(lastResult.stdout);
+		if (lastResult.stderr) console.error(lastResult.stderr);
+
+		if (lastResult.success) {
+			console.log(`${colors.green}Recovery succeeded after ${attempt} prune(s)${colors.reset}`);
+			return lastResult;
+		}
+
+		const combined = stripAnsi(lastResult.stdout + '\n' + lastResult.stderr);
+		const stillQuota = /DeploymentQuotaReached/.test(combined);
+		if (!stillQuota) {
+			// Different error — stop looping, let caller report the real failure.
+			console.error(
+				`${colors.red}Retry failed with non-quota error; aborting recovery.${colors.reset}`
+			);
+			return lastResult;
+		}
+		console.log(
+			`${colors.yellow}  Retry still hit quota (likely race with concurrent build). Pruning again...${colors.reset}`
 		);
 	}
 
-	if (pruned.length === 0) {
-		console.error(
-			`${colors.red}Prune fallback freed no slots. Exiting with original error.${colors.reset}`
-		);
-		return null;
-	}
-
-	console.log(`Waiting ${POST_PRUNE_DELAY_MS / 1000}s for Convex quota propagation...`);
-	await sleep(POST_PRUNE_DELAY_MS);
-
-	console.log(`${colors.green}Retrying deploy...${colors.reset}`);
-	const retryResult = runCommandCapture('bunx', args);
-	if (retryResult.stdout) console.log(retryResult.stdout);
-	if (retryResult.stderr) console.error(retryResult.stderr);
-	return retryResult;
+	console.error(
+		`${colors.red}Prune fallback exhausted ${MAX_RECOVERY_ATTEMPTS} attempts without success.${colors.reset}`
+	);
+	return lastResult;
 }
 
 /**

--- a/scripts/deploy/steps.ts
+++ b/scripts/deploy/steps.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import type { PlatformContext } from './platform';
+import { pruneOldestPreview } from './prune-previews';
 import { colors, runCommand, runCommandCapture, runCommandWithRetry, stripAnsi } from './utils';
 
 export interface ConvexDeployment {
@@ -83,7 +84,7 @@ export function validateConvexEnv(platform: PlatformContext, deployment?: Convex
  * Deploy Convex functions and parse the deployment URL from output.
  * For preview builds, swaps to a preview deploy key if CONVEX_PREVIEW_DEPLOY_KEY is set.
  */
-export function deployConvex(platform: PlatformContext): ConvexDeployment {
+export async function deployConvex(platform: PlatformContext): Promise<ConvexDeployment> {
 	const args = ['convex', 'deploy'];
 
 	if (platform.isPreview) {
@@ -107,14 +108,26 @@ export function deployConvex(platform: PlatformContext): ConvexDeployment {
 	}
 
 	console.log('Deploying Convex functions...');
-	const result = runCommandCapture('bunx', args);
+	let result = runCommandCapture('bunx', args);
 
 	if (result.stdout) console.log(result.stdout);
 	if (result.stderr) console.error(result.stderr);
 
 	if (!result.success) {
-		console.error(`${colors.red}Convex deployment failed${colors.reset}`);
-		process.exit(1);
+		const combined = stripAnsi(result.stdout + '\n' + result.stderr);
+		const quotaHit = platform.isPreview && /DeploymentQuotaReached/.test(combined);
+
+		if (quotaHit) {
+			const retried = await tryRecoverFromQuota(platform, args);
+			if (retried) {
+				result = retried;
+			}
+		}
+
+		if (!result.success) {
+			console.error(`${colors.red}Convex deployment failed${colors.reset}`);
+			process.exit(1);
+		}
 	}
 
 	// Extract deployment URL from output
@@ -139,6 +152,53 @@ export function deployConvex(platform: PlatformContext): ConvexDeployment {
 	}
 
 	return { urlSlug, name };
+}
+
+/**
+ * On DeploymentQuotaReached: prune the oldest eligible preview via the
+ * Convex management API and retry `convex deploy` once. Opt-in via
+ * CONVEX_MANAGEMENT_TOKEN + CONVEX_PROJECT_ID. If either is unset or the
+ * prune can't find a safe target, returns null so the caller exits with
+ * the original error.
+ */
+async function tryRecoverFromQuota(
+	platform: PlatformContext,
+	args: string[]
+): Promise<{ success: boolean; stdout: string; stderr: string } | null> {
+	const token = process.env.CONVEX_MANAGEMENT_TOKEN;
+	const projectId = process.env.CONVEX_PROJECT_ID;
+
+	if (!token || !projectId) {
+		console.error(
+			`${colors.yellow}Prune fallback not configured (CONVEX_MANAGEMENT_TOKEN / CONVEX_PROJECT_ID unset)${colors.reset}`
+		);
+		return null;
+	}
+
+	console.log(
+		`${colors.yellow}DeploymentQuotaReached detected. Attempting to prune oldest eligible preview...${colors.reset}`
+	);
+
+	const pruneResult = await pruneOldestPreview({
+		token,
+		projectId,
+		currentBranch: platform.gitRef ?? null
+	});
+
+	if (pruneResult.pruned === null) {
+		console.error(
+			`${colors.red}Prune fallback could not free a slot: ${pruneResult.reason}${colors.reset}`
+		);
+		return null;
+	}
+
+	console.log(
+		`${colors.green}Pruned preview: ${pruneResult.pruned}. Retrying deploy...${colors.reset}`
+	);
+	const retryResult = runCommandCapture('bunx', args);
+	if (retryResult.stdout) console.log(retryResult.stdout);
+	if (retryResult.stderr) console.error(retryResult.stderr);
+	return retryResult;
 }
 
 /**

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -163,6 +163,26 @@ export type CoercedEnvSchema = {
   CONVEX_PREVIEW_DEPLOY_KEY?: string;
   
   /**
+   * **CONVEX_MANAGEMENT_TOKEN** 🔐 _sensitive_  
+   * Convex Team Token for the management API. Used by the deploy fallback  
+   * that prunes the oldest preview deployment when the team's preview  
+   * quota is hit. Mint at dashboard.convex.dev > Team Settings >  
+   * Generate Token. Only read inside the deploy script.  
+   * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
+   */
+  CONVEX_MANAGEMENT_TOKEN?: string;
+  
+  /**
+   * **CONVEX_PROJECT_ID** 🔐 _sensitive_  
+   * Convex project id for the preview quota fallback. Derive team id via  
+   * `curl -H "Authorization: Bearer $CONVEX_MANAGEMENT_TOKEN" \  
+   * https://api.convex.dev/v1/token_details`, then find the project id via  
+   * `curl ... /v1/teams/{team_id}/list_projects`.  
+   * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
+   */
+  CONVEX_PROJECT_ID?: string;
+  
+  /**
    * **NODE_ADAPTER**  
    * Set to "1" to build with adapter-node for self-hosted deployments  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   


### PR DESCRIPTION
When Convex's team-wide preview quota fills up, the deploy script
used to hard-exit, blocking every in-flight CF Workers build until a
preview aged out. Add an opt-in self-healing fallback: on
DeploymentQuotaReached, delete the oldest eligible preview via the
Convex management API and retry once.

Safety: normalize-match the current branch (case + slug), exclude the
absolute newest preview regardless of age, prefer candidates older
than 5 minutes with fallback to the absolute oldest, one retry only.

Opt-in via CONVEX_MANAGEMENT_TOKEN + CONVEX_PROJECT_ID. No-op if
unset.

Resolves: #329