### PR TITLE
fix(setup): accept CLI flags, fail loud on non-TTY

### DIFF
--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -4,15 +4,56 @@
  *
  * Safe to re-run: prompts with current values as defaults.
  *
- * Usage: bun run setup
+ * Usage:
+ *   bun run setup
+ *   bun run setup --slug my-app --repo owner/my-app --brand "My App"
+ *
+ * Non-interactive mode (piped stdin, CI, agents) requires all three flags.
  */
 
 import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { createInterface } from 'readline';
+import { createInterface, type Interface } from 'readline';
+import { parseArgs } from 'util';
 
 const ROOT = join(import.meta.dirname, '..');
-const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+const { values } = parseArgs({
+	args: Bun.argv.slice(2),
+	options: {
+		slug: { type: 'string' },
+		repo: { type: 'string' },
+		brand: { type: 'string' },
+		help: { type: 'boolean', short: 'h', default: false }
+	},
+	strict: false,
+	allowPositionals: false
+});
+
+if (values.help) {
+	console.log(`Template Setup
+
+Usage:
+  bun run setup                                          (interactive)
+  bun run setup --slug <s> --repo <owner/name> --brand <s>
+
+Flags:
+  --slug    Project slug (lowercase, hyphens; matches ^[a-z0-9-]+$)
+  --repo    GitHub repo in owner/name format
+  --brand   Brand display name
+  -h, --help  Show this help
+
+In non-interactive mode (piped stdin, CI), all three flags are required.
+In interactive mode, missing flags are prompted with current values as defaults.`);
+	process.exit(0);
+}
+
+const interactive = !!process.stdin.isTTY;
+let rl: Interface | undefined;
+function ensureReadline(): Interface {
+	if (!rl) rl = createInterface({ input: process.stdin, output: process.stdout });
+	return rl;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -39,11 +80,21 @@ function replace(rel: string, pairs: Array<[string | RegExp, string]>): void {
 }
 
 function prompt(question: string, fallback: string): Promise<string> {
+	const iface = ensureReadline();
 	return new Promise((resolve) => {
-		rl.question(`${question} [${fallback}]: `, (answer) => {
+		iface.question(`${question} [${fallback}]: `, (answer) => {
 			resolve(answer.trim() || fallback);
 		});
 	});
+}
+
+async function resolveValue(
+	flag: string | undefined,
+	question: string,
+	fallback: string
+): Promise<string> {
+	if (flag !== undefined && flag !== '') return flag;
+	return prompt(question, fallback);
 }
 
 function titleCase(slug: string): string {
@@ -81,20 +132,42 @@ function currentBrand(): string {
 async function main() {
 	console.log('\n📦 Template Setup\n');
 
-	const slug = await prompt('Project slug (lowercase, no spaces)', currentSlug());
+	if (!interactive) {
+		const missing: string[] = [];
+		if (values.slug === undefined || values.slug === '') missing.push('--slug');
+		if (values.repo === undefined || values.repo === '') missing.push('--repo');
+		if (values.brand === undefined || values.brand === '') missing.push('--brand');
+		if (missing.length > 0) {
+			console.error(
+				`Error: bun run setup needs --slug, --repo, --brand in non-interactive mode.\nMissing: ${missing.join(', ')}\nExample: bun run setup --slug my-app --repo owner/my-app --brand "My App"`
+			);
+			process.exit(1);
+		}
+	}
+
+	const slug = await resolveValue(
+		values.slug as string | undefined,
+		'Project slug (lowercase, no spaces)',
+		currentSlug()
+	);
 	if (!/^[a-z0-9-]+$/.test(slug)) {
 		console.error('Error: slug must match ^[a-z0-9-]+$ (lowercase letters, numbers, hyphens)');
 		process.exit(1);
 	}
 
-	const repo = await prompt('GitHub repo (owner/name)', currentRepo());
+	const repo = await resolveValue(
+		values.repo as string | undefined,
+		'GitHub repo (owner/name)',
+		currentRepo()
+	);
 	if (!/^[^/]+\/[^/]+$/.test(repo)) {
 		console.error('Error: repo must be in owner/name format');
 		process.exit(1);
 	}
 	const repoBasename = repo.split('/')[1];
 
-	const brand = await prompt(
+	const brand = await resolveValue(
+		values.brand as string | undefined,
 		'Brand name (display name)',
 		currentBrand() === 'SaaS Starter' ? titleCase(slug) : currentBrand()
 	);
@@ -170,7 +243,7 @@ async function main() {
 	console.log('  2. Update legal/privacy content in src/lib/content/ and src/lib/config/legal.ts');
 	console.log('  3. Replace static/logo.svg with your logo, then run: bun run build:emails');
 	console.log('');
-	rl.close();
+	rl?.close();
 }
 
 main();

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -48,6 +48,15 @@ In interactive mode, missing flags are prompted with current values as defaults.
 	process.exit(0);
 }
 
+function normalizeFlag(v: unknown): string | undefined {
+	if (typeof v !== 'string') return undefined;
+	const t = v.trim();
+	return t === '' ? undefined : t;
+}
+const slugFlag = normalizeFlag(values.slug);
+const repoFlag = normalizeFlag(values.repo);
+const brandFlag = normalizeFlag(values.brand);
+
 const interactive = !!process.stdin.isTTY;
 let rl: Interface | undefined;
 function ensureReadline(): Interface {
@@ -93,7 +102,7 @@ async function resolveValue(
 	question: string,
 	fallback: string
 ): Promise<string> {
-	if (flag !== undefined && flag !== '') return flag;
+	if (flag) return flag;
 	return prompt(question, fallback);
 }
 
@@ -134,9 +143,9 @@ async function main() {
 
 	if (!interactive) {
 		const missing: string[] = [];
-		if (values.slug === undefined || values.slug === '') missing.push('--slug');
-		if (values.repo === undefined || values.repo === '') missing.push('--repo');
-		if (values.brand === undefined || values.brand === '') missing.push('--brand');
+		if (!slugFlag) missing.push('--slug');
+		if (!repoFlag) missing.push('--repo');
+		if (!brandFlag) missing.push('--brand');
 		if (missing.length > 0) {
 			console.error(
 				`Error: bun run setup needs --slug, --repo, --brand in non-interactive mode.\nMissing: ${missing.join(', ')}\nExample: bun run setup --slug my-app --repo owner/my-app --brand "My App"`
@@ -145,21 +154,13 @@ async function main() {
 		}
 	}
 
-	const slug = await resolveValue(
-		values.slug as string | undefined,
-		'Project slug (lowercase, no spaces)',
-		currentSlug()
-	);
+	const slug = await resolveValue(slugFlag, 'Project slug (lowercase, no spaces)', currentSlug());
 	if (!/^[a-z0-9-]+$/.test(slug)) {
 		console.error('Error: slug must match ^[a-z0-9-]+$ (lowercase letters, numbers, hyphens)');
 		process.exit(1);
 	}
 
-	const repo = await resolveValue(
-		values.repo as string | undefined,
-		'GitHub repo (owner/name)',
-		currentRepo()
-	);
+	const repo = await resolveValue(repoFlag, 'GitHub repo (owner/name)', currentRepo());
 	if (!/^[^/]+\/[^/]+$/.test(repo)) {
 		console.error('Error: repo must be in owner/name format');
 		process.exit(1);
@@ -167,7 +168,7 @@ async function main() {
 	const repoBasename = repo.split('/')[1];
 
 	const brand = await resolveValue(
-		values.brand as string | undefined,
+		brandFlag,
 		'Brand name (display name)',
 		currentBrand() === 'SaaS Starter' ? titleCase(slug) : currentBrand()
 	);


### PR DESCRIPTION
Closes #372

`bun run setup` hangs when stdin is not a TTY (piped input, CI, scripted scaffolding, AI agents). `scripts/template-setup.ts` constructs `readline.createInterface` and runs three sequential `rl.question()` calls for slug, repo, and brand. Readline closes after consuming the buffered lines from non-TTY stdin and the third callback never fires, so the awaited promise never resolves. The script exits cleanly with code 0 and writes nothing. Silent failure, hard to diagnose.

This change adds `--slug`, `--repo`, `--brand`, and `--help` via `node:util` `parseArgs`, mirroring the existing pattern in `scripts/create-worktree.ts`. No new dependency. Interactive runs are unchanged: missing flags still prompt with current values as defaults. Non-interactive runs now require all three flags; missing values produce a single error listing exactly which flags are missing plus a copy-paste example, then exit 1. The fallback-to-current-values path was rejected because it would let a misconfigured CI run silently write the unchanged template values back into `package.json`, `README.md`, etc., shifting the silent-failure class rather than removing it.

Readline is now constructed lazily and only when an interactive prompt is actually needed, so pure flag-driven runs skip it entirely.

Verified: `printf "..." | bun run setup` now fails loud with exit 1. `bun run setup --slug my-test --repo owner/my-test --brand "My Test"` patches all nine template files end-to-end. Partial-flag interactive runs prompt only for the missing flags. `--help` prints usage and exits 0. Bad slug/repo input from flags still trips the existing validators. `bun scripts/static-checks.ts scripts/template-setup.ts` passes.