### PR TITLE
fix(ui): correct text-link press effect

### DIFF
--- a/src/lib/components/ErrorDisplay.svelte
+++ b/src/lib/components/ErrorDisplay.svelte
@@ -92,10 +92,7 @@
 			</InputGroup.Root>
 			<Empty.Description>
 				{translations.error_page.need_help}
-				<a
-					href={resolve(homeHref)}
-					class="text-primary underline-offset-4 hover:underline active:translate-y-px"
-				>
+				<a href={resolve(homeHref)} class="text-primary underline-offset-4 hover:underline">
 					{translations.error_page.back_home}
 				</a>
 			</Empty.Description>

--- a/src/lib/components/authenticated/authenticated-header.svelte
+++ b/src/lib/components/authenticated/authenticated-header.svelte
@@ -36,7 +36,7 @@
 					{#if index > 0}
 						<Breadcrumb.Separator class="hidden md:block" />
 					{/if}
-					<Breadcrumb.Item class={index === 0 ? 'hidden md:block' : ''}>
+					<Breadcrumb.Item class={index === 0 ? 'hidden md:inline-flex' : ''}>
 						{#if item.isLast}
 							<Breadcrumb.Page>{item.label}</Breadcrumb.Page>
 						{:else}

--- a/src/lib/components/ui/breadcrumb/breadcrumb-link.svelte
+++ b/src/lib/components/ui/breadcrumb/breadcrumb-link.svelte
@@ -16,7 +16,10 @@
 
 	const attrs = $derived({
 		'data-slot': 'breadcrumb-link',
-		class: cn('hover:text-foreground transition-colors active:translate-y-px', className),
+		class: cn(
+			'hover:text-foreground transition-[color,translate] active:translate-y-px',
+			className
+		),
 		href,
 		...restProps
 	});

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -222,7 +222,7 @@
 								<a
 									href={resolve(localizedHref('/signin'))}
 									data-testid="forgot-password-back-link"
-									class="underline underline-offset-4 active:translate-y-px"
+									class="underline underline-offset-4"
 								>
 									<T keyName="auth.forgot_password.back_to_signin" defaultValue="Back to sign in" />
 								</a>
@@ -242,20 +242,14 @@
 		</Card.Root>
 		<Field.Description class="px-6 text-center">
 			<T keyName="auth.terms.agreement" defaultValue="By clicking continue, you agree to our" />
-			<a
-				href={resolve(localizedHref('/terms'))}
-				class="underline underline-offset-4 active:translate-y-px"
+			<a href={resolve(localizedHref('/terms'))} class="underline underline-offset-4"
 				><T keyName="auth.terms.terms_of_service" defaultValue="Terms of Service" /></a
 			>
 			<T keyName="auth.terms.and" defaultValue="and" />
-			<a
-				href={resolve(localizedHref('/privacy'))}
-				class="underline underline-offset-4 active:translate-y-px"
+			<a href={resolve(localizedHref('/privacy'))} class="underline underline-offset-4"
 				><T keyName="auth.terms.privacy_policy" defaultValue="Privacy Policy" /></a
 			>.
-			<a
-				href={resolve(localizedHref('/'))}
-				class="underline underline-offset-4 active:translate-y-px"
+			<a href={resolve(localizedHref('/'))} class="underline underline-offset-4"
 				><T keyName="auth.back_to_home" defaultValue="Back to home" /></a
 			>
 		</Field.Description>

--- a/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
@@ -202,10 +202,7 @@
 									class="rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400"
 								>
 									<T keyName={message} />
-									<a
-										href={resolve(localizedHref('/signin'))}
-										class="underline active:translate-y-px"
-									>
+									<a href={resolve(localizedHref('/signin'))} class="underline">
 										<T keyName="auth.reset_password.sign_in_link" defaultValue="Sign in" />
 									</a>
 								</div>
@@ -269,7 +266,7 @@
 								<a
 									href={resolve(localizedHref('/signin'))}
 									data-testid="reset-password-back-link"
-									class="underline underline-offset-4 active:translate-y-px"
+									class="underline underline-offset-4"
 								>
 									<T keyName="auth.reset_password.back_to_signin" defaultValue="Back to sign in" />
 								</a>
@@ -289,20 +286,14 @@
 		</Card.Root>
 		<Field.Description class="px-6 text-center">
 			<T keyName="auth.terms.agreement" defaultValue="By clicking continue, you agree to our" />
-			<a
-				href={resolve(localizedHref('/terms'))}
-				class="underline underline-offset-4 active:translate-y-px"
+			<a href={resolve(localizedHref('/terms'))} class="underline underline-offset-4"
 				><T keyName="auth.terms.terms_of_service" defaultValue="Terms of Service" /></a
 			>
 			<T keyName="auth.terms.and" defaultValue="and" />
-			<a
-				href={resolve(localizedHref('/privacy'))}
-				class="underline underline-offset-4 active:translate-y-px"
+			<a href={resolve(localizedHref('/privacy'))} class="underline underline-offset-4"
 				><T keyName="auth.terms.privacy_policy" defaultValue="Privacy Policy" /></a
 			>.
-			<a
-				href={resolve(localizedHref('/'))}
-				class="underline underline-offset-4 active:translate-y-px"
+			<a href={resolve(localizedHref('/'))} class="underline underline-offset-4"
 				><T keyName="auth.back_to_home" defaultValue="Back to home" /></a
 			>
 		</Field.Description>

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -255,18 +255,14 @@
 			<a
 				bind:this={termsLink}
 				href={resolve(localizedHref('/terms'))}
-				class="underline underline-offset-4 active:translate-y-px"
+				class="underline underline-offset-4"
 				><T keyName="auth.terms.terms_of_service" defaultValue="Terms of Service" /></a
 			>
 			<T keyName="auth.terms.and" defaultValue="and" />
-			<a
-				href={resolve(localizedHref('/privacy'))}
-				class="underline underline-offset-4 active:translate-y-px"
+			<a href={resolve(localizedHref('/privacy'))} class="underline underline-offset-4"
 				><T keyName="auth.terms.privacy_policy" defaultValue="Privacy Policy" /></a
 			>.
-			<a
-				href={resolve(localizedHref('/'))}
-				class="underline underline-offset-4 active:translate-y-px"
+			<a href={resolve(localizedHref('/'))} class="underline underline-offset-4"
 				><T keyName="auth.back_to_home" defaultValue="Back to home" /></a
 			>
 		</Field.Description>

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -198,7 +198,7 @@
 							(redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : '')
 					)}
 					onkeydown={handleSignUpLinkKeydown}
-					class="underline underline-offset-4 active:translate-y-px"
+					class="underline underline-offset-4"
 				>
 					<T keyName="auth.signin.link_signup" defaultValue="Sign up" />
 				</a>

--- a/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
@@ -176,7 +176,7 @@
 						localizedHref('/signin') +
 							(redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : '')
 					)}
-					class="underline underline-offset-4 active:translate-y-px"
+					class="underline underline-offset-4"
 				>
 					<T keyName="auth.signup.link_signin" defaultValue="Sign in" />
 				</a>

--- a/src/routes/[[lang]]/(auth)/signup/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signup/+page.svelte
@@ -255,20 +255,14 @@
 		</Card.Root>
 		<Field.Description class="px-6 text-center">
 			<T keyName="auth.terms.agreement" defaultValue="By clicking continue, you agree to our" />
-			<a
-				href={resolve(localizedHref('/terms'))}
-				class="underline underline-offset-4 active:translate-y-px"
+			<a href={resolve(localizedHref('/terms'))} class="underline underline-offset-4"
 				><T keyName="auth.terms.terms_of_service" defaultValue="Terms of Service" /></a
 			>
 			<T keyName="auth.terms.and" defaultValue="and" />
-			<a
-				href={resolve(localizedHref('/privacy'))}
-				class="underline underline-offset-4 active:translate-y-px"
+			<a href={resolve(localizedHref('/privacy'))} class="underline underline-offset-4"
 				><T keyName="auth.terms.privacy_policy" defaultValue="Privacy Policy" /></a
 			>.
-			<a
-				href={resolve(localizedHref('/'))}
-				class="underline underline-offset-4 active:translate-y-px"
+			<a href={resolve(localizedHref('/'))} class="underline underline-offset-4"
 				><T keyName="auth.back_to_home" defaultValue="Back to home" /></a
 			>
 		</Field.Description>


### PR DESCRIPTION
The `active:translate-y-px` press effect from #282 is ignored by CSS on `display: inline` elements, so it silently did nothing on bare inline text links, and on the breadcrumb it worked on every crumb except the first.

For breadcrumbs, the first crumb was rendered with `hidden md:block`, which made the `<li>` `display: block` and left its child link `display: inline`, so the press never fired there while it worked on the later (inline-flex) crumbs. The item now uses `md:inline-flex` so the link is blockified, and `breadcrumb-link.svelte` transitions `translate` alongside color so the 1px shift eases instead of snapping. For inline sentence links on the auth pages and the error page back-home link, the effect is a no-op on `display: inline` and reads as baseline jitter where it does apply, so the class is dropped. It is kept on the flex/block/inline-block targets (sidebar buttons, attachments, reasoning trigger, the forgot-password flex link) where it works as intended.

Closes #411
Closes #412

`bun scripts/static-checks.ts` passes on all changed files (lint, format, svelte-check 0 errors).