### PR TITLE
fix(vite): exclude blocked ports from maxAttempts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,9 +42,13 @@ const BAD_FETCH_PORTS = new Set([
 ]);
 
 async function findAvailablePort(startPort: number, maxAttempts = 100): Promise<number> {
-	for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-		const port = startPort + attempt;
+	// Blocked ports don't count toward maxAttempts, so the limit always reflects
+	// how many connectable ports were actually probed.
+	let checked = 0;
+	for (let offset = 0; checked < maxAttempts; offset += 1) {
+		const port = startPort + offset;
 		if (BAD_FETCH_PORTS.has(port)) continue;
+		checked += 1;
 		if (await isPortAvailable(port)) {
 			return port;
 		}


### PR DESCRIPTION
The dev port allocator skips WHATWG bad-fetch ports so the chosen port stays reachable, but a skipped port still consumed one of the maxAttempts iterations. That made the limit reflect ports walked rather than ports actually probed, so a small maxAttempts landing on a cluster of blocked ports could give up before checking any connectable port.

This counts only non-blocked ports toward the limit: blocked ports are skipped for free via a separate checked counter, while the scan offset keeps advancing. The loop still terminates because the blocked set is finite (max 10080), so once the offset passes it every port counts. Same change applied upstream in juliusmarminge/agent-tools#28, where this allocator originates.

bun scripts/static-checks.ts vite.config.ts passes.