### PR TITLE
feat(dev): emit console notices when optional features are gated

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,14 +1,23 @@
 import { dev, browser } from '$app/environment';
 import { PUBLIC_SENTRY_DSN } from '$env/static/public';
 import { getPosthog } from '$lib/analytics/posthog';
+import { devNotice } from '$lib/dev/notice';
 import * as Sentry from '@sentry/sveltekit';
 import type { HandleClientError } from '@sveltejs/kit';
 
-if (browser && PUBLIC_SENTRY_DSN) {
-	Sentry.init({
-		dsn: PUBLIC_SENTRY_DSN,
-		tracesSampleRate: 0.1
-	});
+if (browser) {
+	if (PUBLIC_SENTRY_DSN) {
+		Sentry.init({
+			dsn: PUBLIC_SENTRY_DSN,
+			tracesSampleRate: 0.1
+		});
+	} else {
+		devNotice({
+			feature: 'Error monitoring (Sentry)',
+			missing: ['PUBLIC_SENTRY_DSN'],
+			scope: 'vite-public'
+		});
+	}
 }
 
 const customHandleError: HandleClientError = ({ error, status }) => {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -9,12 +9,19 @@ import {
 	matchPublicMarketingRoute
 } from '$lib/marketing/public-routes';
 import { createMarketingMarkdownResponse, isMarkdownRequest } from '$lib/markdown/marketing';
+import { devNotice } from '$lib/dev/notice';
 import { safeRedirectPath } from '$lib/utils/url';
 
 if (PUBLIC_SENTRY_DSN) {
 	Sentry.init({
 		dsn: PUBLIC_SENTRY_DSN,
 		tracesSampleRate: 0.1
+	});
+} else {
+	devNotice({
+		feature: 'Error monitoring (Sentry)',
+		missing: ['PUBLIC_SENTRY_DSN'],
+		scope: 'vite-public'
 	});
 }
 

--- a/src/lib/analytics/posthog.ts
+++ b/src/lib/analytics/posthog.ts
@@ -3,6 +3,7 @@ import {
 	PUBLIC_POSTHOG_HOST,
 	PUBLIC_POSTHOG_PROXY_HOST
 } from '$env/static/public';
+import { devNotice } from '$lib/dev/notice';
 
 const READY_EVENT = 'posthog:ready';
 const ADBLOCK_DETECT_TIMEOUT_MS = 3000;
@@ -41,7 +42,17 @@ export async function initPosthog(): Promise<PostHogClient | null> {
 	if (initPromise) return initPromise;
 
 	initPromise = (async () => {
-		if (!PUBLIC_POSTHOG_API_KEY || !PUBLIC_POSTHOG_HOST) return null;
+		if (!PUBLIC_POSTHOG_API_KEY || !PUBLIC_POSTHOG_HOST) {
+			const missing: string[] = [];
+			if (!PUBLIC_POSTHOG_API_KEY) missing.push('PUBLIC_POSTHOG_API_KEY');
+			if (!PUBLIC_POSTHOG_HOST) missing.push('PUBLIC_POSTHOG_HOST');
+			devNotice({
+				feature: 'Product analytics (PostHog)',
+				missing,
+				scope: 'vite-public'
+			});
+			return null;
+		}
 
 		try {
 			const posthog = (await import('posthog-js')).default;

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -13,6 +13,7 @@ import authConfig from './auth.config';
 import { requireEnv, googleOAuth, githubOAuth } from './env';
 import { getFounderWelcomeDelay } from './emails/helpers';
 import { incrementCounter } from './admin/counters';
+import { devNotice } from '../dev/notice';
 
 // Required for triggers to work - references internal auth functions
 const authFunctions: AuthFunctions = internal.auth;
@@ -389,8 +390,24 @@ export const getCurrentUser = query({
 /** Returns which OAuth providers are configured and available */
 export const getAvailableOAuthProviders = query({
 	args: {},
-	handler: async () => ({
-		google: googleOAuth.enabled,
-		github: githubOAuth.enabled
-	})
+	handler: async () => {
+		if (!googleOAuth.enabled) {
+			devNotice({
+				feature: 'Google sign-in',
+				missing: ['AUTH_GOOGLE_ID', 'AUTH_GOOGLE_SECRET'],
+				scope: 'convex'
+			});
+		}
+		if (!githubOAuth.enabled) {
+			devNotice({
+				feature: 'GitHub sign-in',
+				missing: ['AUTH_GITHUB_ID', 'AUTH_GITHUB_SECRET'],
+				scope: 'convex'
+			});
+		}
+		return {
+			google: googleOAuth.enabled,
+			github: githubOAuth.enabled
+		};
+	}
 });

--- a/src/lib/convex/emails/resend.ts
+++ b/src/lib/convex/emails/resend.ts
@@ -1,6 +1,7 @@
 import { components, internal } from '../_generated/api';
 import { Resend } from '@convex-dev/resend';
 import { requireEnv } from '../env';
+import { devNotice } from '../../dev/notice';
 
 /**
  * Resend email client configured for the application.
@@ -20,6 +21,18 @@ import { requireEnv } from '../env';
  * - RESEND_API_KEY: Your Resend API key (required)
  * - RESEND_WEBHOOK_SECRET: Webhook signing secret (optional)
  */
+// Module-load notice (no-op outside local dev): RESEND_WEBHOOK_SECRET gates
+// webhook signature verification. Without it the component throws inside
+// handleResendEventWebhook, so Resend retries 5xx forever and the dev gets
+// no useful signal until they look at component internals.
+if (!process.env.RESEND_WEBHOOK_SECRET) {
+	devNotice({
+		feature: 'Resend webhook signature verification',
+		missing: ['RESEND_WEBHOOK_SECRET'],
+		scope: 'convex'
+	});
+}
+
 export const resend: Resend = new Resend(components.resend, {
 	// Enable test mode in development to prevent accidental sends
 	// In test mode, emails can only be sent to: delivered@resend.dev, bounced@resend.dev, complained@resend.dev

--- a/src/lib/dev/features.ts
+++ b/src/lib/dev/features.ts
@@ -1,16 +1,15 @@
 /**
  * Catalog of optional features and the env keys that gate them.
  *
- * Single source of truth for dev-time diagnostics:
- *   - The `devNotice` helper consumes this to format consistent warnings
- *     when a gated feature degrades silently in local dev.
- *   - The startup banner in `vite.config.ts` consumes this to render the
- *     boot-time status table.
+ * Used by `devNotice` to format consistent dev-time warnings when a gated
+ * feature degrades silently in local dev. The catalog is also designed to
+ * be reusable by future boot-time diagnostics (banners, doctor scripts) —
+ * keep this file free of runtime side effects so it can be imported from
+ * any context, including the Vite config loader.
  *
  * **Constraints (important):**
- * This module is imported by the Vite config loader, so it must stay
- * primitive: no imports from `$env/*`, no Convex `_generated/*`, no Svelte
- * runtime imports. Plain TypeScript and string constants only.
+ * No imports from `$env/*`, no Convex `_generated/*`, no Svelte runtime
+ * imports. Plain TypeScript and string constants only.
  */
 
 export type DevFeatureScope = 'convex' | 'sveltekit' | 'vite-public';
@@ -21,7 +20,7 @@ export type DevFeature = {
 	/** Where the env vars live. Determines the fix command we suggest. */
 	scope: DevFeatureScope;
 	/** Env var names that gate the feature (must all be set to enable it). */
-	missing: string[];
+	missing: readonly string[];
 	/** Reference doc / example file to point developers at. */
 	docs?: string;
 };

--- a/src/lib/dev/features.ts
+++ b/src/lib/dev/features.ts
@@ -1,0 +1,90 @@
+/**
+ * Catalog of optional features and the env keys that gate them.
+ *
+ * Single source of truth for dev-time diagnostics:
+ *   - The `devNotice` helper consumes this to format consistent warnings
+ *     when a gated feature degrades silently in local dev.
+ *   - The startup banner in `vite.config.ts` consumes this to render the
+ *     boot-time status table.
+ *
+ * **Constraints (important):**
+ * This module is imported by the Vite config loader, so it must stay
+ * primitive: no imports from `$env/*`, no Convex `_generated/*`, no Svelte
+ * runtime imports. Plain TypeScript and string constants only.
+ */
+
+export type DevFeatureScope = 'convex' | 'sveltekit' | 'vite-public';
+
+export type DevFeature = {
+	/** Human-readable feature name (shown in notices and banner). */
+	name: string;
+	/** Where the env vars live. Determines the fix command we suggest. */
+	scope: DevFeatureScope;
+	/** Env var names that gate the feature (must all be set to enable it). */
+	missing: string[];
+	/** Reference doc / example file to point developers at. */
+	docs?: string;
+};
+
+export const DEV_FEATURES = [
+	{
+		name: 'Email delivery (Resend)',
+		scope: 'convex',
+		missing: ['RESEND_API_KEY', 'AUTH_EMAIL'],
+		docs: '.env.convex.example'
+	},
+	{
+		name: 'Email webhook signature verification (Resend)',
+		scope: 'convex',
+		missing: ['RESEND_WEBHOOK_SECRET'],
+		docs: '.env.convex.example'
+	},
+	{
+		name: 'Google sign-in',
+		scope: 'convex',
+		missing: ['AUTH_GOOGLE_ID', 'AUTH_GOOGLE_SECRET'],
+		docs: '.env.convex.example'
+	},
+	{
+		name: 'GitHub sign-in',
+		scope: 'convex',
+		missing: ['AUTH_GITHUB_ID', 'AUTH_GITHUB_SECRET'],
+		docs: '.env.convex.example'
+	},
+	{
+		name: 'Billing (Autumn)',
+		scope: 'convex',
+		missing: ['AUTUMN_SECRET_KEY'],
+		docs: '.env.convex.example'
+	},
+	{
+		name: 'Product analytics (PostHog)',
+		scope: 'vite-public',
+		missing: ['PUBLIC_POSTHOG_API_KEY', 'PUBLIC_POSTHOG_HOST'],
+		docs: '.env.schema'
+	},
+	{
+		name: 'Error monitoring (Sentry)',
+		scope: 'vite-public',
+		missing: ['PUBLIC_SENTRY_DSN'],
+		docs: '.env.schema'
+	},
+	{
+		name: 'Tolgee in-context translation editing',
+		scope: 'vite-public',
+		missing: ['VITE_TOLGEE_API_KEY'],
+		docs: '.env.schema'
+	}
+] as const satisfies readonly DevFeature[];
+
+/**
+ * Returns the canonical fix command for a given scope.
+ *
+ * `convex` keys need `bunx convex env set NAME value` against the local
+ * embedded backend (or the cloud deployment). `sveltekit` and `vite-public`
+ * keys are added to `.env.local`.
+ */
+export function fixHintFor(scope: DevFeatureScope, key: string): string {
+	if (scope === 'convex') return `bunx convex env set ${key} <value>`;
+	return `add ${key}=<value> to .env.local`;
+}

--- a/src/lib/dev/notice.test.ts
+++ b/src/lib/dev/notice.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetDevNoticeDedupeForTests, devNotice } from './notice';
+
+describe('devNotice', () => {
+	const originalLocalConvexDev = process.env.LOCAL_CONVEX_DEV;
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		_resetDevNoticeDedupeForTests();
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+		if (originalLocalConvexDev === undefined) {
+			delete (process.env as Record<string, string | undefined>).LOCAL_CONVEX_DEV;
+		} else {
+			process.env.LOCAL_CONVEX_DEV = originalLocalConvexDev;
+		}
+	});
+
+	it('logs a structured warning for a Convex feature in local dev', () => {
+		process.env.LOCAL_CONVEX_DEV = 'true';
+		devNotice({
+			feature: 'GitHub sign-in',
+			missing: ['AUTH_GITHUB_ID', 'AUTH_GITHUB_SECRET'],
+			scope: 'convex'
+		});
+		expect(warnSpy).toHaveBeenCalledOnce();
+		const [message] = warnSpy.mock.calls[0]!;
+		expect(message).toMatch(
+			/GitHub sign-in disabled\. Missing: AUTH_GITHUB_ID, AUTH_GITHUB_SECRET/
+		);
+		expect(message).toMatch(/bunx convex env set AUTH_GITHUB_ID <value>/);
+		expect(message).toMatch(/bunx convex env set AUTH_GITHUB_SECRET <value>/);
+		expect(message).toMatch(/See: \.env\.convex\.example/);
+	});
+
+	it('logs a vite-public feature with the .env.local fix hint', () => {
+		// Vite test runner exposes import.meta.env.DEV by default.
+		devNotice({
+			feature: 'Product analytics (PostHog)',
+			missing: ['PUBLIC_POSTHOG_API_KEY', 'PUBLIC_POSTHOG_HOST'],
+			scope: 'vite-public'
+		});
+		expect(warnSpy).toHaveBeenCalledOnce();
+		const [message] = warnSpy.mock.calls[0]!;
+		expect(message).toMatch(/add PUBLIC_POSTHOG_API_KEY=<value> to \.env\.local/);
+		expect(message).toMatch(/See: \.env\.schema/);
+	});
+
+	it('dedupes identical notices within the process', () => {
+		process.env.LOCAL_CONVEX_DEV = 'true';
+		const payload = {
+			feature: 'GitHub sign-in',
+			missing: ['AUTH_GITHUB_ID'],
+			scope: 'convex'
+		} as const;
+		devNotice(payload);
+		devNotice(payload);
+		devNotice(payload);
+		expect(warnSpy).toHaveBeenCalledOnce();
+	});
+
+	it('is a no-op when LOCAL_CONVEX_DEV is unset for convex scope', () => {
+		delete (process.env as Record<string, string | undefined>).LOCAL_CONVEX_DEV;
+		devNotice({
+			feature: 'GitHub sign-in',
+			missing: ['AUTH_GITHUB_ID'],
+			scope: 'convex'
+		});
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it('is a no-op when the missing list is empty', () => {
+		process.env.LOCAL_CONVEX_DEV = 'true';
+		devNotice({
+			feature: 'Email delivery',
+			missing: [],
+			scope: 'convex'
+		});
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it('honors a custom docs path', () => {
+		process.env.LOCAL_CONVEX_DEV = 'true';
+		devNotice({
+			feature: 'Custom',
+			missing: ['FOO'],
+			scope: 'convex',
+			docs: 'docs/setup.md'
+		});
+		const [message] = warnSpy.mock.calls[0]!;
+		expect(message).toMatch(/See: docs\/setup\.md/);
+	});
+});

--- a/src/lib/dev/notice.ts
+++ b/src/lib/dev/notice.ts
@@ -1,0 +1,70 @@
+/**
+ * Dev-only console notice for gracefully-degraded features.
+ *
+ * Use this at the call site of an optional feature that silently degrades
+ * when its env keys are unset (OAuth providers, PostHog, Sentry, Tolgee
+ * live editing). The notice names the feature and the keys to set so the
+ * developer learns about the gate at the moment they hit it.
+ *
+ * **Dedupe scope is per-process.** Calling this from a Convex isolate logs
+ * once per cold start; calling it from a SvelteKit server logs once per
+ * server boot; calling it from the browser logs once per page session.
+ * No persistence — that's intentional, otherwise the notice never fires
+ * again after a one-time observation.
+ *
+ * **Active only in dev** (Vite DEV flag in the browser, `LOCAL_CONVEX_DEV`
+ * on the Convex backend). The helper is a no-op in production builds and
+ * on cloud deployments.
+ */
+
+import { fixHintFor, type DevFeatureScope } from './features';
+
+const seen = new Set<string>();
+
+function isDev(scope: DevFeatureScope): boolean {
+	if (scope === 'convex') {
+		return typeof process !== 'undefined' && process.env?.LOCAL_CONVEX_DEV === 'true';
+	}
+	// SvelteKit and browser code run under Vite. The cast keeps this module
+	// usable from the Convex tsconfig (no Vite types) without relying on
+	// // @ts-expect-error directives.
+	const meta = import.meta as unknown as { env?: { DEV?: boolean } };
+	return meta.env?.DEV === true;
+}
+
+export type DevNoticeOptions = {
+	/** Human-readable feature name (e.g. "GitHub sign-in"). */
+	feature: string;
+	/** Env var names that gate the feature. */
+	missing: readonly string[];
+	/** Runtime scope — drives the fix command we suggest. */
+	scope: DevFeatureScope;
+	/** Reference doc or example file to point developers at. */
+	docs?: string;
+};
+
+export function devNotice(opts: DevNoticeOptions): void {
+	if (!isDev(opts.scope)) return;
+	if (opts.missing.length === 0) return;
+
+	const dedupeKey = `${opts.feature}::${opts.missing.join(',')}`;
+	if (seen.has(dedupeKey)) return;
+	seen.add(dedupeKey);
+
+	const fixes = opts.missing.map((key) => fixHintFor(opts.scope, key)).join('\n  ');
+	const docs = opts.docs ?? (opts.scope === 'convex' ? '.env.convex.example' : '.env.schema');
+
+	console.warn(
+		`[dev] ${opts.feature} disabled. Missing: ${opts.missing.join(', ')}.\n` +
+			`  Fix: ${fixes}\n` +
+			`  See: ${docs}`
+	);
+}
+
+/**
+ * Visible-for-testing — drops the dedupe set so unit tests can re-trigger
+ * the same notice. Production code should never call this.
+ */
+export function _resetDevNoticeDedupeForTests(): void {
+	seen.clear();
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,6 +17,7 @@
 	import { Toaster } from '$lib/components/ui/sonner';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { watch } from 'runed';
+	import { devNotice } from '$lib/dev/notice';
 	import de from '../i18n/de.json';
 	import en from '../i18n/en.json';
 	import es from '../i18n/es.json';
@@ -36,6 +37,13 @@
 	const tolgeeBuilder = Tolgee().use(FormatIcu());
 	if (import.meta.env.DEV) {
 		tolgeeBuilder.use(DevTools());
+		if (!import.meta.env.VITE_TOLGEE_API_KEY) {
+			devNotice({
+				feature: 'Tolgee in-context translation editing',
+				missing: ['VITE_TOLGEE_API_KEY'],
+				scope: 'vite-public'
+			});
+		}
 	}
 	// svelte-ignore state_referenced_locally
 	const tolgee = tolgeeBuilder.init({


### PR DESCRIPTION
Stacks on #368. Adds the in-context layer of the dev-experience improvement: when a developer hits a silently-degraded optional feature, log a one-time `[dev]` warning naming the feature and the env keys to set.

Today OAuth buttons disappear, PostHog/Sentry no-op, and Tolgee falls back to committed JSON without any signal to the developer about why. Resend webhook signature verification is the same shape — the component throws `"Webhook secret is not set"` from inside `handleResendEventWebhook` and Resend retries the 5xx response forever.

Introduce `src/lib/dev/notice.ts` plus a `DEV_FEATURES` catalog as the single source of truth for which env vars gate which capability. Wire the helper into every silent-degrade gate: `getAvailableOAuthProviders` for Google/GitHub sign-in, `initPosthog`, Sentry init on both client and server hooks, the Resend module-load for the webhook secret, and the Tolgee init in the root layout. Dedupe is per-process, so notices fire once per Convex isolate, server boot, or page session.

The helper is a no-op outside local dev (`LOCAL_CONVEX_DEV` for Convex, `import.meta.env.DEV` everywhere else), so production behavior is unchanged.

`bun run test:unit src/lib/dev/notice.test.ts` passes (6 tests). Full static checks pass on every touched file.