### PR TITLE
fix: return 499 on client-aborted auth requests

### DIFF
--- a/src/lib/server/auth-proxy.test.ts
+++ b/src/lib/server/auth-proxy.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
+import { isAbortError, proxyAuthRequest } from './auth-proxy';
+
+function makeEvent(signal?: AbortSignal): RequestEvent {
+	return {
+		request: new Request('http://localhost/api/auth/get-session', signal ? { signal } : undefined)
+	} as RequestEvent;
+}
+
+describe('isAbortError', () => {
+	it('detects a direct AbortError', () => {
+		expect(isAbortError(new DOMException('aborted', 'AbortError'))).toBe(true);
+	});
+
+	it('detects an AbortError wrapped as a cause', () => {
+		const err = new TypeError('fetch failed', { cause: new DOMException('aborted', 'AbortError') });
+		expect(isAbortError(err)).toBe(true);
+	});
+
+	it('ignores unrelated errors and non-errors', () => {
+		expect(isAbortError(new TypeError('connection refused'))).toBe(false);
+		expect(isAbortError('aborted')).toBe(false);
+		expect(isAbortError(undefined)).toBe(false);
+	});
+});
+
+describe('proxyAuthRequest', () => {
+	it('returns 499 when the handler throws an AbortError', async () => {
+		const handler: RequestHandler = async () => {
+			throw new DOMException('aborted', 'AbortError');
+		};
+		const res = await proxyAuthRequest(handler, makeEvent());
+		expect(res.status).toBe(499);
+	});
+
+	it('returns 499 when the request signal is already aborted', async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const handler: RequestHandler = async () => {
+			throw new Error('socket hang up');
+		};
+		const res = await proxyAuthRequest(handler, makeEvent(controller.signal));
+		expect(res.status).toBe(499);
+	});
+
+	it('logs and rethrows genuine upstream failures', async () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const handler: RequestHandler = async () => {
+			throw new TypeError('upstream exploded');
+		};
+		await expect(proxyAuthRequest(handler, makeEvent())).rejects.toThrow('upstream exploded');
+		expect(consoleError).toHaveBeenCalled();
+		consoleError.mockRestore();
+	});
+
+	it('passes a successful response through with rebuilt headers', async () => {
+		const handler: RequestHandler = async () =>
+			new Response('{"ok":true}', {
+				status: 200,
+				headers: { 'content-type': 'application/json' }
+			});
+		const res = await proxyAuthRequest(handler, makeEvent());
+		expect(res.status).toBe(200);
+		expect(res.headers.get('content-type')).toBe('application/json');
+		expect(await res.text()).toBe('{"ok":true}');
+	});
+});

--- a/src/lib/server/auth-proxy.ts
+++ b/src/lib/server/auth-proxy.ts
@@ -1,0 +1,43 @@
+import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
+
+/**
+ * Recognises a fetch/undici AbortError, including when it is wrapped as the
+ * `cause` of another error (e.g. a `TypeError: fetch failed`).
+ */
+export function isAbortError(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	if (err.name === 'AbortError') return true;
+	const cause = (err as { cause?: unknown }).cause;
+	return cause instanceof Error && cause.name === 'AbortError';
+}
+
+/** Rebuild the response so SvelteKit receives mutable headers it can stream. */
+function normalizeResponse(response: Response): Response {
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: new Headers(response.headers)
+	});
+}
+
+/**
+ * Forwards an auth request through the Better Auth handler. A client abort
+ * (page navigation, unload, query cleanup) propagates to the upstream fetch as
+ * an AbortError; converting it to a 499 (Client Closed Request) stops it from
+ * bubbling up as an unhandled 500 and polluting logs / Sentry. Genuine upstream
+ * failures are logged with request context and rethrown so they still surface.
+ */
+export async function proxyAuthRequest(
+	handler: RequestHandler,
+	event: RequestEvent
+): Promise<Response> {
+	try {
+		return normalizeResponse(await handler(event));
+	} catch (err) {
+		if (isAbortError(err) || event.request.signal.aborted) {
+			return new Response(null, { status: 499 });
+		}
+		console.error('[auth-proxy]', event.request.method, new URL(event.request.url).pathname, err);
+		throw err;
+	}
+}

--- a/src/routes/api/auth/[...all]/+server.ts
+++ b/src/routes/api/auth/[...all]/+server.ts
@@ -1,37 +1,8 @@
 import { createSvelteKitHandler } from '@mmailaender/convex-better-auth-svelte/sveltekit';
 import type { RequestHandler } from '@sveltejs/kit';
+import { proxyAuthRequest } from '$lib/server/auth-proxy';
 
 const { GET: rawGet, POST: rawPost } = createSvelteKitHandler();
 
-function normalizeResponse(response: Response): Response {
-	return new Response(response.body, {
-		status: response.status,
-		statusText: response.statusText,
-		headers: new Headers(response.headers)
-	});
-}
-
-function isAbortError(err: unknown): boolean {
-	if (!(err instanceof Error)) return false;
-	if (err.name === 'AbortError') return true;
-	const cause = (err as { cause?: unknown }).cause;
-	return cause instanceof Error && cause.name === 'AbortError';
-}
-
-async function safeProxy(
-	handler: RequestHandler,
-	event: Parameters<RequestHandler>[0]
-): Promise<Response> {
-	try {
-		return normalizeResponse(await handler(event));
-	} catch (err) {
-		if (isAbortError(err) || event.request.signal.aborted) {
-			return new Response(null, { status: 499 });
-		}
-		console.error('[auth-proxy]', event.request.method, new URL(event.request.url).pathname, err);
-		throw err;
-	}
-}
-
-export const GET: RequestHandler = (event) => safeProxy(rawGet, event);
-export const POST: RequestHandler = (event) => safeProxy(rawPost, event);
+export const GET: RequestHandler = (event) => proxyAuthRequest(rawGet, event);
+export const POST: RequestHandler = (event) => proxyAuthRequest(rawPost, event);

--- a/src/routes/api/auth/[...all]/+server.ts
+++ b/src/routes/api/auth/[...all]/+server.ts
@@ -11,5 +11,27 @@ function normalizeResponse(response: Response): Response {
 	});
 }
 
-export const GET: RequestHandler = async (event) => normalizeResponse(await rawGet(event));
-export const POST: RequestHandler = async (event) => normalizeResponse(await rawPost(event));
+function isAbortError(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	if (err.name === 'AbortError') return true;
+	const cause = (err as { cause?: unknown }).cause;
+	return cause instanceof Error && cause.name === 'AbortError';
+}
+
+async function safeProxy(
+	handler: RequestHandler,
+	event: Parameters<RequestHandler>[0]
+): Promise<Response> {
+	try {
+		return normalizeResponse(await handler(event));
+	} catch (err) {
+		if (isAbortError(err) || event.request.signal.aborted) {
+			return new Response(null, { status: 499 });
+		}
+		console.error('[auth-proxy]', event.request.method, new URL(event.request.url).pathname, err);
+		throw err;
+	}
+}
+
+export const GET: RequestHandler = (event) => safeProxy(rawGet, event);
+export const POST: RequestHandler = (event) => safeProxy(rawPost, event);


### PR DESCRIPTION
Closes #422

Wraps `rawGet`/`rawPost` in the auth proxy with a `safeProxy` helper that catches `AbortError` (or checks `request.signal.aborted`) and returns status 499 instead of letting the error bubble up as a 500.

This keeps DevTools and production logs free of noise from routine client aborts (page navigation, react-query cleanup, page-visibility unload).