### PR TITLE
feat(env): surface gated feature names in requireEnv errors

### DIFF
--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -303,9 +303,9 @@ function buildTrustedOrigins(): string[] {
 // Creates Better Auth options object (used by adapter and betterAuth CLI)
 export const createAuthOptions = (ctx: GenericCtx<DataModel>): BetterAuthOptions => {
 	return {
-		baseURL: requireEnv('SITE_URL'),
+		baseURL: requireEnv('SITE_URL', { feature: 'Better Auth base URL' }),
 		trustedOrigins: buildTrustedOrigins(),
-		secret: requireEnv('BETTER_AUTH_SECRET'),
+		secret: requireEnv('BETTER_AUTH_SECRET', { feature: 'Better Auth session signing' }),
 		database: authComponent.adapter(ctx),
 		user: {
 			additionalFields: {

--- a/src/lib/convex/autumn.ts
+++ b/src/lib/convex/autumn.ts
@@ -3,7 +3,7 @@ import { components } from './_generated/api';
 import { authComponent } from './auth';
 import { requireEnv } from './env';
 
-const secretKey = requireEnv('AUTUMN_SECRET_KEY');
+const secretKey = requireEnv('AUTUMN_SECRET_KEY', { feature: 'billing & checkout' });
 
 export const autumn = new Autumn(components.autumn, {
 	secretKey,

--- a/src/lib/convex/emails/resend.ts
+++ b/src/lib/convex/emails/resend.ts
@@ -1,5 +1,6 @@
 import { components, internal } from '../_generated/api';
 import { Resend } from '@convex-dev/resend';
+import { requireEnv } from '../env';
 
 /**
  * Resend email client configured for the application.
@@ -37,18 +38,13 @@ export const resend: Resend = new Resend(components.resend, {
  * email ever arrives. Calling this at the top of every email-sending handler
  * converts that silent hang into an immediate, named failure in Convex logs.
  *
- * AUTH_EMAIL presence is already covered by `requireEnv('AUTH_EMAIL', ...)` in
- * each handler's `from` argument; this helper only guards the API key.
+ * Delegates to `requireEnv` so the error format and docs path stay in one
+ * place. AUTH_EMAIL presence is covered separately by `requireEnv('AUTH_EMAIL',
+ * ...)` in each handler's `from` argument.
  */
 export function assertResendApiKey(): void {
-	if (process.env.RESEND_API_KEY) return;
 	// E2E test runs propagate AUTH_E2E_TEST_SECRET into the Convex backend
 	// (vite.config.ts) and intentionally do not configure Resend. Stay quiet there.
 	if (process.env.AUTH_E2E_TEST_SECRET) return;
-
-	throw new Error(
-		`[env] Missing RESEND_API_KEY (needed for: email delivery)\n` +
-			`  Fix: bunx convex env set RESEND_API_KEY <value>\n` +
-			`  See: .env.convex.example`
-	);
+	requireEnv('RESEND_API_KEY', { feature: 'email delivery' });
 }

--- a/src/lib/convex/emails/resend.ts
+++ b/src/lib/convex/emails/resend.ts
@@ -27,3 +27,28 @@ export const resend: Resend = new Resend(components.resend, {
 	// Webhook callback for email events (delivered, bounced, complained, opened, clicked)
 	onEmailEvent: internal.emails.events.handleEmailEvent
 });
+
+/**
+ * Throws a loud, copy-paste-friendly error when RESEND_API_KEY is not set.
+ *
+ * Without this preflight, the Resend SDK accepts the send call and queues it,
+ * but the actual API call fails inside the component's workpool. The Better
+ * Auth verify-email flow then "succeeds" from the user's perspective while no
+ * email ever arrives. Calling this at the top of every email-sending handler
+ * converts that silent hang into an immediate, named failure in Convex logs.
+ *
+ * AUTH_EMAIL presence is already covered by `requireEnv('AUTH_EMAIL', ...)` in
+ * each handler's `from` argument; this helper only guards the API key.
+ */
+export function assertResendApiKey(): void {
+	if (process.env.RESEND_API_KEY) return;
+	// E2E test runs propagate AUTH_E2E_TEST_SECRET into the Convex backend
+	// (vite.config.ts) and intentionally do not configure Resend. Stay quiet there.
+	if (process.env.AUTH_E2E_TEST_SECRET) return;
+
+	throw new Error(
+		`[env] Missing RESEND_API_KEY (needed for: email delivery)\n` +
+			`  Fix: bunx convex env set RESEND_API_KEY <value>\n` +
+			`  See: .env.convex.example`
+	);
+}

--- a/src/lib/convex/emails/send.ts
+++ b/src/lib/convex/emails/send.ts
@@ -1,7 +1,7 @@
 import { internalMutation } from '../_generated/server';
 import { v } from 'convex/values';
 import { components, internal } from '../_generated/api';
-import { resend } from './resend';
+import { resend, assertResendApiKey } from './resend';
 import {
 	renderVerificationEmail,
 	renderPasswordResetEmail,
@@ -50,12 +50,13 @@ export const sendVerificationEmail = internalMutation({
 		const { email, verificationUrl, expiryMinutes = 20 } = args;
 
 		if (shouldSkipTestEmail('sendVerificationEmail', email)) return;
+		assertResendApiKey();
 
 		const locale = await getLocaleForEmail(ctx, email);
 		const { html, text } = renderVerificationEmail(verificationUrl, expiryMinutes);
 
 		await resend.sendEmail(ctx, {
-			from: requireEnv('AUTH_EMAIL'),
+			from: requireEnv('AUTH_EMAIL', { feature: 'email delivery' }),
 			to: email,
 			subject: t(locale, 'email.subject.verify'),
 			html,
@@ -85,12 +86,13 @@ export const sendResetPasswordEmail = internalMutation({
 		const { email, resetUrl, userName } = args;
 
 		if (shouldSkipTestEmail('sendResetPasswordEmail', email)) return;
+		assertResendApiKey();
 
 		const locale = await getLocaleForEmail(ctx, email);
 		const { html, text } = renderPasswordResetEmail(resetUrl, userName);
 
 		await resend.sendEmail(ctx, {
-			from: requireEnv('AUTH_EMAIL'),
+			from: requireEnv('AUTH_EMAIL', { feature: 'email delivery' }),
 			to: email,
 			subject: t(locale, 'email.subject.reset_password'),
 			html,
@@ -123,9 +125,10 @@ export const sendAdminReplyNotification = internalMutation({
 		const { email, adminName, messagePreview, threadId, pageUrl } = args;
 
 		if (shouldSkipTestEmail('sendAdminReplyNotification', email)) return;
+		assertResendApiKey();
 
 		const locale = await getLocaleForEmail(ctx, email);
-		const siteUrl = requireEnv('SITE_URL');
+		const siteUrl = requireEnv('SITE_URL', { feature: 'email deep links' });
 
 		// Build deep link that opens the support widget to this thread
 		// Strip any existing support/thread params to avoid duplicates
@@ -139,7 +142,7 @@ export const sendAdminReplyNotification = internalMutation({
 		const { html, text } = renderAdminReplyNotificationEmail(adminName, messagePreview, deepLink);
 
 		await resend.sendEmail(ctx, {
-			from: requireEnv('AUTH_EMAIL'),
+			from: requireEnv('AUTH_EMAIL', { feature: 'email delivery' }),
 			to: email,
 			subject: t(locale, 'email.subject.support_reply'),
 			html,
@@ -178,7 +181,8 @@ export const sendNewTicketAdminNotification = internalMutation({
 	},
 	handler: async (ctx, args) => {
 		const { email, isReopen, userName, messages, threadId } = args;
-		const siteUrl = requireEnv('SITE_URL');
+		assertResendApiKey();
+		const siteUrl = requireEnv('SITE_URL', { feature: 'email deep links' });
 		const locale = await getLocaleForEmail(ctx, email);
 
 		// Build admin dashboard link for this thread
@@ -199,7 +203,7 @@ export const sendNewTicketAdminNotification = internalMutation({
 			: t(locale, 'email.subject.ticket_new', { userName });
 
 		await resend.sendEmail(ctx, {
-			from: requireEnv('AUTH_EMAIL'),
+			from: requireEnv('AUTH_EMAIL', { feature: 'email delivery' }),
 			to: email,
 			subject,
 			html,
@@ -233,8 +237,9 @@ export const sendNewUserSignupNotification = internalMutation({
 		const { userName, userEmail, signupMethod, signupTime } = args;
 
 		if (shouldSkipTestEmail('sendNewUserSignupNotification', userEmail)) return;
+		assertResendApiKey();
 
-		const siteUrl = requireEnv('SITE_URL');
+		const siteUrl = requireEnv('SITE_URL', { feature: 'email deep links' });
 
 		// Get recipients who have new signup notifications enabled
 		const recipients = await ctx.runQuery(
@@ -265,7 +270,7 @@ export const sendNewUserSignupNotification = internalMutation({
 		for (const email of recipients) {
 			try {
 				await resend.sendEmail(ctx, {
-					from: requireEnv('AUTH_EMAIL'),
+					from: requireEnv('AUTH_EMAIL', { feature: 'email delivery' }),
 					to: email,
 					subject: `New user signup: ${userEmail}`,
 					html,
@@ -376,6 +381,8 @@ export const sendFounderWelcomeEmail = internalMutation({
 			return null;
 		}
 
+		assertResendApiKey();
+
 		// Render plain text with {{placeholder}} interpolation
 		const parts = (name?.trim() || 'there').split(/\s+/);
 		const templateVars: Record<string, string> = {
@@ -392,7 +399,7 @@ export const sendFounderWelcomeEmail = internalMutation({
 		const subject = renderTemplate(config.subject);
 
 		await resend.sendEmail(ctx, {
-			from: `${config.name} <${requireEnv('AUTH_EMAIL')}>`,
+			from: `${config.name} <${requireEnv('AUTH_EMAIL', { feature: 'email delivery' })}>`,
 			replyTo: config.replyTo ? [config.replyTo] : undefined,
 			to: email,
 			subject,

--- a/src/lib/convex/emails/send.ts
+++ b/src/lib/convex/emails/send.ts
@@ -237,9 +237,6 @@ export const sendNewUserSignupNotification = internalMutation({
 		const { userName, userEmail, signupMethod, signupTime } = args;
 
 		if (shouldSkipTestEmail('sendNewUserSignupNotification', userEmail)) return;
-		assertResendApiKey();
-
-		const siteUrl = requireEnv('SITE_URL', { feature: 'email deep links' });
 
 		// Get recipients who have new signup notifications enabled
 		const recipients = await ctx.runQuery(
@@ -251,6 +248,13 @@ export const sendNewUserSignupNotification = internalMutation({
 			console.log('[sendNewUserSignupNotification] No recipients configured, skipping');
 			return;
 		}
+
+		// Only require Resend once we know we'll actually send; with no recipients
+		// configured (common in fresh local-dev installs) the function short-circuits
+		// above and must not demand the API key.
+		assertResendApiKey();
+
+		const siteUrl = requireEnv('SITE_URL', { feature: 'email deep links' });
 
 		// Build admin dashboard link with search for this user
 		const adminDashboardLink = `${siteUrl}/admin/users?search=${encodeURIComponent(userEmail)}`;

--- a/src/lib/convex/emails/templates.ts
+++ b/src/lib/convex/emails/templates.ts
@@ -64,7 +64,7 @@ function escapeHtml(str: string): string {
  * Uses EMAIL_ASSET_URL env var - should point to publicly accessible URL
  */
 function getBaseUrl(): string {
-	return requireEnv('EMAIL_ASSET_URL');
+	return requireEnv('EMAIL_ASSET_URL', { feature: 'email asset URLs (logo, etc.)' });
 }
 
 /**

--- a/src/lib/convex/env.test.ts
+++ b/src/lib/convex/env.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { requireEnv } from './env';
+
+const env = process.env as Record<string, string | undefined>;
+
+function withMissing<T>(key: string, fn: () => T): T {
+	const original = env[key];
+	delete env[key];
+	try {
+		return fn();
+	} finally {
+		if (original === undefined) {
+			delete env[key];
+		} else {
+			env[key] = original;
+		}
+	}
+}
+
+describe('requireEnv', () => {
+	const SECRET_KEY = 'BETTER_AUTH_SECRET';
+	const originalSecret = env[SECRET_KEY];
+
+	afterEach(() => {
+		if (originalSecret === undefined) {
+			delete env[SECRET_KEY];
+		} else {
+			env[SECRET_KEY] = originalSecret;
+		}
+	});
+
+	it('returns the env value when set', () => {
+		env[SECRET_KEY] = 'real-value';
+		expect(requireEnv('BETTER_AUTH_SECRET')).toBe('real-value');
+	});
+
+	it('falls back to analysis placeholder when env is unset', () => {
+		// BETTER_AUTH_SECRET has an ANALYSIS_PLACEHOLDER, so it must not throw
+		// when unset — the bundler relies on this during module analysis.
+		delete env[SECRET_KEY];
+		expect(requireEnv('BETTER_AUTH_SECRET')).toBe('placeholder-secret-for-analysis');
+	});
+
+	it('throws a structured error when no value and no placeholder', () => {
+		// AUTH_EMAIL has no ANALYSIS_PLACEHOLDER entry, so an unset value must throw.
+		withMissing('AUTH_EMAIL', () => {
+			expect(() => requireEnv('AUTH_EMAIL')).toThrowError(
+				/\[env\] Missing AUTH_EMAIL\n {2}Fix: bunx convex env set AUTH_EMAIL <value>\n {2}See: \.env\.convex\.example/
+			);
+		});
+	});
+
+	it('includes the feature name in the error message when provided', () => {
+		withMissing('AUTH_EMAIL', () => {
+			expect(() => requireEnv('AUTH_EMAIL', { feature: 'email delivery' })).toThrowError(
+				/\[env\] Missing AUTH_EMAIL \(needed for: email delivery\)/
+			);
+		});
+	});
+
+	it('honors the custom docs path when provided', () => {
+		withMissing('AUTH_EMAIL', () => {
+			expect(() =>
+				requireEnv('AUTH_EMAIL', { feature: 'email delivery', docs: 'docs/email.md' })
+			).toThrowError(/See: docs\/email\.md/);
+		});
+	});
+});

--- a/src/lib/convex/env.ts
+++ b/src/lib/convex/env.ts
@@ -29,23 +29,37 @@ const ANALYSIS_PLACEHOLDERS: Partial<Record<string, string>> = {
 	AUTUMN_SECRET_KEY: 'placeholder-key-for-analysis'
 };
 
+export type RequireEnvOptions = {
+	/** Human-readable feature name this env var gates (e.g., "billing & checkout"). */
+	feature?: string;
+	/** Reference doc or example file path. Defaults to `.env.convex.example`. */
+	docs?: string;
+};
+
 /**
  * Get a required env var or throw with a helpful message.
  * Only accepts keys marked `@required` in `.env-convex.schema`.
  *
  * Falls back to analysis placeholders for vars that are read at module load
  * time (before Convex sets env vars). All other missing vars throw immediately.
+ *
+ * Pass `opts.feature` to make the error message name the gated feature, which
+ * surfaces a useful breadcrumb in Convex logs when an end-user flow trips it.
  */
-export function requireEnv<K extends RequiredKeys>(name: K): string {
+export function requireEnv<K extends RequiredKeys>(name: K, opts?: RequireEnvOptions): string {
 	const value = process.env[name as string];
 	if (value) return value;
 
 	const placeholder = ANALYSIS_PLACEHOLDERS[name as string];
 	if (placeholder) return placeholder;
 
+	const feature = opts?.feature ? ` (needed for: ${opts.feature})` : '';
+	const docs = opts?.docs ?? '.env.convex.example';
+
 	throw new Error(
-		`Missing required environment variable: ${name}\n` +
-			`Set via: bunx convex env set ${name} <value>`
+		`[env] Missing ${name}${feature}\n` +
+			`  Fix: bunx convex env set ${name} <value>\n` +
+			`  See: ${docs}`
 	);
 }
 


### PR DESCRIPTION
First of a three-PR stack improving the dev experience around optional env keys. This bottom PR fixes the worst failure mode and lays the groundwork; PRs #369 and #370 build on top.

Without `RESEND_API_KEY` the Resend SDK accepts `sendEmail` calls and queues them, but the actual API call fails inside the component's workpool. Better Auth's verify-email flow then "succeeds" from the user's perspective while no email ever arrives, the verify link expires, and the only signal is component-internal log noise.

Extend `requireEnv` with an optional `{ feature, docs }` argument so the thrown error names the gated capability, prints the exact `bunx convex env set` fix command, and points at a reference doc. Every existing call site gets a feature label. Add an `assertResendApiKey` preflight to all six email handlers in `emails/send.ts` so unset Resend keys fail fast in Convex logs instead of vanishing into a workpool retry. The preflight no-ops when `AUTH_E2E_TEST_SECRET` is set so the E2E suite stays unaffected.

`bun run test:unit src/lib/convex/env.test.ts` passes (5 tests). `bun run check:convex` and `bun scripts/static-checks.ts` pass on every touched file.