### PR TITLE
chore(lint): ban useDebounce() inside Svelte runes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -548,10 +548,11 @@ How to add: create rule in `eslint/rules/`, register in `eslint.config.js`, add 
 
 #### "This pattern must never appear in code"
 
-Examples: hardcoded aria-labels, barrel icon imports, deprecated Tailwind tokens, bare `animate-spin`.
+Examples: hardcoded aria-labels, barrel icon imports, deprecated Tailwind tokens, bare `animate-spin`, calling a runed `useDebounce()` result inside a `$effect`/`$derived` rune (loops with `effect_update_depth_exceeded`).
 
 → **ESLint custom rule** (for AST-level patterns) or **banned pattern** in `scripts/static-checks.ts` (for simple string matching).
-Pattern: `eslint/rules/no-hardcoded-aria-label.js`, banned patterns list in `static-checks.ts`.
+Pattern: `eslint/rules/no-hardcoded-aria-label.js`, `eslint/rules/no-debounce-in-rune.js`, banned patterns list in `static-checks.ts`.
+Note: these AST guards live in ESLint (not oxlint) because oxlint JS plugins do not support Svelte files yet ("Not supported yet", alpha — https://oxc.rs/docs/guide/usage/linter/js-plugins). Port them to a local oxlint JS plugin once oxlint adds Svelte support.
 
 #### "This build output must have specific properties"
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ import requireMarketingMarkdownRule from './eslint/rules/require-marketing-markd
 import requireMarketingRouteRegistrationRule from './eslint/rules/require-marketing-route-registration.js';
 import noHardcodedAriaLabelRule from './eslint/rules/no-hardcoded-aria-label.js';
 import noHardcodedSrOnlyRule from './eslint/rules/no-hardcoded-sr-only.js';
+import noDebounceInRuneRule from './eslint/rules/no-debounce-in-rune.js';
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
 const localPlugin = {
@@ -19,7 +20,8 @@ const localPlugin = {
 		'require-marketing-markdown': requireMarketingMarkdownRule,
 		'require-marketing-route-registration': requireMarketingRouteRegistrationRule,
 		'no-hardcoded-aria-label': noHardcodedAriaLabelRule,
-		'no-hardcoded-sr-only': noHardcodedSrOnlyRule
+		'no-hardcoded-sr-only': noHardcodedSrOnlyRule,
+		'no-debounce-in-rune': noDebounceInRuneRule
 	}
 };
 
@@ -172,6 +174,18 @@ export default defineConfig(
 		rules: {
 			'local/no-hardcoded-aria-label': 'error',
 			'local/no-hardcoded-sr-only': 'error'
+		}
+	},
+	{
+		// Runes (`$effect`/`$derived`) and `useDebounce` appear in both components and
+		// `.svelte.ts` rune modules. oxlint JS plugins do not support Svelte yet, so this
+		// guard lives in ESLint (see eslint/rules/no-debounce-in-rune.js).
+		files: ['src/**/*.svelte', 'src/**/*.svelte.ts'],
+		plugins: {
+			local: localPlugin
+		},
+		rules: {
+			'local/no-debounce-in-rune': 'error'
 		}
 	},
 	// Convex best-practice rules — v2 ships ESLint 9 flat config natively

--- a/eslint/rules/no-debounce-in-rune.js
+++ b/eslint/rules/no-debounce-in-rune.js
@@ -1,0 +1,102 @@
+/**
+ * ESLint rule: no-debounce-in-rune
+ *
+ * Forbids calling the function returned by runed's `useDebounce(...)` (including
+ * `.cancel()`) from inside a Svelte rune (`$effect`, `$effect.pre`, `$effect.root`,
+ * `$derived`, `$derived.by`).
+ *
+ * Why: `useDebounce` stores its timer state in an internal `$state` that the
+ * returned function both reads and writes on every call. Calling it inside a rune
+ * makes the rune depend on that `$state` and then invalidate it, looping until
+ * `effect_update_depth_exceeded` (see the #402 regression in the support widget).
+ *
+ * ❌ const f = useDebounce(fn, 300); $effect(() => { f(); return () => f.cancel(); });
+ * ✅ const d = new Debounced(() => value, 300);   // reactive debounced value
+ * ✅ $effect(() => { const t = setTimeout(fn, 300); return () => clearTimeout(t); });
+ * ✅ <button onclick={() => f()}>                  // event handler, not a rune
+ */
+
+const DEBOUNCE_FACTORIES = new Set(['useDebounce']);
+const RUNE_ROOTS = new Set(['$effect', '$derived']);
+
+/** Is this CallExpression a rune call: $effect(), $effect.pre(), $derived(), $derived.by()? */
+function isRuneCall(node) {
+	const callee = node.callee;
+	if (!callee) return false;
+	if (callee.type === 'Identifier') return RUNE_ROOTS.has(callee.name);
+	if (
+		callee.type === 'MemberExpression' &&
+		callee.object?.type === 'Identifier' &&
+		RUNE_ROOTS.has(callee.object.name)
+	) {
+		return true;
+	}
+	return false;
+}
+
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow calling a useDebounce() result inside a Svelte rune ($effect/$derived)'
+		},
+		schema: [],
+		messages: {
+			debounceInRune:
+				"Do not call a useDebounce() result inside $effect/$derived. It reads and writes the debouncer's internal $state, which loops (effect_update_depth_exceeded). Use the `Debounced` class for a reactive debounced value, or a plain setTimeout + clearTimeout for a one-shot timer."
+		}
+	},
+	create(context) {
+		// Identifiers bound to a `useDebounce(...)` result. `const` is declared before
+		// use (TDZ), so a single top-down pass always records the name before any call.
+		const debouncedNames = new Set();
+		// Stack of rune CallExpression nodes currently being traversed.
+		const runeStack = [];
+
+		/** Returns the debounced identifier name being called (f() or f.cancel()), or null. */
+		function calledDebouncedName(node) {
+			const callee = node.callee;
+			if (!callee) return null;
+			// f(...)
+			if (callee.type === 'Identifier' && debouncedNames.has(callee.name)) {
+				return callee.name;
+			}
+			// f.cancel(...), f.runScheduledNow(...), etc.
+			if (
+				callee.type === 'MemberExpression' &&
+				callee.object?.type === 'Identifier' &&
+				debouncedNames.has(callee.object.name)
+			) {
+				return callee.object.name;
+			}
+			return null;
+		}
+
+		return {
+			VariableDeclarator(node) {
+				if (
+					node.init?.type === 'CallExpression' &&
+					node.init.callee?.type === 'Identifier' &&
+					DEBOUNCE_FACTORIES.has(node.init.callee.name) &&
+					node.id?.type === 'Identifier'
+				) {
+					debouncedNames.add(node.id.name);
+				}
+			},
+			CallExpression(node) {
+				if (isRuneCall(node)) {
+					runeStack.push(node);
+					return;
+				}
+				if (runeStack.length > 0 && calledDebouncedName(node)) {
+					context.report({ node, messageId: 'debounceInRune' });
+				}
+			},
+			'CallExpression:exit'(node) {
+				if (runeStack[runeStack.length - 1] === node) {
+					runeStack.pop();
+				}
+			}
+		};
+	}
+};

--- a/eslint/rules/no-debounce-in-rune.test.ts
+++ b/eslint/rules/no-debounce-in-rune.test.ts
@@ -52,9 +52,9 @@ describe('no-debounce-in-rune', () => {
 				});
 			`)
 		);
-		// one for forceLoad(), one for forceLoad.cancel()
-		expect(reports.length).toBeGreaterThanOrEqual(1);
-		expect(reports[0].messageId).toBe('debounceInRune');
+		// both the call and the cleanup cancel must be flagged
+		expect(reports).toHaveLength(2);
+		expect(reports.every((r) => r.messageId === 'debounceInRune')).toBe(true);
 	});
 
 	it('flags .cancel() in an $effect cleanup', () => {

--- a/eslint/rules/no-debounce-in-rune.test.ts
+++ b/eslint/rules/no-debounce-in-rune.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import parser from 'svelte-eslint-parser';
+import rule from './no-debounce-in-rune.js';
+
+/**
+ * Walk the parsed AST calling enter (`Type`) and exit (`Type:exit`) listeners,
+ * so the rule's runeStack push/pop works exactly as it does under real ESLint.
+ */
+function lint(code: string): Array<{ messageId: string }> {
+	const reports: Array<{ messageId: string }> = [];
+	const ast = parser.parseForESLint(code, {});
+
+	const context = {
+		report: (opts: { messageId: string }) => reports.push(opts),
+		getFilename: () => 'test.svelte',
+		filename: 'test.svelte'
+	};
+
+	const listeners = rule.create(context) as Record<string, (n: unknown) => void>;
+
+	function walk(node: Record<string, unknown>) {
+		if (!node || typeof node !== 'object') return;
+		const type = node.type as string;
+		if (type && typeof listeners[type] === 'function') listeners[type](node);
+		for (const key of Object.keys(node)) {
+			if (key === 'parent') continue;
+			const val = node[key];
+			if (Array.isArray(val)) val.forEach((v) => walk(v as Record<string, unknown>));
+			else if (val && typeof val === 'object' && (val as Record<string, unknown>).type)
+				walk(val as Record<string, unknown>);
+		}
+		if (type && typeof listeners[`${type}:exit`] === 'function') listeners[`${type}:exit`](node);
+	}
+
+	walk(ast.ast as unknown as Record<string, unknown>);
+	return reports;
+}
+
+const wrap = (script: string) => `<script>\n${script}\n</script>`;
+
+describe('no-debounce-in-rune', () => {
+	// --- Invalid: the #402 regression shapes ---
+
+	it('flags a useDebounce() call inside $effect', () => {
+		const reports = lint(
+			wrap(`
+				import { useDebounce } from 'runed';
+				const forceLoad = useDebounce(() => {}, 3000);
+				$effect(() => {
+					forceLoad().catch(() => {});
+					return () => forceLoad.cancel();
+				});
+			`)
+		);
+		// one for forceLoad(), one for forceLoad.cancel()
+		expect(reports.length).toBeGreaterThanOrEqual(1);
+		expect(reports[0].messageId).toBe('debounceInRune');
+	});
+
+	it('flags .cancel() in an $effect cleanup', () => {
+		const reports = lint(
+			wrap(`
+				import { useDebounce } from 'runed';
+				const schedule = useDebounce(() => {}, 1000);
+				$effect(() => {
+					return () => schedule.cancel();
+				});
+			`)
+		);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('debounceInRune');
+	});
+
+	it('flags a useDebounce() call inside $derived.by', () => {
+		const reports = lint(
+			wrap(`
+				import { useDebounce } from 'runed';
+				const f = useDebounce(() => 1, 200);
+				const x = $derived.by(() => {
+					f();
+					return 1;
+				});
+			`)
+		);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('debounceInRune');
+	});
+
+	// --- Valid: must NOT be flagged ---
+
+	it('allows the Debounced class read inside a rune', () => {
+		const reports = lint(
+			wrap(`
+				import { Debounced } from 'runed';
+				const d = new Debounced(() => value, 300);
+				const x = $derived(d.current);
+			`)
+		);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows a useDebounce() result called from an event handler', () => {
+		const reports = lint(
+			`<script>
+				import { useDebounce } from 'runed';
+				const f = useDebounce(() => {}, 300);
+			</script>
+			<button onclick={() => f()}>go</button>`
+		);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows setTimeout inside an $effect', () => {
+		const reports = lint(
+			wrap(`
+				$effect(() => {
+					const t = setTimeout(() => {}, 300);
+					return () => clearTimeout(t);
+				});
+			`)
+		);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows a useDebounce() result called outside any rune', () => {
+		const reports = lint(
+			wrap(`
+				import { useDebounce } from 'runed';
+				const f = useDebounce(() => {}, 300);
+				function handle() { f(); }
+			`)
+		);
+		expect(reports).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
The support widget froze with `effect_update_depth_exceeded` (fixed in #414) because a runed `useDebounce(...)` result was called inside an `$effect`. `useDebounce` keeps its timer state in an internal `$state` that the returned function reads and writes on every call, so the rune captures it as a dependency and then invalidates it, looping until Svelte bails out. This adds an automated guard so that exact footgun can never reach `main` again.

The new ESLint rule `local/no-debounce-in-rune` errors when a `useDebounce(...)`-bound identifier is called (including `.cancel()`) inside `$effect`, `$effect.pre`, `$effect.root`, `$derived`, or `$derived.by`. It does not flag the safe patterns: the `Debounced` class (reactive debounced value), a `useDebounce` result called from an event handler, or a plain `setTimeout` inside an effect. It applies to `src/**/*.svelte` and `src/**/*.svelte.ts`.

The guard lives in ESLint rather than oxlint on purpose: oxlint JS plugins are in alpha and list "Custom file formats and parsers (e.g. Svelte, Vue, Angular)" under "Not supported yet", so a custom oxlint rule cannot see `.svelte` files where this pattern occurs. AGENTS.md notes a TODO to port it to a local oxlint plugin once oxlint adds Svelte support.

`bun run test:unit` passes (395 tests, including 7 new cases for this rule). `eslint` errors on a `.svelte` fixture that reintroduces the bug and stays clean on the fixed widgets and the existing `new Debounced(...)` usages. `bun scripts/static-checks.ts` passes.

See also: #414