### PR TITLE
ci(static-checks): skip pending E2E status on forks

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -37,8 +37,10 @@ jobs:
   e2e-pending:
     name: E2E Pending Status
     runs-on: ubicloud-standard-2
-    if: github.event_name == 'pull_request'
-    continue-on-error: true
+    # Skip on fork PRs: the pull_request token is read-only for forks, so
+    # writing a commit status returns 403. Fork E2E status is set by the
+    # gated preview workflow instead.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       statuses: write
     steps:


### PR DESCRIPTION
The `E2E Pending Status` job in `static-checks.yml` sets a pending "E2E Tests" commit status via the GitHub API so a PR shows E2E as expected until the CF Workers preview build reports back. On fork PRs the `pull_request` token is read-only, so the API call fails with `403 Resource not accessible by integration`. A `continue-on-error: true` masked this as a red X on the job step for every external contributor PR, which reads as a real failure.

Scope the job to same-repo PRs with `github.event.pull_request.head.repo.full_name == github.repository`, where the token can actually write the status, and drop the `continue-on-error` workaround since the job no longer runs where it would fail. Fork PRs simply skip the pending status; once gated fork preview E2E lands, that workflow will own the fork status.

No behavior change for same-repo PRs. YAML validated; pre-commit static checks pass.