### PR TITLE
fix(breadcrumb): render all intermediate route segments

### DIFF
--- a/src/lib/components/authenticated/authenticated-header.svelte
+++ b/src/lib/components/authenticated/authenticated-header.svelte
@@ -7,7 +7,7 @@
 	import LanguageSwitcher from '$lib/components/LanguageSwitcher.svelte';
 	import LightSwitch from '$lib/components/ui/light-switch/light-switch.svelte';
 	import CommandTrigger from '$lib/components/global-search/command-trigger.svelte';
-	import { localizedHref } from '$lib/utils/i18n';
+	import { buildBreadcrumbs } from './breadcrumbs';
 	import { getTranslate } from '@tolgee/svelte';
 
 	const { t } = getTranslate();
@@ -19,44 +19,9 @@
 
 	let { routePrefix, rootLabel }: Props = $props();
 
-	// Create breadcrumb items based on current route
-	const breadcrumbs = $derived.by(() => {
-		const pathname = page.url.pathname;
-		const segments = pathname.split('/').filter(Boolean);
-
-		if (segments.length === 0) return [];
-
-		const items: { label: string; href: string; isLast: boolean }[] = [];
-
-		// Check if current route matches the prefix
-		const first = segments[0]!;
-		if (first === routePrefix || (first.length === 2 && segments[1] === routePrefix)) {
-			items.push({
-				label: rootLabel,
-				href: localizedHref(`/${routePrefix}`),
-				isLast: segments.length === 1 || (first.length === 2 && segments.length === 2)
-			});
-
-			// Add subsequent segments (skip language segment if present)
-			const prefixSegmentIndex = first === routePrefix ? 0 : 1;
-			if (segments.length > prefixSegmentIndex + 1) {
-				const lastSegment = segments[segments.length - 1]!;
-				// Format the segment name (e.g., "community-chat" -> "Community Chat")
-				const formattedLabel = lastSegment
-					.split('-')
-					.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-					.join(' ');
-
-				items.push({
-					label: formattedLabel,
-					href: pathname,
-					isLast: true
-				});
-			}
-		}
-
-		return items;
-	});
+	const breadcrumbs = $derived(
+		buildBreadcrumbs(page.url.pathname, routePrefix, rootLabel, page.params.lang)
+	);
 </script>
 
 <header

--- a/src/lib/components/authenticated/breadcrumbs.test.ts
+++ b/src/lib/components/authenticated/breadcrumbs.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { buildBreadcrumbs } from './breadcrumbs';
+
+describe('buildBreadcrumbs', () => {
+	it('returns the root crumb only for the bare prefix with a language segment', () => {
+		expect(buildBreadcrumbs('/en/app', 'app', 'App', 'en')).toEqual([
+			{ label: 'App', href: '/en/app', isLast: true }
+		]);
+	});
+
+	it('returns the root crumb only for the bare prefix without a language segment', () => {
+		expect(buildBreadcrumbs('/app', 'app', 'App', 'en')).toEqual([
+			{ label: 'App', href: '/en/app', isLast: true }
+		]);
+	});
+
+	it('renders a 2-level path with the leaf marked isLast', () => {
+		expect(buildBreadcrumbs('/en/app/settings', 'app', 'App', 'en')).toEqual([
+			{ label: 'App', href: '/en/app', isLast: false },
+			{ label: 'Settings', href: '/en/app/settings', isLast: true }
+		]);
+	});
+
+	it('renders all intermediate segments for a 3-level path with cumulative hrefs', () => {
+		expect(buildBreadcrumbs('/en/app/settings/sessions', 'app', 'App', 'en')).toEqual([
+			{ label: 'App', href: '/en/app', isLast: false },
+			{ label: 'Settings', href: '/en/app/settings', isLast: false },
+			{ label: 'Sessions', href: '/en/app/settings/sessions', isLast: true }
+		]);
+	});
+
+	it('preserves a non-default locale across all hrefs', () => {
+		expect(buildBreadcrumbs('/de/app/settings/sessions', 'app', 'App', 'de')).toEqual([
+			{ label: 'App', href: '/de/app', isLast: false },
+			{ label: 'Settings', href: '/de/app/settings', isLast: false },
+			{ label: 'Sessions', href: '/de/app/settings/sessions', isLast: true }
+		]);
+	});
+
+	it('falls back to the default language when lang is undefined', () => {
+		expect(buildBreadcrumbs('/app/settings', 'app', 'App', undefined)).toEqual([
+			{ label: 'App', href: '/en/app', isLast: false },
+			{ label: 'Settings', href: '/en/app/settings', isLast: true }
+		]);
+	});
+
+	it('formats kebab-case segments to title case', () => {
+		expect(buildBreadcrumbs('/en/app/community-chat', 'app', 'App', 'en')).toEqual([
+			{ label: 'App', href: '/en/app', isLast: false },
+			{ label: 'Community Chat', href: '/en/app/community-chat', isLast: true }
+		]);
+	});
+
+	it('renders a 4-level path with cumulative hrefs through dynamic-looking segments', () => {
+		expect(buildBreadcrumbs('/en/admin/users/abc-123/members', 'admin', 'Admin', 'en')).toEqual([
+			{ label: 'Admin', href: '/en/admin', isLast: false },
+			{ label: 'Users', href: '/en/admin/users', isLast: false },
+			{ label: 'Abc 123', href: '/en/admin/users/abc-123', isLast: false },
+			{ label: 'Members', href: '/en/admin/users/abc-123/members', isLast: true }
+		]);
+	});
+
+	it('returns an empty array when the prefix does not match', () => {
+		expect(buildBreadcrumbs('/en/marketing', 'app', 'App', 'en')).toEqual([]);
+	});
+
+	it('returns an empty array for the root path', () => {
+		expect(buildBreadcrumbs('/', 'app', 'App', 'en')).toEqual([]);
+	});
+});

--- a/src/lib/components/authenticated/breadcrumbs.ts
+++ b/src/lib/components/authenticated/breadcrumbs.ts
@@ -1,0 +1,54 @@
+import { getLanguage } from '$lib/i18n/languages';
+import { localizedHref } from '$lib/utils/i18n';
+
+export interface BreadcrumbItem {
+	label: string;
+	href: string;
+	isLast: boolean;
+}
+
+function formatSegment(segment: string): string {
+	return segment
+		.split('-')
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(' ');
+}
+
+export function buildBreadcrumbs(
+	pathname: string,
+	routePrefix: string,
+	rootLabel: string,
+	lang: string | undefined
+): BreadcrumbItem[] {
+	const segments = pathname.split('/').filter(Boolean);
+	if (segments.length === 0) return [];
+
+	// Match the existing heuristic: treat any 2-char first segment as a language prefix.
+	// SvelteKit's [[lang]] matcher upstream restricts this to supported codes in practice.
+	const first = segments[0]!;
+	const prefixSegmentIndex = first.length === 2 && segments.length > 1 ? 1 : 0;
+
+	if (segments[prefixSegmentIndex] !== routePrefix) return [];
+
+	const currentLang = getLanguage(lang).code;
+	const lastIndex = segments.length - 1;
+
+	const items: BreadcrumbItem[] = [
+		{
+			label: rootLabel,
+			href: localizedHref(`/${routePrefix}`, currentLang),
+			isLast: prefixSegmentIndex === lastIndex
+		}
+	];
+
+	for (let i = prefixSegmentIndex + 1; i <= lastIndex; i += 1) {
+		const cumulativePath = `/${segments.slice(prefixSegmentIndex, i + 1).join('/')}`;
+		items.push({
+			label: formatSegment(segments[i]!),
+			href: localizedHref(cumulativePath, currentLang),
+			isLast: i === lastIndex
+		});
+	}
+
+	return items;
+}


### PR DESCRIPTION
Closes #360

The authenticated header breadcrumb only rendered the root crumb plus the leaf segment, dropping every segment in between. So `/en/app/settings/sessions` showed `App › Sessions` instead of `App › Settings › Sessions`. The leaf also linked to the full current URL instead of its own cumulative path, so once intermediates existed they would have pointed at the wrong place too. No shipped route is currently deeper than two levels under `/app` or `/admin`, but this blocks every planned nested route (e.g. `/app/settings/sessions`, `/admin/users/<id>/members`).

Extract the derivation into a pure helper `buildBreadcrumbs(pathname, routePrefix, rootLabel, lang)` that iterates every segment after the prefix and builds cumulative `href`s, so intermediates link to parent pages. The helper takes `lang: string | undefined` (matches `[[lang]]` `RouteParams`) and normalizes via `getLanguage(lang).code` before passing to the explicit `localizedHref(path, lang)` overload, so it stays free of ambient `$app/state`. Cover the behavior with unit tests for mismatched prefix, root path, kebab-case formatting, missing/non-default language, and 3- and 4-level paths with cumulative hrefs.

`bun run test:unit -- breadcrumbs` passes (10/10). `bun scripts/static-checks.ts` clean for the touched files.