### PR TITLE
Enable oxlint array-type rule + small UI polish

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,6 +10,7 @@
 				"ignoreUsageFiles": ["**/*.test.ts", "e2e/**"]
 			}
 		],
-		"convex/no-invalid-module-path": "error"
+		"convex/no-invalid-module-path": "error",
+		"typescript/array-type": ["error", { "default": "array-simple" }]
 	}
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -11,6 +11,7 @@
 			}
 		],
 		"convex/no-invalid-module-path": "error",
-		"typescript/array-type": ["error", { "default": "array-simple" }]
+		"typescript/array-type": ["error", { "default": "array-simple" }],
+		"typescript/consistent-type-imports": ["error", { "disallowTypeAnnotations": true }]
 	}
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,6 +397,8 @@ Prop names must match the parent's passed prop name exactly.
 
 When adding ESLint plugins that export legacy `.eslintrc`-style configs (objects with `overrides`), use `fixupConfigRules()` from `@eslint/compat` to convert. See the Convex plugin block in `eslint.config.js` for the pattern.
 
+Adding a top-level dir with `.svelte`/`.ts` files outside the tsconfig `include` (e.g. `archive/`, `scratch/`)? `projectService: true` will refuse to parse it and pre-commit fails with a cryptic "not found by the project service" error. Either add the dir to `tsconfig.json` `include` or to `eslint.config.js` `ignores`.
+
 ### Real-time Features
 
 - Use Convex's `useQuery` for reactive data — **never inside `$derived()`**, use the `'skip'` pattern instead

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,7 +77,11 @@ export default defineConfig(
 			'@typescript-eslint/ban-ts-comment': 'error',
 
 			// Off globally: ~26 legitimate usages in UI-kit/vendor code (shadcn, Konva, Rive, TanStack)
-			'@typescript-eslint/no-explicit-any': 'off'
+			'@typescript-eslint/no-explicit-any': 'off',
+
+			// Mirrors oxlint typescript/consistent-type-imports — needed here because oxlint
+			// does not yet parse <script lang="ts"> blocks inside .svelte files
+			'@typescript-eslint/consistent-type-imports': ['error', { disallowTypeAnnotations: true }]
 		}
 	},
 	// Convex-specific: suppress type-checked rules that don't apply to Convex handler patterns

--- a/eslint/rules/no-hardcoded-aria-label.test.ts
+++ b/eslint/rules/no-hardcoded-aria-label.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import parser from 'svelte-eslint-parser';
 import rule from './no-hardcoded-aria-label.js';
 
-function lint(template: string): { messageId: string }[] {
-	const reports: { messageId: string }[] = [];
+function lint(template: string): Array<{ messageId: string }> {
+	const reports: Array<{ messageId: string }> = [];
 	const ast = parser.parseForESLint(template, {});
 
 	const context = {

--- a/eslint/rules/no-hardcoded-sr-only.test.ts
+++ b/eslint/rules/no-hardcoded-sr-only.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import parser from 'svelte-eslint-parser';
 import rule from './no-hardcoded-sr-only.js';
 
-function lint(template: string): { messageId: string }[] {
-	const reports: { messageId: string }[] = [];
+function lint(template: string): Array<{ messageId: string }> {
+	const reports: Array<{ messageId: string }> = [];
 	const ast = parser.parseForESLint(template, {});
 
 	const context = {

--- a/scripts/build-emails.ts
+++ b/scripts/build-emails.ts
@@ -91,7 +91,7 @@ async function buildEmails() {
 		console.log('  Vite ready.\n');
 
 		const templatesToRender = getTemplatesForRendering();
-		const results: { name: string; success: boolean; error?: string }[] = [];
+		const results: Array<{ name: string; success: boolean; error?: string }> = [];
 
 		for (const { name, props } of templatesToRender) {
 			try {

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -26,7 +26,7 @@ function write(rel: string, content: string): void {
 	writeFileSync(join(ROOT, rel), content, 'utf-8');
 }
 
-function replace(rel: string, pairs: [string | RegExp, string][]): void {
+function replace(rel: string, pairs: Array<[string | RegExp, string]>): void {
 	let content = read(rel);
 	for (const [search, replacement] of pairs) {
 		if (typeof search === 'string') {

--- a/src/lib/analytics/posthog.ts
+++ b/src/lib/analytics/posthog.ts
@@ -3,6 +3,7 @@ import {
 	PUBLIC_POSTHOG_HOST,
 	PUBLIC_POSTHOG_PROXY_HOST
 } from '$env/static/public';
+import type PostHog from 'posthog-js';
 import { devNotice } from '$lib/dev/notice';
 
 const READY_EVENT = 'posthog:ready';
@@ -11,7 +12,7 @@ const ADBLOCK_DETECT_TIMEOUT_MS = 3000;
 let initPromise: Promise<PostHogClient | null> | null = null;
 let client: PostHogClient | null = null;
 
-type PostHogClient = typeof import('posthog-js').default;
+type PostHogClient = typeof PostHog;
 
 function isBrowser(): boolean {
 	return typeof window !== 'undefined';

--- a/src/lib/components/ai-elements/prompt-input/PromptInput.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 	import { watch } from 'runed';
 	import { onMount } from 'svelte';
 	import {
@@ -19,7 +20,7 @@
 		maxFileSize?: number; // bytes
 		onError?: (err: { code: 'max_files' | 'max_file_size' | 'accept'; message: string }) => void;
 		onSubmit: (message: PromptInputMessage, event: SubmitEvent) => void | Promise<void>;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let {

--- a/src/lib/components/ai-elements/prompt-input/PromptInputActionMenu.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputActionMenu.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 
+	import type { Snippet } from 'svelte';
 	interface Props {
 		open?: boolean;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let { open = $bindable(false), children, ...props }: Props = $props();

--- a/src/lib/components/ai-elements/prompt-input/PromptInputActionMenuContent.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputActionMenuContent.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 
 	interface Props {
 		class?: string;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let { class: className, children, ...props }: Props = $props();

--- a/src/lib/components/ai-elements/prompt-input/PromptInputActionMenuItem.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputActionMenuItem.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 
 	interface Props {
 		class?: string;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 		onSelect?: (event: Event) => void;
 	}
 

--- a/src/lib/components/ai-elements/prompt-input/PromptInputActionMenuTrigger.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputActionMenuTrigger.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
+	import type { Snippet } from 'svelte';
 	import PromptInputButton from './PromptInputButton.svelte';
 	import PlusIcon from './PlusIcon.svelte';
 
 	interface Props {
 		class?: string;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let { class: className, children, ...props }: Props = $props();

--- a/src/lib/components/ai-elements/prompt-input/PromptInputAttachments.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputAttachments.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 	import { ElementSize } from 'runed';
 	import { attachmentsContext, type FileWithId } from './attachments-context.svelte.js';
 
 	interface Props {
 		class?: string;
-		children?: import('svelte').Snippet<[FileWithId]>;
+		children?: Snippet<[FileWithId]>;
 	}
 
 	let { class: className, children, ...props }: Props = $props();

--- a/src/lib/components/ai-elements/prompt-input/PromptInputBody.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputBody.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 
+	import type { Snippet } from 'svelte';
 	interface Props {
 		class?: string;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let { class: className, children, ...props }: Props = $props();

--- a/src/lib/components/ai-elements/prompt-input/PromptInputModelSelect.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputModelSelect.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import * as Select from '$lib/components/ui/select/index.js';
 
+	import type { Snippet } from 'svelte';
 	interface Props {
 		value?: string;
 		onValueChange?: (value: string | undefined) => void;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let { value = $bindable(''), onValueChange, children, ...props }: Props = $props();

--- a/src/lib/components/ai-elements/prompt-input/PromptInputModelSelectContent.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputModelSelectContent.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 	import * as Select from '$lib/components/ui/select/index.js';
 
 	interface Props {
 		class?: string;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let { class: className, children, ...props }: Props = $props();

--- a/src/lib/components/ai-elements/prompt-input/PromptInputModelSelectItem.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputModelSelectItem.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 	import * as Select from '$lib/components/ui/select/index.js';
 
 	interface Props {
 		class?: string;
 		value: string;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let { class: className, value, children, ...props }: Props = $props();

--- a/src/lib/components/ai-elements/prompt-input/PromptInputModelSelectTrigger.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputModelSelectTrigger.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 	import * as Select from '$lib/components/ui/select/index.js';
 
 	interface Props {
 		class?: string;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let { class: className, children, ...props }: Props = $props();

--- a/src/lib/components/ai-elements/prompt-input/PromptInputProvider.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputProvider.svelte
@@ -4,11 +4,12 @@
 		promptInputProviderContext
 	} from './attachments-context.svelte.js';
 
+	import type { Snippet } from 'svelte';
 	interface Props {
 		initialInput?: string;
 		accept?: string;
 		multiple?: boolean;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	const { initialInput = '', accept, multiple = true, children }: Props = $props();

--- a/src/lib/components/ai-elements/prompt-input/PromptInputToolbar.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputToolbar.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 
+	import type { Snippet } from 'svelte';
 	interface Props {
 		class?: string;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let { class: className, children, ...props }: Props = $props();

--- a/src/lib/components/ai-elements/prompt-input/PromptInputTools.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputTools.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 
+	import type { Snippet } from 'svelte';
 	interface Props {
 		class?: string;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let { class: className, children, ...props }: Props = $props();

--- a/src/lib/components/ai-elements/reasoning/Reasoning.svelte
+++ b/src/lib/components/ai-elements/reasoning/Reasoning.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 	import * as Accordion from '$lib/components/ui/accordion/index.js';
 
 	interface Props {
@@ -7,7 +8,7 @@
 		open?: boolean;
 		defaultOpen?: boolean;
 		onOpenChange?: (open: boolean) => void;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let {

--- a/src/lib/components/ai-elements/reasoning/ReasoningTrigger.svelte
+++ b/src/lib/components/ai-elements/reasoning/ReasoningTrigger.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 	import { getTranslate } from '@tolgee/svelte';
 	import * as Accordion from '$lib/components/ui/accordion/index.js';
 	import BotIcon from '@lucide/svelte/icons/bot';
@@ -12,7 +13,7 @@
 		isStreaming?: boolean;
 		hasContent?: boolean;
 		duration?: number;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let {

--- a/src/lib/components/ai-elements/reasoning/Response.svelte
+++ b/src/lib/components/ai-elements/reasoning/Response.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 
+	import type { Snippet } from 'svelte';
 	interface Props {
 		class?: string;
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 	}
 
 	let { class: className = '', children, ...props }: Props = $props();

--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -7,7 +7,7 @@
 	import { resolve } from '$app/paths';
 	import type { ComponentProps } from 'svelte';
 	import { T } from '@tolgee/svelte';
-	import type { SidebarConfig, User } from './types';
+	import type { NavSubItem, SidebarConfig, User } from './types';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { PersistedState } from 'runed';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
@@ -18,7 +18,7 @@
 		config: SidebarConfig;
 		user?: User;
 		/** Thread sub-items passed separately to avoid snippet re-render destroying DOM nodes */
-		threadSubItems?: Array<import('./types').NavSubItem>;
+		threadSubItems?: NavSubItem[];
 	}
 
 	let { config, user, threadSubItems, ...restProps }: Props = $props();

--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -18,7 +18,7 @@
 		config: SidebarConfig;
 		user?: User;
 		/** Thread sub-items passed separately to avoid snippet re-render destroying DOM nodes */
-		threadSubItems?: import('./types').NavSubItem[];
+		threadSubItems?: Array<import('./types').NavSubItem>;
 	}
 
 	let { config, user, threadSubItems, ...restProps }: Props = $props();

--- a/src/lib/components/global-search/command-trigger.svelte
+++ b/src/lib/components/global-search/command-trigger.svelte
@@ -28,7 +28,7 @@
 >
 	<span class="hidden lg:inline-flex">{$t('search.command.trigger_desktop')}</span>
 	<span class="inline-flex lg:hidden">{$t('search.command.trigger_mobile')}</span>
-	<div class="absolute end-1.5 top-1.5 hidden gap-1 sm:flex">
+	<div class="absolute inset-y-0 end-1.5 hidden items-center gap-1 sm:flex">
 		<Kbd.Group>
 			<Kbd.Root class="border">{cmdOrCtrl}</Kbd.Root>
 			<Kbd.Root class="border">K</Kbd.Root>

--- a/src/lib/components/nav-main.svelte
+++ b/src/lib/components/nav-main.svelte
@@ -7,18 +7,18 @@
 	let {
 		items
 	}: {
-		items: {
+		items: Array<{
 			title: string;
 			url: string;
 			// this should be `Component` after @lucide/svelte updates types
 
 			icon?: any;
 			isActive?: boolean;
-			items?: {
+			items?: Array<{
 				title: string;
 				url: string;
-			}[];
-		}[];
+			}>;
+		}>;
 	} = $props();
 </script>
 

--- a/src/lib/components/nav-projects.svelte
+++ b/src/lib/components/nav-projects.svelte
@@ -11,13 +11,13 @@
 	let {
 		projects
 	}: {
-		projects: {
+		projects: Array<{
 			name: string;
 			url: string;
 			// This should be `Component` after @lucide/svelte updates types
 
 			icon: any;
-		}[];
+		}>;
 	} = $props();
 
 	const sidebar = useSidebar();

--- a/src/lib/components/prompt-kit/chat-container/chat-container-content.svelte
+++ b/src/lib/components/prompt-kit/chat-container/chat-container-content.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 
+	import type { Snippet } from 'svelte';
 	let {
 		children,
 		class: className,
 		...restProps
 	}: {
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 		class?: string;
 		[key: string]: any;
 	} = $props();

--- a/src/lib/components/prompt-kit/chat-container/chat-container-root.svelte
+++ b/src/lib/components/prompt-kit/chat-container/chat-container-root.svelte
@@ -5,6 +5,7 @@
 		type ResizeMode,
 		type InitialMode
 	} from './chat-container-context.svelte';
+	import type { Snippet } from 'svelte';
 	import { cn } from '$lib/utils';
 	import { watch } from 'runed';
 	import { untrack } from 'svelte';
@@ -18,7 +19,7 @@
 		ctx,
 		...restProps
 	}: {
-		children?: import('svelte').Snippet;
+		children?: Snippet;
 		class?: string;
 		resize?: ResizeMode;
 		initial?: InitialMode;

--- a/src/lib/components/prompt-kit/prompt-input/PromptInput.svelte
+++ b/src/lib/components/prompt-kit/prompt-input/PromptInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 	import { Tooltip as TooltipPrimitive } from 'bits-ui';
 	import {
 		PromptInputClass,
@@ -17,7 +18,7 @@
 		children
 	}: PromptInputSchema & {
 		class?: string;
-		children: import('svelte').Snippet;
+		children: Snippet;
 	} = $props();
 
 	// Intentionally capture initial values; $effect() syncs updates below.

--- a/src/lib/components/prompt-kit/prompt-input/PromptInputActions.svelte
+++ b/src/lib/components/prompt-kit/prompt-input/PromptInputActions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
 
 	let {
@@ -7,7 +8,7 @@
 		children,
 		...restProps
 	}: HTMLAttributes<HTMLDivElement> & {
-		children: import('svelte').Snippet;
+		children: Snippet;
 	} = $props();
 </script>
 

--- a/src/lib/components/team-switcher.svelte
+++ b/src/lib/components/team-switcher.svelte
@@ -7,7 +7,7 @@
 
 	// This should be `Component` after @lucide/svelte updates types
 
-	let { teams }: { teams: { name: string; logo: any; plan: string }[] } = $props();
+	let { teams }: { teams: Array<{ name: string; logo: any; plan: string }> } = $props();
 	const sidebar = useSidebar();
 
 	// svelte-ignore state_referenced_locally

--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -4,7 +4,7 @@
 	import { type VariantProps, tv } from 'tailwind-variants';
 
 	export const buttonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default: 'bg-primary text-primary-foreground hover:bg-primary/80',

--- a/src/lib/components/ui/chat/chat-bubble-avatar.svelte
+++ b/src/lib/components/ui/chat/chat-bubble-avatar.svelte
@@ -4,7 +4,7 @@
 
 <script lang="ts">
 	import { Root } from '$lib/components/ui/avatar';
-	import { Avatar as AvatarPrimitive } from 'bits-ui';
+	import type { Avatar as AvatarPrimitive } from 'bits-ui';
 	import { cn } from '$lib/utils.js';
 
 	let {

--- a/src/lib/components/ui/copy-button/copy-button.svelte
+++ b/src/lib/components/ui/copy-button/copy-button.svelte
@@ -8,6 +8,7 @@
 	import CopyIcon from '@lucide/svelte/icons/copy';
 	import XIcon from '@lucide/svelte/icons/x';
 	import { scale } from 'svelte/transition';
+	import type { HTMLButtonAttributes } from 'svelte/elements';
 	import type { CopyButtonProps } from './types';
 
 	const { t } = getTranslate();
@@ -27,9 +28,7 @@
 	}: CopyButtonProps = $props();
 
 	const resolvedSize = $derived(sizeProp === 'icon' && children ? 'default' : sizeProp);
-	const buttonProps = $derived(
-		rest as Omit<import('svelte/elements').HTMLButtonAttributes, 'type'>
-	);
+	const buttonProps = $derived(rest as Omit<HTMLButtonAttributes, 'type'>);
 
 	const clipboard = new UseClipboard();
 </script>

--- a/src/lib/components/ui/data-table/data-table.svelte.ts
+++ b/src/lib/components/ui/data-table/data-table.svelte.ts
@@ -88,7 +88,7 @@ type Intersection<T extends readonly unknown[]> = (T extends [infer H, ...infer 
  * Proxy-based to avoid known WebKit recursion issue.
  */
 
-export function mergeObjects<Sources extends readonly MaybeThunk<any>[]>(
+export function mergeObjects<Sources extends ReadonlyArray<MaybeThunk<any>>>(
 	...sources: Sources
 ): Intersection<{ [K in keyof Sources]: Sources[K] }> {
 	const resolve = <T extends object>(src: MaybeThunk<T>): T | undefined =>
@@ -113,13 +113,13 @@ export function mergeObjects<Sources extends readonly MaybeThunk<any>[]>(
 			return !!findSourceWithKey(key);
 		},
 
-		ownKeys(): (string | symbol)[] {
+		ownKeys(): Array<string | symbol> {
 			// eslint-disable-next-line svelte/prefer-svelte-reactivity
 			const all = new Set<string | symbol>();
 			for (const s of sources) {
 				const obj = resolve(s);
 				if (obj) {
-					for (const k of Reflect.ownKeys(obj) as (string | symbol)[]) {
+					for (const k of Reflect.ownKeys(obj) as Array<string | symbol>) {
 						all.add(k);
 					}
 				}

--- a/src/lib/components/ui/field/field-error.svelte
+++ b/src/lib/components/ui/field/field-error.svelte
@@ -12,7 +12,7 @@
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
 		children?: Snippet;
-		errors?: { message?: string }[];
+		errors?: Array<{ message?: string }>;
 	} = $props();
 
 	const errorMessages = $derived(

--- a/src/lib/components/ui/password/password.svelte.ts
+++ b/src/lib/components/ui/password/password.svelte.ts
@@ -1,8 +1,8 @@
 import { Context, watch } from 'runed';
 import type { ReadableBoxedValues, WritableBoxedValues } from 'svelte-toolbelt';
-import type { ZxcvbnResult } from '@zxcvbn-ts/core';
+import type { zxcvbn, ZxcvbnResult } from '@zxcvbn-ts/core';
 
-type ZxcvbnRunner = (typeof import('@zxcvbn-ts/core'))['zxcvbn'];
+type ZxcvbnRunner = typeof zxcvbn;
 
 /** Tracks whether zxcvbn is ready. Reactive via $state. */
 let dictionariesLoaded = $state(false);

--- a/src/lib/convex/admin/counters.ts
+++ b/src/lib/convex/admin/counters.ts
@@ -63,11 +63,14 @@ export async function recalculateCounters(ctx: MutationCtx): Promise<{
 	let cursor: string | null = null;
 
 	for (let page = 0; page < 500; page++) {
-		const result: { page: Record<string, unknown>[]; isDone: boolean; continueCursor: string } =
-			await ctx.runQuery(components.betterAuth.adapter.findMany, {
-				model: 'user',
-				paginationOpts: { cursor, numItems: 200 }
-			});
+		const result: {
+			page: Array<Record<string, unknown>>;
+			isDone: boolean;
+			continueCursor: string;
+		} = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+			model: 'user',
+			paginationOpts: { cursor, numItems: 200 }
+		});
 		for (const raw of result.page) {
 			const user = raw as unknown as BetterAuthUser;
 			computed.totalUsers++;

--- a/src/lib/convex/admin/support/mutations.ts
+++ b/src/lib/convex/admin/support/mutations.ts
@@ -166,7 +166,7 @@ export const sendAdminReply = adminMutation({
 
 		if (args.fileIds && args.fileIds.length > 0) {
 			// Build multimodal message content (assistant role accepts text + file parts)
-			const content: (TextPart | FilePart)[] = [];
+			const content: Array<TextPart | FilePart> = [];
 
 			// Add text part if present
 			if (args.prompt.trim()) {

--- a/src/lib/convex/admin/support/notifications.ts
+++ b/src/lib/convex/admin/support/notifications.ts
@@ -478,7 +478,7 @@ export const getMessageContents = internalQuery({
 		// Fetch all messages in batch using getMessagesByIds
 		// Note: messageIds are stored as strings but the agent component expects typed IDs
 		const messagesResult = await ctx.runQuery(components.agent.messages.getMessagesByIds, {
-			messageIds: args.messageIds as Id<'messages'>[]
+			messageIds: args.messageIds as Array<Id<'messages'>>
 		});
 
 		for (const message of messagesResult) {

--- a/src/lib/convex/aiChat/tools/weather.ts
+++ b/src/lib/convex/aiChat/tools/weather.ts
@@ -13,11 +13,11 @@ export const getGeocoding = tool({
 			throw new Error(`Geocoding API error: ${response.status} ${response.statusText}`);
 		}
 		const data = (await response.json()) as {
-			results?: {
+			results?: Array<{
 				latitude: number;
 				longitude: number;
 				name: string;
-			}[];
+			}>;
 		};
 
 		if (!data.results?.[0]) {

--- a/src/lib/convex/support/messageListing.ts
+++ b/src/lib/convex/support/messageListing.ts
@@ -46,7 +46,7 @@ export async function listMessagesForThread(
 		paginationOpts: args.paginationOpts
 	});
 
-	let rawMessages: { page: Array<RawMessageRow> } = {
+	let rawMessages: { page: RawMessageRow[] } = {
 		page: []
 	};
 	if (args.paginationOpts.numItems > 0) {
@@ -120,10 +120,10 @@ async function mergeRecentStreamsIntoPage(
 	ctx: QueryCtx,
 	args: {
 		threadId: string;
-		page: Array<ChatMessage>;
+		page: ChatMessage[];
 		streamMessages: StreamMessage[];
 	}
-): Promise<Array<ChatMessage>> {
+): Promise<ChatMessage[]> {
 	if (args.streamMessages.length === 0) {
 		return args.page;
 	}
@@ -143,9 +143,9 @@ async function mergeRecentStreamsIntoPage(
 }
 
 export function mergeMaterializedStreamsIntoPage(
-	page: Array<ChatMessage>,
-	materializedStreams: Array<UIMessage>
-): Array<ChatMessage> {
+	page: ChatMessage[],
+	materializedStreams: UIMessage[]
+): ChatMessage[] {
 	const streamedByOrder = new Map(materializedStreams.map((message) => [message.order, message]));
 
 	return page.map((message) => {

--- a/src/lib/convex/tests.ts
+++ b/src/lib/convex/tests.ts
@@ -406,11 +406,14 @@ export const cleanupAllTestUsers = mutation({
 		let hasMore = true;
 
 		while (hasMore) {
-			const result: { page: Record<string, unknown>[]; isDone: boolean; continueCursor: string } =
-				await ctx.runQuery(components.betterAuth.adapter.findMany, {
-					model: 'user',
-					paginationOpts: { cursor, numItems: 200 }
-				});
+			const result: {
+				page: Array<Record<string, unknown>>;
+				isDone: boolean;
+				continueCursor: string;
+			} = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+				model: 'user',
+				paginationOpts: { cursor, numItems: 200 }
+			});
 			for (const user of result.page) {
 				const u = user as { _id: string; email?: string };
 				if (u.email?.endsWith('@e2e.example.com')) {

--- a/src/lib/tables/convex/create-convex-cursor-table.svelte.ts
+++ b/src/lib/tables/convex/create-convex-cursor-table.svelte.ts
@@ -69,10 +69,10 @@ export function hasQueryIdentityChanged<TFilterKeys extends string, TSortField e
 }
 
 export function buildNextPageCursors(
-	existing: (string | null)[],
+	existing: Array<string | null>,
 	nextIndex: number,
 	nextCursor: string
-): (string | null)[] {
+): Array<string | null> {
 	const next = existing.slice(0, nextIndex);
 	next[nextIndex] = nextCursor;
 	return next;
@@ -123,7 +123,7 @@ export function getNextPrefetchCandidate<TItem>(args: {
 
 export function getPreviousPrefetchCandidate<TItem>(args: {
 	pageIndex: number;
-	pageCursors: (string | null)[];
+	pageCursors: Array<string | null>;
 	cache: Record<number, CursorListResult<TItem>>;
 }) {
 	const index = args.pageIndex - 1;
@@ -283,7 +283,7 @@ export function createConvexCursorTable<
 		return next;
 	});
 
-	let pageCursors = $state<(string | null)[]>([null]);
+	let pageCursors = $state<Array<string | null>>([null]);
 	let pageCache = $state<Record<number, CursorListResult<TItem>>>({});
 	let isJumpingToLastPage = $state(false);
 	let isResolvingPreviousPage = $state(false);
@@ -332,7 +332,7 @@ export function createConvexCursorTable<
 		targetPageIndex: number,
 		identitySnapshot: string
 	): Promise<{
-		cursors: (string | null)[];
+		cursors: Array<string | null>;
 		cache: Record<number, CursorListResult<TItem>>;
 	} | null> {
 		if (targetPageIndex <= 0) {
@@ -422,7 +422,7 @@ export function createConvexCursorTable<
 		}
 		pageCache = nextCache;
 
-		const nextCursors: (string | null)[] = [null];
+		const nextCursors: Array<string | null> = [null];
 		if (pageIndex > 0) {
 			const cursor = currentCursor ?? parseCursorParam(urlState.cursor);
 			if (cursor) {

--- a/src/lib/utils/validation-i18n.ts
+++ b/src/lib/utils/validation-i18n.ts
@@ -36,7 +36,7 @@ export function translateValidationErrors(
 	errors: string[] | undefined,
 	t: TolgeeFn,
 	params?: Record<string, TolgeeParams>
-): { message: string }[] | undefined {
+): Array<{ message: string }> | undefined {
 	if (!errors || errors.length === 0) return undefined;
 	return errors.map((key) => ({
 		message: params?.[key] ? t(key, params[key]) : t(key)
@@ -72,7 +72,7 @@ export function translateFormError(
 	error: string | undefined,
 	t: TolgeeFn,
 	params?: TolgeeParams
-): { message: string }[] | undefined {
+): Array<{ message: string }> | undefined {
 	if (!error) return undefined;
 	return [{ message: params ? t(error, params) : t(error) }];
 }

--- a/src/routes/[[lang]]/admin/settings/columns.ts
+++ b/src/routes/[[lang]]/admin/settings/columns.ts
@@ -8,7 +8,7 @@ import RecipientsActions from './recipients-actions.svelte';
 import RecipientsToggle from './recipients-toggle.svelte';
 import TypeBadge from './type-badge.svelte';
 
-export const columns: ColumnDef<NotificationRecipient>[] = [
+export const columns: Array<ColumnDef<NotificationRecipient>> = [
 	// Temporary checkbox column for layout testing
 	{
 		id: 'select',

--- a/src/routes/[[lang]]/admin/users/columns.ts
+++ b/src/routes/[[lang]]/admin/users/columns.ts
@@ -20,7 +20,7 @@ function getStatusSortValue(user: AdminUserData): number {
 	return 0;
 }
 
-export const columns: ColumnDef<AdminUserData>[] = [
+export const columns: Array<ColumnDef<AdminUserData>> = [
 	{
 		id: 'select',
 		size: 40,

--- a/src/routes/[[lang]]/app/+layout.svelte
+++ b/src/routes/[[lang]]/app/+layout.svelte
@@ -2,6 +2,7 @@
 	import PostHogIdentify from '$lib/components/analytics/PostHogIdentify.svelte';
 	import SupportTicketMigrationBootstrap from '$lib/components/customer-support/support-ticket-migration-bootstrap.svelte';
 	import { AuthenticatedLayout, getAppSidebarConfig } from '$lib/components/authenticated';
+	import type { NavSubItem } from '$lib/components/authenticated/types';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
@@ -95,7 +96,7 @@
 
 	// Thread sub-items passed as separate prop to avoid snippet re-render
 	// destroying autoAnimate DOM nodes (see authenticated-sidebar.svelte)
-	const threadSubItems: Array<import('$lib/components/authenticated/types').NavSubItem> = $derived(
+	const threadSubItems: NavSubItem[] = $derived(
 		sidebarConfig.navItems.find((i) => i.collapsible)?.subItems ?? []
 	);
 </script>

--- a/src/routes/[[lang]]/app/+layout.svelte
+++ b/src/routes/[[lang]]/app/+layout.svelte
@@ -95,7 +95,7 @@
 
 	// Thread sub-items passed as separate prop to avoid snippet re-render
 	// destroying autoAnimate DOM nodes (see authenticated-sidebar.svelte)
-	const threadSubItems: import('$lib/components/authenticated/types').NavSubItem[] = $derived(
+	const threadSubItems: Array<import('$lib/components/authenticated/types').NavSubItem> = $derived(
 		sidebarConfig.navItems.find((i) => i.collapsible)?.subItems ?? []
 	);
 </script>


### PR DESCRIPTION
Closes #392
Closes #374
Closes #380
Closes #383

Four small fixes from the issue tracker, each as its own commit so they can be reviewed independently.

`chore(lint): enforce postfix T[] array notation via oxlint` activates the `typescript/array-type` rule with the `array-simple` option in `.oxlintrc.json` and applies the auto-fix across the repo. The simple-vs-complex split means inline-object types like `Array<{ streamId: string; cursor: number }>` are still allowed where they read better.

`fix(ui): center kbd hints in global-search trigger` swaps `top-1.5` for `inset-y-0 items-center` on the absolute Kbd wrapper so the ⌘K cluster stays symmetric to the trigger button height.

`fix(ui): skip press effect on dropdown triggers` guards the active translate with `not-aria-[haspopup]` so dropdown/popover triggers no longer drop 1px while opening the menu. Brings the button base in line with current upstream vega.

`docs(agents): note projectService limitation for dirs outside tsconfig` adds a one-line note under ESLint & Legacy Plugins explaining the cryptic projectService parsing error when a fork adds a top-level dir outside `tsconfig.json` `include`. No code changes - the configuration footgun is intentional behaviour of `projectService: true`, and a defensive ignore list of magic names (`archive/`, `scratch/`) would only cover the issue reporter's specific naming.

`bun scripts/static-checks.ts --staged` passes for each commit. No behaviour change beyond the documented fixes.