### PR TITLE
fix(support): screenshot capture-error dialog

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -2096,7 +2096,6 @@
 				"undo": "Rückgängig (Strg+Z)"
 			},
 			"aria_label": "Screenshot-Editor",
-			"capture_failed": "Screenshot fehlgeschlagen. Überprüfen Sie die Konsole für Details.",
 			"capturing": "Wird aufgenommen...",
 			"next": "Bug Markiert",
 			"tool": {
@@ -2105,6 +2104,17 @@
 				"color": "Farbe ändern",
 				"pen": "Stift (P)",
 				"rectangle": "Rechteck (R)"
+			},
+			"error": {
+				"title": "Screenshot konnte nicht erstellt werden",
+				"description": "Beim Erstellen ist etwas schiefgelaufen. Du kannst es erneut versuchen oder den Support kontaktieren, wenn es weiterhin auftritt.",
+				"event_id": "Gib diese ID an, wenn du den Support kontaktierst: {id}",
+				"retry": "Erneut versuchen",
+				"contact": "Support kontaktieren",
+				"cancel": "Abbrechen",
+				"email_subject": "Screenshot-Aufnahme fehlgeschlagen",
+				"email_body": "Beim Erstellen eines Screenshots auf {url} ist ein Fehler aufgetreten.",
+				"email_reference": "Referenz: {id}"
 			}
 		},
 		"suggestion": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2097,7 +2097,6 @@
 				"undo": "Undo (Ctrl+Z)"
 			},
 			"aria_label": "Screenshot editor",
-			"capture_failed": "Failed to capture screenshot. Check console for details.",
 			"capturing": "Capturing...",
 			"next": "Bug Marked",
 			"tool": {
@@ -2106,6 +2105,17 @@
 				"color": "Change Color",
 				"pen": "Pen (P)",
 				"rectangle": "Rectangle (R)"
+			},
+			"error": {
+				"title": "Couldn't capture the screenshot",
+				"description": "Something went wrong while capturing. You can try again, or contact support if it keeps happening.",
+				"event_id": "Reference this ID when you contact support: {id}",
+				"retry": "Try again",
+				"contact": "Contact support",
+				"cancel": "Cancel",
+				"email_subject": "Screenshot capture failed",
+				"email_body": "I ran into an error while capturing a screenshot on {url}.",
+				"email_reference": "Reference: {id}"
 			}
 		},
 		"suggestion": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2096,7 +2096,6 @@
 				"undo": "Deshacer (Ctrl+Z)"
 			},
 			"aria_label": "Editor de captura de pantalla",
-			"capture_failed": "Error al capturar pantalla. Revisa la consola para más detalles.",
 			"capturing": "Capturando...",
 			"next": "Bug Marcado",
 			"tool": {
@@ -2105,6 +2104,17 @@
 				"color": "Cambiar color",
 				"pen": "Lápiz (P)",
 				"rectangle": "Rectángulo (R)"
+			},
+			"error": {
+				"title": "No se pudo realizar la captura de pantalla",
+				"description": "Algo salió mal al capturar. Puedes intentarlo de nuevo o contactar con soporte si sigue ocurriendo.",
+				"event_id": "Indica este ID al contactar con soporte: {id}",
+				"retry": "Intentar de nuevo",
+				"contact": "Contactar con soporte",
+				"cancel": "Cancelar",
+				"email_subject": "Error al capturar la pantalla",
+				"email_body": "Tuve un error al capturar una captura de pantalla en {url}.",
+				"email_reference": "Referencia: {id}"
 			}
 		},
 		"suggestion": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -2096,7 +2096,6 @@
 				"undo": "Annuler (Ctrl+Z)"
 			},
 			"aria_label": "Éditeur de capture d'écran",
-			"capture_failed": "Échec de la capture d'écran. Consultez la console pour plus de détails.",
 			"capturing": "Capture en cours...",
 			"next": "Bug Marqué",
 			"tool": {
@@ -2105,6 +2104,17 @@
 				"color": "Changer la couleur",
 				"pen": "Stylo (P)",
 				"rectangle": "Rectangle (R)"
+			},
+			"error": {
+				"title": "Impossible de réaliser la capture d'écran",
+				"description": "Une erreur s'est produite lors de la capture. Vous pouvez réessayer ou contacter le support si le problème persiste.",
+				"event_id": "Indiquez cet identifiant lorsque vous contactez le support : {id}",
+				"retry": "Réessayer",
+				"contact": "Contacter le support",
+				"cancel": "Annuler",
+				"email_subject": "Échec de la capture d'écran",
+				"email_body": "J'ai rencontré une erreur lors de la capture d'écran sur {url}.",
+				"email_reference": "Référence : {id}"
 			}
 		},
 		"suggestion": {

--- a/src/lib/components/customer-support/customer-support.svelte
+++ b/src/lib/components/customer-support/customer-support.svelte
@@ -11,6 +11,14 @@
 	import { generateAnonymousUserId, isAnonymousUser } from '$lib/convex/utils/anonymousUser';
 	import { supportUserId } from './support-user-id.svelte';
 	import { useSupportUrlState } from './use-support-url-state.svelte';
+	import { getTranslate } from '@tolgee/svelte';
+	import * as Sentry from '@sentry/sveltekit';
+	import { PUBLIC_SENTRY_DSN } from '$env/static/public';
+	import * as AlertDialog from '$lib/components/ui/alert-dialog';
+	import { Button } from '$lib/components/ui/button';
+	import { getLegalEmailAddress } from '$lib/config/legal';
+
+	const { t } = getTranslate();
 
 	// URL state for shareable links
 	const urlState = useSupportUrlState();
@@ -160,6 +168,34 @@
 		// Upload screenshot via ChatUIContext (adds to ctx.attachments)
 		await chatUIContext.uploadScreenshot(blob, filename, dimensions);
 	}
+
+	// Recoverable capture-failure flow: the editor reports the error, we tear the
+	// overlay down and offer retry / contact support instead of a native alert().
+	let captureErrorOpen = $state(false);
+	let captureEventId = $state<string | undefined>(undefined);
+
+	function handleScreenshotCaptureError(error: unknown) {
+		isScreenshotMode = false;
+		captureEventId = browser && PUBLIC_SENTRY_DSN ? Sentry.captureException(error) : undefined;
+		captureErrorOpen = true;
+	}
+
+	function retryScreenshotCapture() {
+		captureErrorOpen = false;
+		isScreenshotMode = true;
+	}
+
+	function contactSupportAboutCapture() {
+		const subject = $t('support.screenshot.error.email_subject');
+		let body = $t('support.screenshot.error.email_body', { url: page.url.href });
+		if (captureEventId) {
+			body += `\n\n${$t('support.screenshot.error.email_reference', { id: captureEventId })}`;
+		}
+		// Plain location assignment, not an <a href>, so SvelteKit's client router
+		// doesn't intercept the mailto and silently no-op the click.
+		window.location.href = `mailto:${getLegalEmailAddress()}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+		captureErrorOpen = false;
+	}
 </script>
 
 <AIChatbar isFeedbackOpen={!shouldShowAIChatbar} />
@@ -167,6 +203,37 @@
 
 {#if isScreenshotMode}
 	{#await import('./screenshot-editor/ScreenshotEditor.svelte') then { default: ScreenshotEditor }}
-		<ScreenshotEditor onCancel={handleScreenshotCancel} onScreenshotSaved={handleScreenshotSaved} />
+		<ScreenshotEditor
+			onCancel={handleScreenshotCancel}
+			onScreenshotSaved={handleScreenshotSaved}
+			onCaptureError={handleScreenshotCaptureError}
+		/>
 	{/await}
 {/if}
+
+<AlertDialog.Root bind:open={captureErrorOpen}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>{$t('support.screenshot.error.title')}</AlertDialog.Title>
+			<AlertDialog.Description>
+				{$t('support.screenshot.error.description')}
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		{#if captureEventId}
+			<p class="rounded-md bg-muted px-2 py-1.5 font-mono text-xs break-all text-muted-foreground">
+				{$t('support.screenshot.error.event_id', { id: captureEventId })}
+			</p>
+		{/if}
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel onclick={() => (captureErrorOpen = false)}>
+				{$t('support.screenshot.error.cancel')}
+			</AlertDialog.Cancel>
+			<Button variant="outline" onclick={contactSupportAboutCapture}>
+				{$t('support.screenshot.error.contact')}
+			</Button>
+			<AlertDialog.Action onclick={retryScreenshotCapture}>
+				{$t('support.screenshot.error.retry')}
+			</AlertDialog.Action>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotEditor.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotEditor.svelte
@@ -16,7 +16,8 @@
 
 	let {
 		onCancel,
-		onScreenshotSaved
+		onScreenshotSaved,
+		onCaptureError
 	}: {
 		onCancel?: () => void;
 		onScreenshotSaved?: (
@@ -24,6 +25,7 @@
 			filename: string,
 			dimensions: { width: number; height: number }
 		) => void;
+		onCaptureError?: (error: unknown) => void;
 	} = $props();
 
 	// Initialize editor context immediately (no screenshot capture needed)
@@ -128,7 +130,9 @@
 			onCancel?.();
 		} catch (error) {
 			console.error('Failed to capture screenshot:', error);
-			alert($t('support.screenshot.capture_failed'));
+			// Hand the failure to the parent, which tears down this overlay and
+			// surfaces a recoverable error dialog (retry / contact support).
+			onCaptureError?.(error);
 		} finally {
 			editorContext.isSaving = false;
 		}


### PR DESCRIPTION
Closes #406

When a screenshot capture failed, the editor fell back to a native browser `alert()`, which is inconsistent with the rest of the app and a blocking dialog for a recoverable error state.

The editor now reports the failure to its parent through a new `onCaptureError` callback. The parent tears down the screenshot overlay and opens an `AlertDialog` with three actions: try again (re-opens the editor), contact support (opens a `mailto` prefilled with the failed URL), and cancel. When Sentry is configured the error is captured and its event id is shown so users can reference it; without a DSN that line is hidden. All new strings are localized in the four locales and the now-unused `capture_failed` key is removed.

`bun scripts/static-checks.ts` passes and the Svelte autofixer reports no issues.
