### PR TITLE
fix(error-page): Add clickable bug-report mailto link

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1665,7 +1665,9 @@
 	},
 	"error_page": {
 		"back_home": "Zurück zur Startseite",
-		"generic_description": "Beim Laden dieser Seite ist ein unerwarteter Fehler aufgetreten.",
+		"bug_report_body": "Hallo,\n\nbeim Verwenden von SaaS Starter ist ein Fehler aufgetreten.\n\nURL: {url}\nStatus: {status}\n\nWas ich gerade gemacht habe:\n\n\nDanke!",
+		"bug_report_subject": "Fehlerbericht: Fehler {status} in SaaS Starter",
+		"generic_description": "Beim Laden dieser Seite ist ein unerwarteter Fehler aufgetreten. Falls das Problem weiterhin besteht, melden Sie es bitte an {email}.",
 		"generic_title": "Etwas ist schiefgelaufen",
 		"need_help": "Brauchen Sie Hilfe?",
 		"not_found_description": "Die gesuchte Seite existiert nicht. Versuchen Sie unten nach dem zu suchen, was Sie brauchen.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1666,7 +1666,9 @@
 	},
 	"error_page": {
 		"back_home": "Take me home",
-		"generic_description": "An unexpected error occurred while loading this page.",
+		"bug_report_body": "Hi,\n\nI hit an error while using SaaS Starter.\n\nURL: {url}\nStatus: {status}\n\nWhat I was doing:\n\n\nThanks!",
+		"bug_report_subject": "Bug report: error {status} on SaaS Starter",
+		"generic_description": "An unexpected error occurred while loading this page. If this keeps happening, please report it to {email}.",
 		"generic_title": "Something went wrong",
 		"need_help": "Need help?",
 		"not_found_description": "The page you're looking for doesn't exist. Try searching for what you need below.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1665,7 +1665,9 @@
 	},
 	"error_page": {
 		"back_home": "Volver al inicio",
-		"generic_description": "Ocurrió un error inesperado al cargar esta página.",
+		"bug_report_body": "Hola,\n\nEncontré un error mientras usaba SaaS Starter.\n\nURL: {url}\nEstado: {status}\n\nLo que estaba haciendo:\n\n\n¡Gracias!",
+		"bug_report_subject": "Informe de error: error {status} en SaaS Starter",
+		"generic_description": "Ocurrió un error inesperado al cargar esta página. Si esto sigue ocurriendo, repórtalo a {email}.",
 		"generic_title": "Algo salió mal",
 		"need_help": "¿Necesitas ayuda?",
 		"not_found_description": "La página que buscas no existe. Prueba a buscar lo que necesitas abajo.",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1665,7 +1665,9 @@
 	},
 	"error_page": {
 		"back_home": "Retour à l'accueil",
-		"generic_description": "Une erreur inattendue s'est produite lors du chargement de cette page.",
+		"bug_report_body": "Bonjour,\n\nj'ai rencontré une erreur en utilisant SaaS Starter.\n\nURL : {url}\nStatut : {status}\n\nCe que je faisais :\n\n\nMerci !",
+		"bug_report_subject": "Rapport de bug : erreur {status} sur SaaS Starter",
+		"generic_description": "Une erreur inattendue s'est produite lors du chargement de cette page. Si cela se reproduit, merci de le signaler à {email}.",
 		"generic_title": "Un problème est survenu",
 		"need_help": "Besoin d'aide ?",
 		"not_found_description": "La page que vous cherchez n'existe pas. Essayez de rechercher ce dont vous avez besoin ci-dessous.",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1665,7 +1665,7 @@
 	},
 	"error_page": {
 		"back_home": "Retour à l'accueil",
-		"bug_report_body": "Bonjour,\n\nj'ai rencontré une erreur en utilisant SaaS Starter.\n\nURL : {url}\nStatut : {status}\n\nCe que je faisais :\n\n\nMerci !",
+		"bug_report_body": "Bonjour,\n\nJ'ai rencontré une erreur en utilisant SaaS Starter.\n\nURL : {url}\nStatut : {status}\n\nCe que je faisais :\n\n\nMerci !",
 		"bug_report_subject": "Rapport de bug : erreur {status} sur SaaS Starter",
 		"generic_description": "Une erreur inattendue s'est produite lors du chargement de cette page. Si cela se reproduit, merci de le signaler à {email}.",
 		"generic_title": "Un problème est survenu",

--- a/src/lib/components/ErrorDisplay.svelte
+++ b/src/lib/components/ErrorDisplay.svelte
@@ -7,6 +7,7 @@
 	import * as Kbd from '$lib/components/ui/kbd/index.js';
 	import { getLegalEmailAddress } from '$lib/config/legal';
 	import { getLanguage } from '$lib/i18n/languages';
+	import { buildBugReportMailto } from '$lib/utils/mailto';
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import de from '../../i18n/de.json';
 	import en from '../../i18n/en.json';
@@ -51,14 +52,15 @@
 		const [prefix, suffix = ''] = translations.error_page.generic_description.split('{email}');
 		return { prefix, suffix };
 	});
-	const mailtoHref = $derived.by(() => {
-		const status = String(page.status);
-		const subject = translations.error_page.bug_report_subject.replace('{status}', status);
-		const body = translations.error_page.bug_report_body
-			.replace('{url}', page.url.toString())
-			.replace('{status}', status);
-		return `mailto:${email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-	});
+	const mailtoHref = $derived(
+		buildBugReportMailto({
+			email,
+			subjectTemplate: translations.error_page.bug_report_subject,
+			bodyTemplate: translations.error_page.bug_report_body,
+			url: page.url.toString(),
+			status: page.status
+		})
+	);
 
 	let globalSearch: ReturnType<typeof useGlobalSearchContext> | null = null;
 
@@ -66,6 +68,13 @@
 		globalSearch = useGlobalSearchContext();
 	} catch {
 		globalSearch = null;
+	}
+
+	// Assign location directly so the OS mail handler opens in the current tab.
+	// target="_blank" would spawn an empty about:blank tab for the mailto.
+	function openMailto(event: MouseEvent): void {
+		event.preventDefault();
+		window.location.href = mailtoHref;
 	}
 
 	function openGlobalSearch(): void {
@@ -90,8 +99,7 @@
 				{:else if descriptionParts}
 					{descriptionParts.prefix}<!-- eslint-disable-next-line svelte/no-navigation-without-resolve --><a
 						href={mailtoHref}
-						target="_blank"
-						rel="noopener noreferrer"
+						onclick={openMailto}
 						class="hover:!text-current">{email}</a
 					>{descriptionParts.suffix}
 				{/if}

--- a/src/lib/components/ErrorDisplay.svelte
+++ b/src/lib/components/ErrorDisplay.svelte
@@ -90,6 +90,8 @@
 				{:else if descriptionParts}
 					{descriptionParts.prefix}<!-- eslint-disable-next-line svelte/no-navigation-without-resolve --><a
 						href={mailtoHref}
+						target="_blank"
+						rel="noopener noreferrer"
 						class="hover:!text-current">{email}</a
 					>{descriptionParts.suffix}
 				{/if}

--- a/src/lib/components/ErrorDisplay.svelte
+++ b/src/lib/components/ErrorDisplay.svelte
@@ -5,6 +5,7 @@
 	import * as Empty from '$lib/components/ui/empty/index.js';
 	import * as InputGroup from '$lib/components/ui/input-group/index.js';
 	import * as Kbd from '$lib/components/ui/kbd/index.js';
+	import { getLegalEmailAddress } from '$lib/config/legal';
 	import { getLanguage } from '$lib/i18n/languages';
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import de from '../../i18n/de.json';
@@ -15,6 +16,8 @@
 	type ErrorPageTranslations = {
 		error_page: {
 			back_home: string;
+			bug_report_body: string;
+			bug_report_subject: string;
 			generic_description: string;
 			generic_title: string;
 			need_help: string;
@@ -42,11 +45,20 @@
 			? translations.error_page.not_found_title
 			: `${page.status} - ${translations.error_page.generic_title}`
 	);
-	const description = $derived(
-		isNotFound
-			? translations.error_page.not_found_description
-			: translations.error_page.generic_description
-	);
+	const email = getLegalEmailAddress();
+	const descriptionParts = $derived.by(() => {
+		if (isNotFound) return null;
+		const [prefix, suffix = ''] = translations.error_page.generic_description.split('{email}');
+		return { prefix, suffix };
+	});
+	const mailtoHref = $derived.by(() => {
+		const status = String(page.status);
+		const subject = translations.error_page.bug_report_subject.replace('{status}', status);
+		const body = translations.error_page.bug_report_body
+			.replace('{url}', page.url.toString())
+			.replace('{status}', status);
+		return `mailto:${email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+	});
 
 	let globalSearch: ReturnType<typeof useGlobalSearchContext> | null = null;
 
@@ -72,7 +84,16 @@
 	<Empty.Root class="w-full max-w-xl bg-background/60">
 		<Empty.Header>
 			<Empty.Title>{title}</Empty.Title>
-			<Empty.Description>{description}</Empty.Description>
+			<Empty.Description>
+				{#if isNotFound}
+					{translations.error_page.not_found_description}
+				{:else if descriptionParts}
+					{descriptionParts.prefix}<!-- eslint-disable-next-line svelte/no-navigation-without-resolve --><a
+						href={mailtoHref}
+						class="hover:!text-current">{email}</a
+					>{descriptionParts.suffix}
+				{/if}
+			</Empty.Description>
 		</Empty.Header>
 		<Empty.Content>
 			<InputGroup.Root class="sm:w-3/4" onclick={openGlobalSearch}>

--- a/src/lib/utils/__tests__/mailto.test.ts
+++ b/src/lib/utils/__tests__/mailto.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { buildBugReportMailto } from '../mailto';
+
+describe('buildBugReportMailto', () => {
+	const base = {
+		email: 'contact@example.com',
+		subjectTemplate: 'Bug report: error {status}',
+		bodyTemplate: 'I hit an error.\nURL: {url}\nStatus: {status}\n',
+		url: 'https://example.com/en/broken?q=1',
+		status: 500
+	};
+
+	it('addresses the configured email', () => {
+		expect(buildBugReportMailto(base)).toMatch(/^mailto:contact@example\.com\?/);
+	});
+
+	it('substitutes {status} in the subject', () => {
+		const href = buildBugReportMailto(base);
+		const subject = new URLSearchParams(href.split('?')[1]).get('subject');
+		expect(subject).toBe('Bug report: error 500');
+	});
+
+	it('substitutes {url} and {status} in the body', () => {
+		const href = buildBugReportMailto(base);
+		const body = new URLSearchParams(href.split('?')[1]).get('body');
+		expect(body).toContain('URL: https://example.com/en/broken?q=1');
+		expect(body).toContain('Status: 500');
+	});
+
+	it('encodes body line breaks as CRLF (%0D%0A), never bare LF', () => {
+		const href = buildBugReportMailto(base);
+		const encodedBody = href.split('&body=')[1]!;
+		expect(encodedBody).toContain('%0D%0A');
+		// every %0A must be part of a %0D%0A pair
+		expect(encodedBody.replaceAll('%0D%0A', '')).not.toContain('%0A');
+	});
+
+	it('leaves existing CRLF line breaks intact (no doubled CR)', () => {
+		const href = buildBugReportMailto({
+			...base,
+			bodyTemplate: 'Line one.\r\nURL: {url}\r\nStatus: {status}'
+		});
+		const encodedBody = href.split('&body=')[1]!;
+		expect(encodedBody).not.toContain('%0D%0D');
+		expect(encodedBody).toContain('%0D%0A');
+	});
+
+	it('percent-encodes reserved characters in subject and body', () => {
+		const href = buildBugReportMailto({
+			...base,
+			subjectTemplate: 'Bug & error {status}',
+			bodyTemplate: 'URL: {url}\nStatus: {status}'
+		});
+		const query = href.slice(href.indexOf('?') + 1);
+		const params = new URLSearchParams(query);
+		expect(params.get('subject')).toBe('Bug & error 500');
+		expect(params.get('body')).toContain('https://example.com/en/broken?q=1');
+	});
+});

--- a/src/lib/utils/mailto.ts
+++ b/src/lib/utils/mailto.ts
@@ -1,0 +1,23 @@
+/**
+ * Builds an RFC 6068 `mailto:` href for a pre-filled bug report.
+ *
+ * Substitutes `{status}` in the subject and `{url}` / `{status}` in the
+ * body, then normalizes body line breaks to CRLF before percent-encoding.
+ * Apple Mail and other RFC-6068-strict clients silently refuse to open a
+ * mailto whose body uses bare LF (`%0A`); they require `%0D%0A`.
+ */
+export function buildBugReportMailto(options: {
+	email: string;
+	subjectTemplate: string;
+	bodyTemplate: string;
+	url: string;
+	status: number;
+}): string {
+	const status = String(options.status);
+	const subject = options.subjectTemplate.replace('{status}', status);
+	const body = options.bodyTemplate
+		.replace('{url}', options.url)
+		.replace('{status}', status)
+		.replace(/\r?\n/g, '\r\n');
+	return `mailto:${options.email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}


### PR DESCRIPTION
Closes #398

`ErrorDisplay.svelte` showed a generic "An unexpected error occurred while loading this page." with no contact path. Users hitting a 500 had no obvious next step beyond going home, and any bug report they did send arrived with no URL or status code, so reproducing it required a back-and-forth.

On non-404 errors, `generic_description` now includes an `{email}` placeholder that resolves to `LEGAL_CONFIG.email` and renders as a clickable inline `mailto:` link. The mailto opens with a localized subject and body pre-filled with the failed URL and HTTP status. The link inherits the surrounding `text-muted-foreground` color (with the existing `Empty.Description` underline) and overrides the parent's `hover:text-primary` with `hover:!text-current`, so it reads as inline text rather than a primary CTA inside the error empty-state. 404 path is unchanged.

The href is built by a pure `buildBugReportMailto` helper (`src/lib/utils/mailto.ts`) that normalizes the i18n body template's line breaks to CRLF before percent-encoding, because Apple Mail and other RFC-6068-strict clients silently refuse to open a mailto whose body uses bare LF (`%0A`). Clicking assigns `window.location.href` directly so the OS mail handler opens in the current tab; `target="_blank"` spawned an empty `about:blank` tab. The plain href stays on the anchor for right-click copy and accessibility.

Translations added in all four locales (`en`, `de`, `es`, `fr`): `bug_report_subject` with `{status}` and `bug_report_body` with `{url}` + `{status}`. `bun scripts/static-checks.ts` and `bun run test:unit` pass; new unit tests cover CRLF encoding and `{url}`/`{status}` substitution. Visually verified at `http://localhost:5173/en/<unknown-path>` that the email link matches the muted body text color (`oklch(0.705 0.015 286.067)`), not the primary `Back to home` color. The actual handoff to a desktop mail client was not re-verified after the CRLF change.
