### PR TITLE
fix(prompt-suggestion): forward HTML attrs and put title on the button

### DIFF
--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -216,11 +216,11 @@
 						<div
 							class="max-w-full min-w-0 motion-safe:animate-[chip-in_375ms_ease-out_both] sm:max-w-[14rem]"
 							style="animation-delay: {i * 50}ms"
-							title={suggestion.text}
 						>
 							<PromptSuggestion
 								class="w-full"
 								truncate
+								title={suggestion.text}
 								onclick={() => handleSuggestionClick(suggestion.text)}
 							>
 								{suggestion.label}

--- a/src/lib/components/prompt-kit/prompt-suggestion/prompt-suggestion.svelte
+++ b/src/lib/components/prompt-kit/prompt-suggestion/prompt-suggestion.svelte
@@ -2,8 +2,12 @@
 	import type { ButtonVariant, ButtonSize } from '$lib/components/ui/button/index.js';
 	import { cn } from '$lib/utils';
 	import type { Snippet } from 'svelte';
+	import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements';
 
-	export type PromptSuggestionProps = {
+	export type PromptSuggestionProps = Omit<
+		HTMLButtonAttributes & HTMLAnchorAttributes,
+		'class' | 'onclick' | 'disabled' | 'type' | 'children'
+	> & {
 		children?: Snippet;
 		variant?: ButtonVariant;
 		size?: ButtonSize;
@@ -13,6 +17,7 @@
 		onclick?: (event: MouseEvent) => void;
 		disabled?: boolean;
 		type?: 'button' | 'submit' | 'reset';
+		/** Wrap children in a truncating span. Non-highlight mode only — ignored when `highlight` is set. */
 		truncate?: boolean;
 	};
 </script>
@@ -30,7 +35,8 @@
 		onclick,
 		disabled,
 		type = 'button',
-		truncate = false
+		truncate = false,
+		...rest
 	}: PromptSuggestionProps = $props();
 
 	const isHighlightMode = $derived(highlight !== undefined && highlight.trim() !== '');
@@ -90,6 +96,7 @@
 		{onclick}
 		{disabled}
 		{type}
+		{...rest}
 	>
 		{#if truncate}
 			<span class="block min-w-0 truncate">
@@ -108,6 +115,7 @@
 		{onclick}
 		{disabled}
 		{type}
+		{...rest}
 	>
 		{@render children?.()}
 	</Button>
@@ -124,6 +132,7 @@
 		{onclick}
 		{disabled}
 		{type}
+		{...rest}
 	>
 		{#if highlightedContent?.hasMatch}
 			{#if highlightedContent.before}

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -138,11 +138,11 @@
 								<div
 									class="max-w-full min-w-0 motion-safe:animate-[chip-in_375ms_ease-out_both] sm:max-w-[14rem]"
 									style="animation-delay: {i * 50}ms"
-									title={suggestion.text}
 								>
 									<PromptSuggestion
 										class="w-full"
 										truncate
+										title={suggestion.text}
 										onclick={() => {
 											chatUIContext.setInputValue(suggestion.text);
 											tick().then(() => {


### PR DESCRIPTION
## Summary

Follow-up to #339 addressing Copilot's review feedback (review landed after the squash-merge).

- **Forward HTML attributes to `<Button>`**: `PromptSuggestion` now accepts arbitrary HTML attributes (typed against Button's prop shape — `HTMLButtonAttributes & HTMLAnchorAttributes` minus the props it owns) and spreads them through. Callers can set `title`, `aria-*`, `data-*` on the component without wrapping divs.
- **Move `title` from wrapper div to `<PromptSuggestion>`** in the AI chat (`thread-chat.svelte`) and `ChatInput` empty-state chips. Native tooltips and assistive tech now read the title from the focused button itself, not an outer non-interactive div.
- **Document `truncate` scope**: the prop is non-highlight-only — added a JSDoc note to the prop type so the silent prop-ignore in highlight mode isn't surprising.

## Test plan

- [ ] `bun scripts/static-checks.ts` passes
- [ ] Hover any chip in `/app/ai-chat` empty state → title tooltip shows
- [ ] Tab to a chip → focus indicator shows on the button (title attribute is on the button now)
- [ ] No visual regression on the existing chip layout