### PR TITLE
chore(deps): bump @mmailaender/convex-better-auth-svelte to 0.7.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@gilhrpenner/convex-files-control": "^0.5.1",
         "@humanspeak/svelte-markdown": "^1.0.4",
         "@jsquash/webp": "^1.5.0",
-        "@mmailaender/convex-better-auth-svelte": "^0.7.3",
+        "@mmailaender/convex-better-auth-svelte": "^0.7.4",
         "@openrouter/ai-sdk-provider": "^2.9.0",
         "@rive-app/canvas": "^2.32.0",
         "@sentry/sveltekit": "^10.47.0",
@@ -585,7 +585,7 @@
 
     "@mishieck/ink-titled-box": ["@mishieck/ink-titled-box@0.3.0", "", { "peerDependencies": { "ink": "^6.0.0", "react": "^19.1.0", "typescript": "^5" } }, "sha512-ugzVH9hixp3hwKfQ8On/qnsrdAxS3y9rTu/aGOFed4zVUvtZyGZNIR4rxAwXult8HKI4vJEh0OM8wib9NPrwUg=="],
 
-    "@mmailaender/convex-better-auth-svelte": ["@mmailaender/convex-better-auth-svelte@0.7.3", "", { "dependencies": { "is-network-error": "^1.3.0" }, "peerDependencies": { "@convex-dev/better-auth": ">=0.10.10", "@mmailaender/convex-svelte": ">=0.15.0", "better-auth": "^1.4.9", "convex": "^1.31.0", "svelte": "^5.0.0" } }, "sha512-wRT1B1etTPWanZSDkXeUGU467+Ux0KF8gvVC/YDqSwzcswxYe3Jkb+1rcsfoQcIrLiW/1lnMRMAJZa9aPd8plQ=="],
+    "@mmailaender/convex-better-auth-svelte": ["@mmailaender/convex-better-auth-svelte@0.7.4", "", { "dependencies": { "is-network-error": "^1.3.0" }, "peerDependencies": { "@convex-dev/better-auth": ">=0.10.10", "@mmailaender/convex-svelte": ">=0.15.0", "better-auth": "^1.4.9", "convex": "^1.31.0", "svelte": "^5.0.0" } }, "sha512-FySN4W53X6+jb1jNaDHRvqtqpAqeY5ZE0bStEcszuTVOu731VPIu6cu4aL9vzYcpYhDVv6PCnF6N2u3MVd2aUA=="],
 
     "@mmailaender/convex-svelte": ["@mmailaender/convex-svelte@0.18.0", "", { "dependencies": { "esm-env": "^1.2.2", "runed": "^0.37.1" }, "peerDependencies": { "convex": ">1.10.0", "svelte": ">=5.36.0" } }, "sha512-2dv4cQjThk2Hs9BRrvKv8xc/Z6GqZP428uV9OTzVYBHih65uTF+/r3cqnEnDJv34H2Rr7TOHrfpCu/9aXP2yUg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"@gilhrpenner/convex-files-control": "^0.5.1",
 		"@humanspeak/svelte-markdown": "^1.0.4",
 		"@jsquash/webp": "^1.5.0",
-		"@mmailaender/convex-better-auth-svelte": "^0.7.3",
+		"@mmailaender/convex-better-auth-svelte": "^0.7.4",
 		"@openrouter/ai-sdk-provider": "^2.9.0",
 		"@rive-app/canvas": "^2.32.0",
 		"@sentry/sveltekit": "^10.47.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -359,8 +359,9 @@ export default defineConfig(async ({ mode }) => {
 				// files. Without this, they import svelte/server fresh at runtime, get a
 				// separate `ssr_context` variable, and `setContext` throws
 				// `lifecycle_outside_component` even though we ARE in a component init.
+				// @mmailaender/convex-better-auth-svelte (>=0.7.4) ships a top-level `"svelte"`
+				// field, so SvelteKit auto-bundles it without needing it here.
 				'@mmailaender/convex-svelte',
-				'@mmailaender/convex-better-auth-svelte',
 				'@stickerdaniel/convex-autumn-svelte',
 				// WASM image codec used by the image-processing worker. Bundling avoids
 				// SSR-time `import 'svelte'`-style hazards if the package adds main-thread


### PR DESCRIPTION
## Summary

- Bumps \`@mmailaender/convex-better-auth-svelte\` 0.7.3 → 0.7.4
- 0.7.4 ships a top-level \`\"svelte\"\` field ([mmailaender/convex-better-auth-svelte#28](https://github.com/mmailaender/convex-better-auth-svelte/issues/28)) so SvelteKit's auto-detect treats it as a Svelte component library and applies \`ssr.noExternal\` automatically
- Removes the now-redundant explicit \`'@mmailaender/convex-better-auth-svelte'\` entry from \`ssr.noExternal\` in \`vite.config.ts\`

\`@mmailaender/convex-svelte\` (the npm-aliased package) and \`@stickerdaniel/convex-autumn-svelte\` still need the manual entry — verified by build failure when removing them.

## Test plan

- [x] \`bun run build:emails\` ✅
- [x] \`bun run build\` (prerenders marketing pages — would throw \`lifecycle_outside_component\` if SSR context bug returned) ✅
- [x] \`bun scripts/static-checks.ts\` all checks pass
- [ ] Workers Builds preview deploys green
- [ ] CI checks (lint, type, unit, E2E) green