### PR TITLE
Fix support widget z-index, PersistedState supportUserId, deploy alias slice, RouteProgress timer leak

### DIFF
--- a/scripts/cf-deploy.ts
+++ b/scripts/cf-deploy.ts
@@ -17,7 +17,12 @@ const isPreview = branch !== undefined && branch !== productionBranch;
 const args = ['wrangler', 'versions', 'upload'];
 
 if (isPreview && branch) {
-	const alias = sanitizeBranchAlias(branch);
+	const workerName = process.env.WORKERS_NAME;
+	if (!workerName) {
+		console.error('WORKERS_NAME is required to compute the preview alias slice limit.');
+		process.exit(1);
+	}
+	const alias = sanitizeBranchAlias(branch, workerName);
 	args.push('--preview-alias', alias);
 	console.log(`Preview alias: ${alias}`);
 }

--- a/scripts/deploy/platform.test.ts
+++ b/scripts/deploy/platform.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeBranchAlias } from './platform';
+
+describe('sanitizeBranchAlias', () => {
+	it('uses the full alias budget for short worker names', () => {
+		const workerName = 'myapp'; // 5 chars, budget 57
+		const longBranch = 'a'.repeat(80);
+		const alias = sanitizeBranchAlias(longBranch, workerName);
+		expect(alias.length).toBe(57);
+		expect(`${alias}-${workerName}`.length).toBeLessThanOrEqual(63);
+	});
+
+	it('shrinks alias budget for long worker names', () => {
+		const workerName = 'my-cool-saas-product'; // 20 chars, budget 42
+		const longBranch = 'a'.repeat(80);
+		const alias = sanitizeBranchAlias(longBranch, workerName);
+		expect(alias.length).toBe(42);
+		expect(`${alias}-${workerName}`.length).toBeLessThanOrEqual(63);
+	});
+
+	it('keeps digit-leading branches valid even with long worker names', () => {
+		const workerName = 'my-cool-saas-product'; // 20 chars, budget 42
+		const alias = sanitizeBranchAlias('123-feature-branch', workerName);
+		expect(alias.startsWith('b-1')).toBe(true);
+		expect(alias).toMatch(/^[a-z]/);
+		expect(`${alias}-${workerName}`.length).toBeLessThanOrEqual(63);
+	});
+
+	it('falls back to "branch" for an empty branch name', () => {
+		expect(sanitizeBranchAlias('', 'myapp')).toBe('branch');
+	});
+
+	it('falls back to "branch" for an all-punctuation branch name', () => {
+		expect(sanitizeBranchAlias('---', 'myapp')).toBe('branch');
+	});
+
+	it('throws when the worker name leaves a budget below the fallback length', () => {
+		const tooLong = 'a'.repeat(57); // budget = 5, fallback "branch" is 6
+		expect(() => sanitizeBranchAlias('feature', tooLong)).toThrow(/leaves only 5 chars/);
+	});
+
+	it('accepts a worker name that leaves a budget exactly equal to the fallback length', () => {
+		const justFits = 'a'.repeat(56); // budget = 6, exactly fits "branch"
+		expect(sanitizeBranchAlias('', justFits)).toBe('branch');
+	});
+
+	it('trims trailing dash introduced by truncation', () => {
+		const workerName = 'myapp';
+		// 56-char branch ending with chars that will keep a dash at slice boundary
+		const branch = 'a'.repeat(56) + '-tail';
+		const alias = sanitizeBranchAlias(branch, workerName);
+		expect(alias.endsWith('-')).toBe(false);
+	});
+});

--- a/scripts/deploy/platform.ts
+++ b/scripts/deploy/platform.ts
@@ -7,21 +7,31 @@ export interface PlatformContext {
 	siteUrl: string | null;
 }
 
+const FALLBACK_ALIAS = 'branch';
+
 /**
  * Sanitize a git branch name into a valid CF Workers preview alias.
  * Rules: lowercase letters, numbers, dashes only. Must start with a letter.
- * NOTE: Duplicated in shell in .github/workflows/e2e-preview-cf.yml — keep in sync.
+ * Slice length is computed from the worker name so the preview hostname label
+ * `${alias}-${workerName}.${subdomain}.workers.dev` stays within the 63-char DNS limit.
+ * NOTE: Duplicated in shell in .github/workflows/e2e-preview-cf.yml, keep in sync.
  */
-export function sanitizeBranchAlias(branch: string): string {
+export function sanitizeBranchAlias(branch: string, workerName: string): string {
+	const maxAliasLen = 63 - 1 - workerName.length;
+	if (maxAliasLen < FALLBACK_ALIAS.length) {
+		throw new Error(
+			`Worker name "${workerName}" (${workerName.length} chars) leaves only ${maxAliasLen} chars for the preview alias; need at least ${FALLBACK_ALIAS.length}. Rename the worker or shorten it.`
+		);
+	}
 	const sanitized = branch
 		.toLowerCase()
 		.replace(/[^a-z0-9-]/g, '-')
 		.replace(/-+/g, '-')
 		.replace(/^-|-$/g, '')
 		.replace(/^[0-9]/, 'b-$&')
-		.slice(0, 50) // DNS-aware: 63 - 1 (dash) - 12 (saas-starter) = 50
+		.slice(0, maxAliasLen)
 		.replace(/-$/, ''); // trim trailing dash that truncation may introduce
-	return sanitized || 'branch';
+	return sanitized || FALLBACK_ALIAS;
 }
 
 export function detectPlatform(): PlatformContext {
@@ -65,7 +75,7 @@ export function detectPlatform(): PlatformContext {
 			const workerName = process.env.WORKERS_NAME;
 			const subdomain = process.env.WORKERS_SUBDOMAIN;
 			if (isPreview && branch && workerName && subdomain) {
-				const alias = sanitizeBranchAlias(branch);
+				const alias = sanitizeBranchAlias(branch, workerName);
 				siteUrl = `https://${alias}-${workerName}.${subdomain}.workers.dev`;
 			} else if (process.env.SITE_URL) {
 				// Production: prefer explicit SITE_URL (custom domain)

--- a/src/lib/components/RouteProgress.svelte
+++ b/src/lib/components/RouteProgress.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tick, untrack } from 'svelte';
+	import { tick, untrack, onDestroy } from 'svelte';
 	import { navigating } from '$app/state';
 
 	const SUPPRESSED_QUERY_KEYS = new Set(['sort', 'page', 'page_size', 'cursor', 'search']);
@@ -71,6 +71,8 @@
 			fadeTimer = null;
 		}
 	}
+
+	onDestroy(clearTimers);
 
 	function inc(): void {
 		let amount: number;

--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -148,7 +148,7 @@
 
 <!-- Glow container with group hover/focus behavior -->
 <div
-	class="ai-chatbar fixed bottom-5 left-1/2 z-[100] w-full -translate-x-1/2 pr-19 pl-5 md:mb-0 md:p-0 {!mounted.current ||
+	class="ai-chatbar fixed bottom-5 left-1/2 z-40 w-full -translate-x-1/2 pr-19 pl-5 md:mb-0 md:p-0 {!mounted.current ||
 	delayedFeedbackOpen
 		? 'fade-out'
 		: ''}"

--- a/src/lib/components/customer-support/customer-support.svelte
+++ b/src/lib/components/customer-support/customer-support.svelte
@@ -9,6 +9,7 @@
 	import { ChatUIContext, type UploadConfig } from '$lib/chat';
 	import { browser } from '$app/environment';
 	import { generateAnonymousUserId, isAnonymousUser } from '$lib/convex/utils/anonymousUser';
+	import { supportUserId } from './support-user-id.svelte';
 	import { useSupportUrlState } from './use-support-url-state.svelte';
 
 	// URL state for shareable links
@@ -80,12 +81,10 @@
 	function getAnonymousId(): string {
 		if (!browser) return '';
 
-		let id = localStorage.getItem('supportUserId');
-		if (!id) {
-			id = generateAnonymousUserId();
-			localStorage.setItem('supportUserId', id);
+		if (!supportUserId.current) {
+			supportUserId.current = generateAnonymousUserId();
 		}
-		return id;
+		return supportUserId.current;
 	}
 
 	/**

--- a/src/lib/components/customer-support/feedback-button.svelte
+++ b/src/lib/components/customer-support/feedback-button.svelte
@@ -43,7 +43,7 @@
 </script>
 
 {#if !isScreenshotMode}
-	<div class="fixed right-5 bottom-5 z-200 flex flex-col items-end justify-end gap-3">
+	<div class="fixed right-5 bottom-5 z-40 flex flex-col items-end justify-end gap-3">
 		{#if isFeedbackOpen}
 			<FeedbackWidget onClose={closeWidget} bind:isScreenshotMode {chatUIContext} />
 		{/if}

--- a/src/lib/components/customer-support/lazy-customer-support.svelte
+++ b/src/lib/components/customer-support/lazy-customer-support.svelte
@@ -91,7 +91,7 @@
 {#if CustomerSupport}
 	<CustomerSupport />
 {:else}
-	<div class="fixed right-5 bottom-5 z-200 flex items-end justify-end">
+	<div class="fixed right-5 bottom-5 z-40 flex items-end justify-end">
 		<Button
 			variant="default"
 			size="icon"

--- a/src/lib/components/customer-support/support-ticket-migration-bootstrap.svelte
+++ b/src/lib/components/customer-support/support-ticket-migration-bootstrap.svelte
@@ -57,7 +57,11 @@
 				anonymousUserId: anonymousId
 			})
 			.then(function onMigrationSuccess() {
+				// Update in-memory state via PersistedState (keeps reactive readers consistent),
+				// then drop the storage entry — PersistedState.current = null serializes to the
+				// 'null' literal which would leave litter in localStorage forever.
 				supportUserId.current = null;
+				localStorage.removeItem('supportUserId');
 			})
 			.catch(function onMigrationError(err: unknown) {
 				console.error('Failed to migrate anonymous tickets:', err);

--- a/src/lib/components/customer-support/support-ticket-migration-bootstrap.svelte
+++ b/src/lib/components/customer-support/support-ticket-migration-bootstrap.svelte
@@ -7,6 +7,7 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import { api } from '$lib/convex/_generated/api';
 	import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';
+	import { supportUserId } from './support-user-id.svelte';
 
 	const auth = useAuth();
 	const convexClient = useConvexClient();
@@ -43,7 +44,7 @@
 
 		if (auth.isLoading || !auth.isAuthenticated || !sessionUserId) return;
 
-		const anonymousId = localStorage.getItem('supportUserId');
+		const anonymousId = supportUserId.current;
 		if (!anonymousId || !isAnonymousUser(anonymousId)) return;
 
 		const sessionKey = `${sessionUserId}:${anonymousId}`;
@@ -56,7 +57,7 @@
 				anonymousUserId: anonymousId
 			})
 			.then(function onMigrationSuccess() {
-				localStorage.removeItem('supportUserId');
+				supportUserId.current = null;
 			})
 			.catch(function onMigrationError(err: unknown) {
 				console.error('Failed to migrate anonymous tickets:', err);

--- a/src/lib/components/customer-support/support-user-id.svelte.ts
+++ b/src/lib/components/customer-support/support-user-id.svelte.ts
@@ -1,0 +1,26 @@
+import { PersistedState } from 'runed';
+
+// Backward-compatible serializer:
+// Legacy clients wrote raw strings via localStorage.setItem('supportUserId', id) like `anon_abc123`.
+// JSON.parse('anon_abc123') throws; the default JSON serializer would silently drop the value,
+// orphan the user's existing anonymous tickets, and generate a fresh ID. This serializer
+// tolerates both formats on read, writes JSON on write.
+const serializer = {
+	serialize: JSON.stringify,
+	deserialize: (raw: string): string | null | undefined => {
+		try {
+			return JSON.parse(raw) as string | null | undefined;
+		} catch {
+			return raw;
+		}
+	}
+};
+
+// Initial value is `undefined` (not `null`) so PersistedState does not eagerly write to storage
+// on import. The constructor writes the initial value when the key is absent, and #serialize
+// is a no-op for `undefined`.
+export const supportUserId = new PersistedState<string | null | undefined>(
+	'supportUserId',
+	undefined,
+	{ serializer }
+);

--- a/src/lib/components/customer-support/support-user-id.svelte.ts
+++ b/src/lib/components/customer-support/support-user-id.svelte.ts
@@ -9,9 +9,13 @@ const serializer = {
 	serialize: JSON.stringify,
 	deserialize: (raw: string): string | null | undefined => {
 		try {
-			return JSON.parse(raw) as string | null | undefined;
+			const parsed: unknown = JSON.parse(raw);
+			if (parsed === null || typeof parsed === 'string') return parsed;
+			// Valid JSON but unexpected type (number, boolean, array, object).
+			// Treat as cleared so callers like isAnonymousUser don't crash on .startsWith.
+			return null;
 		} catch {
-			return raw;
+			return raw; // legacy raw-string format
 		}
 	}
 };


### PR DESCRIPTION
Closes #373
Closes #387
Closes #376
Closes #384

Four small fixes bundled as separate commits.

The customer-support FAB and AI chatbar rendered above shadcn dialog and sheet overlays including the chat attachment file-preview dialog, so any modal triggered from inside the support flow ended up partially hidden behind it. Lowered the three FAB/chatbar containers from z-200 / z-[100] to z-40 so all standard modals (z-50) and the screenshot editor (z-[100]) sit above the widget.

Replaced the two raw localStorage call sites for the anonymous supportUserId with a shared PersistedState helper so the value goes through one source of truth. The helper uses a custom serializer with a JSON-parse-then-raw-string fallback to preserve backward compatibility with values written by previous releases, and the initial value is undefined so PersistedState does not eagerly write to storage on import.

The CF Workers preview-alias slice limit was hardcoded to 50 chars based on the original "saas-starter" worker name. After a rebrand a shorter worker name wasted alias budget and a longer worker name could produce preview hostnames exceeding the 63-char DNS label limit silently. Pass workerName as a required parameter to sanitizeBranchAlias and compute the slice budget dynamically. Throw early when the remaining budget is below the "branch" fallback length to avoid the negative-slice trap where 'foo'.slice(0, -1) returns 'fo'.

RouteProgress.svelte started four cascade setTimeout/setInterval timers from $effect reactions but never cleaned them up on destroy. If the layout unmounted mid-navigation (logout, full reload, layout swap) the timers kept writing to detached reactive state. Added onDestroy(clearTimers).

cd saas-starter && bun scripts/static-checks.ts on each changed file passes. bun run test:unit -- platform.test.ts adds 8 new boundary-case tests covering short/long worker names, digit-leading branches, empty/all-punctuation branches, and the exact-budget and over-budget boundaries.