### PR TITLE
fix(convex): Materialize active streams only

### DIFF
--- a/src/lib/convex/support/messageListing.ts
+++ b/src/lib/convex/support/messageListing.ts
@@ -90,17 +90,27 @@ export async function listMessagesForThread(
 		return { ...paginated, page: enrichedPage, streams };
 	}
 
-	const materializedPage = await mergeRecentStreamsIntoPage(ctx, {
-		threadId: args.threadId,
-		page: enrichedPage,
-		streamMessages: streams.messages ?? []
-	});
+	// Only materialize ACTIVE streams over the historical page. Once a stream
+	// is finished/aborted, the persisted MessageDoc rows are authoritative
+	// (toUIMessages already sets state='output-available' for completed tool
+	// calls). Materializing finished streams was clobbering that with the
+	// in-flight stream snapshot, leaving renderUI stuck at input-streaming
+	// even though the result was saved.
+	const activeStreamMessages = (streams.messages ?? []).filter(
+		(streamMessage) => streamMessage.status === 'streaming'
+	);
+	const materializedPage =
+		activeStreamMessages.length === 0
+			? enrichedPage
+			: await mergeRecentStreamsIntoPage(ctx, {
+					threadId: args.threadId,
+					page: enrichedPage,
+					streamMessages: activeStreamMessages
+				});
 
 	const liveStreams = {
 		kind: 'list' as const,
-		messages: (streams.messages ?? []).filter(
-			(streamMessage) => streamMessage.status === 'streaming'
-		)
+		messages: activeStreamMessages
 	};
 
 	return { ...paginated, page: materializedPage, streams: liveStreams };


### PR DESCRIPTION
syncStreams returns streaming, finished, and aborted streams when called
with includeStatuses set to all three. listMessagesForThread was passing
the full list into mergeRecentStreamsIntoPage, so finished streams
clobbered the persisted MessageDoc (already at output-available) with
their in-flight snapshot. Tools whose final delta did not transition
cleanly stayed at input-streaming after reload, and any text following
the tool part went missing.

Filter to status === 'streaming' before materialization. The persisted
rows are authoritative once a stream finishes. Reuse the filtered array
for liveStreams so the response stays consistent.

Closes #334