### PR TITLE
fix(support): stop widget render loop from useDebounce in $effect

### DIFF
--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { useConvexClient, useQuery } from '@mmailaender/convex-svelte';
 	import { page } from '$app/state';
-	import { useDebounce, watch } from 'runed';
+	import { watch } from 'runed';
 	import { api } from '$lib/convex/_generated/api';
 	import { supportThreadContext } from './support-thread-context.svelte';
 	import { lockscroll } from '@svelte-put/lockscroll';
@@ -178,28 +178,22 @@
 	]);
 
 	// Auto-clear rate limit when it expires.
-	// The wait getter is evaluated when scheduleClearRateLimit() is called, which happens
-	// on every effect re-run (rateLimitedUntil change), so the timer uses the latest delay.
-	const scheduleClearRateLimit = useDebounce(
-		() => threadContext.clearRateLimit(),
-		() => Math.max(0, (threadContext.rateLimitedUntil ?? 0) - Date.now())
-	);
-
+	// Uses a plain setTimeout (not runed's useDebounce): calling a useDebounce
+	// function inside an $effect makes the effect track the debouncer's internal
+	// reactive state and re-run in an `effect_update_depth_exceeded` loop. See #402
+	// regression (same fix applied to the avatar preload fallback in threads-overview).
 	$effect(() => {
-		if (!threadContext.rateLimitedUntil) return;
+		const until = threadContext.rateLimitedUntil;
+		if (!until) return;
 
-		if (threadContext.rateLimitedUntil <= Date.now()) {
+		const delay = until - Date.now();
+		if (delay <= 0) {
 			threadContext.clearRateLimit();
 			return;
 		}
 
-		// useDebounce returns a promise that rejects with "Cancelled" when cancel() is called;
-		// we don't await the result, so swallow the rejection to avoid console noise.
-		scheduleClearRateLimit().catch(() => {});
-
-		return () => {
-			scheduleClearRateLimit.cancel();
-		};
+		const timer = setTimeout(() => threadContext.clearRateLimit(), delay);
+		return () => clearTimeout(timer);
 	});
 
 	// Derive title icon based on handoff state

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
-	import { useDebounce } from 'runed';
 	import { useQuery } from '@mmailaender/convex-svelte';
 	import { getTranslate } from '@tolgee/svelte';
 	import { api } from '$lib/convex/_generated/api';
@@ -160,22 +159,22 @@
 		return () => controller.abort();
 	});
 
-	// Fallback: Force animations if images take too long to load
+	// Fallback: force animations if images take too long to load.
+	// Uses a plain setTimeout (not runed's useDebounce): calling a useDebounce
+	// function inside an $effect makes the effect track the debouncer's internal
+	// reactive state, so it re-runs, cancels itself in cleanup, reschedules, and
+	// loops until `effect_update_depth_exceeded` (the debounced callback never
+	// fires, so allImagesLoaded never settles). See #402 regression.
 	const ANIMATION_TIMEOUT = 3000;
-	const forceLoadImages = useDebounce(() => {
-		imageUrlsToLoad.forEach((url) => preloadedUrls.add(url));
-	}, ANIMATION_TIMEOUT);
 
 	$effect(() => {
 		if (allImagesLoaded || !isAdminDataLoaded) return;
 
-		// useDebounce returns a promise that rejects with "Cancelled" when cancel() is called;
-		// we don't await the result, so swallow the rejection to avoid console noise.
-		forceLoadImages().catch(() => {});
+		const timer = setTimeout(() => {
+			imageUrlsToLoad.forEach((url) => preloadedUrls.add(url));
+		}, ANIMATION_TIMEOUT);
 
-		return () => {
-			forceLoadImages.cancel();
-		};
+		return () => clearTimeout(timer);
 	});
 
 	// Fade animation state - triggers only on first successful load

--- a/src/lib/components/prompt-kit/prompt-suggestion/prompt-suggestion.svelte
+++ b/src/lib/components/prompt-kit/prompt-suggestion/prompt-suggestion.svelte
@@ -92,7 +92,7 @@
 		bind:ref
 		variant={variant || 'outline'}
 		size={size || 'lg'}
-		class={cn('min-w-0 rounded-lg px-4', className)}
+		class={cn('min-w-0 rounded-chip px-4', className)}
 		{onclick}
 		{disabled}
 		{type}

--- a/src/lib/dev/notice.ts
+++ b/src/lib/dev/notice.ts
@@ -25,11 +25,13 @@ function isDev(scope: DevFeatureScope): boolean {
 	if (scope === 'convex') {
 		return typeof process !== 'undefined' && process.env?.LOCAL_CONVEX_DEV === 'true';
 	}
-	// SvelteKit and browser code run under Vite. The cast keeps this module
-	// usable from the Convex tsconfig (no Vite types) without relying on
-	// // @ts-expect-error directives.
-	const meta = import.meta as unknown as { env?: { DEV?: boolean } };
-	return meta.env?.DEV === true;
+	// SvelteKit and browser code run under Vite, which statically replaces the
+	// `import.meta.env.DEV` member expression at build time. Vite 8 rejects a
+	// *dynamic* read (e.g. via an intermediate variable), so the expression must
+	// stay a direct member access. The inline cast keeps it usable from the
+	// Convex tsconfig (no Vite ambient types); the convex scope returns above, so
+	// this line only ever runs in the Vite-built app/browser.
+	return (import.meta as unknown as { env: { DEV: boolean } }).env.DEV === true;
 }
 
 export type DevNoticeOptions = {

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -385,6 +385,14 @@
 	-webkit-user-drag: none;
 }
 
+/* Pill-shaped by default, collapsing to sharp corners when the active theme
+   sets --radius: 0 (fully squared-off themes). sign() returns 0 for a zero
+   radius and 1 otherwise. Falls back to a pill on engines without sign(). */
+@utility rounded-chip {
+	border-radius: 9999px;
+	border-radius: calc(9999px * sign(var(--radius)));
+}
+
 @utility ease-sidebar {
 	transition-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
 }


### PR DESCRIPTION
The customer support widget froze the whole page with `effect_update_depth_exceeded` as soon as the overview listed a conversation, and on the `?support=open&thread=` deep link the chat never opened. Separately, `bun run dev` 500'd on every SSR page in this repo after the Vite 8 upgrade.

The avatar-preload fallback in `threads-overview.svelte` and the rate-limit auto-clear in `feedback-widget.svelte` (both added in #402) called a runed `useDebounce` function from inside an `$effect`. The effect tracked the debouncer's internal reactive state, so it re-ran, cancelled itself in cleanup, and rescheduled in a loop until Svelte bailed out. The debounced callback never fired, so `allImagesLoaded` never settled. Both now use a plain `setTimeout` with `clearTimeout` cleanup, which keeps the one-shot fallback behaviour without the reactive feedback loop.

The dev SSR 500 (from #288's Vite 7 to 8 bump) came from `isDev()` reading `import.meta.env` off an intermediate variable; Vite 8's dev module runner rejects dynamic `import.meta.env` access. It now reads `import.meta.env.DEV` directly so Vite can statically replace it, with an inline cast so the module still type-checks from the Convex tsconfig.

Reproduced locally by seeding a support thread and opening the widget: the looping effect ran 1002 times before the fix and 0 after. The overview and the `?support=open&thread=` deep link both render and open the conversation with a clean console. `bun scripts/static-checks.ts` and `bun run check:convex` pass.