### PR TITLE
feat(sidebar): support action callback on nav items

### DIFF
--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -7,7 +7,7 @@
 	import { resolve } from '$app/paths';
 	import type { ComponentProps } from 'svelte';
 	import { T } from '@tolgee/svelte';
-	import type { NavSubItem, SidebarConfig, User } from './types';
+	import type { NavItem, NavSubItem, SidebarConfig, User } from './types';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { PersistedState } from 'runed';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
@@ -25,6 +25,20 @@
 
 	const aiChatOpen = new PersistedState('ai-chat-threads-open', true);
 </script>
+
+{#snippet navItemBody(item: NavItem)}
+	{#if item.icon}
+		<item.icon />
+	{/if}
+	<span><T keyName={item.translationKey} /></span>
+	{#if item.kbd}
+		<Kbd.Group class="ml-auto opacity-0 group-hover/menu-button:opacity-50">
+			{#each item.kbd as key (key)}
+				<Kbd.Root>{key}</Kbd.Root>
+			{/each}
+		</Kbd.Group>
+	{/if}
+{/snippet}
 
 <Sidebar.Root collapsible="offcanvas" {...restProps}>
 	<Sidebar.Header>
@@ -102,21 +116,11 @@
 										>
 											{#snippet child({ props })}
 												<a
-													href={resolve(item.url)}
+													href={item.url ? resolve(item.url) : undefined}
 													{...props}
 													onclick={item.disableNav ? (e) => e.preventDefault() : undefined}
 												>
-													{#if item.icon}
-														<item.icon />
-													{/if}
-													<span><T keyName={item.translationKey} /></span>
-													{#if item.kbd}
-														<Kbd.Group class="ml-auto opacity-0 group-hover/menu-button:opacity-50">
-															{#each item.kbd as key (key)}
-																<Kbd.Root>{key}</Kbd.Root>
-															{/each}
-														</Kbd.Group>
-													{/if}
+													{@render navItemBody(item)}
 												</a>
 											{/snippet}
 										</Sidebar.MenuButton>
@@ -134,27 +138,26 @@
 								{/snippet}
 							</Collapsible.Root>
 						{:else}
-							<!-- Standard nav item -->
+							<!-- Standard nav item: anchor when it has a url, button when it triggers an action -->
 							<Sidebar.MenuItem>
 								<Sidebar.MenuButton
 									isActive={item.isActive}
 									class="!transition-transform"
-									onclick={() => haptic.trigger('light')}
+									onclick={() => {
+										haptic.trigger('light');
+										item.onSelect?.();
+									}}
 								>
 									{#snippet child({ props })}
-										<a href={resolve(item.url)} {...props}>
-											{#if item.icon}
-												<item.icon />
-											{/if}
-											<span><T keyName={item.translationKey} /></span>
-											{#if item.kbd}
-												<Kbd.Group class="ml-auto opacity-0 group-hover/menu-button:opacity-50">
-													{#each item.kbd as key (key)}
-														<Kbd.Root>{key}</Kbd.Root>
-													{/each}
-												</Kbd.Group>
-											{/if}
-										</a>
+										{#if item.url}
+											<a href={resolve(item.url)} {...props}>
+												{@render navItemBody(item)}
+											</a>
+										{:else}
+											<button type="button" {...props}>
+												{@render navItemBody(item)}
+											</button>
+										{/if}
 									{/snippet}
 								</Sidebar.MenuButton>
 								{#if item.badge && item.badge > 0}

--- a/src/lib/components/authenticated/types.ts
+++ b/src/lib/components/authenticated/types.ts
@@ -15,7 +15,13 @@ export interface NavSubItem {
 
 export interface NavItem {
 	translationKey: string;
-	url: string;
+	/** Navigates to this path (renders an anchor). Omit when using `onSelect`. */
+	url?: string;
+	/**
+	 * Runs an action instead of navigating (renders a `<button type="button">`).
+	 * Used when the item has no `url`, e.g. opening a dialog or command palette.
+	 */
+	onSelect?: () => void;
 	icon?: LucideIcon;
 	isActive?: boolean;
 	badge?: number;


### PR DESCRIPTION
Closes #408

The authenticated sidebar rendered every nav item as an anchor to `item.url`, and the `NavItem` type required `url`, so a sidebar entry could only be a link. Entries that are actions rather than destinations (open a creation dialog, trigger the command palette) had no clean home and needed a phantom route whose only job was to host a modal.

This makes `url` optional and adds an `onSelect?: () => void` callback to `NavItem`. In the standard nav-item branch the item renders as an anchor (`resolve(item.url)`) when it has a `url`, otherwise as a `<button type="button">` that runs `onSelect`. The callback is folded into the existing `MenuButton` onclick so the haptic feedback still fires, and branching on `item.url` lets TypeScript narrow the type for a clean `resolve()` with no assertion. The shared icon, label and kbd body is extracted into a snippet so the anchor and button branches do not duplicate markup. Configs that set `url` are unaffected and `FooterLink` stays URL-only.

`bun scripts/static-checks.ts` passes for both files. The sidebar E2E suite (`ai-chat.spec.ts`, `sidebar-persistence.spec.ts`) is green.