### PR TITLE
refactor(support): replace setTimeout with useDebounce in widgets

### DIFF
--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { useConvexClient, useQuery } from '@mmailaender/convex-svelte';
 	import { page } from '$app/state';
-	import { watch } from 'runed';
+	import { useDebounce, watch } from 'runed';
 	import { api } from '$lib/convex/_generated/api';
 	import { supportThreadContext } from './support-thread-context.svelte';
 	import { lockscroll } from '@svelte-put/lockscroll';
@@ -177,21 +177,29 @@
 		{ text: $t('support.suggestion.help_text'), label: $t('support.suggestion.help_label') }
 	]);
 
-	// Auto-clear rate limit when it expires
+	// Auto-clear rate limit when it expires.
+	// The wait getter is evaluated when scheduleClearRateLimit() is called, which happens
+	// on every effect re-run (rateLimitedUntil change), so the timer uses the latest delay.
+	const scheduleClearRateLimit = useDebounce(
+		() => threadContext.clearRateLimit(),
+		() => Math.max(0, (threadContext.rateLimitedUntil ?? 0) - Date.now())
+	);
+
 	$effect(() => {
 		if (!threadContext.rateLimitedUntil) return;
 
-		const timeUntilExpiry = threadContext.rateLimitedUntil - Date.now();
-		if (timeUntilExpiry <= 0) {
+		if (threadContext.rateLimitedUntil <= Date.now()) {
 			threadContext.clearRateLimit();
 			return;
 		}
 
-		const timeout = setTimeout(() => {
-			threadContext.clearRateLimit();
-		}, timeUntilExpiry);
+		// useDebounce returns a promise that rejects with "Cancelled" when cancel() is called;
+		// we don't await the result, so swallow the rejection to avoid console noise.
+		scheduleClearRateLimit().catch(() => {});
 
-		return () => clearTimeout(timeout);
+		return () => {
+			scheduleClearRateLimit.cancel();
+		};
 	});
 
 	// Derive title icon based on handoff state

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
+	import { useDebounce } from 'runed';
 	import { useQuery } from '@mmailaender/convex-svelte';
 	import { getTranslate } from '@tolgee/svelte';
 	import { api } from '$lib/convex/_generated/api';
@@ -161,14 +162,20 @@
 
 	// Fallback: Force animations if images take too long to load
 	const ANIMATION_TIMEOUT = 3000;
+	const forceLoadImages = useDebounce(() => {
+		imageUrlsToLoad.forEach((url) => preloadedUrls.add(url));
+	}, ANIMATION_TIMEOUT);
+
 	$effect(() => {
 		if (allImagesLoaded || !isAdminDataLoaded) return;
 
-		const timer = setTimeout(() => {
-			imageUrlsToLoad.forEach((url) => preloadedUrls.add(url));
-		}, ANIMATION_TIMEOUT);
+		// useDebounce returns a promise that rejects with "Cancelled" when cancel() is called;
+		// we don't await the result, so swallow the rejection to avoid console noise.
+		forceLoadImages().catch(() => {});
 
-		return () => clearTimeout(timer);
+		return () => {
+			forceLoadImages.cancel();
+		};
 	});
 
 	// Fade animation state - triggers only on first successful load


### PR DESCRIPTION
Closes #386

Two customer-support widgets kept ad-hoc `setTimeout` + `clearTimeout` plumbing for cancellable one-shot timers: a fallback that force-resolves the avatar-load animation after `ANIMATION_TIMEOUT` ms in `threads-overview.svelte`, and a self-clearing rate-limit timer in `feedback-widget.svelte`. Both patterns are exactly what runed's `useDebounce` covers, with the bonus that the wait can be a reactive getter (used in `feedback-widget` to compute `rateLimitedUntil - Date.now()` lazily on each effect re-run).

The one gotcha: `useDebounce` returns a promise that rejects with `"Cancelled"` when `cancel()` is called on a pending timer. Neither call site awaits the result, so without a `.catch(() => {})` every cleanup logs `Uncaught (in promise) Cancelled` to the console. Both call sites swallow the rejection explicitly and document why in a comment.

`bun scripts/static-checks.ts src/lib/components/customer-support/threads-overview.svelte src/lib/components/customer-support/feedback-widget.svelte` passes.
