### PR TITLE
fix(marquee): coerce numeric props and pause on focus

### DIFF
--- a/src/lib/components/spell/marquee/marquee.svelte
+++ b/src/lib/components/spell/marquee/marquee.svelte
@@ -59,14 +59,19 @@
 	}: MarqueeProps = $props();
 
 	const isVertical = $derived(direction === 'up' || direction === 'down');
-	const safeDuration = $derived(Number.isFinite(duration) ? Math.max(duration, 0.01) : 20);
-	const clampedFadeAmount = $derived(
-		Number.isFinite(fadeAmount) ? Math.min(Math.max(fadeAmount, 0), 50) : 10
-	);
+	const safeDuration = $derived.by(() => {
+		const n = Number(duration);
+		return Number.isFinite(n) ? Math.max(n, 0.01) : 20;
+	});
+	const clampedFadeAmount = $derived.by(() => {
+		const n = Number(fadeAmount);
+		return Number.isFinite(n) ? Math.min(Math.max(n, 0), 50) : 10;
+	});
 	const MAX_REPEAT = 100;
-	const safeRepeat = $derived(
-		Number.isFinite(repeat) ? Math.min(MAX_REPEAT, Math.max(1, Math.floor(repeat))) : 1
-	);
+	const safeRepeat = $derived.by(() => {
+		const n = Number(repeat);
+		return Number.isFinite(n) ? Math.min(MAX_REPEAT, Math.max(1, Math.floor(n))) : 1;
+	});
 
 	const maskImage = $derived.by(() => {
 		if (!fade) {
@@ -117,7 +122,7 @@
 				isVertical ? 'spell-marquee__segment--vertical' : 'spell-marquee__segment--horizontal'
 			)}
 		>
-			{#each Array(safeRepeat) as _, i (i)}
+			{#each { length: safeRepeat } as _, i (i)}
 				{#if i === 0}
 					{@render children()}
 				{:else}
@@ -139,7 +144,7 @@
 				isVertical ? 'spell-marquee__segment--vertical' : 'spell-marquee__segment--horizontal'
 			)}
 		>
-			{#each Array(safeRepeat) as _, i (i)}
+			{#each { length: safeRepeat } as _, i (i)}
 				{@render children()}
 			{/each}
 		</div>
@@ -223,7 +228,8 @@
 		animation-name: spell-marquee-scroll-y-reverse;
 	}
 
-	.group:hover .spell-marquee__scroller--pause-on-hover {
+	.group:hover .spell-marquee__scroller--pause-on-hover,
+	.group:focus-within .spell-marquee__scroller--pause-on-hover {
 		animation-play-state: paused;
 	}
 


### PR DESCRIPTION
Three polish items carried back from the review feedback on the upstream port of this component at SikandarJODD/cnblocks#97.

`safeDuration`, `clampedFadeAmount` and `safeRepeat` now coerce their input through `Number()` before the finite-number check, so a numeric-string prop value (e.g. `repeat="4"`) behaves the same as a numeric one rather than silently falling back to the default.

The two segment `{#each}` blocks iterate `{ length: safeRepeat }` instead of `Array(safeRepeat)`. The array-like literal is cheaper than allocating a sparse array on every reactivity tick and matches the idiom we used in the earlier magic marquee.

The `pauseOnHover` rule now also fires on `.group:focus-within`, so when a marquee carries focusable children the animation pauses while the user is interacting via keyboard, not just hovering.

No API changes, defaults unchanged. bun scripts/static-checks.ts on the file passes.