### PR TITLE
feat(marquee): add repeat prop for short content

### DIFF
--- a/src/lib/components/spell/marquee/marquee.svelte
+++ b/src/lib/components/spell/marquee/marquee.svelte
@@ -13,6 +13,32 @@
 		direction?: MarqueeDirection;
 		fade?: boolean;
 		fadeAmount?: number;
+		/**
+		 * How many copies of the children to render inside each segment of
+		 * the loop. The marquee stays seamless only when one segment fully
+		 * spans its container along the scroll axis; with short content in
+		 * a long container the loop exposes empty space at the seam.
+		 *
+		 * Pick the smallest N such that N copies of one rendered child
+		 * (including any internal gaps) span the container along the
+		 * direction axis. A safe estimate is
+		 * `Math.ceil(containerSize / oneCopySize) + 1`.
+		 *
+		 * Total rendered copies of `children` = `2 * repeat` (every segment
+		 * is rendered twice for the loop), so keep this as low as needed.
+		 * Defaults to `1`, which is correct when one copy already spans the
+		 * container.
+		 *
+		 * @example
+		 * // short pills in a wide row: 1 copy is ~120px, container ~900px
+		 * <Marquee repeat={9}>
+		 *   {#snippet children()}
+		 *     <span class="pill">Launch</span>
+		 *     <span class="pill">Updates</span>
+		 *   {/snippet}
+		 * </Marquee>
+		 */
+		repeat?: number;
 	}
 
 	let {
@@ -24,6 +50,7 @@
 		direction = 'left',
 		fade = true,
 		fadeAmount = 10,
+		repeat = 1,
 		...props
 	}: MarqueeProps = $props();
 
@@ -32,6 +59,7 @@
 	const clampedFadeAmount = $derived(
 		Number.isFinite(fadeAmount) ? Math.min(Math.max(fadeAmount, 0), 50) : 10
 	);
+	const safeRepeat = $derived(Number.isFinite(repeat) ? Math.max(1, Math.floor(repeat)) : 1);
 
 	const maskImage = $derived.by(() => {
 		if (!fade) {
@@ -82,7 +110,9 @@
 				isVertical ? 'spell-marquee__segment--vertical' : 'spell-marquee__segment--horizontal'
 			)}
 		>
-			{@render children()}
+			{#each Array(safeRepeat) as _, i (i)}
+				{@render children()}
+			{/each}
 		</div>
 
 		<div
@@ -93,7 +123,9 @@
 				isVertical ? 'spell-marquee__segment--vertical' : 'spell-marquee__segment--horizontal'
 			)}
 		>
-			{@render children()}
+			{#each Array(safeRepeat) as _, i (i)}
+				{@render children()}
+			{/each}
 		</div>
 	</div>
 </div>

--- a/src/lib/components/spell/marquee/marquee.svelte
+++ b/src/lib/components/spell/marquee/marquee.svelte
@@ -27,7 +27,11 @@
 		 * Total rendered copies of `children` = `2 * repeat` (every segment
 		 * is rendered twice for the loop), so keep this as low as needed.
 		 * Defaults to `1`, which is correct when one copy already spans the
-		 * container.
+		 * container. Values are clamped to the range `[1, 100]`.
+		 *
+		 * Only the first rendered copy is exposed to assistive tech; the
+		 * remaining copies are hidden via `aria-hidden` and `inert` so
+		 * screen readers and keyboard navigation see the content once.
 		 *
 		 * @example
 		 * // short pills in a wide row: 1 copy is ~120px, container ~900px
@@ -59,7 +63,10 @@
 	const clampedFadeAmount = $derived(
 		Number.isFinite(fadeAmount) ? Math.min(Math.max(fadeAmount, 0), 50) : 10
 	);
-	const safeRepeat = $derived(Number.isFinite(repeat) ? Math.max(1, Math.floor(repeat)) : 1);
+	const MAX_REPEAT = 100;
+	const safeRepeat = $derived(
+		Number.isFinite(repeat) ? Math.min(MAX_REPEAT, Math.max(1, Math.floor(repeat))) : 1
+	);
 
 	const maskImage = $derived.by(() => {
 		if (!fade) {
@@ -111,7 +118,16 @@
 			)}
 		>
 			{#each Array(safeRepeat) as _, i (i)}
-				{@render children()}
+				{#if i === 0}
+					{@render children()}
+				{:else}
+					<!-- Repeated copies fill the segment visually but must stay
+					     invisible to assistive tech and unreachable by keyboard.
+					     display:contents keeps the flex layout identical to copy 0. -->
+					<div style="display: contents" aria-hidden="true" inert>
+						{@render children()}
+					</div>
+				{/if}
 			{/each}
 		</div>
 


### PR DESCRIPTION
The spell marquee renders the children twice and loops via translateX(-50%). That stays seamless only when a single segment is at least as wide as its container. With short content (a handful of tags, a tiny headline) in a wide container the second segment scrolls off before the next cycle starts, leaving empty space that snaps back at the loop reset. This is the limitation flagged in the original review as finding 5 and deferred.

Add a repeat prop (default 1, identical to current behavior) that renders the children N times inside each segment. A consumer with short content sets it high enough that one segment exceeds the container, restoring seamlessness without any measurement or JS. The math: segment width becomes N times one copy, scroller width 2N copies, translate stays -50% so the loop point still lands seg2 exactly where seg1 started.

bun scripts/static-checks.ts on the change passes (format, lint, types). Seamlessness will be verified on the preview deployment via Playwright coverage sampling across a full cycle once CI is green.