### PR TITLE
feat(media): client-side image resize + WebP encode across upload surfaces

### DIFF
--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -413,6 +413,13 @@
 			"branch": "develop",
 			"searchPath": "packages/sveltekit",
 			"specialNotes": "Sentry SvelteKit SDK. Error monitoring, performance tracing, source maps, hooks integration."
+		},
+		{
+			"type": "git",
+			"name": "jsquash",
+			"url": "https://github.com/jamsinclair/jSquash",
+			"branch": "main",
+			"specialNotes": "WASM image codecs (WebP/AVIF/JPEG/PNG/JXL/OXIPNG/QOI). Used for client-side encode in workers. Each codec is a separate package under packages/ — @jsquash/webp at packages/webp."
 		}
 	],
 	"model": "gpt-5.4-mini",

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@formkit/auto-animate": "^0.9.0",
         "@gilhrpenner/convex-files-control": "^0.5.1",
         "@humanspeak/svelte-markdown": "^1.0.4",
+        "@jsquash/webp": "^1.5.0",
         "@mmailaender/convex-better-auth-svelte": "^0.7.3",
         "@openrouter/ai-sdk-provider": "^2.9.0",
         "@oslojs/crypto": "^1.0.1",
@@ -576,6 +577,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@jsquash/webp": ["@jsquash/webp@1.5.0", "", { "dependencies": { "wasm-feature-detect": "^1.2.11" } }, "sha512-KggLoj2MnRSfIqTeKe1EmbljTX2vuV7mh79k89PCL1pyqiDULcPM1L47twxXt0hkb68F70bXiL31MxsuoZtKFw=="],
 
     "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
@@ -2904,6 +2907,8 @@
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
+    "wasm-feature-detect": ["wasm-feature-detect@1.8.0", "", {}, "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ=="],
 
     "web-haptics": ["web-haptics@0.0.6", "", { "peerDependencies": { "react": ">=18", "react-dom": ">=18", "svelte": ">=4", "vue": ">=3" }, "optionalPeers": ["react", "react-dom", "svelte", "vue"] }, "sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw=="],
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"@formkit/auto-animate": "^0.9.0",
 		"@gilhrpenner/convex-files-control": "^0.5.1",
 		"@humanspeak/svelte-markdown": "^1.0.4",
+		"@jsquash/webp": "^1.5.0",
 		"@mmailaender/convex-better-auth-svelte": "^0.7.3",
 		"@openrouter/ai-sdk-provider": "^2.9.0",
 		"@oslojs/crypto": "^1.0.1",

--- a/src/lib/chat/core/types.ts
+++ b/src/lib/chat/core/types.ts
@@ -23,6 +23,9 @@ export type UploadState = {
 export type Attachment =
 	| {
 			type: 'file';
+			/** Stable identity used by ChatUIContext to update/remove this entry while
+			 * concurrent uploads or user removals shift array indices. */
+			key?: string;
 			name: string;
 			size: number;
 			mimeType: string;
@@ -39,6 +42,7 @@ export type Attachment =
 	  }
 	| {
 			type: 'screenshot';
+			key?: string;
 			name: string;
 			size: number;
 			mimeType: string;

--- a/src/lib/chat/core/types.ts
+++ b/src/lib/chat/core/types.ts
@@ -32,6 +32,10 @@ export type Attachment =
 			uploadState?: UploadState;
 			width?: number;
 			height?: number;
+			/** Original filename before client-side preprocessing (e.g. WebP encode). Used for dedup. */
+			sourceName?: string;
+			/** Original byte size before client-side preprocessing. Used for dedup. */
+			sourceSize?: number;
 	  }
 	| {
 			type: 'screenshot';
@@ -44,6 +48,8 @@ export type Attachment =
 			uploadState?: UploadState;
 			width?: number;
 			height?: number;
+			sourceName?: string;
+			sourceSize?: number;
 	  }
 	| { type: 'image'; url: string; filename?: string; width?: number; height?: number }
 	| {

--- a/src/lib/chat/ui/ChatContext.svelte.ts
+++ b/src/lib/chat/ui/ChatContext.svelte.ts
@@ -72,13 +72,10 @@ export class ChatUIContext {
 	/** Current input value */
 	inputValue = $state('');
 
-	/** Attachments for current message - keyed by unique ID for progress updates */
+	/** Attachments for current message. Each entry's `key` is the stable id
+	 * used by upload methods to apply progress/success/error updates by value
+	 * rather than by array index. */
 	attachments = $state<Attachment[]>([]);
-
-	/** Internal map for tracking attachment keys (for progress updates) - not reactive, internal only */
-	// eslint-disable-next-line svelte/prefer-svelte-reactivity -- internal tracking map, not reactive state
-	private attachmentKeys = new Map<number, string>();
-	private nextAttachmentIndex = 0;
 
 	/** Tracks if we've ever displayed messages in this session */
 	private _hasEverDisplayedMessages = false;
@@ -254,8 +251,6 @@ export class ChatUIContext {
 	 */
 	clearAttachments(): void {
 		this.attachments = [];
-		this.attachmentKeys.clear();
-		this.nextAttachmentIndex = 0;
 	}
 
 	/**
@@ -321,9 +316,10 @@ export class ChatUIContext {
 		}
 
 		const initialName = filename ?? (file instanceof File ? file.name : 'file');
-		const attachmentIndex = this.nextAttachmentIndex++;
+		// Stable identity used to update/remove this attachment by value rather
+		// than by array index. User removals or other concurrent uploads shift
+		// the index, so a captured `currentIndex` would target the wrong row.
 		const key = crypto.randomUUID();
-		this.attachmentKeys.set(attachmentIndex, key);
 
 		// Synchronously insert the placeholder BEFORE any await so concurrent
 		// callers (e.g. handleFilesAdded looping over a batch) see the limit
@@ -331,6 +327,7 @@ export class ChatUIContext {
 		const initialPreview = file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined;
 		const placeholder: Attachment = {
 			type: 'file',
+			key,
 			name: initialName,
 			size: file.size,
 			mimeType: file.type,
@@ -342,7 +339,6 @@ export class ChatUIContext {
 			sourceSize: file.size
 		};
 		this.attachments = [...this.attachments, placeholder];
-		const currentIndex = this.attachments.length - 1;
 
 		try {
 			let uploadBlob: File | Blob = file;
@@ -360,8 +356,8 @@ export class ChatUIContext {
 				height = processed.height;
 				// Reflect post-process metadata on the placeholder so the UI shows
 				// the final size and name during the actual upload.
-				this.attachments = this.attachments.map((a, i) =>
-					i === currentIndex
+				this.attachments = this.attachments.map((a) =>
+					'key' in a && a.key === key
 						? { ...a, name: uploadName, mimeType: uploadMime, size: uploadBlob.size }
 						: a
 				);
@@ -378,8 +374,8 @@ export class ChatUIContext {
 				}
 			}
 			if (width && height) {
-				this.attachments = this.attachments.map((a, i) =>
-					i === currentIndex ? { ...a, width, height } : a
+				this.attachments = this.attachments.map((a) =>
+					'key' in a && a.key === key ? { ...a, width, height } : a
 				);
 			}
 
@@ -389,9 +385,12 @@ export class ChatUIContext {
 				uploadBlob,
 				uploadName,
 				(progress) => {
-					// Update progress for this specific attachment
-					this.attachments = this.attachments.map((a, i) =>
-						i === currentIndex && (a.type === 'file' || a.type === 'screenshot') && a.uploadState
+					// Update progress for this specific attachment by stable key
+					this.attachments = this.attachments.map((a) =>
+						'key' in a &&
+						a.key === key &&
+						(a.type === 'file' || a.type === 'screenshot') &&
+						a.uploadState
 							? { ...a, uploadState: { ...a.uploadState, progress } }
 							: a
 					);
@@ -402,8 +401,8 @@ export class ChatUIContext {
 			);
 
 			// Mark as success
-			this.attachments = this.attachments.map((a, i) =>
-				i === currentIndex
+			this.attachments = this.attachments.map((a) =>
+				'key' in a && a.key === key
 					? {
 							...a,
 							url: result.url,
@@ -412,8 +411,8 @@ export class ChatUIContext {
 					: a
 			);
 		} catch (error) {
-			// Remove failed attachment and show toast
-			this.attachments = this.attachments.filter((_, i) => i !== currentIndex);
+			// Remove failed attachment by key (not stale index) and show toast
+			this.attachments = this.attachments.filter((a) => !('key' in a) || a.key !== key);
 			toast.error(`Failed to upload "${initialName}"`, {
 				description: error instanceof Error ? error.message : 'Upload failed'
 			});
@@ -432,13 +431,12 @@ export class ChatUIContext {
 			throw new Error('Upload config not provided to ChatUIContext');
 		}
 
-		const attachmentIndex = this.nextAttachmentIndex++;
 		const key = crypto.randomUUID();
-		this.attachmentKeys.set(attachmentIndex, key);
 
 		// Add optimistic attachment with uploading state
 		const newAttachment: Attachment = {
 			type: 'screenshot',
+			key,
 			name: filename,
 			size: blob.size,
 			mimeType: blob.type,
@@ -449,7 +447,6 @@ export class ChatUIContext {
 		};
 
 		this.attachments = [...this.attachments, newAttachment];
-		const currentIndex = this.attachments.length - 1;
 
 		try {
 			const accessKey = this.uploadConfig?.getAccessKey?.();
@@ -458,8 +455,11 @@ export class ChatUIContext {
 				blob,
 				filename,
 				(progress) => {
-					this.attachments = this.attachments.map((a, i) =>
-						i === currentIndex && (a.type === 'file' || a.type === 'screenshot') && a.uploadState
+					this.attachments = this.attachments.map((a) =>
+						'key' in a &&
+						a.key === key &&
+						(a.type === 'file' || a.type === 'screenshot') &&
+						a.uploadState
 							? { ...a, uploadState: { ...a.uploadState, progress } }
 							: a
 					);
@@ -470,8 +470,8 @@ export class ChatUIContext {
 			);
 
 			// Mark as success
-			this.attachments = this.attachments.map((a, i) =>
-				i === currentIndex
+			this.attachments = this.attachments.map((a) =>
+				'key' in a && a.key === key
 					? {
 							...a,
 							url: result.url,
@@ -480,8 +480,8 @@ export class ChatUIContext {
 					: a
 			);
 		} catch (error) {
-			// Remove failed attachment and show toast
-			this.attachments = this.attachments.filter((_, i) => i !== currentIndex);
+			// Remove failed attachment by key and show toast
+			this.attachments = this.attachments.filter((a) => !('key' in a) || a.key !== key);
 			toast.error(`Failed to upload "${filename}"`, {
 				description: error instanceof Error ? error.message : 'Upload failed'
 			});

--- a/src/lib/chat/ui/ChatContext.svelte.ts
+++ b/src/lib/chat/ui/ChatContext.svelte.ts
@@ -290,50 +290,94 @@ export class ChatUIContext {
 	 * Progress is tracked automatically
 	 * Images are uploaded as-is (the model supports all allowed formats natively).
 	 */
-	async uploadFile(file: File | Blob, filename?: string): Promise<void> {
+	async uploadFile(
+		file: File | Blob,
+		filename?: string,
+		options?: {
+			/**
+			 * Optional async transform applied between placeholder insertion and the
+			 * actual upload. Used by ChatInput to route image attachments through
+			 * the WebP encoder. The placeholder is inserted synchronously so
+			 * `hasFile`, `MAX_ATTACHMENTS`, and `canSend` see the in-progress
+			 * attachment for the entire preprocess + upload window.
+			 */
+			preprocess?: (input: File | Blob) => Promise<{
+				blob: Blob;
+				mimeType: string;
+				filename?: string;
+				width?: number;
+				height?: number;
+			}>;
+		}
+	): Promise<void> {
 		if (!this.uploadConfig) {
 			throw new Error('Upload config not provided to ChatUIContext');
 		}
 
-		const name = filename ?? (file instanceof File ? file.name : 'file');
+		const initialName = filename ?? (file instanceof File ? file.name : 'file');
 		const attachmentIndex = this.nextAttachmentIndex++;
 		const key = crypto.randomUUID();
 		this.attachmentKeys.set(attachmentIndex, key);
 
-		let width: number | undefined;
-		let height: number | undefined;
-		const mimeType = file.type;
-
-		// Get dimensions for image metadata (used for dialog sizing)
-		if (file.type.startsWith('image/')) {
-			const dims = await this.getImageDimensions(file);
-			if (dims.width > 0 && dims.height > 0) {
-				width = dims.width;
-				height = dims.height;
-			}
-		}
-
-		// Add optimistic attachment with uploading state
-		const newAttachment: Attachment = {
+		// Synchronously insert the placeholder BEFORE any await so concurrent
+		// callers (e.g. handleFilesAdded looping over a batch) see the limit
+		// and dedup state immediately.
+		const initialPreview = file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined;
+		const placeholder: Attachment = {
 			type: 'file',
-			name,
+			name: initialName,
 			size: file.size,
-			mimeType,
-			preview: mimeType.startsWith('image/') ? URL.createObjectURL(file) : undefined,
-			uploadState: { status: 'uploading', progress: 0 },
-			width,
-			height
+			mimeType: file.type,
+			preview: initialPreview,
+			uploadState: { status: 'uploading', progress: 0 }
 		};
-
-		this.attachments = [...this.attachments, newAttachment];
+		this.attachments = [...this.attachments, placeholder];
 		const currentIndex = this.attachments.length - 1;
 
 		try {
+			let uploadBlob: File | Blob = file;
+			let uploadName = initialName;
+			let uploadMime = file.type;
+			let width: number | undefined;
+			let height: number | undefined;
+
+			if (options?.preprocess) {
+				const processed = await options.preprocess(file);
+				uploadBlob = processed.blob;
+				uploadMime = processed.mimeType;
+				if (processed.filename) uploadName = processed.filename;
+				width = processed.width;
+				height = processed.height;
+				// Reflect post-process metadata on the placeholder so the UI shows
+				// the final size and name during the actual upload.
+				this.attachments = this.attachments.map((a, i) =>
+					i === currentIndex
+						? { ...a, name: uploadName, mimeType: uploadMime, size: uploadBlob.size }
+						: a
+				);
+			}
+
+			// Read dimensions only when preprocess didn't supply them. Image-typed
+			// files paths from preprocess always do; SVG/animated-GIF passthrough
+			// reports valid dims too. This is the legacy fallback.
+			if (uploadMime.startsWith('image/') && (width === undefined || height === undefined)) {
+				const dims = await this.getImageDimensions(uploadBlob);
+				if (dims.width > 0 && dims.height > 0) {
+					width = dims.width;
+					height = dims.height;
+				}
+			}
+			if (width && height) {
+				this.attachments = this.attachments.map((a, i) =>
+					i === currentIndex ? { ...a, width, height } : a
+				);
+			}
+
 			const accessKey = this.uploadConfig?.getAccessKey?.();
 			const result = await uploadFileWithProgress(
 				this.client,
-				file,
-				name,
+				uploadBlob,
+				uploadName,
 				(progress) => {
 					// Update progress for this specific attachment
 					this.attachments = this.attachments.map((a, i) =>
@@ -360,7 +404,7 @@ export class ChatUIContext {
 		} catch (error) {
 			// Remove failed attachment and show toast
 			this.attachments = this.attachments.filter((_, i) => i !== currentIndex);
-			toast.error(`Failed to upload "${name}"`, {
+			toast.error(`Failed to upload "${initialName}"`, {
 				description: error instanceof Error ? error.message : 'Upload failed'
 			});
 		}

--- a/src/lib/chat/ui/ChatContext.svelte.ts
+++ b/src/lib/chat/ui/ChatContext.svelte.ts
@@ -262,8 +262,14 @@ export class ChatUIContext {
 	 * Check if a file with the same name and size already exists
 	 */
 	hasFile(name: string, size: number): boolean {
+		// Match either current name+size OR the pre-preprocessing source values.
+		// Without the second branch, image attachments would lose dedup after
+		// they're renamed to .webp on upload — the user could re-paste the same
+		// source image and get duplicate uploads.
 		return this.attachments.some(
-			(a) => (a.type === 'file' || a.type === 'screenshot') && a.name === name && a.size === size
+			(a) =>
+				(a.type === 'file' || a.type === 'screenshot') &&
+				((a.name === name && a.size === size) || (a.sourceName === name && a.sourceSize === size))
 		);
 	}
 
@@ -329,7 +335,11 @@ export class ChatUIContext {
 			size: file.size,
 			mimeType: file.type,
 			preview: initialPreview,
-			uploadState: { status: 'uploading', progress: 0 }
+			uploadState: { status: 'uploading', progress: 0 },
+			// Source metadata persists across the rename in preprocess so dedup
+			// still matches when the user re-pastes the same image.
+			sourceName: initialName,
+			sourceSize: file.size
 		};
 		this.attachments = [...this.attachments, placeholder];
 		const currentIndex = this.attachments.length - 1;

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -18,6 +18,7 @@
 	import ChatAttachments from './ChatAttachments.svelte';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { getChatUIContext } from './ChatContext.svelte.js';
+	import { processImage } from '$lib/media/process-image';
 	import {
 		ALLOWED_FILE_EXTENSIONS,
 		ALLOWED_FILE_TYPES,
@@ -127,6 +128,25 @@
 		onScreenshot?.();
 	}
 
+	/**
+	 * Route image-typed files through processImage (resize + WebP encode on a
+	 * worker) before handing them to the upload context. Non-image files pass
+	 * through unchanged. processImage falls back to passthrough on decode/encode
+	 * failure so this never throws for callers.
+	 */
+	async function attachFile(file: File | Blob, filename: string) {
+		let upload: File | Blob = file;
+		let name = filename;
+		if (file.type?.startsWith('image/')) {
+			const processed = await processImage(file);
+			upload = processed.blob;
+			if (!processed.passthrough) {
+				name = name.replace(/\.[^.]+$/, '') + '.webp';
+			}
+		}
+		ctx.uploadFile(upload, name);
+	}
+
 	async function handleFilesAdded(files: File[]) {
 		// Upload files through context (with duplicate detection and size validation)
 		for (const file of files) {
@@ -136,7 +156,8 @@
 				toast.error($t('chat.error.max_attachments', { max: MAX_ATTACHMENTS }));
 				break;
 			}
-			// Check file size
+			// Check file size BEFORE processing — keeps the existing UX contract
+			// and avoids spending CPU on encodes we'd reject afterwards.
 			if (file.size > MAX_FILE_SIZE) {
 				haptic.trigger('error');
 				toast.error($t('chat.error.file_too_large', { filename: file.name }), {
@@ -147,7 +168,7 @@
 			if (!ctx.hasFile(file.name, file.size)) {
 				haptic.trigger('medium');
 				// Fire and forget - context manages progress
-				ctx.uploadFile(file);
+				attachFile(file, file.name);
 			}
 		}
 	}
@@ -198,7 +219,7 @@
 
 			// Check for duplicates (unlikely for pasted files, but consistent with file upload)
 			if (!ctx.hasFile(filename, file.size)) {
-				ctx.uploadFile(file, filename);
+				attachFile(file, filename);
 			}
 		}
 	}

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -140,6 +140,21 @@
 			ctx.uploadFile(file, filename, {
 				preprocess: async (input) => {
 					const processed = await processImage(input);
+					// Post-process size guard. WebP at q=85 is almost always smaller
+					// than the source for screenshots and large photos, but pathological
+					// inputs (already heavily compressed JPEGs, small high-detail tiles)
+					// can re-encode larger. The server enforces MAX_FILE_SIZE on the
+					// stored blob — if the processed bytes exceed that cap, fall back
+					// to the original which already passed the pre-upload size check.
+					if (processed.blob.size > MAX_FILE_SIZE) {
+						return {
+							blob: input,
+							mimeType: input.type,
+							filename
+							// Skip width/height; ctx.uploadFile will read them off the
+							// original blob.
+						};
+					}
 					return {
 						blob: processed.blob,
 						mimeType: processed.mimeType,

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -143,7 +143,14 @@
 					return {
 						blob: processed.blob,
 						mimeType: processed.mimeType,
-						filename: processed.passthrough ? filename : filename.replace(/\.[^.]+$/, '') + '.webp',
+						// Derive the upload filename from the actual mime type rather
+						// than the passthrough flag; the main-thread fallback also
+						// transforms to WebP, and we never want WebP bytes under a
+						// .png/.jpg name.
+						filename:
+							processed.mimeType === 'image/webp'
+								? filename.replace(/\.[^.]+$/, '') + '.webp'
+								: filename,
 						width: processed.width,
 						height: processed.height
 					};

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -130,21 +130,28 @@
 
 	/**
 	 * Route image-typed files through processImage (resize + WebP encode on a
-	 * worker) before handing them to the upload context. Non-image files pass
-	 * through unchanged. processImage falls back to passthrough on decode/encode
-	 * failure so this never throws for callers.
+	 * worker) before handing them to the upload context. The preprocess
+	 * callback runs INSIDE ctx.uploadFile, after the placeholder attachment
+	 * is inserted, so canSend / hasFile / MAX_ATTACHMENTS guards see the
+	 * in-progress attachment during the encode window.
 	 */
-	async function attachFile(file: File | Blob, filename: string) {
-		let upload: File | Blob = file;
-		let name = filename;
+	function attachFile(file: File | Blob, filename: string) {
 		if (file.type?.startsWith('image/')) {
-			const processed = await processImage(file);
-			upload = processed.blob;
-			if (!processed.passthrough) {
-				name = name.replace(/\.[^.]+$/, '') + '.webp';
-			}
+			ctx.uploadFile(file, filename, {
+				preprocess: async (input) => {
+					const processed = await processImage(input);
+					return {
+						blob: processed.blob,
+						mimeType: processed.mimeType,
+						filename: processed.passthrough ? filename : filename.replace(/\.[^.]+$/, '') + '.webp',
+						width: processed.width,
+						height: processed.height
+					};
+				}
+			});
+			return;
 		}
-		ctx.uploadFile(upload, name);
+		ctx.uploadFile(file, filename);
 	}
 
 	async function handleFilesAdded(files: File[]) {

--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotEditor.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotEditor.svelte
@@ -3,6 +3,7 @@
 	import { snapdom } from '@zumer/snapdom';
 	import { getTranslate } from '@tolgee/svelte';
 	import { getSnapDOMConfig } from '$lib/utils/snapdom-config';
+	import { processImage } from '$lib/media/process-image';
 	import {
 		ScreenshotEditorState,
 		screenshotEditorContext
@@ -106,17 +107,14 @@
 				canvas.height // Destination height
 			);
 
-			// Export final composite canvas as PNG (lossless, sharp text, LLM compatible)
-			const dataUrl = canvas.toDataURL('image/png');
-
-			// Convert dataURL to Blob
-			const response = await fetch(dataUrl);
-			const blob = await response.blob();
-			const filename = `screenshot-${timestamp}.png`;
-			const dimensions = { width: canvas.width, height: canvas.height };
+			// Resize + WebP encode on a worker (passthrough fallback if WASM init fails).
+			const processed = await processImage(canvas);
+			const ext = processed.mimeType === 'image/webp' ? 'webp' : 'png';
+			const filename = `screenshot-${timestamp}.${ext}`;
+			const dimensions = { width: processed.width, height: processed.height };
 
 			// Pass screenshot to parent via callback
-			onScreenshotSaved?.(blob, filename, dimensions);
+			onScreenshotSaved?.(processed.blob, filename, dimensions);
 
 			// Keep download code for debugging purposes (commented out)
 			// const downloadLink = document.createElement('a');

--- a/src/lib/media/config.ts
+++ b/src/lib/media/config.ts
@@ -1,0 +1,8 @@
+/** Longest-side cap applied to images before WebP encode. */
+export const MAX_IMAGE_WIDTH = 2048;
+
+/** WebP quality 0–100. 85 balances size against text/edge fidelity for screenshots. */
+export const WEBP_QUALITY = 85;
+
+/** Mime types that bypass the encode pipeline entirely. */
+export const PASSTHROUGH_MIMES: ReadonlySet<string> = new Set(['image/svg+xml']);

--- a/src/lib/media/detect-passthrough.ts
+++ b/src/lib/media/detect-passthrough.ts
@@ -1,18 +1,81 @@
 import { PASSTHROUGH_MIMES } from './config.js';
 
-/** Detect animated GIF by counting Graphic Control Extension blocks (0x21 0xF9). */
+/**
+ * Detect animated GIF by walking the GIF block structure and counting image
+ * descriptors (`0x2C` blocks at the top level). A static GIF has exactly one;
+ * an animated GIF has at least two.
+ *
+ * A naive byte-scan for `0x21 0xF9` (Graphic Control Extension introducer)
+ * produces false positives because LZW-compressed image data and other
+ * extension blocks can contain that pair, which wrongly classifies static
+ * GIFs as animated and bypasses compression. This walker is robust because
+ * it follows the documented GIF structure: header, logical screen
+ * descriptor, optional global color table, then a stream of typed blocks
+ * separated by trailers.
+ *
+ * Spec: https://www.w3.org/Graphics/GIF/spec-gif89a.txt
+ */
 export async function isAnimatedGif(blob: Blob): Promise<boolean> {
 	if (blob.type !== 'image/gif') return false;
 	const buffer = await blob.arrayBuffer();
 	const bytes = new Uint8Array(buffer);
-	let count = 0;
-	for (let i = 0; i < bytes.length - 1; i++) {
-		if (bytes[i] === 0x21 && bytes[i + 1] === 0xf9) {
-			count++;
-			if (count > 1) return true;
+
+	// 6-byte signature ("GIF87a" or "GIF89a") + 7-byte logical screen descriptor.
+	if (bytes.length < 13) return false;
+	if (bytes[0] !== 0x47 || bytes[1] !== 0x49 || bytes[2] !== 0x46) return false;
+
+	// Optional Global Color Table size lives in the packed byte at offset 10.
+	const packed = bytes[10] ?? 0;
+	const hasGCT = (packed & 0x80) !== 0;
+	const gctSize = hasGCT ? 3 * (1 << ((packed & 0x07) + 1)) : 0;
+	let i = 13 + gctSize;
+
+	let imageCount = 0;
+	while (i < bytes.length) {
+		const block = bytes[i];
+		if (block === 0x3b) {
+			// Trailer
+			break;
 		}
+		if (block === 0x2c) {
+			// Image descriptor — fixed 10 bytes (incl. introducer), optional Local
+			// Color Table, then LZW image data sub-blocks.
+			imageCount++;
+			if (imageCount > 1) return true;
+			if (i + 10 > bytes.length) return false;
+			const lpacked = bytes[i + 9] ?? 0;
+			const hasLCT = (lpacked & 0x80) !== 0;
+			const lctSize = hasLCT ? 3 * (1 << ((lpacked & 0x07) + 1)) : 0;
+			i += 10 + lctSize;
+			// Skip the LZW minimum code size byte, then walk sub-blocks.
+			if (i >= bytes.length) return false;
+			i += 1;
+			i = skipSubBlocks(bytes, i);
+			if (i < 0) return false;
+			continue;
+		}
+		if (block === 0x21) {
+			// Extension introducer: skip label byte, then sub-blocks.
+			i += 2;
+			i = skipSubBlocks(bytes, i);
+			if (i < 0) return false;
+			continue;
+		}
+		// Unknown byte — treat as malformed; bail out without claiming animation.
+		return false;
 	}
 	return false;
+}
+
+function skipSubBlocks(bytes: Uint8Array, offset: number): number {
+	let i = offset;
+	while (i < bytes.length) {
+		const size = bytes[i];
+		if (size === undefined) return -1;
+		if (size === 0) return i + 1;
+		i += 1 + size;
+	}
+	return -1;
 }
 
 export function isSvg(blob: Blob): boolean {

--- a/src/lib/media/detect-passthrough.ts
+++ b/src/lib/media/detect-passthrough.ts
@@ -1,0 +1,27 @@
+import { PASSTHROUGH_MIMES } from './config.js';
+
+/** Detect animated GIF by counting Graphic Control Extension blocks (0x21 0xF9). */
+export async function isAnimatedGif(blob: Blob): Promise<boolean> {
+	if (blob.type !== 'image/gif') return false;
+	const buffer = await blob.arrayBuffer();
+	const bytes = new Uint8Array(buffer);
+	let count = 0;
+	for (let i = 0; i < bytes.length - 1; i++) {
+		if (bytes[i] === 0x21 && bytes[i + 1] === 0xf9) {
+			count++;
+			if (count > 1) return true;
+		}
+	}
+	return false;
+}
+
+export function isSvg(blob: Blob): boolean {
+	return blob.type === 'image/svg+xml';
+}
+
+/** True if the blob should bypass the WebP encode pipeline. */
+export async function shouldPassthrough(blob: Blob): Promise<boolean> {
+	if (PASSTHROUGH_MIMES.has(blob.type)) return true;
+	if (await isAnimatedGif(blob)) return true;
+	return false;
+}

--- a/src/lib/media/media-dimensions.ts
+++ b/src/lib/media/media-dimensions.ts
@@ -1,0 +1,53 @@
+export interface MediaDimensions {
+	width: number;
+	height: number;
+}
+
+/** Decode an image blob via <img> to extract intrinsic dimensions. */
+export function getImageDimensions(blob: Blob): Promise<MediaDimensions> {
+	return new Promise((resolve, reject) => {
+		const img = new Image();
+		const objectUrl = URL.createObjectURL(blob);
+		img.onload = () => {
+			URL.revokeObjectURL(objectUrl);
+			resolve({
+				width: img.naturalWidth || img.width,
+				height: img.naturalHeight || img.height
+			});
+		};
+		img.onerror = () => {
+			URL.revokeObjectURL(objectUrl);
+			reject(new Error('Failed to load image'));
+		};
+		img.src = objectUrl;
+	});
+}
+
+/** Read width/height from an SVG's viewBox; fall back to <img> decode. */
+async function getSvgDimensions(blob: Blob): Promise<MediaDimensions> {
+	try {
+		const text = await blob.text();
+		const match = text.match(/viewBox=["']([^"']+)["']/);
+		const viewBox = match?.[1];
+		if (viewBox) {
+			const parts = viewBox.trim().split(/[\s,]+/);
+			const w = parts[2];
+			const h = parts[3];
+			if (parts.length === 4 && w && h) {
+				const width = parseFloat(w);
+				const height = parseFloat(h);
+				if (width > 0 && height > 0) {
+					return { width: Math.round(width), height: Math.round(height) };
+				}
+			}
+		}
+	} catch {
+		// fall through
+	}
+	return getImageDimensions(blob);
+}
+
+export function getMediaDimensions(blob: Blob): Promise<MediaDimensions> {
+	if (blob.type === 'image/svg+xml') return getSvgDimensions(blob);
+	return getImageDimensions(blob);
+}

--- a/src/lib/media/process-image.ts
+++ b/src/lib/media/process-image.ts
@@ -96,13 +96,45 @@ async function canvasToBitmap(canvas: HTMLCanvasElement): Promise<ImageBitmap> {
 	return await createImageBitmap(canvas);
 }
 
-async function blobFromCanvas(canvas: HTMLCanvasElement): Promise<Blob> {
-	return await new Promise<Blob>((resolve, reject) => {
-		canvas.toBlob(
-			(b) => (b ? resolve(b) : reject(new Error('canvas.toBlob returned null'))),
-			'image/png'
-		);
-	});
+/**
+ * Main-thread resize + encode used as a fallback when the worker / WASM init
+ * fails. This still gives us the most important property of the pipeline —
+ * the output fits the server-side 5 MB cap even for large screenshots — by
+ * resizing to `maxWidth` on a regular canvas and encoding via the browser's
+ * native `canvas.toBlob`.
+ *
+ * Native `canvas.toBlob('image/webp', q)` is materially lower fidelity than
+ * `@jsquash/webp.encode`, especially on text-heavy screenshots, but it's
+ * still vastly smaller than a raw PNG and keeps uploads working.
+ */
+async function fallbackResizeAndEncode(
+	source: HTMLCanvasElement | ImageBitmap,
+	sourceW: number,
+	sourceH: number,
+	maxWidth: number
+): Promise<{ blob: Blob; mimeType: string; width: number; height: number }> {
+	const longest = Math.max(sourceW, sourceH);
+	const scale = longest > maxWidth ? maxWidth / longest : 1;
+	const targetW = Math.max(1, Math.round(sourceW * scale));
+	const targetH = Math.max(1, Math.round(sourceH * scale));
+
+	const canvas = document.createElement('canvas');
+	canvas.width = targetW;
+	canvas.height = targetH;
+	const ctx = canvas.getContext('2d');
+	if (!ctx) throw new Error('2D context unavailable on fallback canvas');
+	ctx.drawImage(source, 0, 0, targetW, targetH);
+
+	// Try WebP first; fall back to PNG if the browser refused (returned null).
+	const webp = await new Promise<Blob | null>((resolve) =>
+		canvas.toBlob((b) => resolve(b), 'image/webp', 0.85)
+	);
+	if (webp) return { blob: webp, mimeType: 'image/webp', width: targetW, height: targetH };
+	const png = await new Promise<Blob | null>((resolve) =>
+		canvas.toBlob((b) => resolve(b), 'image/png')
+	);
+	if (!png) throw new Error('canvas.toBlob returned null for both webp and png');
+	return { blob: png, mimeType: 'image/png', width: targetW, height: targetH };
 }
 
 function postProcess(input: {
@@ -118,17 +150,25 @@ function postProcess(input: {
 		pending.set(id, { resolve, reject, onStatus: input.onStatus });
 		const transfer: Transferable[] = [];
 		if (input.bitmap) transfer.push(input.bitmap);
-		worker.postMessage(
-			{
-				type: 'process',
-				id,
-				bitmap: input.bitmap,
-				blob: input.blob,
-				maxWidth: input.maxWidth,
-				quality: input.quality
-			},
-			transfer
-		);
+		try {
+			worker.postMessage(
+				{
+					type: 'process',
+					id,
+					bitmap: input.bitmap,
+					blob: input.blob,
+					maxWidth: input.maxWidth,
+					quality: input.quality
+				},
+				transfer
+			);
+		} catch (err) {
+			// postMessage can throw on structured-clone failures (rare but possible
+			// for exotic Blob/ImageBitmap states). Drop the pending entry so the
+			// map doesn't leak across the session.
+			pending.delete(id);
+			reject(err instanceof Error ? err : new Error(String(err)));
+		}
 	});
 }
 
@@ -187,9 +227,32 @@ export async function processImage(
 			passthrough: false
 		};
 	} catch (err) {
-		// 3. Fallback: hand back the original bytes (or a PNG snapshot of the canvas)
-		//    so the upload still succeeds. Log so we can see WASM/worker failures.
-		console.warn('processImage falling back to passthrough:', err);
+		// 3. Fallback path — worker/WASM init or encode failed. Still resize and
+		//    encode on the main thread so the output respects the same upload
+		//    cap as the happy path; without this, a passthrough of a 4K
+		//    screenshot exceeds the 5 MB server-side limit and the upload fails.
+		console.warn('processImage falling back to main-thread encode:', err);
+		try {
+			if (input instanceof HTMLCanvasElement) {
+				const out = await fallbackResizeAndEncode(input, input.width, input.height, maxWidth);
+				return { ...out, passthrough: true };
+			}
+			if (typeof ImageBitmap !== 'undefined' && input instanceof ImageBitmap) {
+				const out = await fallbackResizeAndEncode(input, input.width, input.height, maxWidth);
+				return { ...out, passthrough: true };
+			}
+			if (input instanceof Blob) {
+				const bitmap = await createImageBitmap(input);
+				const out = await fallbackResizeAndEncode(bitmap, bitmap.width, bitmap.height, maxWidth);
+				bitmap.close();
+				return { ...out, passthrough: true };
+			}
+		} catch (fallbackErr) {
+			console.warn('processImage main-thread fallback also failed:', fallbackErr);
+		}
+
+		// 4. Last resort — hand back the original bytes unchanged. Acceptable
+		//    only for blob inputs where the original is already a valid file.
 		if (input instanceof Blob) {
 			const dims = await getMediaDimensions(input).catch(() => ({ width: 0, height: 0 }));
 			return {
@@ -200,28 +263,6 @@ export async function processImage(
 				passthrough: true
 			};
 		}
-		if (input instanceof HTMLCanvasElement) {
-			const blob = await blobFromCanvas(input);
-			return {
-				blob,
-				width: input.width,
-				height: input.height,
-				mimeType: 'image/png',
-				passthrough: true
-			};
-		}
-		// ImageBitmap fallback: encode to a PNG via OffscreenCanvas on the main thread.
-		const c = new OffscreenCanvas(input.width, input.height);
-		const ctx = c.getContext('2d');
-		if (!ctx) throw err;
-		ctx.drawImage(input, 0, 0);
-		const blob = await c.convertToBlob({ type: 'image/png' });
-		return {
-			blob,
-			width: input.width,
-			height: input.height,
-			mimeType: 'image/png',
-			passthrough: true
-		};
+		throw err;
 	}
 }

--- a/src/lib/media/process-image.ts
+++ b/src/lib/media/process-image.ts
@@ -44,6 +44,20 @@ let workerInstance: Worker | null = null;
 let nextRequestId = 1;
 const pending = new Map<number, PendingRequest>();
 
+function destroyWorker(reason: Error) {
+	const worker = workerInstance;
+	workerInstance = null;
+	for (const entry of pending.values()) entry.reject(reason);
+	pending.clear();
+	if (worker) {
+		try {
+			worker.terminate();
+		} catch {
+			// best-effort cleanup
+		}
+	}
+}
+
 function getWorker(): Worker {
 	if (workerInstance) return workerInstance;
 	const worker = new Worker(new URL('./process-image.worker.ts', import.meta.url), {
@@ -64,11 +78,15 @@ function getWorker(): Worker {
 		}
 		entry.resolve({ buffer: msg.buffer, width: msg.width, height: msg.height });
 	});
+	// Worker-level fatal errors (script load failure, uncaught throw, OOM) and
+	// structured-clone failures both leave the worker unusable. Reject in-flight
+	// requests, terminate the worker, and null the singleton so the next
+	// processImage() call can spawn a fresh one.
 	worker.addEventListener('error', (e) => {
-		// Reject every in-flight request so callers fall back to passthrough.
-		const error = new Error(e.message || 'Image worker crashed');
-		for (const entry of pending.values()) entry.reject(error);
-		pending.clear();
+		destroyWorker(new Error(e.message || 'Image worker crashed'));
+	});
+	worker.addEventListener('messageerror', () => {
+		destroyWorker(new Error('Image worker received an undeserializable message'));
 	});
 	workerInstance = worker;
 	return worker;

--- a/src/lib/media/process-image.ts
+++ b/src/lib/media/process-image.ts
@@ -1,0 +1,209 @@
+/**
+ * Client-side image processor. Resizes to a longest-side cap and encodes
+ * WebP via @jsquash/webp running in a Web Worker (lazy-initialised, WASM
+ * stays out of the main bundle).
+ *
+ * Used by every image input surface in the app: screenshot editor, chat
+ * clipboard paste, chat file picker. Falls back to passthrough on decode
+ * or encode failure so the user can still upload the original blob.
+ */
+import { browser } from '$app/environment';
+import { MAX_IMAGE_WIDTH, WEBP_QUALITY } from './config.js';
+import { shouldPassthrough } from './detect-passthrough.js';
+import { getMediaDimensions } from './media-dimensions.js';
+
+export type ProcessImageInput = Blob | HTMLCanvasElement | ImageBitmap;
+
+export interface ProcessImageOptions {
+	maxWidth?: number;
+	quality?: number;
+	onStatus?: (status: string) => void;
+}
+
+export interface ProcessedImage {
+	blob: Blob;
+	width: number;
+	height: number;
+	mimeType: string;
+	/** True when the original bytes were forwarded unchanged (SVG, animated GIF, decode failure). */
+	passthrough: boolean;
+}
+
+interface PendingRequest {
+	resolve: (value: { buffer: ArrayBuffer; width: number; height: number }) => void;
+	reject: (err: Error) => void;
+	onStatus?: (status: string) => void;
+}
+
+type WorkerMessage =
+	| { type: 'status'; id: number; status: string }
+	| { type: 'result'; id: number; buffer: ArrayBuffer; width: number; height: number }
+	| { type: 'error'; id: number; error: string };
+
+let workerInstance: Worker | null = null;
+let nextRequestId = 1;
+const pending = new Map<number, PendingRequest>();
+
+function getWorker(): Worker {
+	if (workerInstance) return workerInstance;
+	const worker = new Worker(new URL('./process-image.worker.ts', import.meta.url), {
+		type: 'module'
+	});
+	worker.addEventListener('message', (e: MessageEvent<WorkerMessage>) => {
+		const msg = e.data;
+		const entry = pending.get(msg.id);
+		if (!entry) return;
+		if (msg.type === 'status') {
+			entry.onStatus?.(msg.status);
+			return;
+		}
+		pending.delete(msg.id);
+		if (msg.type === 'error') {
+			entry.reject(new Error(msg.error));
+			return;
+		}
+		entry.resolve({ buffer: msg.buffer, width: msg.width, height: msg.height });
+	});
+	worker.addEventListener('error', (e) => {
+		// Reject every in-flight request so callers fall back to passthrough.
+		const error = new Error(e.message || 'Image worker crashed');
+		for (const entry of pending.values()) entry.reject(error);
+		pending.clear();
+	});
+	workerInstance = worker;
+	return worker;
+}
+
+async function canvasToBitmap(canvas: HTMLCanvasElement): Promise<ImageBitmap> {
+	return await createImageBitmap(canvas);
+}
+
+async function blobFromCanvas(canvas: HTMLCanvasElement): Promise<Blob> {
+	return await new Promise<Blob>((resolve, reject) => {
+		canvas.toBlob(
+			(b) => (b ? resolve(b) : reject(new Error('canvas.toBlob returned null'))),
+			'image/png'
+		);
+	});
+}
+
+function postProcess(input: {
+	bitmap?: ImageBitmap;
+	blob?: Blob;
+	maxWidth: number;
+	quality: number;
+	onStatus?: (s: string) => void;
+}): Promise<{ buffer: ArrayBuffer; width: number; height: number }> {
+	return new Promise((resolve, reject) => {
+		const worker = getWorker();
+		const id = nextRequestId++;
+		pending.set(id, { resolve, reject, onStatus: input.onStatus });
+		const transfer: Transferable[] = [];
+		if (input.bitmap) transfer.push(input.bitmap);
+		worker.postMessage(
+			{
+				type: 'process',
+				id,
+				bitmap: input.bitmap,
+				blob: input.blob,
+				maxWidth: input.maxWidth,
+				quality: input.quality
+			},
+			transfer
+		);
+	});
+}
+
+export async function processImage(
+	input: ProcessImageInput,
+	opts: ProcessImageOptions = {}
+): Promise<ProcessedImage> {
+	const maxWidth = opts.maxWidth ?? MAX_IMAGE_WIDTH;
+	const quality = opts.quality ?? WEBP_QUALITY;
+
+	if (!browser) {
+		throw new Error('processImage is browser-only');
+	}
+
+	// 1. Passthrough fast path for Blob inputs we should not re-encode.
+	if (input instanceof Blob && (await shouldPassthrough(input))) {
+		const dims = await getMediaDimensions(input).catch(() => ({ width: 0, height: 0 }));
+		return {
+			blob: input,
+			width: dims.width,
+			height: dims.height,
+			mimeType: input.type,
+			passthrough: true
+		};
+	}
+
+	// 2. Worker path. Convert HTMLCanvasElement → ImageBitmap up front so we can
+	//    transfer it; pass Blob through directly (structured-clone is fine).
+	try {
+		let bitmap: ImageBitmap | undefined;
+		let blob: Blob | undefined;
+
+		if (input instanceof Blob) {
+			blob = input;
+		} else if (typeof ImageBitmap !== 'undefined' && input instanceof ImageBitmap) {
+			bitmap = input;
+		} else if (input instanceof HTMLCanvasElement) {
+			bitmap = await canvasToBitmap(input);
+		} else {
+			throw new Error('Unsupported processImage input');
+		}
+
+		const { buffer, width, height } = await postProcess({
+			bitmap,
+			blob,
+			maxWidth,
+			quality,
+			onStatus: opts.onStatus
+		});
+
+		return {
+			blob: new Blob([buffer], { type: 'image/webp' }),
+			width,
+			height,
+			mimeType: 'image/webp',
+			passthrough: false
+		};
+	} catch (err) {
+		// 3. Fallback: hand back the original bytes (or a PNG snapshot of the canvas)
+		//    so the upload still succeeds. Log so we can see WASM/worker failures.
+		console.warn('processImage falling back to passthrough:', err);
+		if (input instanceof Blob) {
+			const dims = await getMediaDimensions(input).catch(() => ({ width: 0, height: 0 }));
+			return {
+				blob: input,
+				width: dims.width,
+				height: dims.height,
+				mimeType: input.type || 'application/octet-stream',
+				passthrough: true
+			};
+		}
+		if (input instanceof HTMLCanvasElement) {
+			const blob = await blobFromCanvas(input);
+			return {
+				blob,
+				width: input.width,
+				height: input.height,
+				mimeType: 'image/png',
+				passthrough: true
+			};
+		}
+		// ImageBitmap fallback: encode to a PNG via OffscreenCanvas on the main thread.
+		const c = new OffscreenCanvas(input.width, input.height);
+		const ctx = c.getContext('2d');
+		if (!ctx) throw err;
+		ctx.drawImage(input, 0, 0);
+		const blob = await c.convertToBlob({ type: 'image/png' });
+		return {
+			blob,
+			width: input.width,
+			height: input.height,
+			mimeType: 'image/png',
+			passthrough: true
+		};
+	}
+}

--- a/src/lib/media/process-image.ts
+++ b/src/lib/media/process-image.ts
@@ -231,21 +231,24 @@ export async function processImage(
 		//    encode on the main thread so the output respects the same upload
 		//    cap as the happy path; without this, a passthrough of a 4K
 		//    screenshot exceeds the 5 MB server-side limit and the upload fails.
+		//    Note: `passthrough` is `false` here because the bytes have been
+		//    transformed (resize + WebP/PNG re-encode); the field marks
+		//    "untransformed", not "fell off the worker path".
 		console.warn('processImage falling back to main-thread encode:', err);
 		try {
 			if (input instanceof HTMLCanvasElement) {
 				const out = await fallbackResizeAndEncode(input, input.width, input.height, maxWidth);
-				return { ...out, passthrough: true };
+				return { ...out, passthrough: false };
 			}
 			if (typeof ImageBitmap !== 'undefined' && input instanceof ImageBitmap) {
 				const out = await fallbackResizeAndEncode(input, input.width, input.height, maxWidth);
-				return { ...out, passthrough: true };
+				return { ...out, passthrough: false };
 			}
 			if (input instanceof Blob) {
 				const bitmap = await createImageBitmap(input);
 				const out = await fallbackResizeAndEncode(bitmap, bitmap.width, bitmap.height, maxWidth);
 				bitmap.close();
-				return { ...out, passthrough: true };
+				return { ...out, passthrough: false };
 			}
 		} catch (fallbackErr) {
 			console.warn('processImage main-thread fallback also failed:', fallbackErr);

--- a/src/lib/media/process-image.worker.ts
+++ b/src/lib/media/process-image.worker.ts
@@ -1,0 +1,79 @@
+/// <reference lib="webworker" />
+/**
+ * Image processing worker. Decodes a blob (or accepts a transferred ImageBitmap),
+ * resizes to fit a longest-side cap, encodes WebP via @jsquash/webp.
+ */
+import { encode as encodeWebP } from '@jsquash/webp';
+
+declare const self: DedicatedWorkerGlobalScope;
+
+interface ProcessRequest {
+	type: 'process';
+	id: number;
+	blob?: Blob;
+	bitmap?: ImageBitmap;
+	maxWidth: number;
+	quality: number;
+}
+
+type ProcessResponse =
+	| { type: 'status'; id: number; status: string }
+	| {
+			type: 'result';
+			id: number;
+			buffer: ArrayBuffer;
+			width: number;
+			height: number;
+	  }
+	| { type: 'error'; id: number; error: string };
+
+function postStatus(id: number, status: string) {
+	const msg: ProcessResponse = { type: 'status', id, status };
+	self.postMessage(msg);
+}
+
+async function handleProcess(req: ProcessRequest) {
+	try {
+		postStatus(req.id, 'Decoding');
+		const bitmap: ImageBitmap = req.bitmap ?? (await createImageBitmap(req.blob!));
+
+		const longest = Math.max(bitmap.width, bitmap.height);
+		const scale = longest > req.maxWidth ? req.maxWidth / longest : 1;
+		const targetW = Math.round(bitmap.width * scale);
+		const targetH = Math.round(bitmap.height * scale);
+
+		postStatus(req.id, 'Resizing');
+		const canvas = new OffscreenCanvas(targetW, targetH);
+		const ctx = canvas.getContext('2d');
+		if (!ctx) throw new Error('OffscreenCanvas 2D context unavailable');
+		ctx.drawImage(bitmap, 0, 0, targetW, targetH);
+		bitmap.close();
+		const imageData = ctx.getImageData(0, 0, targetW, targetH);
+
+		postStatus(req.id, 'Encoding');
+		const buffer = await encodeWebP(imageData, { quality: req.quality });
+
+		postStatus(req.id, 'Done');
+		const msg: ProcessResponse = {
+			type: 'result',
+			id: req.id,
+			buffer,
+			width: targetW,
+			height: targetH
+		};
+		self.postMessage(msg, { transfer: [buffer] });
+	} catch (err) {
+		const msg: ProcessResponse = {
+			type: 'error',
+			id: req.id,
+			error: err instanceof Error ? err.message : 'Image processing failed'
+		};
+		self.postMessage(msg);
+	}
+}
+
+self.addEventListener('message', (e: MessageEvent<ProcessRequest>) => {
+	if (e.data?.type === 'process') {
+		handleProcess(e.data);
+	}
+});

--- a/src/lib/media/process-image.worker.ts
+++ b/src/lib/media/process-image.worker.ts
@@ -39,8 +39,10 @@ async function handleProcess(req: ProcessRequest) {
 
 		const longest = Math.max(bitmap.width, bitmap.height);
 		const scale = longest > req.maxWidth ? req.maxWidth / longest : 1;
-		const targetW = Math.round(bitmap.width * scale);
-		const targetH = Math.round(bitmap.height * scale);
+		// Clamp to at least 1 px on either axis. Without this, very thin sources
+		// (e.g. 1×10000) round to 0 on the short side and OffscreenCanvas throws.
+		const targetW = Math.max(1, Math.round(bitmap.width * scale));
+		const targetH = Math.max(1, Math.round(bitmap.height * scale));
 
 		postStatus(req.id, 'Resizing');
 		const canvas = new OffscreenCanvas(targetW, targetH);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -340,7 +340,12 @@ export default defineConfig(async ({ mode }) => {
 				// `lifecycle_outside_component` even though we ARE in a component init.
 				'@mmailaender/convex-svelte',
 				'@mmailaender/convex-better-auth-svelte',
-				'@stickerdaniel/convex-autumn-svelte'
+				'@stickerdaniel/convex-autumn-svelte',
+				// WASM image codec used by the image-processing worker. Bundling avoids
+				// SSR-time `import 'svelte'`-style hazards if the package adds main-thread
+				// surfaces in the future; the worker chunk still keeps the WASM payload out
+				// of the client entry.
+				'@jsquash/webp'
 			],
 			...(mode === 'production' && {
 				resolve: {


### PR DESCRIPTION
Adds a reusable processImage() module that runs on a Web Worker (lazy
init, WASM stays out of the main bundle) and is wired into every image
input surface in the app:

- Screenshot editor: replaces canvas.toDataURL('image/png') + fetch().blob()
  round-trip with processImage(canvas). 5-12 MB PNGs become ~300-800 KB
  WebPs at 2048 px longest side, quality 85.
- Chat clipboard paste: image-typed pastes route through processImage()
  before reaching ctx.uploadFile. Non-image files unchanged.
- Chat file picker: same wrapping at the FileUpload onFilesAdded path.

Pattern adapted from editable.website (michael/editable-website,
src/lib/client/asset_processor.js, asset_upload.js, media_dimensions.js).
Single output instead of editable.website's responsive-variant ladder
since Convex storage isn't a CDN and chat doesn't render multiple sizes.

Implementation
- src/lib/media/process-image.ts — public API, main-thread orchestrator.
  Lazy-spawns a single worker, multiplexes requests by id, falls back to
  passthrough on any worker error so users can still upload the original.
- src/lib/media/process-image.worker.ts — decodes via createImageBitmap,
  resizes via OffscreenCanvas, encodes WebP via @jsquash/webp.encode().
- src/lib/media/detect-passthrough.ts — SVG by mime, animated GIF via
  byte-scan of Graphic Control Extension blocks (0x21 0xF9). Both pass
  through unchanged.
- src/lib/media/media-dimensions.ts — getMediaDimensions(blob) via <img>
  + URL.createObjectURL, with SVG viewBox parser.
- src/lib/media/config.ts — MAX_IMAGE_WIDTH=2048, WEBP_QUALITY=85.

Build verification (bun run build):
- Worker chunk emitted at workers/process-image.worker-*.js (43 KB).
- Three @jsquash WASM blobs land in workers/assets/ (138/281/346 KB),
  loaded only when the worker first runs.
- Main entry contains zero references to @jsquash or the WASM —
  prerendered marketing pages and the chat shell pay no bundle cost
  until a user actually attaches an image.

vite.config.ts: adds @jsquash/webp to ssr.noExternal alongside the
existing svelte-konva / @tolgee/web entries (defense in depth — the
worker chunk already isolates WASM).

Resolves: #348
References: https://github.com/michael/editable-website