### PR TITLE
fix(env): default SITE_URL to localhost in convex example

### DIFF
--- a/.env.convex.example
+++ b/.env.convex.example
@@ -76,8 +76,9 @@ AUTH_GITHUB_SECRET=
 # Base URL for OAuth redirects and deep links (can be preview URL)
 # Auto-derived from VERCEL_URL for preview deployments
 # Note: For email images, use EMAIL_ASSET_URL (always production)
-# Command: bunx convex env set SITE_URL https://yourapp.com
-SITE_URL=https://yourapp.com
+# Local dev default: http://localhost:5173 (matches `bun run dev`)
+# For cloud/prod, set via: bunx convex env set SITE_URL https://yourapp.com
+SITE_URL=http://localhost:5173
 
 # ====================================
 # E2E Testing (REQUIRED for test setup)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Local dev notes (`bun run dev`):
 - Local seeded admin credentials: `admin@local.dev` / `LocalDevAdmin123!`
 - Convex backend env vars are loaded from `.env.convex.local` (optional services like email, OAuth, billing, AI).
 - `RESEND_API_KEY` and `AUTH_EMAIL` in `.env.convex.local` are only needed for real signup, verification, and password reset email flows.
+- `SITE_URL` in `.env.convex.local` must point to your local dev origin (`http://localhost:5173`). The default in `.env.convex.example` is already set for this. A production URL here breaks the admin sign-in via Better Auth.
 - Local Convex state is isolated per branch/worktree under `.convex/`.
 - `RESET_LOCAL_BACKEND=true bun run dev` clears the existing local Convex state before startup and restores the default seeded admin credentials.
 


### PR DESCRIPTION
Closes #365

Copying `.env.convex.example` to `.env.convex.local` left `SITE_URL=https://yourapp.com` as the local-dev default, which silently breaks Better Auth admin sign-in on the embedded backend (callback URL mismatch). The Convex-side env file is gitignored, so every fresh checkout reproduces the same trap.

Default `SITE_URL` in the example to `http://localhost:5173` to match `bun run dev`, and keep the cloud override discoverable via the existing comment (`bunx convex env set SITE_URL https://yourapp.com`). Added a one-liner under `AGENTS.md` "Local dev notes" so the constraint shows up where the rest of the local-backend gotchas live.

Static checks pass locally.