### PR TITLE
feat(e2e): isolated local test backend with shared site URL helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,10 +313,18 @@ This project uses **PostHog** for product analytics with an optional **Cloudflar
 
 - Located in `e2e/` directory
 - Test users are automatically created with unique emails each run (via globalSetup) and deleted after tests (via globalTeardown)
-- Requires `.env.test` with: AUTH_E2E_TEST_SECRET (must match Convex backend) and PUBLIC_CONVEX_URL
+- Requires `.env.test` with `AUTH_E2E_TEST_SECRET` only. The Convex backend URL is auto-resolved from `.convex/.test-backend-url`; no `PUBLIC_CONVEX_URL` needed locally.
 - `AuthenticatedLayout` sets `data-hydrated` on `<html>` in `onMount`; `waitForAuthenticated` in `e2e/utils/auth.ts` waits for it so clicks happen after Svelte hydration, not on inert SSR markup.
 - See `.env.schema` for all available env vars with types and descriptions
 - **CI E2E timing (CF Workers):** E2E tests only start after the CF Workers Build preview deployment completes (~2-3 min). The `e2e-preview-cf.yml` workflow triggers on the CF `check_run` event, extracts the preview URL, then runs Playwright against it. Results are posted as a commit status, not a check run. Total time from push to E2E result is ~7-8 min.
+
+#### Local e2e isolation
+
+- `bun run test:e2e` spawns an isolated test stack via `bun run dev:test`: separate vite port (`:5174`), separate local Convex backend (different port + state dir under `.convex/<branch>...e2e-<hash>/`), and a separate BetterAuth secret file. Safe to run alongside `bun run dev` on `:5173`.
+- `AUTH_E2E_TEST_SECRET` is sourced from `.env.test` and **auto-propagated into the test Convex backend** by `vite.config.ts`. You no longer need to mirror it into `.env.convex.local`.
+- Local test mode forces `baseURL` and `SITE_URL` to `http://localhost:5174` regardless of what `.env.test` contains, so a stale gitignored `PUBLIC_SITE_URL` can't silently misroute signups. The wrapper `scripts/dev-test.ts` warns loudly if leftover `PUBLIC_CONVEX_URL` / `PUBLIC_SITE_URL` are still set.
+- `globalSetup` polls `api.tests.health` before the first signup, so a cold backend boot doesn't surface as a flaky 500.
+- `RESET_LOCAL_BACKEND=true bun run test:e2e` resets only the test state dir; dev's BetterAuth secret and DB are untouched.
 
 #### `data-testid` convention
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Local dev notes (`bun run dev`):
 
 **IMPORTANT:** When any task involves Convex backend code — writing, reviewing, or modifying queries, mutations, actions, schema, HTTP endpoints, auth, file storage, or crons — you MUST read the `convex-guidelines` skill (`skills/convex-guidelines/SKILL.md`) first. It contains the canonical Convex coding patterns for this project.
 
-- `bun run check:convex` - Convex TypeScript project check. **Run after any change to `src/lib/convex/**`\*\* or shared code imported by Convex.
+- `bun run check:convex` - Convex TypeScript project check. **Required after any change** to `src/lib/convex/**` or shared code imported by Convex.
 - `bun run generate` - Regenerate `_generated/` from a Convex deployment. Rarely needed manually — the convex-vite-plugin keeps it in sync while `bun run dev` is running. Auto-detects: cloud/self-hosted (if configured) > local embedded backend > offline. **Caution**: from a worktree without `bun run dev`, this falls through to cloud and can produce surprising diffs.
 
 - `bun convex env set KEY value` - Set Convex environment variables (cloud)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,8 +100,8 @@ Local dev notes (`bun run dev`):
 
 **IMPORTANT:** When any task involves Convex backend code — writing, reviewing, or modifying queries, mutations, actions, schema, HTTP endpoints, auth, file storage, or crons — you MUST read the `convex-guidelines` skill (`skills/convex-guidelines/SKILL.md`) first. It contains the canonical Convex coding patterns for this project.
 
-- `bun run generate` - Regenerate Convex type definitions (`_generated/`). Auto-detects environment in priority order: cloud/self-hosted deployment (if configured) > local embedded backend (if `bun run dev` is running) > offline validation of existing types. Safe to run in any environment.
-- `bun run check:convex` - Run the Convex TypeScript project check. Run this whenever you change `src/lib/convex/**` or shared code imported by Convex.
+- `bun run check:convex` - Convex TypeScript project check. **Run after any change to `src/lib/convex/**`\*\* or shared code imported by Convex.
+- `bun run generate` - Regenerate `_generated/` from a Convex deployment. Rarely needed manually — the convex-vite-plugin keeps it in sync while `bun run dev` is running. Auto-detects: cloud/self-hosted (if configured) > local embedded backend > offline. **Caution**: from a worktree without `bun run dev`, this falls through to cloud and can produce surprising diffs.
 
 - `bun convex env set KEY value` - Set Convex environment variables (cloud)
 - `bun convex env set KEY value --prod` - Set production environment variables (cloud)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,37 +1,28 @@
 # Run the e2e tests
 
-## The mostly automated way
-
-After an `bun install`, run `bun test`.
-This tests against the most recently published official binary.
-
-## The more manual way
-
-The following instructions require some pre-work, but once you've done the first couple steps once
-you can skip to running the test command at the end.
-
-1. Clone [convex-backend](https://github.com/get-convex/convex-backend)
-
-1. Follow the instructions in its [README](https://github.com/get-convex/convex-backend/blob/main/README.md) to get it building
-
-1. From the `test-sveltekit` directory, run:
+## Default — isolated local stack
 
 ```
-CONVEX_LOCAL_BACKEND_PATH=/path/to/your/convex-backend bun run test
+bun run test:e2e
 ```
 
-## The most manual way
+Spawns `bun run dev:test`, which boots an isolated local Convex backend on a separate
+state dir (`.convex/<branch>...e2e-<hash>/`) and a separate vite port (`:5174`). Safe to
+run alongside `bun run dev`. Requires `AUTH_E2E_TEST_SECRET` in `.env.test`. See
+`AGENTS.md` → Testing Guidelines → "Local e2e isolation".
 
-You'll need manage your own Convex deployment to follow these instructions.
+## Targeting a developer-managed deployment
 
-1. Set up your Convex deployment for auth ([instructions](https://labs.convex.dev/auth/setup/manual))
+To point the suite at a CF preview, staging environment, or your own remote Convex
+deployment instead of the isolated local stack:
 
-1. Create a test user
+```
+E2E_OVERRIDE_SITE_URL=https://your-preview.example.com \
+PUBLIC_CONVEX_URL=https://your-deployment.convex.cloud \
+bun run test:e2e
+```
 
-   `bunx convex run tests:init`
-
-1. Set up the secret on a Convex backend matching the one in `.env.test`:
-
-   `bunx convex env set AUTH_E2E_TEST_SECRET <something>`
-
-1. Run `playwright test`
+When `E2E_OVERRIDE_SITE_URL` is set, playwright skips the local `dev:test` webServer,
+`baseURL`/`SITE_URL` use the override, and the Convex resolver falls through to
+`PUBLIC_CONVEX_URL` (the local `.test-backend-url` file is ignored). Make sure
+`AUTH_E2E_TEST_SECRET` in `.env.test` matches the secret on the target backend.

--- a/e2e/admin-users-table.spec.ts
+++ b/e2e/admin-users-table.spec.ts
@@ -8,9 +8,10 @@ import {
 	getTableQueryParam
 } from './utils/convex-table-url-assertions';
 import { resolveConvexUrl } from './utils/convex-url';
+import { resolveSiteUrl } from './utils/site-url';
 import { getPreviewBypass } from './utils/preview-bypass';
 
-const SITE_URL = process.env.PUBLIC_SITE_URL || 'http://localhost:5173';
+const SITE_URL = resolveSiteUrl();
 const TEST_PASSWORD = 'TestPassword123!';
 const bypass = getPreviewBypass();
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -9,16 +9,18 @@
 
 import { ConvexHttpClient } from 'convex/browser';
 import { api } from '../src/lib/convex/_generated/api';
+import { setTimeout as sleep } from 'node:timers/promises';
 import 'varlock/auto-load';
 import fs from 'fs';
 import path from 'path';
 
-const SITE_URL = process.env.PUBLIC_SITE_URL || 'http://localhost:5173';
+const SITE_URL = resolveSiteUrl();
 const TEST_PASSWORD = 'TestPassword123!';
 const SETUP_RETRY_ATTEMPTS = 3;
 
 import type { TestCredentials } from './utils/types';
 import { resolveConvexUrl } from './utils/convex-url';
+import { resolveSiteUrl } from './utils/site-url';
 import { getPreviewBypass, fetchVercelBypassCookie } from './utils/preview-bypass';
 
 function isTransientSetupError(error: unknown): boolean {
@@ -57,6 +59,45 @@ async function retrySetupStep<T>(label: string, run: () => Promise<T>): Promise<
 	throw new Error(`[Setup] Unexpected retry fallthrough for ${label}`);
 }
 
+/**
+ * Wait until the Convex backend reports ready via api.tests.health.
+ *
+ * The convex-vite-plugin starts backend deploy asynchronously after vite begins
+ * serving (node_modules/convex-vite-plugin/src/index.ts:302), so Playwright's
+ * webServer port-check on :5174 succeeds well before Convex is reachable. Without
+ * this gate, the first signup HTTP call can hit a 500 from a not-yet-ready
+ * backend and globalSetup's existing retry only covers transient network errors.
+ *
+ * The probe also doubles as a propagation check: if AUTH_E2E_TEST_SECRET didn't
+ * reach the backend (vite.config.ts envVars wiring), the call returns
+ * Unauthorized and we fail fast with a clear error.
+ */
+async function waitForBackendReady(client: ConvexHttpClient, secret: string): Promise<void> {
+	const TIMEOUT_MS = 90_000;
+	const POLL_INTERVAL_MS = 1000;
+	const start = Date.now();
+	let lastError: unknown;
+	console.log('[Setup] Waiting for Convex backend readiness (api.tests.health)...');
+	while (true) {
+		try {
+			const r = await client.query(api.tests.health, { secret });
+			if (r?.ok) {
+				console.log(`[Setup] Backend ready after ${Date.now() - start}ms`);
+				return;
+			}
+		} catch (err) {
+			lastError = err;
+		}
+		if (Date.now() - start > TIMEOUT_MS) {
+			console.error('[Setup] Last error from health probe:', lastError);
+			throw new Error(
+				`Test backend never reported ready (api.tests.health) within ${TIMEOUT_MS}ms`
+			);
+		}
+		await sleep(POLL_INTERVAL_MS);
+	}
+}
+
 async function globalSetup() {
 	const testSecret = process.env.AUTH_E2E_TEST_SECRET;
 	const convexUrl = resolveConvexUrl();
@@ -78,6 +119,10 @@ async function globalSetup() {
 	}
 
 	const client = new ConvexHttpClient(convexUrl);
+
+	// Gate user creation on real backend readiness (not just the vite port being open).
+	await waitForBackendReady(client, testSecret);
+
 	const timestamp = Date.now();
 
 	// Generate unique emails for this test run

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -86,6 +86,17 @@ async function waitForBackendReady(client: ConvexHttpClient, secret: string): Pr
 				return;
 			}
 		} catch (err) {
+			// Distinguish auth failure (config bug, fail fast) from cold-boot/network errors (retry).
+			// A backend that returns "Unauthorized" is already serving — polling won't fix it.
+			const message = err instanceof Error ? err.message : String(err);
+			if (message.includes('Unauthorized: Invalid test secret')) {
+				throw new Error(
+					'Test backend rejected AUTH_E2E_TEST_SECRET. The secret in .env.test does not ' +
+						'match what the backend received from vite.config.ts envVars. Check that ' +
+						'`bun run dev:test` is running and that AUTH_E2E_TEST_SECRET is set in .env.test.',
+					{ cause: err }
+				);
+			}
 			lastError = err;
 		}
 		if (Date.now() - start > TIMEOUT_MS) {

--- a/e2e/utils/convex-url.ts
+++ b/e2e/utils/convex-url.ts
@@ -4,18 +4,37 @@ import path from 'path';
 /**
  * Resolve the Convex backend URL.
  *
- * Priority:
- * 1. Env var PUBLIC_CONVEX_URL or VITE_CONVEX_URL (CI, cloud deployments)
- * 2. `.convex/.backend-url` file written by vite.config.ts (local dev)
+ * Local test mode (VARLOCK_ENV=test, no CI):
+ *   1. `.convex/.test-backend-url` (written by `bun run dev:test`)
+ *   2. `PUBLIC_CONVEX_URL` / `VITE_CONVEX_URL` env (fallback)
+ *   3. `.convex/.backend-url` (dev backend, last-resort fallback)
+ *
+ *   The file deliberately wins over env in local test mode so a stale cloud URL in
+ *   a developer's gitignored `.env.test` can't silently route "local" e2e at cloud
+ *   Convex while other plumbing points at the local stack.
+ *
+ * Everything else (CI, cloud, ad-hoc):
+ *   1. `PUBLIC_CONVEX_URL` / `VITE_CONVEX_URL` env (set by CI workflows)
+ *   2. `.convex/.backend-url` file written by vite.config.ts
  */
 export function resolveConvexUrl(): string | undefined {
+	const isLocalTest = process.env.VARLOCK_ENV === 'test' && !process.env.CI;
+	const testBackendFile = path.join(process.cwd(), '.convex', '.test-backend-url');
+	const devBackendFile = path.join(process.cwd(), '.convex', '.backend-url');
+
+	if (isLocalTest && fs.existsSync(testBackendFile)) {
+		const url = fs.readFileSync(testBackendFile, 'utf-8').trim();
+		if (url) {
+			console.log(`[E2E] Using isolated local test backend: ${url}`);
+			return url;
+		}
+	}
+
 	const envUrl = process.env.PUBLIC_CONVEX_URL || process.env.VITE_CONVEX_URL;
 	if (envUrl) return envUrl;
 
-	// Local dev: read URL written by vite.config.ts convex-vite-plugin
-	const backendUrlFile = path.join(process.cwd(), '.convex', '.backend-url');
-	if (fs.existsSync(backendUrlFile)) {
-		const url = fs.readFileSync(backendUrlFile, 'utf-8').trim();
+	if (fs.existsSync(devBackendFile)) {
+		const url = fs.readFileSync(devBackendFile, 'utf-8').trim();
 		if (url) {
 			console.log(`[E2E] Using local Convex backend: ${url}`);
 			return url;

--- a/e2e/utils/convex-url.ts
+++ b/e2e/utils/convex-url.ts
@@ -18,7 +18,11 @@ import path from 'path';
  *   2. `.convex/.backend-url` file written by vite.config.ts
  */
 export function resolveConvexUrl(): string | undefined {
-	const isLocalTest = process.env.VARLOCK_ENV === 'test' && !process.env.CI;
+	// E2E_OVERRIDE_SITE_URL signals the caller is targeting a developer-managed deployment;
+	// in that mode we want PUBLIC_CONVEX_URL (set alongside the override) to win, NOT a
+	// stale local .test-backend-url file from a previous dev:test run.
+	const isLocalTest =
+		process.env.VARLOCK_ENV === 'test' && !process.env.CI && !process.env.E2E_OVERRIDE_SITE_URL;
 	const testBackendFile = path.join(process.cwd(), '.convex', '.test-backend-url');
 	const devBackendFile = path.join(process.cwd(), '.convex', '.backend-url');
 

--- a/e2e/utils/site-url.ts
+++ b/e2e/utils/site-url.ts
@@ -1,0 +1,17 @@
+/**
+ * Resolve the site URL e2e tests should hit.
+ *
+ * Local test mode (no CI): hard-code the test vite port. We deliberately ignore
+ * PUBLIC_SITE_URL here because a stale gitignored .env.test could otherwise route
+ * signups to a cloud preview while the Convex resolver points at the local backend
+ * (asymmetric isolation = confusing failures).
+ *
+ * CI: workflow injects the real preview URL via PUBLIC_SITE_URL.
+ *
+ * Future explicit overrides should use a different variable name (e.g.
+ * E2E_OVERRIDE_SITE_URL) so the cloud-leftover trap can't reopen.
+ */
+export function resolveSiteUrl(): string {
+	if (!process.env.CI) return 'http://localhost:5174';
+	return process.env.PUBLIC_SITE_URL || 'http://localhost:5173';
+}

--- a/e2e/utils/site-url.ts
+++ b/e2e/utils/site-url.ts
@@ -1,17 +1,25 @@
 /**
+ * Single source of truth for the local test stack's vite port.
+ * Imported by scripts/dev-test.ts (where vite is spawned), playwright.config.ts
+ * (webServer + baseURL), and resolveSiteUrl below. Don't hardcode 5174 elsewhere.
+ */
+export const TEST_VITE_PORT = 5174;
+const TEST_BASE_URL = `http://localhost:${TEST_VITE_PORT}`;
+
+/**
  * Resolve the site URL e2e tests should hit.
  *
- * Local test mode (no CI): hard-code the test vite port. We deliberately ignore
- * PUBLIC_SITE_URL here because a stale gitignored .env.test could otherwise route
- * signups to a cloud preview while the Convex resolver points at the local backend
- * (asymmetric isolation = confusing failures).
- *
- * CI: workflow injects the real preview URL via PUBLIC_SITE_URL.
- *
- * Future explicit overrides should use a different variable name (e.g.
- * E2E_OVERRIDE_SITE_URL) so the cloud-leftover trap can't reopen.
+ * Order:
+ *   1. `E2E_OVERRIDE_SITE_URL` — explicit escape hatch for running the suite against a
+ *      developer-managed deployment (CF preview, staging, custom convex). Skips the local
+ *      dev:test stack entirely; pair with `PUBLIC_CONVEX_URL` for the matching backend.
+ *   2. Local test mode (no CI): hard-code the test vite port. Deliberately ignores
+ *      `PUBLIC_SITE_URL` so a stale gitignored .env.test can't asymmetrically misroute
+ *      signups while the Convex resolver points at the local backend.
+ *   3. CI: workflow injects the real preview URL via `PUBLIC_SITE_URL`.
  */
 export function resolveSiteUrl(): string {
-	if (!process.env.CI) return 'http://localhost:5174';
+	if (process.env.E2E_OVERRIDE_SITE_URL) return process.env.E2E_OVERRIDE_SITE_URL;
+	if (!process.env.CI) return TEST_BASE_URL;
 	return process.env.PUBLIC_SITE_URL || 'http://localhost:5173';
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"dev:frontend": "vite dev",
 		"dev:backend:cloud": "convex dev",
 		"dev:cloud": "bun-tasks dev:frontend ::: dev:backend:cloud",
+		"dev:test": "VARLOCK_ENV=test bun scripts/dev-test.ts",
 		"generate": "bun scripts/generate-convex.ts",
 		"postinstall": "bun svelte-kit sync && varlock typegen && varlock typegen --path .env-convex.schema && bun run build:emails",
 		"prebuild": "bun run build:emails",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,10 +6,12 @@ import { defineConfig, devices } from '@playwright/test';
  */
 import 'varlock/auto-load';
 import { getPreviewBypass } from './e2e/utils/preview-bypass';
+import { resolveSiteUrl } from './e2e/utils/site-url';
 
-// In CI, tests run against actual preview deployment (PUBLIC_SITE_URL set by workflow)
-// Locally, tests run against dev server on localhost
-const baseURL = process.env.PUBLIC_SITE_URL || 'http://localhost:5173';
+// CI: tests run against actual preview deployment (PUBLIC_SITE_URL set by workflow).
+// Local: forced to http://localhost:5174 (the test vite port spawned by `bun run dev:test`).
+// See e2e/utils/site-url.ts for why PUBLIC_SITE_URL is deliberately ignored locally.
+const baseURL = resolveSiteUrl();
 const isCI = !!process.env.CI;
 
 // Preview bypass headers for protected preview deployments (Vercel or Cloudflare Access)
@@ -108,14 +110,16 @@ export default defineConfig({
 		}
 	],
 
-	// Only start local dev server when not in CI
-	// In CI, we test against the actual preview deployment
+	// Local: spawn an isolated dev:test stack (separate vite port + Convex backend +
+	// state dir). reuseExistingServer is false so we never inherit a backend whose
+	// state we don't own. Cold backend boot can take ~60s, hence 90s timeout.
+	// CI: test against the actual preview deployment (no local server).
 	webServer: isCI
 		? undefined
 		: {
-				command: 'bun run dev:frontend',
-				port: 5173,
-				reuseExistingServer: true,
-				timeout: 60000
+				command: 'bun run dev:test',
+				port: 5174,
+				reuseExistingServer: false,
+				timeout: 90000
 			}
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,13 +6,16 @@ import { defineConfig, devices } from '@playwright/test';
  */
 import 'varlock/auto-load';
 import { getPreviewBypass } from './e2e/utils/preview-bypass';
-import { resolveSiteUrl } from './e2e/utils/site-url';
+import { resolveSiteUrl, TEST_VITE_PORT } from './e2e/utils/site-url';
 
 // CI: tests run against actual preview deployment (PUBLIC_SITE_URL set by workflow).
-// Local: forced to http://localhost:5174 (the test vite port spawned by `bun run dev:test`).
+// Local default: forced to the test vite port spawned by `bun run dev:test`.
+// E2E_OVERRIDE_SITE_URL: explicit escape hatch — point tests at a developer-managed
+// deployment (CF preview, staging, etc.) and skip the local dev:test webServer.
 // See e2e/utils/site-url.ts for why PUBLIC_SITE_URL is deliberately ignored locally.
 const baseURL = resolveSiteUrl();
 const isCI = !!process.env.CI;
+const hasOverrideUrl = !!process.env.E2E_OVERRIDE_SITE_URL;
 
 // Preview bypass headers for protected preview deployments (Vercel or Cloudflare Access)
 const bypass = getPreviewBypass();
@@ -110,16 +113,17 @@ export default defineConfig({
 		}
 	],
 
-	// Local: spawn an isolated dev:test stack (separate vite port + Convex backend +
-	// state dir). reuseExistingServer is false so we never inherit a backend whose
-	// state we don't own. Cold backend boot can take ~60s, hence 90s timeout.
-	// CI: test against the actual preview deployment (no local server).
-	webServer: isCI
-		? undefined
-		: {
-				command: 'bun run dev:test',
-				port: 5174,
-				reuseExistingServer: false,
-				timeout: 90000
-			}
+	// Local default: spawn an isolated dev:test stack (separate vite port + Convex backend
+	// + state dir). reuseExistingServer is false so we never inherit a backend whose state
+	// we don't own. Cold backend boot can take ~60s, hence 90s timeout.
+	// CI or E2E_OVERRIDE_SITE_URL: skip — caller manages the deployment under test.
+	webServer:
+		isCI || hasOverrideUrl
+			? undefined
+			: {
+					command: 'bun run dev:test',
+					port: TEST_VITE_PORT,
+					reuseExistingServer: false,
+					timeout: 90000
+				}
 });

--- a/scripts/dev-test.ts
+++ b/scripts/dev-test.ts
@@ -1,4 +1,7 @@
 import 'varlock/auto-load';
+import { TEST_VITE_PORT } from '../e2e/utils/site-url';
+
+const TEST_BASE_URL = `http://localhost:${TEST_VITE_PORT}`;
 
 if (process.env.PUBLIC_CONVEX_URL) {
 	console.warn(
@@ -7,23 +10,24 @@ if (process.env.PUBLIC_CONVEX_URL) {
 			`Remove PUBLIC_CONVEX_URL from .env.test to silence this warning.`
 	);
 }
-if (process.env.PUBLIC_SITE_URL && process.env.PUBLIC_SITE_URL !== 'http://localhost:5174') {
+if (process.env.PUBLIC_SITE_URL && process.env.PUBLIC_SITE_URL !== TEST_BASE_URL) {
 	console.warn(
 		`[dev:test] WARNING: PUBLIC_SITE_URL=${process.env.PUBLIC_SITE_URL} is set. ` +
-			`Local test mode forces http://localhost:5174 — see e2e/utils/site-url.ts.`
+			`Local test mode forces ${TEST_BASE_URL} — see e2e/utils/site-url.ts.`
 	);
 }
 
 process.env.npm_lifecycle_event = 'dev:test';
 
-// --strictPort: vite's default is to find the next free port if 5174 is taken; that would
-// silently start a second test backend on :5175 and break playwright's port expectation.
+// --strictPort: vite's default is to find the next free port if TEST_VITE_PORT is taken;
+// that would silently start a second test backend on a different port and break
+// playwright's port expectation.
 // We deliberately do NOT pass --host. Vite's default host is `localhost`, which makes
-// resolvedUrls.local[0] resolve to `http://localhost:5174/`. That value is forwarded as
+// resolvedUrls.local[0] resolve to `${TEST_BASE_URL}/`. That value is forwarded as
 // SITE_URL into the Convex backend (vite.config.ts envVars callback) and becomes the
-// trustedOrigin for BetterAuth. Test setup sends Origin: http://localhost:5174 — the
+// trustedOrigin for BetterAuth. Test setup sends Origin: ${TEST_BASE_URL} — the
 // hostnames must match. Forcing --host 127.0.0.1 here breaks BetterAuth's origin check.
-const child = Bun.spawn(['vite', 'dev', '--port', '5174', '--strictPort'], {
+const child = Bun.spawn(['vite', 'dev', '--port', String(TEST_VITE_PORT), '--strictPort'], {
 	stdio: ['inherit', 'inherit', 'inherit']
 });
 

--- a/scripts/dev-test.ts
+++ b/scripts/dev-test.ts
@@ -1,0 +1,41 @@
+import 'varlock/auto-load';
+
+if (process.env.PUBLIC_CONVEX_URL) {
+	console.warn(
+		`[dev:test] WARNING: PUBLIC_CONVEX_URL=${process.env.PUBLIC_CONVEX_URL} is set in your env. ` +
+			`Local test backend file (.convex/.test-backend-url) will be used instead — see e2e/utils/convex-url.ts. ` +
+			`Remove PUBLIC_CONVEX_URL from .env.test to silence this warning.`
+	);
+}
+if (process.env.PUBLIC_SITE_URL && process.env.PUBLIC_SITE_URL !== 'http://localhost:5174') {
+	console.warn(
+		`[dev:test] WARNING: PUBLIC_SITE_URL=${process.env.PUBLIC_SITE_URL} is set. ` +
+			`Local test mode forces http://localhost:5174 — see e2e/utils/site-url.ts.`
+	);
+}
+
+process.env.npm_lifecycle_event = 'dev:test';
+
+// --strictPort: vite's default is to find the next free port if 5174 is taken; that would
+// silently start a second test backend on :5175 and break playwright's port expectation.
+// We deliberately do NOT pass --host. Vite's default host is `localhost`, which makes
+// resolvedUrls.local[0] resolve to `http://localhost:5174/`. That value is forwarded as
+// SITE_URL into the Convex backend (vite.config.ts envVars callback) and becomes the
+// trustedOrigin for BetterAuth. Test setup sends Origin: http://localhost:5174 — the
+// hostnames must match. Forcing --host 127.0.0.1 here breaks BetterAuth's origin check.
+const child = Bun.spawn(['vite', 'dev', '--port', '5174', '--strictPort'], {
+	stdio: ['inherit', 'inherit', 'inherit']
+});
+
+const onSignal = (signal: NodeJS.Signals) => {
+	try {
+		child.kill(signal);
+	} catch {
+		/* already dead */
+	}
+};
+process.on('SIGINT', () => onSignal('SIGINT'));
+process.on('SIGTERM', () => onSignal('SIGTERM'));
+
+const code = await child.exited;
+process.exit(code ?? 0);

--- a/src/lib/convex/tests.ts
+++ b/src/lib/convex/tests.ts
@@ -1,5 +1,5 @@
 import { components } from './_generated/api';
-import { mutation, internalQuery } from './_generated/server';
+import { query, mutation, internalQuery } from './_generated/server';
 import { v } from 'convex/values';
 import { supportAgent } from './support/agent';
 import { isAnonymousUser } from './utils/anonymousUser';
@@ -15,6 +15,25 @@ function requireTestSecret(secret: string): void {
 		throw new Error('Unauthorized: Invalid test secret');
 	}
 }
+
+/**
+ * Health probe used by e2e/global-setup.ts to gate the first signup HTTP call
+ * on actual Convex backend readiness. The convex-vite-plugin starts backend
+ * deploy asynchronously after vite begins serving, so a cold backend can 500
+ * even though Playwright's webServer port-check has already succeeded.
+ *
+ * Gated by AUTH_E2E_TEST_SECRET so it doubles as a propagation check: if the
+ * secret didn't reach the backend (vite.config.ts envVars wiring), this
+ * returns Unauthorized and globalSetup fails fast with a clear error.
+ */
+export const health = query({
+	args: { secret: v.string() },
+	returns: v.object({ ok: v.boolean() }),
+	handler: async (_ctx, { secret }) => {
+		requireTestSecret(secret);
+		return { ok: true };
+	}
+});
 
 function buildSearchText(fields: {
 	title?: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,8 +60,12 @@ function computeLocalConvexStateId(projectDir: string, suffix?: string): string 
 	return `${sanitizedBranch}${sanitizedSuffix}-${hash}`;
 }
 
-function getPersistentBetterAuthSecret(projectDir: string, reset: boolean): string {
-	const stateId = computeLocalConvexStateId(projectDir);
+function getPersistentBetterAuthSecret(
+	projectDir: string,
+	reset: boolean,
+	suffix?: string
+): string {
+	const stateId = computeLocalConvexStateId(projectDir, suffix);
 	const stateDir = path.join(projectDir, '.convex', stateId);
 	const secretPath = path.join(stateDir, 'better-auth-secret');
 
@@ -168,10 +172,13 @@ function parseSensitiveVarNames(schemaPath: string): Set<string> {
 export default defineConfig(async ({ mode }) => {
 	const cwd = process.cwd();
 	const loadedEnv = loadEnv(mode, cwd, '');
-	// Local Convex backend only during `bun run dev` (not CI, builds, postinstall, or scripts).
+	// Local Convex backend during `bun run dev` and `bun run dev:test` (not CI, builds, postinstall, or scripts).
 	// build:emails uses createServer() which re-enters this config -- lifecycle check prevents that.
 	// dev:cloud runs via dev:frontend (lifecycle = "dev:frontend"), so it's excluded naturally.
-	const useLocalConvex = process.env.npm_lifecycle_event === 'dev' && !process.env.CI;
+	const lifecycle = process.env.npm_lifecycle_event;
+	const useLocalConvex = (lifecycle === 'dev' || lifecycle === 'dev:test') && !process.env.CI;
+	const isTestMode = lifecycle === 'dev:test';
+	const stateIdSuffix = isTestMode ? 'e2e' : undefined;
 	const plugins: PluginOption[] = [];
 
 	if (useLocalConvex) {
@@ -181,12 +188,16 @@ export default defineConfig(async ({ mode }) => {
 		const siteProxyUrl = `http://localhost:${siteProxyPort}`;
 		const resetLocalBackend = process.env.RESET_LOCAL_BACKEND === 'true';
 
-		// Write backend URL so E2E tests (Playwright) can discover it
+		// Write backend URL so E2E tests (Playwright) can discover it.
+		// Test mode writes to a separate file so dev's .backend-url isn't clobbered when
+		// `bun run dev` and `bun run dev:test` run concurrently.
 		const convexStateDir = path.join(cwd, '.convex');
 		fs.mkdirSync(convexStateDir, { recursive: true });
-		fs.writeFileSync(path.join(convexStateDir, '.backend-url'), backendUrl);
+		const backendUrlFile = isTestMode ? '.test-backend-url' : '.backend-url';
+		fs.writeFileSync(path.join(convexStateDir, backendUrlFile), backendUrl);
 		const betterAuthSecret =
-			loadedEnv.BETTER_AUTH_SECRET?.trim() || getPersistentBetterAuthSecret(cwd, resetLocalBackend);
+			loadedEnv.BETTER_AUTH_SECRET?.trim() ||
+			getPersistentBetterAuthSecret(cwd, resetLocalBackend, stateIdSuffix);
 
 		// Load Convex backend env vars from .env.convex.local
 		const convexLocalEnv = parseEnvFile(path.join(cwd, '.env.convex.local'));
@@ -196,6 +207,7 @@ export default defineConfig(async ({ mode }) => {
 		// the Convex backend values marked @sensitive in .env-convex.schema.
 		const convexSensitiveNames = parseSensitiveVarNames(path.join(cwd, '.env-convex.schema'));
 		convexSensitiveNames.add('BETTER_AUTH_SECRET');
+		convexSensitiveNames.add('AUTH_E2E_TEST_SECRET');
 
 		const mergedConfig: Record<string, { value: any; isSensitive: boolean }> = {
 			...varlockLoadedEnv?.config
@@ -204,7 +216,10 @@ export default defineConfig(async ({ mode }) => {
 		const allConvexEnvVars: Record<string, string> = {
 			BETTER_AUTH_SECRET: betterAuthSecret,
 			LOCAL_SEEDED_ADMIN_PASSWORD: 'LocalDevAdmin123!',
-			...convexLocalEnv
+			...convexLocalEnv,
+			...(isTestMode && process.env.AUTH_E2E_TEST_SECRET
+				? { AUTH_E2E_TEST_SECRET: process.env.AUTH_E2E_TEST_SECRET }
+				: {})
 		};
 
 		for (const [key, value] of Object.entries(allConvexEnvVars)) {
@@ -245,6 +260,7 @@ export default defineConfig(async ({ mode }) => {
 				convexDir: 'src/lib/convex',
 				port: backendPort,
 				siteProxyPort,
+				stateIdSuffix,
 				reset: resetLocalBackend,
 				onReady: [{ name: 'localDev:ensureSeededAdmin' }],
 				envVars: ({ vitePort, resolvedUrls }) => {
@@ -258,7 +274,12 @@ export default defineConfig(async ({ mode }) => {
 						LOCAL_SEEDED_ADMIN_PASSWORD: 'LocalDevAdmin123!',
 						LOCAL_SEEDED_ADMIN_NAME: 'Local Admin',
 						// User overrides from .env.convex.local (takes precedence)
-						...convexLocalEnv
+						...convexLocalEnv,
+						// Test mode: forward AUTH_E2E_TEST_SECRET so api.tests.* mutations
+						// authorize correctly. Source: process.env loaded from .env.test by varlock.
+						...(isTestMode && process.env.AUTH_E2E_TEST_SECRET
+							? { AUTH_E2E_TEST_SECRET: process.env.AUTH_E2E_TEST_SECRET }
+							: {})
 					};
 				}
 			})


### PR DESCRIPTION
## Summary

Local e2e was silently routed at the cloud Convex deployment because Playwright spawned `bun run dev:frontend`, whose lifecycle event did not match `vite.config.ts:174`'s gate that starts the embedded local Convex backend. The previous `.env.test` workaround (cloud URLs hard-coded) hid bugs and polluted shared cloud state. This PR introduces an isolated test stack that runs alongside `bun run dev` with zero collisions.

**One command:** `bun run test:e2e` now spawns `bun run dev:test`, which boots a separate vite (`:5174`), separate local Convex backend (random port + isolated state dir under `.convex/<branch>...e2e-<hash>/`), and a separate BetterAuth secret file. Tests never touch dev data.

## Key changes

- **`scripts/dev-test.ts`** + `dev:test` package script — varlock loads `.env.test` (priming `VARLOCK_ENV` before any imports), warns loudly if stale `PUBLIC_CONVEX_URL` / `PUBLIC_SITE_URL` leftovers exist, sets `npm_lifecycle_event=dev:test` deterministically, spawns vite with `--strictPort` on `:5174`, forwards `SIGINT`/`SIGTERM`, propagates exit code.
- **`vite.config.ts`** — gate widened to also accept `dev:test`; threads `'e2e'` `stateIdSuffix` through `convexLocal()` AND `getPersistentBetterAuthSecret`; `AUTH_E2E_TEST_SECRET` is forwarded into the backend via the `convexLocal({ envVars })` callback (the actual backend env source) and added to the redaction map; test mode writes `.convex/.test-backend-url`.
- **`playwright.config.ts`** — spawns `dev:test` on `:5174` with `reuseExistingServer: false`; forces `baseURL` to `http://localhost:5174` in local mode regardless of `PUBLIC_SITE_URL`.
- **`e2e/utils/site-url.ts`** (new) — shared helper centralises localhost forcing; used by `global-setup.ts` and `admin-users-table.spec.ts`.
- **`e2e/utils/convex-url.ts`** — env-var precedence inverted in local test mode so `.test-backend-url` wins over a stale `PUBLIC_CONVEX_URL`.
- **`api.tests.health`** Convex query gates `globalSetup` on real backend readiness (90s budget, ~1s polling). Closes the cold-boot race + doubles as a test-secret propagation check.
- **`.env.test`** simplified: `AUTH_E2E_TEST_SECRET` only.
- **`AGENTS.md`** — Local e2e isolation subsection added.

## Test plan

- [x] `bun run check:convex` — clean
- [x] `bun scripts/static-checks.ts` on all 10 changed files — clean
- [x] Sanity boot — vite on :5174, backend on random port, state dir suffixed `-e2e-`, BetterAuth secret in suffixed dir, `AUTH_E2E_TEST_SECRET` reaches backend (verified via `api.tests.health` round-trip with right + wrong secrets)
- [x] `bun run test:e2e -- ai-chat support-migration` — **9/9 passed in 47s** against the isolated backend (these were the suites broken before)
- [x] Wrapper exit-code propagation — second `bun run dev:test` exits with code 1 (`Port 5174 is already in use`), confirming `--strictPort` + `process.exit(await child.exited)`
- [x] Wrapper signal forwarding — Ctrl+C cleanly stops vite, no orphan listener on :5174
- [x] Stale-URL canary — both warnings fire as designed when `PUBLIC_CONVEX_URL` / `PUBLIC_SITE_URL` are still present in `.env.test`
- [ ] CI green (CF Preview e2e workflow — should be unchanged since the local-only branches are gated on `!process.env.CI`)