### PR TITLE
fix(scripts): sanitize git env in pre-commit hook

### DIFF
--- a/scripts/git-context.staged-files.test.ts
+++ b/scripts/git-context.staged-files.test.ts
@@ -1,0 +1,77 @@
+import { spawnSync } from 'child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Resolved from the project root (where vitest runs). Avoids `import.meta.url`,
+// which vitest may rewrite to a non-file scheme during transform.
+const HELPER = resolve(process.cwd(), 'scripts/git-context.ts');
+
+/**
+ * Spawn a subprocess that imports the real `getStagedFiles` helper and
+ * prints its result as JSON. Importing the same exported function
+ * `static-checks.ts` consumes ensures the test catches regressions in
+ * the helper without re-implementing the git command.
+ */
+function runGetStagedFiles(cwd: string, extraEnv: Record<string, string> = {}): string[] {
+	const code = `import(${JSON.stringify(HELPER)}).then((m) => { process.stdout.write(JSON.stringify(m.getStagedFiles())); });`;
+	const result = spawnSync('bun', ['-e', code], {
+		cwd,
+		env: { ...process.env, ...extraEnv },
+		encoding: 'utf-8'
+	});
+	if (result.status !== 0) {
+		throw new Error(`harness failed (status ${result.status}): ${result.stderr}`);
+	}
+	return JSON.parse(result.stdout || '[]') as string[];
+}
+
+function gitInTmp(tmp: string, args: string[]): void {
+	const result = spawnSync('git', args, { cwd: tmp, encoding: 'utf-8' });
+	if (result.status !== 0) {
+		throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
+	}
+}
+
+describe('getStagedFiles (integration)', () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), 'git-context-test-'));
+
+		gitInTmp(tmp, ['init', '-q', '-b', 'main']);
+		gitInTmp(tmp, ['config', 'user.email', 'test@example.com']);
+		gitInTmp(tmp, ['config', 'user.name', 'Test']);
+		gitInTmp(tmp, ['config', 'commit.gpgsign', 'false']);
+
+		mkdirSync(join(tmp, 'web', 'src'), { recursive: true });
+		mkdirSync(join(tmp, 'other'), { recursive: true });
+		writeFileSync(join(tmp, 'web', 'src', 'a.ts'), 'export const a = 1;\n');
+		writeFileSync(join(tmp, 'other', 'b.ts'), 'export const b = 2;\n');
+
+		gitInTmp(tmp, ['add', 'web/src/a.ts', 'other/b.ts']);
+	});
+
+	afterEach(() => {
+		if (tmp) rmSync(tmp, { recursive: true, force: true });
+	});
+
+	it('returns paths under cwd only, with the cwd prefix stripped', () => {
+		const files = runGetStagedFiles(join(tmp, 'web'));
+		expect(files).toEqual(['src/a.ts']);
+	});
+
+	it('filters siblings + relativizes when GIT_DIR is set externally (pre-commit framework simulation)', () => {
+		// Issue #332 repro: a parent process (pre-commit framework) sets GIT_DIR
+		// to the parent repo's gitdir and clears GIT_WORK_TREE before invoking
+		// the hook. Without `--relative` + sanitizedGitEnv, the helper would
+		// return both `web/src/a.ts` and `other/b.ts`, leaking the sibling and
+		// breaking downstream tools that run from `cwd=web/`.
+		const files = runGetStagedFiles(join(tmp, 'web'), {
+			GIT_DIR: join(tmp, '.git'),
+			GIT_WORK_TREE: ''
+		});
+		expect(files).toEqual(['src/a.ts']);
+	});
+});

--- a/scripts/git-context.test.ts
+++ b/scripts/git-context.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { hasExternalGitContext, sanitizedGitEnv } from './git-context';
+import { isUnderPreCommit, sanitizedGitEnv } from './git-context';
 
 const SCRUBBED = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_OBJECT_DIRECTORY'] as const;
 const PRE_COMMIT_KEYS = [
@@ -48,7 +48,7 @@ describe('sanitizedGitEnv', () => {
 	});
 });
 
-describe('hasExternalGitContext', () => {
+describe('isUnderPreCommit', () => {
 	const saved = new Map<string, string | undefined>();
 
 	beforeEach(() => {
@@ -65,21 +65,21 @@ describe('hasExternalGitContext', () => {
 	});
 
 	it('returns false when no relevant env vars are set', () => {
-		expect(hasExternalGitContext()).toBe(false);
+		expect(isUnderPreCommit()).toBe(false);
 	});
 
-	it('returns true when GIT_DIR is set', () => {
+	it('returns false when only GIT_DIR is set (git itself sets this for every hook)', () => {
 		process.env['GIT_DIR'] = '/parent/.git';
-		expect(hasExternalGitContext()).toBe(true);
+		expect(isUnderPreCommit()).toBe(false);
 	});
 
 	it('returns true when PRE_COMMIT is set', () => {
 		process.env['PRE_COMMIT'] = '1';
-		expect(hasExternalGitContext()).toBe(true);
+		expect(isUnderPreCommit()).toBe(true);
 	});
 
 	it('returns true when any PRE_COMMIT_* var is set', () => {
 		process.env['PRE_COMMIT_FROM_REF'] = 'abc123';
-		expect(hasExternalGitContext()).toBe(true);
+		expect(isUnderPreCommit()).toBe(true);
 	});
 });

--- a/scripts/git-context.test.ts
+++ b/scripts/git-context.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { hasExternalGitContext, sanitizedGitEnv } from './git-context';
+
+const SCRUBBED = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_OBJECT_DIRECTORY'] as const;
+const PRE_COMMIT_KEYS = [
+	'PRE_COMMIT',
+	'PRE_COMMIT_FROM_REF',
+	'PRE_COMMIT_TO_REF',
+	'PRE_COMMIT_HOME'
+];
+
+describe('sanitizedGitEnv', () => {
+	const saved = new Map<string, string | undefined>();
+
+	beforeEach(() => {
+		for (const key of SCRUBBED) saved.set(key, process.env[key]);
+	});
+
+	afterEach(() => {
+		for (const [key, value] of saved) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		saved.clear();
+	});
+
+	it('removes all four scrubbed git env vars', () => {
+		for (const key of SCRUBBED) process.env[key] = 'parent-value';
+		const env = sanitizedGitEnv();
+		for (const key of SCRUBBED) {
+			expect(env[key]).toBeUndefined();
+		}
+	});
+
+	it('preserves other env vars', () => {
+		process.env['GIT_DIR'] = '/parent/.git';
+		process.env['MY_UNRELATED_VAR'] = 'keep-me';
+		const env = sanitizedGitEnv();
+		expect(env['GIT_DIR']).toBeUndefined();
+		expect(env['MY_UNRELATED_VAR']).toBe('keep-me');
+		delete process.env['MY_UNRELATED_VAR'];
+	});
+
+	it('returns a copy, does not mutate process.env', () => {
+		process.env['GIT_DIR'] = '/parent/.git';
+		sanitizedGitEnv();
+		expect(process.env['GIT_DIR']).toBe('/parent/.git');
+	});
+});
+
+describe('hasExternalGitContext', () => {
+	const saved = new Map<string, string | undefined>();
+
+	beforeEach(() => {
+		for (const key of [...SCRUBBED, ...PRE_COMMIT_KEYS]) saved.set(key, process.env[key]);
+		for (const key of [...SCRUBBED, ...PRE_COMMIT_KEYS]) delete process.env[key];
+	});
+
+	afterEach(() => {
+		for (const [key, value] of saved) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		saved.clear();
+	});
+
+	it('returns false when no relevant env vars are set', () => {
+		expect(hasExternalGitContext()).toBe(false);
+	});
+
+	it('returns true when GIT_DIR is set', () => {
+		process.env['GIT_DIR'] = '/parent/.git';
+		expect(hasExternalGitContext()).toBe(true);
+	});
+
+	it('returns true when PRE_COMMIT is set', () => {
+		process.env['PRE_COMMIT'] = '1';
+		expect(hasExternalGitContext()).toBe(true);
+	});
+
+	it('returns true when any PRE_COMMIT_* var is set', () => {
+		process.env['PRE_COMMIT_FROM_REF'] = 'abc123';
+		expect(hasExternalGitContext()).toBe(true);
+	});
+});

--- a/scripts/git-context.ts
+++ b/scripts/git-context.ts
@@ -1,0 +1,54 @@
+/**
+ * Git context helpers for scripts that run inside `git` hooks.
+ *
+ * Hooks may be dispatched by tools (notably the Python `pre-commit` framework)
+ * that pre-set GIT_DIR / GIT_WORK_TREE in the hook's environment to point at
+ * a parent repository. When the saas-starter app is nested in a subdirectory
+ * of such a repo, those env vars cause `git diff --cached` and `git add` to
+ * operate against the wrong worktree, silently corrupting commits (issue #332).
+ *
+ * These helpers scrub the relevant env vars before shelling out and prefer
+ * `git diff --relative` so paths come back filtered + cwd-relative.
+ */
+
+import { spawnSync } from 'child_process';
+
+const SCRUBBED = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_OBJECT_DIRECTORY'] as const;
+
+/** process.env with externally-set git context vars removed. */
+export function sanitizedGitEnv(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	for (const key of SCRUBBED) delete env[key];
+	return env;
+}
+
+/**
+ * True if a parent process supplied git context via env vars. Most commonly
+ * the pre-commit framework, but also any `GIT_DIR=… cmd` invocation. Used
+ * only for diagnostics — does NOT change behavior.
+ */
+export function hasExternalGitContext(): boolean {
+	if (process.env['GIT_DIR']) return true;
+	return Object.keys(process.env).some((k) => k.startsWith('PRE_COMMIT'));
+}
+
+/**
+ * Staged files relative to the current working directory. `--relative`
+ * filters siblings outside cwd and strips the cwd prefix in one shot.
+ * Sanitized env ensures the index is read against the correct worktree
+ * even when a parent process set GIT_DIR / GIT_WORK_TREE.
+ */
+export function getStagedFiles(): string[] {
+	const result = spawnSync(
+		'git',
+		['diff', '--cached', '--name-only', '--diff-filter=ACMR', '--relative'],
+		{ encoding: 'utf-8', env: sanitizedGitEnv() }
+	);
+
+	if (result.status !== 0) {
+		console.error('Failed to get staged files');
+		process.exit(1);
+	}
+
+	return result.stdout.trim().split('\n').filter(Boolean);
+}

--- a/scripts/git-context.ts
+++ b/scripts/git-context.ts
@@ -23,12 +23,15 @@ export function sanitizedGitEnv(): NodeJS.ProcessEnv {
 }
 
 /**
- * True if a parent process supplied git context via env vars. Most commonly
- * the pre-commit framework, but also any `GIT_DIR=… cmd` invocation. Used
- * only for diagnostics — does NOT change behavior.
+ * True if the Python `pre-commit` framework is dispatching this hook
+ * (detected via its `PRE_COMMIT*` env vars). Used only for diagnostics —
+ * does NOT change behavior.
+ *
+ * Note: `GIT_DIR` is intentionally NOT checked. Git sets `GIT_DIR` for
+ * every hook invocation (Husky, native, anything), so it's not a useful
+ * signal for "pre-commit framework specifically."
  */
-export function hasExternalGitContext(): boolean {
-	if (process.env['GIT_DIR']) return true;
+export function isUnderPreCommit(): boolean {
 	return Object.keys(process.env).some((k) => k.startsWith('PRE_COMMIT'));
 }
 

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -20,6 +20,7 @@
 
 import { spawnSync, type SpawnSyncOptions } from 'child_process';
 import { parseArgs } from 'util';
+import { getStagedFiles, hasExternalGitContext, sanitizedGitEnv } from './git-context';
 
 // Configuration (matches CI static-checks.yml exclusions)
 const CONFIG = {
@@ -94,22 +95,6 @@ function runCommand(command: string, args: string[], options?: SpawnSyncOptions)
 		console.error(`${colors.red}Command failed: ${command} ${args.join(' ')}${colors.reset}`);
 		process.exit(result.status ?? 1);
 	}
-}
-
-/**
- * Get list of staged files from git
- */
-function getStagedFiles(): string[] {
-	const result = spawnSync('git', ['diff', '--cached', '--name-only', '--diff-filter=ACMR'], {
-		encoding: 'utf-8'
-	});
-
-	if (result.status !== 0) {
-		console.error('Failed to get staged files');
-		process.exit(1);
-	}
-
-	return result.stdout.trim().split('\n').filter(Boolean);
 }
 
 /**
@@ -359,10 +344,19 @@ async function main(): Promise<void> {
 		console.log('\n');
 	}
 
-	// Re-stage files if they were modified during --staged checks
+	// Re-stage files if they were modified during --staged checks.
+	// Sanitized env ensures `git add` writes into the correct index even when
+	// a parent process (e.g. the pre-commit framework) set GIT_DIR/GIT_WORK_TREE.
 	if (mode === 'staged' && !ciMode) {
 		console.log('Re-staging modified files...');
-		runCommand('git', ['add', ...allFiles]);
+		if (hasExternalGitContext()) {
+			console.log(
+				'  (note: external git context detected — likely the pre-commit framework. ' +
+					'It will report "files were modified by this hook" and abort the commit. ' +
+					'Run `git commit` again with no further changes to land the auto-fixes.)'
+			);
+		}
+		runCommand('git', ['add', ...allFiles], { env: sanitizedGitEnv() });
 		console.log('');
 	}
 

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -20,7 +20,7 @@
 
 import { spawnSync, type SpawnSyncOptions } from 'child_process';
 import { parseArgs } from 'util';
-import { getStagedFiles, hasExternalGitContext, sanitizedGitEnv } from './git-context';
+import { getStagedFiles, isUnderPreCommit, sanitizedGitEnv } from './git-context';
 
 // Configuration (matches CI static-checks.yml exclusions)
 const CONFIG = {
@@ -349,11 +349,11 @@ async function main(): Promise<void> {
 	// a parent process (e.g. the pre-commit framework) set GIT_DIR/GIT_WORK_TREE.
 	if (mode === 'staged' && !ciMode) {
 		console.log('Re-staging modified files...');
-		if (hasExternalGitContext()) {
+		if (isUnderPreCommit()) {
 			console.log(
-				'  (note: external git context detected — likely the pre-commit framework. ' +
-					'It will report "files were modified by this hook" and abort the commit. ' +
-					'Run `git commit` again with no further changes to land the auto-fixes.)'
+				'  (note: pre-commit framework detected. It will report "files were modified ' +
+					'by this hook" and abort the commit. Run `git commit` again with no further ' +
+					'changes to land the auto-fixes.)'
 			);
 		}
 		runCommand('git', ['add', ...allFiles], { env: sanitizedGitEnv() });


### PR DESCRIPTION
## Summary

Resolves #332. `scripts/static-checks.ts --staged` silently corrupted commits when the saas-starter app was nested in a monorepo subdirectory AND the host repo dispatched hooks via the [pre-commit](https://pre-commit.com/) framework instead of Husky.

`pre-commit` sets `GIT_DIR` to the parent repo's gitdir and clears `GIT_WORK_TREE` per hook. With those env vars set externally:

- `git diff --cached --name-only` returned **all parent-repo staged files** — siblings outside the app dir leaked through to prettier/eslint/misspell.
- `git add` wrote into the wrong index, recording the staged files as deletions. The "successful" commit shipped only deletions; a subsequent push wiped the files.

## Fix

- New `scripts/git-context.ts` helper exports `sanitizedGitEnv()`, `isUnderPreCommit()`, and `getStagedFiles()`. Production and tests import the same exported function — no test/production drift.
- `getStagedFiles()` runs `git diff --cached --name-only --diff-filter=ACMR --relative` with sanitized env. `--relative` filters siblings AND strips the cwd prefix in one shot.
- Re-stage step in `static-checks.ts` now passes sanitized env so `git add` targets the correct index. A one-line hint fires only when the pre-commit framework is detected (via `PRE_COMMIT*` env vars — not `GIT_DIR`, since git itself sets that for every hook), explaining its mandatory abort-then-retry flow.

Husky users see no behavioral change.

## Test plan

- [x] `scripts/git-context.test.ts` — env scrubbing + framework detection (7 cases, including a negative case that asserts `GIT_DIR` alone does not flip the detector).
- [x] `scripts/git-context.staged-files.test.ts` — integration test: real temp git repo, `web/src/a.ts` and `other/b.ts` staged, subprocess imports `getStagedFiles` from the helper, runs with `cwd=tmp/web` and externally-set `GIT_DIR`. Asserts the result is exactly `['src/a.ts']` (sibling filtered, prefix stripped).
- [x] `bun scripts/static-checks.ts` on the four touched files — green.
