### PR TITLE
ci(fork-preview): gated E2E + preview deploy for fork PRs

### DIFF
--- a/.github/workflows/e2e-fork-preview.yml
+++ b/.github/workflows/e2e-fork-preview.yml
@@ -1,0 +1,150 @@
+name: E2E Tests (Fork Preview)
+
+# Builds a Cloudflare Workers preview and runs Playwright E2E for FORK pull
+# requests, gated behind the `fork-preview` Environment (required reviewer).
+# Cloudflare Workers Builds does not build fork PRs, and a fork `pull_request`
+# gets no secrets / a read-only token, so this uses `pull_request_target`
+# (base-repo context: secrets + read-write token) and only runs after a
+# maintainer approves the `fork-preview` deployment. Approving means trusting
+# the entire checked-out fork tree (lockfile, install/postinstall scripts,
+# scripts/deploy*, tests) to run with the preview-scoped secrets.
+#
+# Same-repo PRs are skipped here (they use CF Workers Builds + e2e-preview-cf.yml).
+#
+# NOTE: Convex preview-quota recovery is intentionally disabled (no
+# CONVEX_MANAGEMENT_TOKEN in this environment), so a quota hit fails the run;
+# prune old previews and re-run.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: fork-e2e-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  fork-preview-e2e:
+    name: Fork Preview E2E
+    # Forks only. Same-repo PRs keep CF Workers Builds + e2e-preview-cf.yml.
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubicloud-standard-2
+    environment: fork-preview
+    permissions:
+      contents: read
+      statuses: write
+    env:
+      # CF Workers Builds mimicry (so scripts/deploy.ts detects a preview build)
+      WORKERS_CI: '1'
+      PRODUCTION_BRANCH: main
+      # Base-repo-unique preview key: fork branch names are not unique across
+      # forks, which would collide on the Workers alias and Convex preview.
+      WORKERS_CI_BRANCH: fork-pr-${{ github.event.pull_request.number }}
+      WORKERS_NAME: ${{ vars.WORKERS_NAME }}
+      WORKERS_SUBDOMAIN: ${{ vars.WORKERS_SUBDOMAIN }}
+      CONVEX_PROJECT_ID: ${{ vars.CONVEX_PROJECT_ID }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+      NODE_OPTIONS: --max-old-space-size=4096
+      CI: 'true'
+
+    steps:
+      - name: Checkout reviewed fork SHA
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Don't leave the read-write pull_request_target token in .git/config
+          # where the untrusted checkout's install scripts could grab it.
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      # No secrets in env here: untrusted postinstall must not see them.
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install Playwright
+        run: bunx playwright install chromium --with-deps
+
+      - name: Build and deploy fork preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CONVEX_PREVIEW_DEPLOY_KEY: ${{ secrets.CONVEX_PREVIEW_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          # Build + Convex preview deploy + e2e-config + SvelteKit build
+          bunx varlock run -- bun scripts/deploy.ts
+          # Upload the worker version with a preview alias (must exit 0)
+          bun scripts/cf-deploy.ts
+          # Compute the preview URL only after a successful upload, using the
+          # canonical alias function (single source of truth) — do not parse
+          # cf-deploy stdout (it logs the alias before the upload runs).
+          ALIAS=$(bun -e 'import("./scripts/deploy/platform.ts").then((m) => { process.stdout.write(m.sanitizeBranchAlias(process.env.WORKERS_CI_BRANCH, process.env.WORKERS_NAME)); })')
+          PREVIEW_URL="https://${ALIAS}-${WORKERS_NAME}.${WORKERS_SUBDOMAIN}.workers.dev"
+          echo "PREVIEW_URL=${PREVIEW_URL}" >> "$GITHUB_ENV"
+          echo "Preview URL: ${PREVIEW_URL}"
+
+      - name: Fetch E2E config from preview
+        run: |
+          set -euo pipefail
+          echo "Fetching config from: ${PREVIEW_URL}/.well-known/e2e-config.json"
+          CONFIG=$(curl -sf "${PREVIEW_URL}/.well-known/e2e-config.json")
+          echo "$CONFIG" | jq .
+          {
+            echo "PUBLIC_CONVEX_URL=$(echo "$CONFIG" | jq -r '.convexUrl')"
+            echo "PUBLIC_CONVEX_SITE_URL=$(echo "$CONFIG" | jq -r '.convexSiteUrl')"
+            echo "PUBLIC_SITE_URL=${PREVIEW_URL}"
+          } >> "$GITHUB_ENV"
+
+      - name: Wait for Convex backend readiness
+        run: |
+          echo "Waiting for Convex backend at: ${PUBLIC_CONVEX_URL}"
+          for i in $(seq 1 12); do
+            if curl -sf --connect-timeout 5 --max-time 10 "${PUBLIC_CONVEX_URL}" > /dev/null; then
+              echo "Convex backend is ready (attempt $i)"
+              exit 0
+            fi
+            echo "Not ready yet (attempt $i/12), waiting 5s..."
+            [ "$i" -lt 12 ] && sleep 5
+          done
+          echo "::error::Convex backend not ready after 60s: ${PUBLIC_CONVEX_URL}"
+          exit 1
+
+      - name: Run E2E tests
+        env:
+          AUTH_E2E_TEST_SECRET: ${{ secrets.AUTH_E2E_TEST_SECRET }}
+        run: bun run test:e2e
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: playwright-report
+          path: playwright-report/
+
+      # Branch protection requires both "E2E Tests" and "Workers Builds: saas-starter".
+      # This job performs the equivalent build+deploy, so on success it satisfies
+      # both. "E2E Tests" is pinned to the GitHub Actions app; "Workers Builds:
+      # saas-starter" was un-pinned (any app) so this Actions-posted status counts.
+      - name: Report status to PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          STATE=$([ "$JOB_STATUS" = "success" ] && echo success || echo failure)
+          TARGET="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          for CONTEXT in "E2E Tests" "Workers Builds: saas-starter"; do
+            for i in 1 2 3; do
+              if gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
+                -f state="$STATE" \
+                -f context="$CONTEXT" \
+                -f description="Fork preview ($STATE)" \
+                -f target_url="$TARGET"; then
+                break
+              fi
+              echo "Attempt $i for '$CONTEXT' failed, retrying in 5s..."
+              sleep 5
+            done
+          done


### PR DESCRIPTION
Fork PRs from external contributors cannot currently be merged without an admin override. Branch protection on `main` requires the `Workers Builds: saas-starter` and `E2E Tests` checks, but Cloudflare Workers Builds does not build fork PRs, so neither check ever runs for a fork and the merge button stays blocked.

This adds a `pull_request_target` workflow that runs only for fork PRs and is gated behind the `fork-preview` GitHub Environment (required reviewer). Nothing deploys or touches the preview-scoped secrets until a maintainer approves the run, so external contributors cannot spam preview builds. After approval the job checks out the reviewed fork SHA, builds a Cloudflare Workers preview in CI by reusing the existing `scripts/deploy.ts` and `scripts/cf-deploy.ts` (so the fork path stays in sync with the production CF path), runs Playwright against the live preview, and posts both required commit statuses. Same-repo PRs are unaffected and keep using CF Workers Builds plus `e2e-preview-cf.yml`.

Security choices: `pull_request_target` is required because fork `pull_request` jobs get no secrets and a read-only token; the workflow file therefore comes from `main` and cannot be modified by a fork. The checkout uses `persist-credentials: false`, deploy and test secrets are scoped to their steps (so `bun install` postinstall runs without secrets), the preview key is `fork-pr-<number>` to avoid cross-fork alias collisions, and only preview-scoped Convex and Cloudflare credentials are exposed. Approving a run means trusting the entire checked-out fork tree to run with those preview secrets, which is the documented trust boundary.

This required two repo-config changes already applied: the `fork-pr-contributor-approval` policy is set to `all_external_contributors`, and the `Workers Builds: saas-starter` required check was un-pinned from the Cloudflare app so the Actions-posted status can satisfy it.

The workflow cannot be exercised by this PR (for forks GitHub uses the workflow file from the base branch), so it is validated after merge by driving a fork PR through the approval gate. `bun scripts/static-checks.ts` passes on the workflow file.