### PR TITLE
Centralise brand identity on LEGAL_CONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,12 @@ Once the app runs, rebrand it:
 bun run setup
 ```
 
-The setup script replaces the project name, GitHub links, and brand name. After running it:
+The setup script replaces the project name, GitHub links, and prompts for brand, company, operator, address, and contact email — all written to `src/lib/config/legal.ts`. After running it:
 
-1. Update brand name in translation files (`src/i18n/{en,de,es,fr}.json`), search for "SaaS Starter"
-2. Update legal/privacy content in `src/lib/content/` and `src/lib/config/legal.ts` (address, email, operator)
-3. Replace `static/logo.svg` with your logo, then run `bun run build:emails`
+1. Replace `static/logo.svg` with your logo, then run `bun run build:emails`
+2. Refresh email snapshots: `bun run test:unit -- email-snapshots.test.ts -u`
+3. Update editorial brand mentions in `src/i18n/{en,de,es,fr}.json` (FAQ, hero copy, pricing tier names)
+4. Update legal copy in `src/lib/content/privacy.ts` and `src/lib/content/terms.ts` if needed
 
 ## Preview Deployments
 

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -309,7 +309,9 @@ async function main() {
 	console.log(
 		'  3. Update editorial brand mentions in src/i18n/*.json (FAQ, hero, marketing prose, pricing tier names)'
 	);
-	console.log('  4. Update src/lib/content/privacy.ts and terms.ts if you want different legal copy');
+	console.log(
+		'  4. Update src/lib/content/privacy.ts and terms.ts if you want different legal copy'
+	);
 	console.log('');
 	rl?.close();
 }

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -8,7 +8,9 @@
  *   bun run setup
  *   bun run setup --slug my-app --repo owner/my-app --brand "My App"
  *
- * Non-interactive mode (piped stdin, CI, agents) requires all three flags.
+ * Non-interactive mode (piped stdin, CI, agents) requires --slug, --repo, --brand.
+ * Identity fields (company, operator, address, email) preserve current legal.ts
+ * values when no flag is given; pass --company/--operator/--address/--email to override.
  */
 
 import { readFileSync, writeFileSync } from 'fs';
@@ -24,6 +26,10 @@ const { values } = parseArgs({
 		slug: { type: 'string' },
 		repo: { type: 'string' },
 		brand: { type: 'string' },
+		company: { type: 'string' },
+		operator: { type: 'string' },
+		address: { type: 'string' },
+		email: { type: 'string' },
 		help: { type: 'boolean', short: 'h', default: false }
 	},
 	strict: false,
@@ -35,15 +41,20 @@ if (values.help) {
 
 Usage:
   bun run setup                                          (interactive)
-  bun run setup --slug <s> --repo <owner/name> --brand <s>
+  bun run setup --slug <s> --repo <owner/name> --brand <s> [--company <s>] [--operator <s>] [--address <s>] [--email <user@domain.tld>]
 
 Flags:
-  --slug    Project slug (lowercase, hyphens; matches ^[a-z0-9-]+$)
-  --repo    GitHub repo in owner/name format
-  --brand   Brand display name
+  --slug      Project slug (lowercase, hyphens; matches ^[a-z0-9-]+$)
+  --repo      GitHub repo in owner/name format
+  --brand     Brand display name
+  --company   Company name (legal entity)
+  --operator  Operator name (person or org running the service)
+  --address   Address used in Impressum and email footer
+  --email     Contact email in user@domain.tld form
   -h, --help  Show this help
 
-In non-interactive mode (piped stdin, CI), all three flags are required.
+In non-interactive mode (piped stdin, CI), --slug, --repo, --brand are required.
+Identity fields without flags preserve current legal.ts values.
 In interactive mode, missing flags are prompted with current values as defaults.`);
 	process.exit(0);
 }
@@ -56,6 +67,10 @@ function normalizeFlag(v: unknown): string | undefined {
 const slugFlag = normalizeFlag(values.slug);
 const repoFlag = normalizeFlag(values.repo);
 const brandFlag = normalizeFlag(values.brand);
+const companyFlag = normalizeFlag(values.company);
+const operatorFlag = normalizeFlag(values.operator);
+const addressFlag = normalizeFlag(values.address);
+const emailFlag = normalizeFlag(values.email);
 
 const interactive = !!process.stdin.isTTY;
 let rl: Interface | undefined;
@@ -103,6 +118,7 @@ async function resolveValue(
 	fallback: string
 ): Promise<string> {
 	if (flag) return flag;
+	if (!interactive) return fallback;
 	return prompt(question, fallback);
 }
 
@@ -128,10 +144,40 @@ function currentRepo(): string {
 	return match?.[1]?.replace(/\.git$/, '') ?? 'user/my-saas';
 }
 
+function readLegalField(field: 'brandName' | 'companyName' | 'operatorName' | 'address'): string {
+	const src = read('src/lib/config/legal.ts');
+	const m = src.match(new RegExp(`${field}:\\s*'([^']*)'`));
+	return m?.[1] ?? '';
+}
+
+function readLegalEmailParts(): { user: string; domain: string; tld: string } {
+	const src = read('src/lib/config/legal.ts');
+	const user = src.match(/user:\s*'([^']*)'/)?.[1] ?? '';
+	const domain = src.match(/domain:\s*'([^']*)'/)?.[1] ?? '';
+	const tld = src.match(/tld:\s*'([^']*)'/)?.[1] ?? '';
+	return { user, domain, tld };
+}
+
 function currentBrand(): string {
-	const seo = read('src/lib/components/SEOHead.svelte');
-	const match = seo.match(/\| (.+)<\/title>/);
-	return match?.[1]?.trim() ?? 'SaaS Starter';
+	return readLegalField('brandName') || 'SaaS Starter';
+}
+
+function currentCompany(): string {
+	return readLegalField('companyName') || `${currentBrand()} Inc.`;
+}
+
+function currentOperator(): string {
+	return readLegalField('operatorName');
+}
+
+function currentAddress(): string {
+	return readLegalField('address');
+}
+
+function currentEmail(): string {
+	const { user, domain, tld } = readLegalEmailParts();
+	if (!user || !domain || !tld) return '';
+	return `${user}@${domain}.${tld}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -167,23 +213,54 @@ async function main() {
 	}
 	const repoBasename = repo.split('/')[1];
 
+	const oldBrand = currentBrand();
 	const brand = await resolveValue(
 		brandFlag,
 		'Brand name (display name)',
-		currentBrand() === 'SaaS Starter' ? titleCase(slug) : currentBrand()
+		oldBrand === 'SaaS Starter' ? titleCase(slug) : oldBrand
 	);
+
+	const oldCompany = currentCompany();
+	const company = await resolveValue(
+		companyFlag,
+		'Company name (legal entity)',
+		oldCompany || `${brand} Inc.`
+	);
+
+	const oldOperator = currentOperator();
+	const operator = await resolveValue(
+		operatorFlag,
+		'Operator name (person or org running the service)',
+		oldOperator
+	);
+
+	const oldAddress = currentAddress();
+	const address = await resolveValue(
+		addressFlag,
+		'Address (for Impressum and email footer)',
+		oldAddress
+	);
+
+	const oldEmail = currentEmail();
+	const email = await resolveValue(emailFlag, 'Contact email (user@domain.tld)', oldEmail);
+	const emailMatch = email.match(/^([^@]+)@([^.]+)\.(.+)$/);
+	if (!emailMatch) {
+		console.error(`Error: email must match user@domain.tld pattern, got: ${email}`);
+		process.exit(1);
+	}
+	const [, emailUser, emailDomain, emailTld] = emailMatch;
 
 	const oldSlug = currentSlug();
 	const oldRepo = currentRepo();
-	const oldBrand = currentBrand();
 	const githubUrl = `https://github.com/${repo}`;
 	const oldGithubUrl = `https://github.com/${oldRepo}`;
 
 	console.log(`\nApplying: slug=${slug}, repo=${repo}, brand="${brand}"\n`);
 
-	// package.json — name field only
+	// package.json — name and author
 	const pkg = JSON.parse(read('package.json'));
 	pkg.name = slug;
+	pkg.author = operator;
 	write('package.json', JSON.stringify(pkg, null, '\t') + '\n');
 	console.log('  ✓ package.json');
 
@@ -193,7 +270,7 @@ async function main() {
 
 	// README.md
 	replace('README.md', [
-		[`# ${oldBrand === 'SaaS Starter' ? 'SaaS Starter' : oldBrand}`, `# ${brand}`],
+		[`# ${oldBrand}`, `# ${brand}`],
 		[oldGithubUrl, githubUrl],
 		[`cd ${oldSlug === 'saas-starter' ? 'saas-starter' : repoBasename}`, `cd ${repoBasename}`],
 		// Remove demo link line (matches the > See a live demo... line)
@@ -201,16 +278,8 @@ async function main() {
 	]);
 	console.log('  ✓ README.md');
 
-	// SEOHead.svelte
-	replace('src/lib/components/SEOHead.svelte', [[`| ${oldBrand}</title>`, `| ${brand}</title>`]]);
-	console.log('  ✓ SEOHead.svelte');
-
-	// Marketing header
-	replace('src/lib/components/marketing/marketing-header.svelte', [
-		[oldGithubUrl, githubUrl],
-		// Brand text between Logo component and closing Button
-		[/(<Logo class="size-5" \/>)\n\t+.+/m, `$1\n\t\t\t\t\t${brand}`]
-	]);
+	// Marketing header — keep the GitHub URL rewrite; the brand text reads from LEGAL_CONFIG now
+	replace('src/lib/components/marketing/marketing-header.svelte', [[oldGithubUrl, githubUrl]]);
 	console.log('  ✓ marketing-header.svelte');
 
 	// Authenticated header
@@ -219,30 +288,28 @@ async function main() {
 	]);
 	console.log('  ✓ authenticated-header.svelte');
 
-	// Legal config
+	// Legal config — single source of truth for brand identity
+	const oldUser = readLegalEmailParts().user;
+	const oldDomain = readLegalEmailParts().domain;
+	const oldTld = readLegalEmailParts().tld;
+	const oldEmailBlock = `user: '${oldUser}',\n\t\tdomain: '${oldDomain}',\n\t\ttld: '${oldTld}'`;
+	const newEmailBlock = `user: '${emailUser}',\n\t\tdomain: '${emailDomain}',\n\t\ttld: '${emailTld}'`;
 	replace('src/lib/config/legal.ts', [
 		[`brandName: '${oldBrand}'`, `brandName: '${brand}'`],
-		[`companyName: '${oldBrand} Inc.'`, `companyName: '${brand}'`]
+		[`companyName: '${oldCompany}'`, `companyName: '${company}'`],
+		[`operatorName: '${oldOperator}'`, `operatorName: '${operator}'`],
+		[`address: '${oldAddress}'`, `address: '${address}'`],
+		[oldEmailBlock, newEmailBlock]
 	]);
 	console.log('  ✓ legal.ts');
 
-	// Email header
-	replace('src/lib/emails/components/layout/EmailHeader.svelte', [
-		[`appName = '${oldBrand}'`, `appName = '${brand}'`],
-		[`alt="${oldBrand} Logo"`, `alt="${brand} Logo"`]
-	]);
-	console.log('  ✓ EmailHeader.svelte');
-
-	// Support agent instructions
-	replace('src/lib/convex/support/agent.ts', [[oldBrand, brand]]);
-	console.log('  ✓ support/agent.ts');
-
 	console.log('\n✅ Done! Next steps:');
+	console.log('  1. Replace static/logo.svg with your logo, then run: bun run build:emails');
+	console.log('  2. Refresh email snapshots: bun run test:unit -- email-snapshots.test.ts -u');
 	console.log(
-		'  1. Update brand in translation files (src/i18n/*.json) — search for "SaaS Starter"'
+		'  3. Update editorial brand mentions in src/i18n/*.json (FAQ, hero, marketing prose, pricing tier names)'
 	);
-	console.log('  2. Update legal/privacy content in src/lib/content/ and src/lib/config/legal.ts');
-	console.log('  3. Replace static/logo.svg with your logo, then run: bun run build:emails');
+	console.log('  4. Update src/lib/content/privacy.ts and terms.ts if you want different legal copy');
 	console.log('');
 	rl?.close();
 }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1325,7 +1325,6 @@
 			"subtitle": "Dies ist Ihre Zentrale. Echtzeit-Metriken und Aktivitäten werden hier angezeigt, während Sie Ihre App aufbauen.",
 			"title": "Willkommen in Ihrem Dashboard"
 		},
-		"name": "SaaS Starter",
 		"sidebar": {
 			"admin_panel": "Admin-Bereich",
 			"ai_chat": "KI-Chat",
@@ -1671,7 +1670,7 @@
 		"search_placeholder": "Versuchen Sie, nach Seiten zu suchen..."
 	},
 	"footer": {
-		"copyright": "© {year} SaaS Starter",
+		"copyright": "© {year} {brand}",
 		"impressum": "Impressum",
 		"privacy": "Datenschutz",
 		"terms": "Nutzungsbedingungen"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1326,7 +1326,6 @@
 			"subtitle": "This is your home base. Real-time metrics and activity will appear here as you build out your app.",
 			"title": "Welcome to your dashboard"
 		},
-		"name": "SaaS Starter",
 		"sidebar": {
 			"admin_panel": "Admin Panel",
 			"ai_chat": "AI Chat",
@@ -1672,7 +1671,7 @@
 		"search_placeholder": "Try searching for pages..."
 	},
 	"footer": {
-		"copyright": "© {year} SaaS Starter",
+		"copyright": "© {year} {brand}",
 		"impressum": "Legal Notice",
 		"privacy": "Privacy Policy",
 		"terms": "Terms of Service"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1325,7 +1325,6 @@
 			"subtitle": "Este es tu centro de control. Las métricas en tiempo real y la actividad aparecerán aquí a medida que desarrolles tu aplicación.",
 			"title": "Bienvenido a tu panel"
 		},
-		"name": "SaaS Starter",
 		"sidebar": {
 			"admin_panel": "Panel de Admin",
 			"ai_chat": "Chat IA",
@@ -1671,7 +1670,7 @@
 		"search_placeholder": "Prueba a buscar páginas..."
 	},
 	"footer": {
-		"copyright": "© {year} SaaS Starter",
+		"copyright": "© {year} {brand}",
 		"impressum": "Aviso legal",
 		"privacy": "Privacidad",
 		"terms": "Condiciones de uso"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1325,7 +1325,6 @@
 			"subtitle": "Voici votre base. Les métriques en temps réel et l'activité apparaîtront ici au fur et à mesure que vous développez votre application.",
 			"title": "Bienvenue sur votre tableau de bord"
 		},
-		"name": "SaaS Starter",
 		"sidebar": {
 			"admin_panel": "Panneau Admin",
 			"ai_chat": "Chat IA",
@@ -1671,7 +1670,7 @@
 		"search_placeholder": "Essayez de rechercher des pages..."
 	},
 	"footer": {
-		"copyright": "© {year} SaaS Starter",
+		"copyright": "© {year} {brand}",
 		"impressum": "Mentions légales",
 		"privacy": "Confidentialité",
 		"terms": "Conditions d'utilisation"

--- a/src/lib/components/SEOHead.svelte
+++ b/src/lib/components/SEOHead.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from '$lib/i18n/languages';
+	import { LEGAL_CONFIG } from '$lib/config/legal';
 
 	interface Props {
 		/** Page title (without site name suffix) */
@@ -49,7 +50,7 @@
 
 <svelte:head>
 	{#if title}
-		<title>{title} | SaaS Starter</title>
+		<title>{title} | {LEGAL_CONFIG.brandName}</title>
 		<meta property="og:title" content={title} />
 		<meta name="twitter:title" content={title} />
 	{/if}

--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -41,7 +41,11 @@
 								>
 									<config.header.icon class="!size-5" />
 									<span class="text-base font-semibold">
-										<T keyName={config.header.titleKey} />
+										{#if config.header.title !== undefined}
+											{config.header.title}
+										{:else}
+											<T keyName={config.header.titleKey} />
+										{/if}
 									</span>
 								</Button>
 							{/snippet}
@@ -65,7 +69,11 @@
 					>
 						<config.header.icon class="!size-5" />
 						<span class="text-base font-semibold">
-							<T keyName={config.header.titleKey} />
+							{#if config.header.title !== undefined}
+								{config.header.title}
+							{:else}
+								<T keyName={config.header.titleKey} />
+							{/if}
 						</span>
 					</Button>
 				{/if}

--- a/src/lib/components/authenticated/configs/app-sidebar-config.ts
+++ b/src/lib/components/authenticated/configs/app-sidebar-config.ts
@@ -4,6 +4,7 @@ import MessagesSquareIcon from '@lucide/svelte/icons/messages-square';
 import BotMessageSquareIcon from '@lucide/svelte/icons/bot-message-square';
 import ServerCogIcon from '@lucide/svelte/icons/server-cog';
 import Logo from '$lib/components/icons/logo.svelte';
+import { LEGAL_CONFIG } from '$lib/config/legal';
 import type { SidebarConfig, NavSubItem } from '../types';
 
 interface PageState {
@@ -51,7 +52,7 @@ export function getAppSidebarConfig(
 	return {
 		header: {
 			icon: Logo,
-			titleKey: 'app.name',
+			title: LEGAL_CONFIG.brandName,
 			href: localizedHref('/')
 		},
 		navItems: [

--- a/src/lib/components/authenticated/types.ts
+++ b/src/lib/components/authenticated/types.ts
@@ -35,12 +35,11 @@ export interface HeaderDropdownItem {
 	icon: LucideIcon;
 }
 
-export interface HeaderConfig {
+export type HeaderConfig = {
 	icon: LucideIcon;
-	titleKey: string;
 	href: string;
 	dropdownItems?: HeaderDropdownItem[];
-}
+} & ({ title: string; titleKey?: never } | { titleKey: string; title?: never });
 
 export interface FooterLink {
 	translationKey: string;

--- a/src/lib/components/marketing/marketing-footer.svelte
+++ b/src/lib/components/marketing/marketing-footer.svelte
@@ -3,6 +3,7 @@
 	import { localizedHref } from '$lib/utils/i18n';
 	import { resolve } from '$app/paths';
 	import Button from '$lib/components/ui/button/button.svelte';
+	import { LEGAL_CONFIG } from '$lib/config/legal';
 </script>
 
 <footer class="mt-auto pt-24">
@@ -12,7 +13,13 @@
 		>
 			<div class="flex items-start justify-between sm:items-center">
 				<p class="text-xs text-muted-foreground">
-					<T keyName="footer.copyright" params={{ year: new Date().getFullYear().toString() }} />
+					<T
+						keyName="footer.copyright"
+						params={{
+							year: new Date().getFullYear().toString(),
+							brand: LEGAL_CONFIG.brandName
+						}}
+					/>
 				</p>
 				<nav
 					class="flex flex-col items-end gap-0 text-xs text-muted-foreground sm:flex-row sm:items-center sm:gap-1"

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -14,6 +14,7 @@
 	import { authClient } from '$lib/auth-client';
 	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 	import { T, getTranslate } from '@tolgee/svelte';
+	import { LEGAL_CONFIG } from '$lib/config/legal';
 
 	const { t } = getTranslate();
 	const auth = useAuth();
@@ -103,7 +104,7 @@
 					class="-ml-3.5 flex items-center gap-2 px-3 font-semibold"
 				>
 					<Logo class="size-5" />
-					SaaS Starter
+					{LEGAL_CONFIG.brandName}
 				</Button>
 
 				<!-- Desktop Navigation -->

--- a/src/lib/content/privacy.ts
+++ b/src/lib/content/privacy.ts
@@ -1,10 +1,12 @@
-# Privacy Policy
+import { LEGAL_CONFIG } from '$lib/config/legal';
+
+export const privacyMarkdown = `# Privacy Policy
 
 Last Updated: March 18, 2026
 
 ---
 
-Daniel Sticker ("we", "us", "our") operates the SaaS Starter service (the "Service") as a personal project. This Privacy Policy explains how we collect, use, and protect your personal data in accordance with the General Data Protection Regulation (GDPR) and applicable German data protection law.
+${LEGAL_CONFIG.operatorName} ("we", "us", "our") operates the ${LEGAL_CONFIG.brandName} service (the "Service") as a personal project. This Privacy Policy explains how we collect, use, and protect your personal data in accordance with the General Data Protection Regulation (GDPR) and applicable German data protection law.
 
 ## I. Information We Collect.
 
@@ -39,3 +41,4 @@ Under the GDPR, you have the right to access your personal data (Art. 15), recti
 We may update this Privacy Policy from time to time. If we do this, we will post the changes on this page and will indicate the date these terms were last revised. Your continued use of the Service after the date any such changes become effective constitutes your acceptance of the updated Privacy Policy.
 
 ## Questions?
+`;

--- a/src/lib/content/terms.ts
+++ b/src/lib/content/terms.ts
@@ -1,10 +1,12 @@
-# Terms of Service
+import { LEGAL_CONFIG } from '$lib/config/legal';
+
+export const termsMarkdown = `# Terms of Service
 
 Last Updated: March 18, 2026
 
 ---
 
-Daniel Sticker ("we", "us", "our"), provides the SaaS Starter service (described below) to you through the website and its related services (collectively, such services, including any new features and applications, the "Service"), subject to the following Terms of Service (as amended from time to time, the "Terms of Service"). We reserve the right, at our sole discretion, to change or modify portions of these Terms of Service at any time. If we do this, we will post the changes on this page and will indicate at the top of this page the date these terms were last revised. Your continued use of the Service after the date any such changes become effective constitutes your acceptance of the new Terms of Service.
+${LEGAL_CONFIG.operatorName} ("we", "us", "our"), provides the ${LEGAL_CONFIG.brandName} service (described below) to you through the website and its related services (collectively, such services, including any new features and applications, the "Service"), subject to the following Terms of Service (as amended from time to time, the "Terms of Service"). We reserve the right, at our sole discretion, to change or modify portions of these Terms of Service at any time. If we do this, we will post the changes on this page and will indicate at the top of this page the date these terms were last revised. Your continued use of the Service after the date any such changes become effective constitutes your acceptance of the new Terms of Service.
 
 By using the Service or by clicking to accept the Terms of Service when this option is made available to you, you accept and agree to be bound and abide by these Terms of Service and our [Privacy Policy](privacy). If you do not want to agree to these Terms of Service or the Privacy Policy, you must not access or use the Service.
 
@@ -53,3 +55,4 @@ We process personal data in accordance with our [Privacy Policy](privacy) and ap
 These Terms of Service shall be governed by and interpreted in accordance with the laws of the Federal Republic of Germany. Any disputes shall be subject to the jurisdiction of the courts in Germany. If you are a consumer and habitually reside in the European Union, the laws of the territory in which you reside will apply to any claim that you have against us arising out of or relating to these Terms of Service, and you may resolve your claim in any competent court in that territory.
 
 ## Questions?
+`;

--- a/src/lib/convex/support/agent.ts
+++ b/src/lib/convex/support/agent.ts
@@ -2,12 +2,13 @@ import { Agent } from '@convex-dev/agent';
 import { components } from '../_generated/api';
 import { openrouter } from '@openrouter/ai-sdk-provider';
 import { CHAT_MODEL_ID } from '../utils/chatModel';
+import { LEGAL_CONFIG } from '../../config/legal';
 
 /**
  * Customer Support AI Agent
  *
  * This agent handles customer support conversations with the following capabilities:
- * - Answer questions about the SaaS Starter product
+ * - Answer product questions
  * - Help with feature requests and bug reports
  * - Provide guidance on setup and configuration
  * - Maintain conversation context across messages
@@ -23,7 +24,7 @@ export const supportAgent = new Agent(components.agent, {
 	}),
 
 	// System instructions defining agent behavior
-	instructions: `You are a helpful customer support agent for SaaS Starter, a modern SaaS application template built with SvelteKit, Convex, and Tailwind CSS. Your answers are brief and in WhatsApp style.
+	instructions: `You are a helpful customer support agent for ${LEGAL_CONFIG.brandName}, a modern SaaS application template built with SvelteKit, Convex, and Tailwind CSS. Your answers are brief and in WhatsApp style.
 
 Your responsibilities:
 - Answer questions about features and capabilities

--- a/src/lib/emails/components/layout/EmailHeader.svelte
+++ b/src/lib/emails/components/layout/EmailHeader.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { Section, Row, Column, Img, Text } from '@better-svelte-email/components';
 	import { cn } from '$lib/utils.js';
+	import { LEGAL_CONFIG } from '$lib/config/legal';
 
 	let {
-		appName = 'SaaS Starter',
+		appName = LEGAL_CONFIG.brandName,
 		class: className
 	}: {
 		appName?: string;
@@ -18,7 +19,7 @@
 				src="__BASEURL__/logo-email.png"
 				width="28"
 				height="28"
-				alt="SaaS Starter Logo"
+				alt={`${appName} Logo`}
 				class="my-0 mr-2 inline-block align-middle"
 			/>
 			<Text class="my-0 inline-block align-middle text-[20px] font-bold text-black">

--- a/src/lib/markdown/marketing.test.ts
+++ b/src/lib/markdown/marketing.test.ts
@@ -13,6 +13,7 @@ import {
 } from './marketing';
 import type { MarketingMarkdownDocument } from './types';
 import { marketingMarkdown as homeMarketingMarkdown } from '../../routes/[[lang]]/(marketing)/page.md';
+import { LEGAL_CONFIG } from '$lib/config/legal';
 
 const sampleDocument: MarketingMarkdownDocument = {
 	title: 'Sample Page',
@@ -94,7 +95,7 @@ describe('marketing markdown helpers', () => {
 	it('renders llms discovery content with canonical marketing links', () => {
 		const llms = renderLlmsTxt('https://example.com');
 
-		expect(llms).toContain('# SaaS Starter');
+		expect(llms).toContain(`# ${LEGAL_CONFIG.brandName}`);
 		expect(llms).toContain('https://example.com/en/about');
 		expect(llms).toContain('https://example.com/en/privacy');
 		expect(llms).toContain('https://example.com/en/terms');

--- a/src/lib/markdown/marketing.ts
+++ b/src/lib/markdown/marketing.ts
@@ -5,6 +5,7 @@ import type {
 } from './types';
 import { getLocalizedMarketingUrls } from '$lib/marketing/public-routes';
 import { SUPPORTED_LANGUAGES } from '$lib/i18n/languages';
+import { LEGAL_CONFIG } from '$lib/config/legal';
 
 const MARKDOWN_CONTENT_TYPE = 'text/markdown; charset=utf-8';
 const TEXT_CONTENT_TYPE = 'text/plain; charset=utf-8';
@@ -131,13 +132,13 @@ export function renderLlmsTxt(origin: string): string {
 		getLocalizedMarketingUrls(baseOrigin).filter((url) => url.startsWith(`${baseOrigin}/en`));
 
 	return [
-		'# SaaS Starter',
+		`# ${LEGAL_CONFIG.brandName}`,
 		'',
-		'> Public marketing content for the SaaS Starter SvelteKit template.',
+		`> Public marketing content for the ${LEGAL_CONFIG.brandName} SvelteKit template.`,
 		'',
 		'## Overview',
 		'',
-		'SaaS Starter is a full-stack starter built with SvelteKit, Convex, Better Auth, Tolgee, and modern SaaS infrastructure. This file only describes the public marketing pages.',
+		`${LEGAL_CONFIG.brandName} is a full-stack starter built with SvelteKit, Convex, Better Auth, Tolgee, and modern SaaS infrastructure. This file only describes the public marketing pages.`,
 		'',
 		'## Canonical Pages',
 		'',

--- a/src/routes/[[lang]]/(marketing)/impressum/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/impressum/page.md.ts
@@ -3,7 +3,7 @@ import type { MarketingMarkdownDocument } from '$lib/markdown/types';
 
 export const marketingMarkdown: MarketingMarkdownDocument = {
 	title: 'Impressum',
-	description: 'Provider identification and contact details for SaaS Starter.',
+	description: `Provider identification and contact details for ${LEGAL_CONFIG.brandName}.`,
 	sections: [
 		{
 			heading: 'Impressum',

--- a/src/routes/[[lang]]/(marketing)/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/page.md.ts
@@ -1,4 +1,5 @@
 import type { MarketingMarkdownDocument } from '$lib/markdown/types';
+import { LEGAL_CONFIG } from '$lib/config/legal';
 
 export const marketingMarkdown: MarketingMarkdownDocument = {
 	title: 'Build & Ship Your Product Faster',
@@ -8,7 +9,7 @@ export const marketingMarkdown: MarketingMarkdownDocument = {
 		{
 			heading: 'What this starter is',
 			paragraphs: [
-				'SaaS Starter packages the core infrastructure needed to launch a production-ready SaaS product with SvelteKit, Convex, Better Auth, Tolgee, and modern billing, email, and analytics tooling.',
+				`${LEGAL_CONFIG.brandName} packages the core infrastructure needed to launch a production-ready SaaS product with SvelteKit, Convex, Better Auth, Tolgee, and modern billing, email, and analytics tooling.`,
 				'It is designed for founders and product teams who want to focus on product differentiation rather than rebuilding authentication, billing, localization, and operational plumbing.'
 			]
 		},

--- a/src/routes/[[lang]]/(marketing)/pricing/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/pricing/page.md.ts
@@ -1,9 +1,9 @@
 import type { MarketingMarkdownDocument } from '$lib/markdown/types';
+import { LEGAL_CONFIG } from '$lib/config/legal';
 
 export const marketingMarkdown: MarketingMarkdownDocument = {
 	title: 'Pricing',
-	description:
-		'Review the public pricing structure for the SaaS Starter template, including the free, pro, and enterprise tiers shown on the marketing site.',
+	description: `Review the public pricing structure for the ${LEGAL_CONFIG.brandName} template, including the free, pro, and enterprise tiers shown on the marketing site.`,
 	sections: [
 		{
 			heading: 'Pricing summary',

--- a/src/routes/[[lang]]/(marketing)/privacy/+page.svelte
+++ b/src/routes/[[lang]]/(marketing)/privacy/+page.svelte
@@ -3,22 +3,23 @@
 	import ObfuscatedEmail from '$lib/components/obfuscated-email.svelte';
 	import SEOHead from '$lib/components/SEOHead.svelte';
 	import { getTranslate } from '@tolgee/svelte';
-	import source from '$lib/content/privacy.md?raw';
+	import { privacyMarkdown as source } from '$lib/content/privacy';
+	import { LEGAL_CONFIG } from '$lib/config/legal';
 
 	const { t } = getTranslate();
 </script>
 
 <SEOHead title={$t('meta.privacy.title')} description={$t('meta.privacy.description')} />
 
-<!-- Legal text is intentionally English-only — the English version is the governed version. -->
+<!-- Legal text is intentionally English-only, the English version is the governed version. -->
 <div lang="en" class="mx-auto prose prose-sm max-w-3xl px-6 pt-40 pb-24 lg:px-12 dark:prose-invert">
 	<SvelteMarkdown {source} />
 	<p>
 		For privacy-related questions or to exercise your rights, please contact us at
 		<ObfuscatedEmail
-			user="daniel"
-			domain="sticker"
-			tld="name"
+			user={LEGAL_CONFIG.email.user}
+			domain={LEGAL_CONFIG.email.domain}
+			tld={LEGAL_CONFIG.email.tld}
 			class="underline underline-offset-4"
 		/>.
 	</p>

--- a/src/routes/[[lang]]/(marketing)/privacy/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/privacy/page.md.ts
@@ -1,3 +1,4 @@
+import { LEGAL_CONFIG, getObfuscatedLegalEmailAddress } from '$lib/config/legal';
 import type { MarketingMarkdownDocument } from '$lib/markdown/types';
 
 export const marketingMarkdown: MarketingMarkdownDocument = {
@@ -7,12 +8,12 @@ export const marketingMarkdown: MarketingMarkdownDocument = {
 		{
 			heading: 'Privacy Policy',
 			paragraphs: [
-				'SaaS Starter is operated by Daniel Sticker as a personal project. This Privacy Policy explains how we handle your personal data in accordance with the GDPR.',
+				`${LEGAL_CONFIG.brandName} is operated by ${LEGAL_CONFIG.operatorName} as a personal project. This Privacy Policy explains how we handle your personal data in accordance with the GDPR.`,
 				'We collect account data (name, email, auth provider), usage data (analytics), and support data (chat messages).',
 				'We use your data to provide your account, send transactional emails, and improve the Service. We do not sell or share your data.',
 				'Third-party processors: Convex (EU Ireland, database), Vercel (Frankfurt, hosting), Resend (email), PostHog (analytics). All are GDPR-compliant.',
 				'Under the GDPR you have the right to access, rectify, delete, restrict, port, and object to processing of your personal data.',
-				'Contact: daniel [at] sticker [dot] name'
+				`Contact: ${getObfuscatedLegalEmailAddress()}`
 			]
 		}
 	]

--- a/src/routes/[[lang]]/(marketing)/terms/+page.svelte
+++ b/src/routes/[[lang]]/(marketing)/terms/+page.svelte
@@ -3,22 +3,23 @@
 	import ObfuscatedEmail from '$lib/components/obfuscated-email.svelte';
 	import SEOHead from '$lib/components/SEOHead.svelte';
 	import { getTranslate } from '@tolgee/svelte';
-	import source from '$lib/content/terms.md?raw';
+	import { termsMarkdown as source } from '$lib/content/terms';
+	import { LEGAL_CONFIG } from '$lib/config/legal';
 
 	const { t } = getTranslate();
 </script>
 
 <SEOHead title={$t('meta.terms.title')} description={$t('meta.terms.description')} />
 
-<!-- Legal text is intentionally English-only — the English version is the governed version. -->
+<!-- Legal text is intentionally English-only, the English version is the governed version. -->
 <div lang="en" class="mx-auto prose prose-sm max-w-3xl px-6 pt-40 pb-24 lg:px-12 dark:prose-invert">
 	<SvelteMarkdown {source} />
 	<p>
 		To report any violations of these Terms of Service or to pose any questions, please contact us
 		at <ObfuscatedEmail
-			user="daniel"
-			domain="sticker"
-			tld="name"
+			user={LEGAL_CONFIG.email.user}
+			domain={LEGAL_CONFIG.email.domain}
+			tld={LEGAL_CONFIG.email.tld}
 			class="underline underline-offset-4"
 		/>.
 	</p>

--- a/src/routes/[[lang]]/(marketing)/terms/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/terms/page.md.ts
@@ -1,14 +1,15 @@
+import { LEGAL_CONFIG } from '$lib/config/legal';
 import type { MarketingMarkdownDocument } from '$lib/markdown/types';
 
 export const marketingMarkdown: MarketingMarkdownDocument = {
 	title: 'Terms of Service',
-	description: 'The terms and conditions for using SaaS Starter.',
+	description: `The terms and conditions for using ${LEGAL_CONFIG.brandName}.`,
 	sections: [
 		{
 			heading: 'Terms of Service',
 			paragraphs: [
-				'By accessing or using SaaS Starter you agree to be bound by these Terms of Service.',
-				'SaaS Starter is a web application template and starter kit provided by Daniel Sticker as a personal project.',
+				`By accessing or using ${LEGAL_CONFIG.brandName} you agree to be bound by these Terms of Service.`,
+				`${LEGAL_CONFIG.brandName} is a web application template and starter kit provided by ${LEGAL_CONFIG.operatorName} as a personal project.`,
 				'You are responsible for maintaining the confidentiality of your account credentials.',
 				'The Service is provided "as is" without warranties of any kind.',
 				'These Terms are governed by the laws of the Federal Republic of Germany.'


### PR DESCRIPTION
Closes #377

`src/lib/config/legal.ts` is the declared single source of truth for brand identity (`brandName`, `companyName`, `operatorName`, `address`, `email`), but several user-facing surfaces hardcoded the same values. A rebrand via `bun run setup` plus a manual edit of `legal.ts` still leaked `Daniel Sticker` / `daniel@sticker.name` / `SaaS Starter` into rendered HTML and agent-facing markdown.

This PR drives every identity reference through `LEGAL_CONFIG` (or a Tolgee `{brand}` param where the value is rendered through a translation key). SEOHead, EmailHeader, marketing-header, the llms.txt generator, the support agent prompt, all marketing `page.md.ts` descriptions, and the privacy/terms pages now read `LEGAL_CONFIG.brandName` / `LEGAL_CONFIG.operatorName` / `LEGAL_CONFIG.email.*`. `privacy.md` and `terms.md` are converted to TS modules that interpolate `LEGAL_CONFIG` at module scope, mirroring the impressum pattern. The `footer.copyright` translation key is parametrised with `{brand}` across all four locales; the marketing footer passes `LEGAL_CONFIG.brandName`. The authenticated sidebar's `app.name` translation key is removed in favour of a literal `title` field on `HeaderConfig`, populated with `LEGAL_CONFIG.brandName` directly. `scripts/template-setup.ts` now sources brand from `legal.ts` (not SEOHead, which used to be the source) and prompts for the full identity set (brand, company, operator, address, contact email parsed as user@domain.tld), rewriting all five `legal.ts` fields in one shot plus `package.json` `author`. Obsolete rewrites for Svelte components that now read `LEGAL_CONFIG` directly are removed.

`bun scripts/static-checks.ts` passes across all changed files. `bun run test:unit -- marketing.test.ts` and `bun run test:unit -- email-snapshots.test.ts` both pass without snapshot updates because `LEGAL_CONFIG` values are unchanged in this PR — the regenerated `_generated/*.ts` outputs are byte-identical to main. `bun run i18n:pull` followed by `bun run i18n:push --force-mode OVERRIDE` synchronised Tolgee Cloud.