### PR TITLE
fix(admin): inline passkey icon to survive ad blockers

### DIFF
--- a/src/routes/[[lang]]/admin/users/provider-badge.svelte
+++ b/src/routes/[[lang]]/admin/users/provider-badge.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { T, getTranslate } from '@tolgee/svelte';
 	import Mail from '@lucide/svelte/icons/mail';
-	import Fingerprint from '@lucide/svelte/icons/fingerprint';
 
 	const { t } = getTranslate();
 
@@ -64,7 +63,30 @@
 				class="inline-flex items-center rounded-md border px-1.5 py-0.5 text-muted-foreground ring-1 ring-border ring-inset"
 				title={$t('admin.users.provider_passkey')}
 			>
-				<Fingerprint class="size-3.5" aria-hidden="true" />
+				<!-- Inlined lucide "fingerprint" glyph: a real module import resolves to a
+				     dev URL containing "fingerprint", which anti-tracking blockers drop,
+				     breaking route hydration. Inlining removes the request entirely. -->
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					class="size-3.5"
+					aria-hidden="true"
+				>
+					<path d="M12 10a2 2 0 0 0-2 2c0 1.02-.1 2.51-.26 4" />
+					<path d="M14 13.12c0 2.38 0 6.38-1 8.88" />
+					<path d="M17.29 21.02c.12-.6.43-2.3.5-3.02" />
+					<path d="M2 12a10 10 0 0 1 18-6" />
+					<path d="M2 16h.01" />
+					<path d="M21.8 16c.2-2 .131-5.354 0-6" />
+					<path d="M5 19.5C5.5 18 6 15 6 12a6 6 0 0 1 .34-2" />
+					<path d="M8.65 22c.21-.66.45-1.32.57-2" />
+					<path d="M9 6.8a6 6 0 0 1 9 5.2v2" />
+				</svg>
 				<span class="sr-only"><T keyName="admin.users.provider_passkey" /></span>
 			</span>
 		{:else}


### PR DESCRIPTION
Closes #409

The `/admin/users` route failed to hydrate and the page crashed for anyone browsing with a privacy or ad blocker enabled. The passkey provider badge imported its icon via `import Fingerprint from '@lucide/svelte/icons/fingerprint'`. In dev, Vite serves lucide from the unbundled module graph, so the import resolves to a real fetchable URL containing the literal word `fingerprint`. Anti-tracking filter lists block any request whose path matches `fingerprint`, returning `ERR_BLOCKED_BY_CLIENT`, and since that module is a transitive dependency of the route chunk, the route node import fails and SvelteKit cannot hydrate the page.

Renaming the import binding does not help, because the blocked thing is the module URL path, not the JS identifier, and a local re-export still fetches the same module by URL in dev. Instead I inlined the fingerprint glyph as an SVG, the same way the Google and GitHub provider icons are already inlined in this file. That removes the network request entirely, so there is nothing for a blocker to match, and the rendering is identical in dev and prod. The path data and stroke attributes are taken verbatim from the lucide source; fingerprint is a multi-path stroke icon, so the SVG uses `fill="none"` with `stroke="currentColor"` rather than the filled-path style of the Google/GitHub badges. The `mail` lucide import for the credential provider is unaffected and stays as an import.

`bun scripts/static-checks.ts` passes on the changed file (format, lint, types, banned patterns).