### PR TITLE
fix(marketing): keep markdown responses out of shared caches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,8 +510,9 @@ Marketing routes that are NOT prerendered get edge caching via `handleCacheContr
 
 - Condition: unauthenticated + matches `matchPublicMarketingRoute()`
 - Headers: `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400`
-- Placed AFTER `handleMarketingMarkdown` in `sequence()` to preserve markdown's own 5-minute TTL
-- **Disabled on CF Workers preview deployments** — preview hostnames (`ALIAS-saas-starter.*.workers.dev`) skip `s-maxage` to prevent stale cached HTML from breaking `Accept: text/markdown` content negotiation.
+- Placed AFTER `handleMarketingMarkdown` in `sequence()` to preserve markdown's own TTL
+
+Markdown responses on the same URLs use `Cache-Control: private` to stay out of shared caches: CF Edge ignores `Vary: Accept`, so any edge-cacheable markdown would poison subsequent HTML requests on the same URL.
 
 #### Cache purging (production)
 

--- a/src/lib/markdown/marketing.test.ts
+++ b/src/lib/markdown/marketing.test.ts
@@ -76,7 +76,10 @@ describe('marketing markdown helpers', () => {
 		expect(response.status).toBe(200);
 		expect(response.headers.get('content-type')).toBe('text/markdown; charset=utf-8');
 		expect(response.headers.get('vary')).toBe('Accept');
-		expect(response.headers.get('cache-control')).toContain('s-maxage=300');
+		// Markdown must stay out of shared caches: CF Edge (and most CDNs) ignore Vary,
+		// so any edge-cacheable markdown would poison subsequent HTML requests on the same URL.
+		expect(response.headers.get('cache-control')).toContain('private');
+		expect(response.headers.get('cache-control')).not.toContain('s-maxage');
 
 		const body = await response.text();
 		expect(body).toContain('# Build & Ship Your Product Faster');

--- a/src/lib/markdown/marketing.ts
+++ b/src/lib/markdown/marketing.ts
@@ -10,6 +10,12 @@ import { LEGAL_CONFIG } from '$lib/config/legal';
 const MARKDOWN_CONTENT_TYPE = 'text/markdown; charset=utf-8';
 const TEXT_CONTENT_TYPE = 'text/plain; charset=utf-8';
 const MARKETING_CACHE_CONTROL = 'public, max-age=0, s-maxage=300, stale-while-revalidate=300';
+// Markdown is served on URLs that also serve HTML, negotiated via Accept.
+// CF Edge (and most shared caches) ignore Vary, so a public cache would key
+// one variant under the URL and serve it for the other Accept value, poisoning
+// HTML responses with Markdown (and vice versa). Keep Markdown out of shared
+// caches; browsers may still cache it privately.
+const MARKDOWN_CACHE_CONTROL = 'private, max-age=300, stale-while-revalidate=300';
 
 function quoteFrontmatterValue(value: string): string {
 	return JSON.stringify(value);
@@ -89,7 +95,7 @@ export function createMarketingMarkdownResponse(
 		status: 200,
 		headers: {
 			'Content-Type': MARKDOWN_CONTENT_TYPE,
-			'Cache-Control': MARKETING_CACHE_CONTROL,
+			'Cache-Control': MARKDOWN_CACHE_CONTROL,
 			Vary: 'Accept'
 		}
 	});


### PR DESCRIPTION
The CF Workers preview E2E suite has been intermittently failing on the public-a11y and public-agent-surface specs with errors that look like rendering bugs (no `<title>`, no `<html lang>`, `text/markdown` returned for browser navigation). The real cause is at the edge: the marketing markdown response is served with `public, max-age=0, s-maxage=300`, and CF Edge ignores `Vary: Accept`, so the markdown response gets URL-keyed at the edge and is then returned for subsequent HTML requests on the same URL until the TTL expires. This was reproduced live against the current preview: a request with `Accept: text/markdown` followed by a request with `Accept: text/html` on the same URL returns markdown with `cf-cache-status: HIT`. The same vector applies in production behind a custom domain, since shared caches generally ignore Vary.

Switch markdown responses to `private, max-age=300, stale-while-revalidate=300` so they stay out of shared caches entirely; browsers may still cache them per session. The static-URL helpers for `llms.txt`, `robots.txt`, and `sitemap.xml` keep `MARKETING_CACHE_CONTROL` since each of those has a single content type per URL and no cross-type cache key. Drop the AGENTS.md bullet about a preview-only `s-maxage` skip that was never implemented and replace it with a short note about markdown staying out of shared caches. Add regression assertions that the markdown response is `private` and never contains `s-maxage`.

`bun scripts/static-checks.ts` passes. `bun run test:unit -- src/lib/markdown/marketing.test.ts` passes (10/10).