### PR TITLE
fix(dev): avoid dynamic import.meta.env access in dev notice helper

### DIFF
--- a/src/lib/dev/notice.test.ts
+++ b/src/lib/dev/notice.test.ts
@@ -3,10 +3,12 @@ import { _resetDevNoticeDedupeForTests, devNotice } from './notice';
 
 describe('devNotice', () => {
 	const originalLocalConvexDev = process.env.LOCAL_CONVEX_DEV;
+	const originalNodeEnv = process.env.NODE_ENV;
 	let warnSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
 		_resetDevNoticeDedupeForTests();
+		process.env.NODE_ENV = 'development';
 		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 	});
 
@@ -16,6 +18,11 @@ describe('devNotice', () => {
 			delete (process.env as Record<string, string | undefined>).LOCAL_CONVEX_DEV;
 		} else {
 			process.env.LOCAL_CONVEX_DEV = originalLocalConvexDev;
+		}
+		if (originalNodeEnv === undefined) {
+			delete (process.env as Record<string, string | undefined>).NODE_ENV;
+		} else {
+			process.env.NODE_ENV = originalNodeEnv;
 		}
 	});
 
@@ -37,7 +44,7 @@ describe('devNotice', () => {
 	});
 
 	it('logs a vite-public feature with the .env.local fix hint', () => {
-		// Vite test runner exposes import.meta.env.DEV by default.
+		// `beforeEach` set NODE_ENV='development' to mimic SvelteKit dev runtime.
 		devNotice({
 			feature: 'Product analytics (PostHog)',
 			missing: ['PUBLIC_POSTHOG_API_KEY', 'PUBLIC_POSTHOG_HOST'],

--- a/src/lib/dev/notice.ts
+++ b/src/lib/dev/notice.ts
@@ -12,9 +12,9 @@
  * No persistence — that's intentional, otherwise the notice never fires
  * again after a one-time observation.
  *
- * **Active only in dev** (Vite DEV flag in the browser, `LOCAL_CONVEX_DEV`
- * on the Convex backend). The helper is a no-op in production builds and
- * on cloud deployments.
+ * **Active only in dev** (`NODE_ENV === 'development'` under SvelteKit and
+ * in the browser, `LOCAL_CONVEX_DEV` on the Convex backend). The helper is
+ * a no-op in production builds and on cloud deployments.
  */
 
 import { fixHintFor, type DevFeatureScope } from './features';
@@ -25,11 +25,12 @@ function isDev(scope: DevFeatureScope): boolean {
 	if (scope === 'convex') {
 		return typeof process !== 'undefined' && process.env?.LOCAL_CONVEX_DEV === 'true';
 	}
-	// SvelteKit and browser code run under Vite. The cast keeps this module
-	// usable from the Convex tsconfig (no Vite types) without relying on
-	// // @ts-expect-error directives.
-	const meta = import.meta as unknown as { env?: { DEV?: boolean } };
-	return meta.env?.DEV === true;
+	// SvelteKit SSR reads NODE_ENV from Node; the browser gets it via Vite's
+	// static define replacement at build time. Avoids the dynamic
+	// `import.meta.env` access that Vite's module-runner rejects, and
+	// type-checks under both the Vite tsconfig and the Convex tsconfig
+	// (which has @types/node but not Vite's import.meta augmentations).
+	return typeof process !== 'undefined' && process.env?.NODE_ENV === 'development';
 }
 
 export type DevNoticeOptions = {


### PR DESCRIPTION
SvelteKit dev was crashing every request with HTTP 500 because Vite's module-runner now rejects dynamic property access on `import.meta.env` ("Dynamic access of import.meta.env is not supported"). The crash happened in `src/lib/dev/notice.ts` via `hooks.server.ts:21`, before any `+error.svelte` could render, so every page on `bun run dev` looked broken.

The notice helper had to dodge `import.meta.env.DEV` originally because the module is imported from both the Vite tsconfig (SvelteKit, browser) and the Convex tsconfig (Convex isolates), and the Convex tsconfig has no Vite types. The previous workaround was a cast to a partial type, but the runtime access was still dynamic, which is what Vite's module-runner objects to.

Switched the SvelteKit/browser dev check from `import.meta.env.DEV` to `process.env.NODE_ENV === 'development'`. SvelteKit SSR gets NODE_ENV from Node at runtime, and Vite statically replaces `process.env.NODE_ENV` in the browser bundle, so the check works in both environments. `@types/node` covers it under both tsconfigs, no `@ts-expect-error` needed. The Convex-scope branch is unchanged.

The Vitest case now sets `NODE_ENV='development'` in `beforeEach` and restores it in `afterEach` so the live "logs a vite-public feature" assertion still exercises the dev path.

`bun scripts/static-checks.ts` and `bun run test:unit src/lib/dev/notice.test.ts` pass. Verified live: `curl http://localhost:5175/en` returned HTTP 500 before the fix and HTTP 200 after, on a fresh dev server in this worktree.