### PR TITLE
fix(prompt-suggestion): truncate long labels and use rounded-lg

### DIFF
--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -293,6 +293,8 @@ async function main(): Promise<void> {
 					formatFlag,
 					'--plugin',
 					'prettier-plugin-svelte',
+					'--plugin',
+					'prettier-plugin-tailwindcss',
 					...formattableFiles
 				]);
 			} else if (!scopedMode) {

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -214,7 +214,7 @@
 				<div class="flex flex-wrap gap-2">
 					{#each suggestions as suggestion, i (suggestion.text)}
 						<div
-							class="min-w-0 max-w-full motion-safe:animate-[chip-in_375ms_ease-out_both] sm:max-w-[14rem]"
+							class="max-w-full min-w-0 motion-safe:animate-[chip-in_375ms_ease-out_both] sm:max-w-[14rem]"
 							style="animation-delay: {i * 50}ms"
 							title={suggestion.text}
 						>

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -214,10 +214,15 @@
 				<div class="flex flex-wrap gap-2">
 					{#each suggestions as suggestion, i (suggestion.text)}
 						<div
-							class="motion-safe:animate-[chip-in_375ms_ease-out_both]"
+							class="min-w-0 max-w-full motion-safe:animate-[chip-in_375ms_ease-out_both] sm:max-w-[14rem]"
 							style="animation-delay: {i * 50}ms"
+							title={suggestion.text}
 						>
-							<PromptSuggestion onclick={() => handleSuggestionClick(suggestion.text)}>
+							<PromptSuggestion
+								class="w-full"
+								truncate
+								onclick={() => handleSuggestionClick(suggestion.text)}
+							>
 								{suggestion.label}
 							</PromptSuggestion>
 						</div>

--- a/src/lib/components/prompt-kit/prompt-suggestion/prompt-suggestion.svelte
+++ b/src/lib/components/prompt-kit/prompt-suggestion/prompt-suggestion.svelte
@@ -13,6 +13,7 @@
 		onclick?: (event: MouseEvent) => void;
 		disabled?: boolean;
 		type?: 'button' | 'submit' | 'reset';
+		truncate?: boolean;
 	};
 </script>
 
@@ -28,7 +29,8 @@
 		ref = $bindable(null),
 		onclick,
 		disabled,
-		type = 'button'
+		type = 'button',
+		truncate = false
 	}: PromptSuggestionProps = $props();
 
 	const isHighlightMode = $derived(highlight !== undefined && highlight.trim() !== '');
@@ -84,12 +86,18 @@
 		bind:ref
 		variant={variant || 'outline'}
 		size={size || 'lg'}
-		class={cn('rounded-full px-4', className)}
+		class={cn('min-w-0 rounded-lg px-4', className)}
 		{onclick}
 		{disabled}
 		{type}
 	>
-		{@render children?.()}
+		{#if truncate}
+			<span class="block min-w-0 truncate">
+				{@render children?.()}
+			</span>
+		{:else}
+			{@render children?.()}
+		{/if}
 	</Button>
 {:else if !content}
 	<Button

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -136,10 +136,13 @@
 						<div class="flex flex-wrap gap-2">
 							{#each suggestions as suggestion, i (suggestion.text)}
 								<div
-									class="motion-safe:animate-[chip-in_375ms_ease-out_both]"
+									class="min-w-0 max-w-full motion-safe:animate-[chip-in_375ms_ease-out_both] sm:max-w-[14rem]"
 									style="animation-delay: {i * 50}ms"
+									title={suggestion.text}
 								>
 									<PromptSuggestion
+										class="w-full"
+										truncate
 										onclick={() => {
 											chatUIContext.setInputValue(suggestion.text);
 											tick().then(() => {

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -136,7 +136,7 @@
 						<div class="flex flex-wrap gap-2">
 							{#each suggestions as suggestion, i (suggestion.text)}
 								<div
-									class="min-w-0 max-w-full motion-safe:animate-[chip-in_375ms_ease-out_both] sm:max-w-[14rem]"
+									class="max-w-full min-w-0 motion-safe:animate-[chip-in_375ms_ease-out_both] sm:max-w-[14rem]"
 									style="animation-delay: {i * 50}ms"
 									title={suggestion.text}
 								>


### PR DESCRIPTION
Non-highlight chips hardcoded rounded-full and lacked min-w-0, so
long labels broke flex-wrap layout and the radius looked oversized
on wide chips. Switch to rounded-lg, add min-w-0 to the Button, and
add an opt-in `truncate` prop that wraps text children in a
truncating span. Apply truncate + max-width + title in the AI chat
empty-state suggestions and ChatInput suggestions.

Resolves: #335
Resolves: #336