### PR TITLE
feat(chat): preview markdown and text attachments

### DIFF
--- a/e2e/ai-chat-attachment-preview.spec.ts
+++ b/e2e/ai-chat-attachment-preview.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { waitForAuthenticated } from './utils/auth';
+
+const MARKDOWN = `# Preview Heading
+
+A paragraph with a [safe link](https://example.com) and an ![tracker](https://example.com/pixel.png).
+
+- first item
+- second item
+`;
+
+test.describe('AI Chat - attachment text preview', () => {
+	test('previewing an attached .md renders formatted markdown, not raw source', async ({
+		page
+	}) => {
+		await page.goto('/app/ai-chat');
+		await waitForAuthenticated(page);
+		await page.waitForURL(/\/app\/ai-chat\?thread=/, { timeout: 15000 });
+		await expect(page.locator('textarea')).toBeVisible({ timeout: 10000 });
+
+		// Attach a markdown file through the hidden file input. Uploading also
+		// exercises the server MIME allowlist: the chip only becomes clickable
+		// once the upload succeeds.
+		await page
+			.locator('input[type="file"]')
+			.first()
+			.setInputFiles({
+				name: 'e2e-notes.md',
+				mimeType: 'text/markdown',
+				buffer: Buffer.from(MARKDOWN, 'utf8')
+			});
+
+		const chip = page.getByTestId('attachment-chip').first();
+		await expect(chip).toBeVisible({ timeout: 15000 });
+		// role="button" is only set once the attachment is clickable (upload done).
+		await expect(chip).toHaveAttribute('role', 'button', { timeout: 20000 });
+		await chip.click();
+
+		const content = page.getByTestId('attachment-preview-content');
+		await expect(content).toBeVisible({ timeout: 15000 });
+
+		// Heading is rendered as an <h1>, not shown as literal "# Preview Heading".
+		await expect(content.locator('h1', { hasText: 'Preview Heading' })).toBeVisible();
+		await expect(content).not.toContainText('# Preview Heading');
+
+		// The hardened renderer blocks images entirely (no <img> is loaded).
+		await expect(content.locator('img')).toHaveCount(0);
+	});
+});

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1571,7 +1571,10 @@
 			"dialog_title": "Anhang",
 			"file_fallback": "Datei",
 			"generic_fallback": "Anhang",
-			"image_fallback": "Bild"
+			"image_fallback": "Bild",
+			"preview_error": "Vorschau konnte nicht geladen werden",
+			"preview_loading": "Vorschau wird geladen…",
+			"preview_truncated": "Vorschau auf {size} gekürzt"
 		},
 		"avatar": {
 			"team_member": "Teammitglied"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1572,7 +1572,10 @@
 			"dialog_title": "Attachment",
 			"file_fallback": "File",
 			"generic_fallback": "Attachment",
-			"image_fallback": "Image"
+			"image_fallback": "Image",
+			"preview_error": "Couldn't load preview",
+			"preview_loading": "Loading preview…",
+			"preview_truncated": "Preview truncated to {size}"
 		},
 		"avatar": {
 			"team_member": "Team member"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1571,7 +1571,10 @@
 			"dialog_title": "Adjunto",
 			"file_fallback": "Archivo",
 			"generic_fallback": "Adjunto",
-			"image_fallback": "Imagen"
+			"image_fallback": "Imagen",
+			"preview_error": "No se pudo cargar la vista previa",
+			"preview_loading": "Cargando vista previa…",
+			"preview_truncated": "Vista previa truncada a {size}"
 		},
 		"avatar": {
 			"team_member": "Miembro del equipo"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1571,7 +1571,10 @@
 			"dialog_title": "Pièce jointe",
 			"file_fallback": "Fichier",
 			"generic_fallback": "Pièce jointe",
-			"image_fallback": "Image"
+			"image_fallback": "Image",
+			"preview_error": "Impossible de charger l'aperçu",
+			"preview_loading": "Chargement de l'aperçu…",
+			"preview_truncated": "Aperçu tronqué à {size}"
 		},
 		"avatar": {
 			"team_member": "Membre de l'équipe"

--- a/src/lib/chat/core/attachmentPreview.test.ts
+++ b/src/lib/chat/core/attachmentPreview.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+	getExtension,
+	getPreviewKind,
+	isTextPreviewable,
+	longestBacktickRun,
+	buildCodeMarkdown,
+	capPreviewText,
+	MAX_PREVIEW_TEXT_CHARS
+} from './attachmentPreview.js';
+import { ALLOWED_FILE_EXT_MIME, ALLOWED_FILE_TYPES } from './types.js';
+import { isAllowedStorageUrl } from '../../convex/files/attachmentText.js';
+
+describe('getExtension', () => {
+	it('returns the lowercased extension with dot', () => {
+		expect(getExtension('README.md')).toBe('.md');
+		expect(getExtension('photo.JPG')).toBe('.jpg');
+		expect(getExtension('archive.tar.gz')).toBe('.gz');
+	});
+	it('returns null when there is no extension or filename', () => {
+		expect(getExtension('noext')).toBeNull();
+		expect(getExtension(undefined)).toBeNull();
+	});
+});
+
+describe('getPreviewKind', () => {
+	it('detects markdown by extension or mime', () => {
+		expect(getPreviewKind('text/markdown', 'a.md')).toEqual({ kind: 'markdown' });
+		expect(getPreviewKind(undefined, 'a.markdown')).toEqual({ kind: 'markdown' });
+		expect(getPreviewKind('text/markdown', undefined)).toEqual({ kind: 'markdown' });
+		// charset suffix must not break mime detection
+		expect(getPreviewKind('text/markdown; charset=utf-8', undefined)).toEqual({ kind: 'markdown' });
+	});
+	it('maps known code extensions to highlighted code', () => {
+		expect(getPreviewKind(undefined, 'data.json')).toEqual({ kind: 'code', lang: 'json' });
+		expect(getPreviewKind(undefined, 'main.ts')).toEqual({ kind: 'code', lang: 'typescript' });
+		expect(getPreviewKind('application/json', undefined)).toEqual({ kind: 'code', lang: 'json' });
+	});
+	it('treats csv and txt and unknown as plain text', () => {
+		expect(getPreviewKind(undefined, 'rows.csv')).toEqual({ kind: 'plaintext' });
+		expect(getPreviewKind('text/plain', 'notes.txt')).toEqual({ kind: 'plaintext' });
+		expect(getPreviewKind('text/plain', 'weird.unknownext')).toEqual({ kind: 'plaintext' });
+		expect(getPreviewKind(undefined, undefined)).toEqual({ kind: 'plaintext' });
+	});
+});
+
+describe('isTextPreviewable', () => {
+	it('is true for text-like content', () => {
+		expect(isTextPreviewable('text/markdown', 'a.md')).toBe(true);
+		expect(isTextPreviewable('text/plain; charset=utf-8', undefined)).toBe(true);
+		expect(isTextPreviewable(undefined, 'notes.txt')).toBe(true);
+		expect(isTextPreviewable(undefined, 'data.json')).toBe(true);
+		expect(isTextPreviewable('application/json', undefined)).toBe(true);
+	});
+	it('is false for pdf, images and unknown binaries', () => {
+		expect(isTextPreviewable('application/pdf', 'doc.pdf')).toBe(false);
+		expect(isTextPreviewable('image/png', 'a.png')).toBe(false);
+		expect(isTextPreviewable(undefined, 'photo.png')).toBe(false);
+		expect(isTextPreviewable(undefined, undefined)).toBe(false);
+	});
+});
+
+describe('longestBacktickRun', () => {
+	it('counts the longest run', () => {
+		expect(longestBacktickRun('no ticks here')).toBe(0);
+		expect(longestBacktickRun('inline `code` span')).toBe(1);
+		expect(longestBacktickRun('a ``` b')).toBe(3);
+		expect(longestBacktickRun('```` and ``')).toBe(4);
+	});
+});
+
+describe('buildCodeMarkdown', () => {
+	it('uses a 3-backtick fence when content has none', () => {
+		const out = buildCodeMarkdown('console.log(1)', 'javascript');
+		expect(out).toBe('```javascript\nconsole.log(1)\n```');
+	});
+	it('uses a longer fence than any backtick run in the content', () => {
+		const out = buildCodeMarkdown('a ``` b', 'json');
+		expect(out.startsWith('````json\n')).toBe(true);
+		expect(out.endsWith('\n````')).toBe(true);
+		// the inner triple-backtick can no longer break out of the 4-fence
+		expect(out).toContain('a ``` b');
+	});
+	it('handles content that ends with backticks and no trailing newline', () => {
+		const out = buildCodeMarkdown('text```', 'text');
+		expect(out).toBe('````text\ntext```\n````');
+	});
+});
+
+describe('capPreviewText', () => {
+	it('passes short text through untouched', () => {
+		expect(capPreviewText('hello')).toEqual({ text: 'hello', truncated: false });
+	});
+	it('truncates text over the cap', () => {
+		const big = 'x'.repeat(MAX_PREVIEW_TEXT_CHARS + 10);
+		const res = capPreviewText(big);
+		expect(res.truncated).toBe(true);
+		expect(res.text.length).toBe(MAX_PREVIEW_TEXT_CHARS);
+	});
+});
+
+describe('isAllowedStorageUrl (SSRF guard)', () => {
+	const cloud = 'https://jovial-sturgeon-545.convex.cloud';
+	it('accepts this deployment storage URLs', () => {
+		expect(isAllowedStorageUrl(`${cloud}/api/storage/abc-123`, cloud)).toBe(true);
+	});
+	it('rejects foreign origins', () => {
+		expect(isAllowedStorageUrl('https://evil.com/api/storage/abc', cloud)).toBe(false);
+		// look-alike host must not match
+		expect(
+			isAllowedStorageUrl('https://jovial-sturgeon-545.convex.cloud.evil.com/api/storage/x', cloud)
+		).toBe(false);
+	});
+	it('rejects non-storage paths', () => {
+		expect(isAllowedStorageUrl(`${cloud}/api/run/foo`, cloud)).toBe(false);
+	});
+	it('rejects unparsable URLs and a missing cloud origin (fail closed)', () => {
+		expect(isAllowedStorageUrl('not a url', cloud)).toBe(false);
+		expect(isAllowedStorageUrl(`${cloud}/api/storage/abc`, undefined)).toBe(false);
+	});
+});
+
+describe('client / server MIME allowlist parity', () => {
+	// Guard: every MIME the client offers for upload must also be accepted by the
+	// server validators, or uploads of that type get rejected after the round-trip.
+	const serverList = (relativePath: string): string[] => {
+		const path = fileURLToPath(new URL(relativePath, import.meta.url));
+		const source = readFileSync(path, 'utf8');
+		const match = source.match(/const ALLOWED_MIME_TYPES = \[([\s\S]*?)\]/);
+		if (!match) throw new Error(`ALLOWED_MIME_TYPES not found in ${relativePath}`);
+		return [...match[1]!.matchAll(/'([^']+)'/g)].map((m) => m[1]!);
+	};
+
+	const clientMimes = [...new Set(Object.values(ALLOWED_FILE_EXT_MIME))];
+
+	it.each([['../../convex/support/files.ts'], ['../../convex/aiChat/files.ts']])(
+		'%s accepts every client-offered MIME',
+		(relativePath) => {
+			const allowed = serverList(relativePath);
+			for (const mime of clientMimes) {
+				expect(allowed).toContain(mime);
+			}
+		}
+	);
+
+	it('exposes the new text types in the derived client lists', () => {
+		expect(ALLOWED_FILE_EXT_MIME['.md']).toBe('text/markdown');
+		expect(ALLOWED_FILE_EXT_MIME['.txt']).toBe('text/plain');
+		expect(ALLOWED_FILE_TYPES).toContain('text/markdown');
+		expect(ALLOWED_FILE_TYPES).toContain('text/plain');
+	});
+});

--- a/src/lib/chat/core/attachmentPreview.ts
+++ b/src/lib/chat/core/attachmentPreview.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure helpers for the in-app text/markdown/code attachment preview.
+ *
+ * Kept separate from the Svelte component so the detection, fencing and
+ * truncation logic can be unit-tested without a DOM.
+ */
+
+/** Max characters of attachment text the client renders in the preview. */
+export const MAX_PREVIEW_TEXT_CHARS = 256 * 1024;
+
+/**
+ * File extension -> Shiki language id for code-style previews. Extensions not
+ * listed fall back to plain text. CSV has no dedicated Shiki grammar, so it is
+ * shown as plain monospaced text rather than highlighted.
+ */
+export const EXT_TO_SHIKI_LANG: Readonly<Record<string, string>> = {
+	'.json': 'json',
+	'.js': 'javascript',
+	'.mjs': 'javascript',
+	'.cjs': 'javascript',
+	'.ts': 'typescript',
+	'.tsx': 'tsx',
+	'.jsx': 'jsx',
+	'.css': 'css',
+	'.html': 'html',
+	'.htm': 'html',
+	'.xml': 'xml',
+	'.svg': 'xml',
+	'.yaml': 'yaml',
+	'.yml': 'yaml',
+	'.toml': 'toml',
+	'.sh': 'bash',
+	'.bash': 'bash',
+	'.zsh': 'bash',
+	'.py': 'python',
+	'.sql': 'sql',
+	'.csv': 'text'
+};
+
+export type PreviewKind =
+	| { kind: 'markdown' }
+	| { kind: 'plaintext' }
+	| { kind: 'code'; lang: string };
+
+/** Lowercased file extension including the dot, or null. */
+export function getExtension(filename: string | undefined): string | null {
+	if (!filename) return null;
+	const dot = filename.lastIndexOf('.');
+	if (dot < 0) return null;
+	return filename.slice(dot).toLowerCase();
+}
+
+/** MIME essence (drops any `; charset=...` parameter), lowercased. */
+function mimeEssence(mimeType: string | undefined): string {
+	return (mimeType ?? '').split(';')[0]!.trim().toLowerCase();
+}
+
+/**
+ * Decide how to render a text attachment from its MIME type and filename.
+ * Extension wins over MIME because a stored text file's served MIME is often
+ * generic, and structured types map to highlighted code.
+ */
+export function getPreviewKind(
+	mimeType: string | undefined,
+	filename: string | undefined
+): PreviewKind {
+	const ext = getExtension(filename);
+	const mime = mimeEssence(mimeType);
+
+	if (ext === '.md' || ext === '.markdown' || mime === 'text/markdown') {
+		return { kind: 'markdown' };
+	}
+	if (ext && ext in EXT_TO_SHIKI_LANG) {
+		const lang = EXT_TO_SHIKI_LANG[ext]!;
+		return lang === 'text' ? { kind: 'plaintext' } : { kind: 'code', lang };
+	}
+	if (mime === 'application/json') return { kind: 'code', lang: 'json' };
+	if (mime === 'application/xml' || mime === 'text/xml') return { kind: 'code', lang: 'xml' };
+	// .txt, text/plain and any other text-like content render as plain text.
+	return { kind: 'plaintext' };
+}
+
+/**
+ * Whether an attachment should render in the rich text preview (markdown /
+ * plain text / highlighted code) rather than the raw <iframe>. PDFs and other
+ * browser-native or binary types return false and keep the iframe.
+ */
+export function isTextPreviewable(
+	mimeType: string | undefined,
+	filename: string | undefined
+): boolean {
+	const mime = mimeEssence(mimeType);
+	if (mime.startsWith('text/')) return true;
+	if (mime === 'application/json' || mime === 'application/xml') return true;
+	const ext = getExtension(filename);
+	if (ext === '.md' || ext === '.markdown' || ext === '.txt') return true;
+	return !!ext && ext in EXT_TO_SHIKI_LANG;
+}
+
+/** Longest run of consecutive backticks in the text (0 if none). */
+export function longestBacktickRun(text: string): number {
+	const runs = text.match(/`+/g);
+	if (!runs) return 0;
+	return runs.reduce((max, run) => Math.max(max, run.length), 0);
+}
+
+/**
+ * Wrap raw file content in a fenced code block for Streamdown. The fence is one
+ * backtick longer than the longest backtick run in the content (min 3), so
+ * content containing ``` cannot break out of the fence and have its remainder
+ * re-parsed as Markdown.
+ */
+export function buildCodeMarkdown(text: string, lang: string): string {
+	const fence = '`'.repeat(Math.max(3, longestBacktickRun(text) + 1));
+	return `${fence}${lang}\n${text}\n${fence}`;
+}
+
+/** Cap text to MAX_PREVIEW_TEXT_CHARS, reporting whether it was truncated. */
+export function capPreviewText(text: string): { text: string; truncated: boolean } {
+	if (text.length > MAX_PREVIEW_TEXT_CHARS) {
+		return { text: text.slice(0, MAX_PREVIEW_TEXT_CHARS), truncated: true };
+	}
+	return { text, truncated: false };
+}

--- a/src/lib/chat/core/types.ts
+++ b/src/lib/chat/core/types.ts
@@ -246,7 +246,9 @@ export const ALLOWED_FILE_EXT_MIME: Readonly<Record<string, string>> = {
 	'.jpeg': 'image/jpeg',
 	'.webp': 'image/webp',
 	'.gif': 'image/gif',
-	'.pdf': 'application/pdf'
+	'.pdf': 'application/pdf',
+	'.md': 'text/markdown',
+	'.txt': 'text/plain'
 };
 export const ALLOWED_FILE_EXTENSIONS = Object.keys(ALLOWED_FILE_EXT_MIME).join(',');
 export const ALLOWED_FILE_TYPES = Array.from(new Set(Object.values(ALLOWED_FILE_EXT_MIME)));

--- a/src/lib/chat/ui/AttachmentTextPreview.svelte
+++ b/src/lib/chat/ui/AttachmentTextPreview.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+	import { Streamdown } from 'svelte-streamdown';
+	import Code from 'svelte-streamdown/code';
+	import Math from 'svelte-streamdown/math';
+	import { mode } from 'mode-watcher';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { getTranslate } from '@tolgee/svelte';
+	import { tryGetChatUIContext } from './ChatContext.svelte.js';
+	import { getPreviewKind, buildCodeMarkdown, capPreviewText } from '../core/attachmentPreview.js';
+
+	const { t } = getTranslate();
+	const ctx = tryGetChatUIContext();
+
+	let {
+		url,
+		mimeType,
+		filename,
+		blob
+	}: {
+		/** Remote storage URL (used when there is no local blob). */
+		url?: string;
+		mimeType?: string;
+		filename?: string;
+		/** In-memory blob for freshly attached files (no network needed). */
+		blob?: Blob | null;
+	} = $props();
+
+	const previewKind = $derived(getPreviewKind(mimeType, filename));
+
+	let status = $state<'loading' | 'loaded' | 'error'>('loading');
+	let text = $state('');
+	let truncated = $state(false);
+
+	// Load the text whenever the source (local blob or remote url) changes.
+	// Local blob -> read directly (no network, no CORS). Otherwise fetch the
+	// text server-side via the surface's getAttachmentText action (Convex
+	// storage URLs are not CORS-readable from the browser). On any failure we
+	// fall back to the raw <iframe> below.
+	$effect(() => {
+		const localBlob = blob;
+		const remoteUrl = url;
+		const action = ctx?.uploadConfig?.getAttachmentText;
+		let cancelled = false;
+
+		status = 'loading';
+		text = '';
+		truncated = false;
+
+		(async () => {
+			try {
+				if (localBlob) {
+					const capped = capPreviewText(await localBlob.text());
+					if (cancelled) return;
+					text = capped.text;
+					truncated = capped.truncated;
+				} else if (remoteUrl && action && ctx?.client) {
+					const extraArgs = ctx.uploadConfig?.getGenerateUploadUrlArgs?.() ?? {};
+					const res = (await ctx.client.action(action, {
+						url: remoteUrl,
+						locale: ctx.uploadConfig?.locale,
+						...extraArgs
+					})) as { text: string; truncated: boolean };
+					if (cancelled) return;
+					text = res.text;
+					truncated = res.truncated;
+				} else {
+					throw new Error('No text source for attachment preview');
+				}
+				status = 'loaded';
+			} catch {
+				if (cancelled) return;
+				status = 'error';
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	const renderedMarkdown = $derived.by(() => {
+		if (status !== 'loaded') return '';
+		if (previewKind.kind === 'markdown') return text;
+		if (previewKind.kind === 'code') return buildCodeMarkdown(text, previewKind.lang);
+		return '';
+	});
+
+	const shikiTheme = $derived(
+		mode.current === 'dark' ? 'github-dark-default' : 'github-light-default'
+	);
+
+	function isSafeHttpUrl(href: string | undefined | null): boolean {
+		return !!href && /^https?:\/\//i.test(href.trim());
+	}
+</script>
+
+{#if status === 'loading'}
+	<div
+		class="flex h-[70vh] w-full items-center justify-center rounded-md"
+		data-testid="attachment-preview-loading"
+	>
+		<LoaderCircleIcon class="size-6 text-muted-foreground motion-safe:animate-spin" />
+		<span class="sr-only">{$t('chat.attachment.preview_loading')}</span>
+	</div>
+{:else if status === 'error'}
+	{#if url}
+		<!-- Fall back to the raw browser view when text could not be loaded. -->
+		<iframe src={url} title={filename ?? ''} class="h-[70vh] w-full rounded-md"></iframe>
+	{:else}
+		<div
+			class="flex h-[70vh] w-full items-center justify-center text-sm text-muted-foreground"
+			data-testid="attachment-preview-error"
+		>
+			{$t('chat.attachment.preview_error')}
+		</div>
+	{/if}
+{:else}
+	<div class="h-[70vh] w-full overflow-auto rounded-md" data-testid="attachment-preview-content">
+		{#if previewKind.kind === 'plaintext'}
+			<pre class="text-sm break-words whitespace-pre-wrap">{text}</pre>
+		{:else}
+			<Streamdown
+				content={renderedMarkdown}
+				{shikiTheme}
+				baseTheme="shadcn"
+				renderHtml={false}
+				parseIncompleteMarkdown={false}
+				allowedImagePrefixes={[]}
+				allowedLinkPrefixes={['*']}
+				components={{ code: Code, math: Math }}
+				class="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+			>
+				{#snippet image({ token })}
+					<!-- Block all images (incl. relative / protocol-relative) -->
+					<span>{token.text}</span>
+				{/snippet}
+				{#snippet link({ token, children })}
+					{#if isSafeHttpUrl(token.href)}
+						<a href={token.href} target="_blank" rel="noopener noreferrer nofollow">
+							{@render children()}
+						</a>
+					{:else}
+						{@render children()}
+					{/if}
+				{/snippet}
+			</Streamdown>
+		{/if}
+		{#if truncated}
+			<p class="mt-2 text-xs text-muted-foreground">
+				{$t('chat.attachment.preview_truncated', { size: '256 KB' })}
+			</p>
+		{/if}
+	</div>
+{/if}

--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -7,6 +7,8 @@
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import Progress from '$lib/components/ui/progress/progress.svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import AttachmentTextPreview from './AttachmentTextPreview.svelte';
+	import { isTextPreviewable } from '../core/attachmentPreview.js';
 	import type { Attachment, UploadState } from '../core/types.js';
 	import type { ChatAlignment } from './ChatContext.svelte.js';
 
@@ -94,6 +96,26 @@
 	}
 
 	/**
+	 * MIME type for a non-image attachment (drives the text-preview decision).
+	 */
+	function getMimeType(attachment: Attachment): string | undefined {
+		if (attachment.type === 'file') return attachment.mimeType;
+		if (attachment.type === 'screenshot') return attachment.mimeType;
+		if (attachment.type === 'remote-file') return attachment.contentType;
+		return undefined;
+	}
+
+	/**
+	 * In-memory blob for a freshly attached file, so the preview can read text
+	 * locally without a network round-trip. null for already-sent (remote) ones.
+	 */
+	function getLocalBlob(attachment: Attachment): Blob | null {
+		if (attachment.type === 'file') return attachment.file ?? null;
+		if (attachment.type === 'screenshot') return attachment.blob ?? null;
+		return null;
+	}
+
+	/**
 	 * Check if attachment is a screenshot
 	 */
 	function isScreenshot(attachment: Attachment): boolean {
@@ -173,11 +195,21 @@
 			{@const openUrl = getOpenUrl(selectedAttachment)}
 			{@const isImage = isImageAttachment(selectedAttachment)}
 			{#if openUrl && !isImage}
-				<iframe
-					src={openUrl}
-					title={getFilename(selectedAttachment)}
-					class="h-[70vh] w-full rounded-md"
-				></iframe>
+				{@const mimeType = getMimeType(selectedAttachment)}
+				{#if isTextPreviewable(mimeType, getFilename(selectedAttachment))}
+					<AttachmentTextPreview
+						url={openUrl}
+						{mimeType}
+						filename={getFilename(selectedAttachment)}
+						blob={getLocalBlob(selectedAttachment)}
+					/>
+				{:else}
+					<iframe
+						src={openUrl}
+						title={getFilename(selectedAttachment)}
+						class="h-[70vh] w-full rounded-md"
+					></iframe>
+				{/if}
 			{:else if openUrl && isImage}
 				{#if displayDimensions}
 					<div
@@ -219,6 +251,7 @@
 			<!-- tabindex and role are set together: when isClickable, role="button" makes this interactive -->
 			<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 			<div
+				data-testid="attachment-chip"
 				class="relative flex items-center justify-between gap-2 overflow-hidden rounded-lg px-2 py-2 transition-transform {isClickable
 					? 'cursor-pointer active:translate-y-px'
 					: ''} {readonly ? 'border text-foreground transition-colors' : 'bg-secondary/50'}"

--- a/src/lib/chat/ui/ChatContext.svelte.ts
+++ b/src/lib/chat/ui/ChatContext.svelte.ts
@@ -31,6 +31,13 @@ export interface UploadConfig {
 	getAccessKey?: () => string | undefined;
 	/** Provider for extra args to pass to generateUploadUrl (e.g., anonymousUserId for rate limiting) */
 	getGenerateUploadUrlArgs?: () => Record<string, unknown>;
+	/**
+	 * Optional action that returns the text of a stored attachment for the
+	 * preview dialog. Required to render markdown/text/code previews of
+	 * already-sent attachments (no local blob); without it the preview falls
+	 * back to the raw iframe. Receives `{ url, locale, ...getGenerateUploadUrlArgs() }`.
+	 */
+	getAttachmentText?: Parameters<ConvexClient['action']>[0];
 }
 
 /**
@@ -324,7 +331,8 @@ export class ChatUIContext {
 		// Synchronously insert the placeholder BEFORE any await so concurrent
 		// callers (e.g. handleFilesAdded looping over a batch) see the limit
 		// and dedup state immediately.
-		const initialPreview = file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined;
+		const isImageType = file.type.startsWith('image/');
+		const initialPreview = isImageType ? URL.createObjectURL(file) : undefined;
 		const placeholder: Attachment = {
 			type: 'file',
 			key,
@@ -332,6 +340,11 @@ export class ChatUIContext {
 			size: file.size,
 			mimeType: file.type,
 			preview: initialPreview,
+			// Retain the original blob for non-image files (bounded by the 5MB
+			// upload cap) so the attachment preview can read their text locally,
+			// with no round-trip. Images are omitted: they are re-encoded on
+			// upload and never use the text preview.
+			file: !isImageType && file instanceof File ? file : undefined,
 			uploadState: { status: 'uploading', progress: 0 },
 			// Source metadata persists across the rename in preprocess so dedup
 			// still matches when the user re-pastes the same image.

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -288,10 +288,18 @@
 		if (!items) return;
 
 		for (const item of items) {
-			// Only process allowed file types
-			if (!ALLOWED_FILE_TYPES.includes(item.type)) {
-				continue;
-			}
+			// Only file items become attachments; string items (e.g. pasted
+			// text, which now matches text/plain in the allowlist) fall through
+			// to the textarea's default paste handling.
+			if (item.kind !== 'file') continue;
+
+			const raw = item.getAsFile();
+			if (!raw) continue;
+
+			// Extension-aware allowlist gate: a pasted file's clipboard type is
+			// often empty/generic (notably .md/.txt), so check the extension
+			// fallback like handleFilesAdded rather than the bare item.type.
+			if (!isAllowedKind(raw)) continue;
 
 			// Check attachment limit
 			if (ctx.attachments.length >= MAX_ATTACHMENTS) {
@@ -300,8 +308,10 @@
 				break;
 			}
 
-			const file = item.getAsFile();
-			if (!file) continue;
+			// Coerce empty/generic MIME from the extension before branching, so
+			// attachFile routes images through processImage and the upload sends
+			// the correct Content-Type for text files.
+			const file = normalizeMime(raw);
 
 			// Type-aware size cap — images go through processImage which
 			// shrinks them before upload, so we only enforce the absurdity

--- a/src/lib/components/customer-support/customer-support.svelte
+++ b/src/lib/components/customer-support/customer-support.svelte
@@ -70,6 +70,7 @@
 	const uploadConfig: UploadConfig = {
 		generateUploadUrl: api.support.files.generateUploadUrl,
 		saveUploadedFile: api.support.files.saveUploadedFile,
+		getAttachmentText: api.support.files.getAttachmentText,
 		locale: page.data.lang,
 		getAccessKey: () => threadContext.threadId ?? threadContext.userId ?? 'support',
 		getGenerateUploadUrlArgs: () => {

--- a/src/lib/convex/aiChat/files.ts
+++ b/src/lib/convex/aiChat/files.ts
@@ -1,10 +1,11 @@
 import { v, ConvexError } from 'convex/values';
 import { storeFile } from '@convex-dev/agent';
-import { action, mutation } from '../_generated/server';
+import { action, internalMutation, mutation } from '../_generated/server';
 import { components, internal } from '../_generated/api';
 import { t } from '../i18n/translations';
 import { aiChatRateLimiter } from './rateLimit';
 import { authComponent } from '../auth';
+import { fetchAttachmentText } from '../files/attachmentText';
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
@@ -13,7 +14,9 @@ const ALLOWED_MIME_TYPES = [
 	'image/jpeg',
 	'image/webp',
 	'image/gif',
-	'application/pdf'
+	'application/pdf',
+	'text/markdown',
+	'text/plain'
 ];
 
 /**
@@ -117,10 +120,13 @@ export const saveUploadedFile = action({
 				);
 			}
 
-			if (!ALLOWED_MIME_TYPES.includes(blob.type)) {
+			// Compare the essence only: text/* often comes back with a charset suffix
+			// (e.g. "text/plain; charset=utf-8").
+			const mimeEssence = blob.type.split(';')[0]!.trim().toLowerCase();
+			if (!ALLOWED_MIME_TYPES.includes(mimeEssence)) {
 				throw new ConvexError(t(args.locale, 'backend.files.type_not_allowed'));
 			}
-			verifiedMimeType = blob.type;
+			verifiedMimeType = mimeEssence;
 
 			const result = await storeFile(ctx, components.agent, blob, {
 				filename: args.filename
@@ -151,5 +157,42 @@ export const saveUploadedFile = action({
 			filename: file.filename,
 			isImage: verifiedMimeType.startsWith('image/')
 		};
+	}
+});
+
+/**
+ * Gate a preview read: require auth and rate-limit. Runs in a mutation ctx so
+ * it can resolve the authenticated user and write to the rate limiter; the
+ * action below calls it via runMutation.
+ */
+export const checkPreviewAccess = internalMutation({
+	args: {},
+	handler: async (ctx) => {
+		const user = await authComponent.getAuthUser(ctx);
+		if (!user) {
+			throw new ConvexError('Authentication required');
+		}
+		const rateLimitStatus = await aiChatRateLimiter.limit(ctx, 'aiChatFilePreview', {
+			key: user._id
+		});
+		if (!rateLimitStatus.ok) {
+			throw new ConvexError('Too many preview requests. Please try again later.');
+		}
+	}
+});
+
+/**
+ * Read a text attachment's content for the in-app preview dialog.
+ *
+ * Used by the shared preview component when an attachment has no local blob
+ * (e.g. a message reloaded from history). Server-side fetch sidesteps the lack
+ * of CORS headers on Convex storage URLs; see fetchAttachmentText for the SSRF
+ * guard and size cap.
+ */
+export const getAttachmentText = action({
+	args: { url: v.string(), locale: v.optional(v.string()) },
+	handler: async (ctx, args): Promise<{ text: string; truncated: boolean }> => {
+		await ctx.runMutation(internal.aiChat.files.checkPreviewAccess, {});
+		return await fetchAttachmentText(args.url, args.locale);
 	}
 });

--- a/src/lib/convex/aiChat/rateLimit.ts
+++ b/src/lib/convex/aiChat/rateLimit.ts
@@ -24,5 +24,14 @@ export const aiChatRateLimiter = new RateLimiter(components.rateLimiter, {
 		rate: 10,
 		period: HOUR,
 		capacity: 10
+	},
+
+	// Per-user text-attachment preview reads (getAttachmentText)
+	// Generous: previews are cheap and the file URL is already public.
+	aiChatFilePreview: {
+		kind: 'token bucket',
+		rate: 120,
+		period: HOUR,
+		capacity: 30
 	}
 });

--- a/src/lib/convex/files/attachmentText.ts
+++ b/src/lib/convex/files/attachmentText.ts
@@ -1,0 +1,114 @@
+import { ConvexError } from 'convex/values';
+import { t } from '../i18n/translations';
+
+/**
+ * Max bytes of attachment text returned to the client for the preview dialog.
+ * The client renderer also caps; both layers cap so a large object is never
+ * fully read on either side.
+ */
+export const MAX_PREVIEW_TEXT_SIZE = 256 * 1024; // 256KB
+
+const PREVIEWABLE_MIME_EXACT = new Set(['application/json', 'application/xml']);
+
+/**
+ * SSRF guard: a previewable attachment URL must live on this deployment's own
+ * Convex storage origin (`cloudOrigin`, i.e. CONVEX_CLOUD_URL) and use the
+ * storage path. Returns false for foreign origins, non-storage paths, unparsable
+ * URLs, and a missing/unparsable cloud origin (fail closed).
+ */
+export function isAllowedStorageUrl(url: string, cloudOrigin: string | undefined): boolean {
+	if (!cloudOrigin) return false;
+	let target: URL;
+	let allowed: URL;
+	try {
+		target = new URL(url);
+		allowed = new URL(cloudOrigin);
+	} catch {
+		return false;
+	}
+	return target.origin === allowed.origin && target.pathname.startsWith('/api/storage/');
+}
+
+function isPreviewableContentType(contentType: string): boolean {
+	const essence = contentType.split(';')[0]!.trim().toLowerCase();
+	if (!essence) return false;
+	if (essence.startsWith('text/')) return true;
+	return PREVIEWABLE_MIME_EXACT.has(essence);
+}
+
+/**
+ * Read a chat attachment's text content server-side for the preview dialog.
+ *
+ * CORS-independent (Convex storage URLs do not send Access-Control-Allow-Origin,
+ * so a browser cannot read them cross-origin; the server can). SSRF-guarded: the
+ * URL must point at this deployment's own Convex storage origin and storage path.
+ * Bounded read so an oversized or binary object is never fully decoded.
+ *
+ * @throws {ConvexError} when the URL is not this deployment's storage, the fetch
+ *   fails, or the content type is not text-like.
+ */
+export async function fetchAttachmentText(
+	url: string,
+	locale?: string
+): Promise<{ text: string; truncated: boolean }> {
+	// SSRF guard. CONVEX_CLOUD_URL is a Convex system env var (available in app
+	// functions on cloud and self-hosted) and is the origin ctx.storage.getUrl()
+	// serves from. Fail closed if it is unset or the URL is not our storage.
+	if (!isAllowedStorageUrl(url, process.env.CONVEX_CLOUD_URL)) {
+		throw new ConvexError(t(locale, 'backend.files.fetch_failed'));
+	}
+
+	const response = await fetch(url, { redirect: 'manual' });
+	if (!response.ok) {
+		throw new ConvexError(t(locale, 'backend.files.fetch_failed'));
+	}
+
+	if (!isPreviewableContentType(response.headers.get('content-type') ?? '')) {
+		throw new ConvexError(t(locale, 'backend.files.type_not_allowed'));
+	}
+
+	// Bounded read: stop once we have MAX_PREVIEW_TEXT_SIZE bytes so a large
+	// object is never fully buffered/decoded.
+	const reader = response.body?.getReader();
+	if (!reader) {
+		const whole = await response.text();
+		return {
+			text: whole.slice(0, MAX_PREVIEW_TEXT_SIZE),
+			truncated: whole.length > MAX_PREVIEW_TEXT_SIZE
+		};
+	}
+
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	let truncated = false;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (value) {
+				chunks.push(value);
+				total += value.byteLength;
+				if (total >= MAX_PREVIEW_TEXT_SIZE) {
+					truncated = true;
+					break;
+				}
+			}
+		}
+	} finally {
+		await reader.cancel().catch(() => {});
+	}
+
+	const limit = Math.min(total, MAX_PREVIEW_TEXT_SIZE);
+	const buf = new Uint8Array(limit);
+	let offset = 0;
+	for (const chunk of chunks) {
+		if (offset >= limit) break;
+		const take = Math.min(chunk.byteLength, limit - offset);
+		buf.set(chunk.subarray(0, take), offset);
+		offset += take;
+	}
+	// TextDecoder is non-fatal by default: a UTF-8 sequence cut at the cap
+	// boundary degrades to U+FFFD rather than throwing.
+	const text = new TextDecoder().decode(buf);
+	return { text, truncated };
+}

--- a/src/lib/convex/support/files.ts
+++ b/src/lib/convex/support/files.ts
@@ -6,6 +6,7 @@ import { t } from '../i18n/translations';
 import { supportRateLimiter } from './rateLimit';
 import { createRateLimitError } from './types';
 import { getSupportOwnerIdentity } from './ownership';
+import { fetchAttachmentText } from '../files/attachmentText';
 
 /**
  * Maximum file size for support uploads (5MB)
@@ -20,7 +21,9 @@ const ALLOWED_MIME_TYPES = [
 	'image/jpeg',
 	'image/webp',
 	'image/gif',
-	'application/pdf'
+	'application/pdf',
+	'text/markdown',
+	'text/plain'
 ];
 
 /**
@@ -77,7 +80,7 @@ export const generateUploadUrl = mutation({
  * @param args.width - Optional image width for metadata storage
  * @param args.height - Optional image height for metadata storage
  * @returns Object containing fileId, storageId, url, filename, and isImage flag
- * @throws {Error} When file type is not allowed (only PNG, JPEG, WebP, GIF, PDF supported)
+ * @throws {Error} When file type is not allowed (PNG, JPEG, WebP, GIF, PDF, Markdown, plain text)
  * @throws {Error} When download grant cannot be created or consumed
  * @throws {Error} When file fetch fails
  */
@@ -155,11 +158,13 @@ export const saveUploadedFile = action({
 			}
 
 			// Validate MIME type against the actual blob — not the client-supplied args.mimeType
-			// which is untrusted input and could be spoofed.
-			if (!ALLOWED_MIME_TYPES.includes(blob.type)) {
+			// which is untrusted input and could be spoofed. Compare the essence only:
+			// text/* often comes back with a charset suffix (e.g. "text/plain; charset=utf-8").
+			const mimeEssence = blob.type.split(';')[0]!.trim().toLowerCase();
+			if (!ALLOWED_MIME_TYPES.includes(mimeEssence)) {
 				throw new ConvexError(t(args.locale, 'backend.files.type_not_allowed'));
 			}
-			verifiedMimeType = blob.type;
+			verifiedMimeType = mimeEssence;
 
 			// Register with agent component
 			const result = await storeFile(ctx, components.agent, blob, {
@@ -234,5 +239,55 @@ export const storeFileMetadata = internalMutation({
 			height: args.height,
 			createdAt: Date.now()
 		});
+	}
+});
+
+/**
+ * Gate a preview read: resolve owner (auth or anonymous) and rate-limit. Runs
+ * in a mutation ctx so it can read auth and write to the rate limiter; the
+ * action below calls it via runMutation.
+ *
+ * @security Anonymous access mirrors the upload flow: support previews are
+ * available to unauthenticated users, anonymous callers share a global bucket.
+ */
+export const checkPreviewAccess = internalMutation({
+	args: { anonymousUserId: v.optional(v.string()) },
+	handler: async (ctx, args) => {
+		const owner = await getSupportOwnerIdentity(ctx, args.anonymousUserId);
+		const isAnon = !owner || owner.isAnonymous;
+		const limitName = isAnon ? 'supportFilePreviewAnon' : 'supportFilePreview';
+		const userKey = isAnon ? 'anonymous-global' : owner.ownerId;
+
+		const rateLimitStatus = await supportRateLimiter.limit(ctx, limitName, { key: userKey });
+		if (!rateLimitStatus.ok) {
+			throw createRateLimitError(
+				rateLimitStatus.retryAfter,
+				'Too many preview requests. Please try again later.'
+			);
+		}
+	}
+});
+
+/**
+ * Read a text attachment's content for the in-app preview dialog.
+ *
+ * Used by the shared preview component when an attachment has no local blob
+ * (e.g. an admin viewing a user-uploaded file, or a message reloaded from
+ * history). Server-side fetch sidesteps the lack of CORS headers on Convex
+ * storage URLs; see fetchAttachmentText for the SSRF guard and size cap.
+ *
+ * @security Anonymous access: available to unauthenticated support users.
+ */
+export const getAttachmentText = action({
+	args: {
+		url: v.string(),
+		anonymousUserId: v.optional(v.string()),
+		locale: v.optional(v.string())
+	},
+	handler: async (ctx, args): Promise<{ text: string; truncated: boolean }> => {
+		await ctx.runMutation(internal.support.files.checkPreviewAccess, {
+			anonymousUserId: args.anonymousUserId
+		});
+		return await fetchAttachmentText(args.url, args.locale);
 	}
 });

--- a/src/lib/convex/support/rateLimit.ts
+++ b/src/lib/convex/support/rateLimit.ts
@@ -53,6 +53,23 @@ export const supportRateLimiter = new RateLimiter(components.rateLimiter, {
 		capacity: 10
 	},
 
+	// Authenticated text-attachment preview reads (getAttachmentText)
+	// Generous: previews are cheap and the file URL is already public.
+	supportFilePreview: {
+		kind: 'token bucket',
+		rate: 120,
+		period: HOUR,
+		capacity: 30
+	},
+
+	// Anonymous preview reads — GLOBAL shared bucket (spoofable client IDs)
+	supportFilePreviewAnon: {
+		kind: 'token bucket',
+		rate: 120,
+		period: HOUR,
+		capacity: 30
+	},
+
 	// Global LLM call limit (cost protection)
 	// Soft-fails when exceeded - saves explanatory message for user
 	// Sharded for high throughput across all users

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -48,6 +48,7 @@
 	const uploadConfig: UploadConfig = {
 		generateUploadUrl: api.support.files.generateUploadUrl,
 		saveUploadedFile: api.support.files.saveUploadedFile,
+		getAttachmentText: api.support.files.getAttachmentText,
 		locale: page.data.lang,
 		getAccessKey: () => threadId || 'support-admin'
 	};

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -43,6 +43,7 @@
 	const uploadConfig: UploadConfig = {
 		generateUploadUrl: api.aiChat.files.generateUploadUrl,
 		saveUploadedFile: api.aiChat.files.saveUploadedFile,
+		getAttachmentText: api.aiChat.files.getAttachmentText,
 		locale: page.data.lang,
 		getAccessKey: () => threadId || 'ai-chat'
 	};


### PR DESCRIPTION
Closes #410

The attachment preview dialog rendered every non-image attachment with an iframe, so a markdown or text file showed its raw source (`# Heading`, `[label](url)`) instead of formatted content. It did not surface in the default template because only images and PDF were accepted, but it broke as soon as a consumer allowed text/markdown through the shared `ChatAttachments` component.

Text-based attachments now render through the same Streamdown engine that already renders chat messages: markdown formatted, plain text in a `pre` block, and JSON or code syntax-highlighted, while PDFs keep the browser iframe. The renderer is locked down for untrusted uploaded content so it stays at or below the trust level the app already accepts for message rendering. Raw HTML stays off. Images are blocked through a snippet override rather than the prefix allowlist, because Streamdown still renders relative and protocol-relative URLs (`//evil.com/x.png`) regardless of `allowedImagePrefixes`. Links are clickable only when the resolved href is absolute http(s). Mermaid is shown as a code block instead of a rendered diagram.

Freshly attached files read their text from the in-memory blob. Already-sent attachments, such as an admin viewing a user upload or a reloaded thread, load it through a new `getAttachmentText` action, since Convex storage URLs do not send CORS headers and cannot be read cross-origin from the browser. The action validates the URL against the deployment's own storage origin (`CONVEX_CLOUD_URL`) and the `/api/storage/` path, requires a text content type, and caps the response size.

The template now accepts `.md` and `.txt` uploads in both the client and server allowlists so the preview is reachable, and the paste handler accepts text files whose clipboard MIME type is empty.

In the worktree, `bun run check:convex`, `bun scripts/static-checks.ts` on the changed files, and `bun run test:unit` pass. `bun run test:e2e e2e/ai-chat-attachment-preview.spec.ts` passes: it uploads a `.md`, opens the preview, and asserts the rendered heading with no image loaded.
