### PR TITLE
chore(chat): Switch to Gemma 4 26B A4B on OpenRouter

### DIFF
--- a/src/lib/convex/utils/chatModel.ts
+++ b/src/lib/convex/utils/chatModel.ts
@@ -9,4 +9,4 @@
  * support surface) and that divergence should remain visible at the agent
  * definition rather than hidden behind a default.
  */
-export const CHAT_MODEL_ID = 'google/gemma-4-31b-it';
+export const CHAT_MODEL_ID = 'google/gemma-4-26b-a4b-it';


### PR DESCRIPTION
## Summary
- Point `CHAT_MODEL_ID` at `google/gemma-4-26b-a4b-it` (faster/cheaper than 31B; keeps reasoning, vision, and tools on OpenRouter).

## Test plan
- [ ] CI green
- [ ] Smoke AI chat + support after deploy