### PR TITLE
fix(env): Mark Convex deployment id as public

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -19,7 +19,8 @@ VARLOCK_ENV=
 # ====================================
 
 # Local dev deployment identifier, auto-set by `bunx convex dev`
-# @optional
+# Not secret: the deployment slug is also embedded in PUBLIC_CONVEX_URL.
+# @public @optional
 CONVEX_DEPLOYMENT=
 
 # Convex deployment API URL
@@ -144,7 +145,8 @@ CONVEX_MANAGEMENT_TOKEN=
 # `curl -H "Authorization: Bearer $CONVEX_MANAGEMENT_TOKEN" \
 # https://api.convex.dev/v1/token_details`, then find the project id via
 # `curl ... /v1/teams/{team_id}/list_projects`.
-# @optional
+# Identifier, not a secret (the secret is CONVEX_MANAGEMENT_TOKEN).
+# @public @optional
 CONVEX_PROJECT_ID=
 
 # Set to "1" to build with adapter-node for self-hosted deployments

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,8 +14,9 @@ export type CoercedEnvSchema = {
   VARLOCK_ENV?: "development" | "preview" | "production" | "test";
   
   /**
-   * **CONVEX_DEPLOYMENT** 🔐 _sensitive_  
+   * **CONVEX_DEPLOYMENT**  
    * Local dev deployment identifier, auto-set by `bunx convex dev`  
+   * Not secret: the deployment slug is also embedded in PUBLIC_CONVEX_URL.  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   CONVEX_DEPLOYMENT?: string;
@@ -174,11 +175,12 @@ export type CoercedEnvSchema = {
   CONVEX_MANAGEMENT_TOKEN?: string;
   
   /**
-   * **CONVEX_PROJECT_ID** 🔐 _sensitive_  
+   * **CONVEX_PROJECT_ID**  
    * Convex project id for the preview quota fallback. Derive team id via  
    * `curl -H "Authorization: Bearer $CONVEX_MANAGEMENT_TOKEN" \  
    * https://api.convex.dev/v1/token_details`, then find the project id via  
    * `curl ... /v1/teams/{team_id}/list_projects`.  
+   * Identifier, not a secret (the secret is CONVEX_MANAGEMENT_TOKEN).  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
    */
   CONVEX_PROJECT_ID?: string;
@@ -323,7 +325,7 @@ type _CoercedEnvSchema_8eb0ae17 = CoercedEnvSchema;
 
 declare module 'varlock/env' {
   export interface TypedEnvSchema extends Readonly<_CoercedEnvSchema_8eb0ae17> {}
-  export interface PublicTypedEnvSchema extends Readonly<Pick<_CoercedEnvSchema_8eb0ae17, 'VARLOCK_ENV' | 'PUBLIC_CONVEX_URL' | 'PUBLIC_CONVEX_SITE_URL' | 'VITE_TOLGEE_API_URL' | 'VITE_TOLGEE_API_KEY' | 'PUBLIC_POSTHOG_API_KEY' | 'PUBLIC_POSTHOG_HOST' | 'PUBLIC_POSTHOG_PROXY_HOST' | 'PUBLIC_SENTRY_DSN' | 'PUBLIC_SNAPDOM_PROXY_URL' | 'PUBLIC_SITE_URL' | 'NODE_ADAPTER' | 'VERCEL_ENV' | 'VERCEL_URL' | 'VERCEL_GIT_COMMIT_REF' | 'WORKERS_CI' | 'WORKERS_CI_BRANCH' | 'WORKERS_CI_COMMIT_SHA' | 'WORKERS_NAME' | 'WORKERS_SUBDOMAIN' | 'CF_PAGES' | 'CF_PAGES_URL' | 'CF_PAGES_BRANCH' | 'PRODUCTION_BRANCH' | 'CI'>> {}
+  export interface PublicTypedEnvSchema extends Readonly<Pick<_CoercedEnvSchema_8eb0ae17, 'VARLOCK_ENV' | 'CONVEX_DEPLOYMENT' | 'PUBLIC_CONVEX_URL' | 'PUBLIC_CONVEX_SITE_URL' | 'VITE_TOLGEE_API_URL' | 'VITE_TOLGEE_API_KEY' | 'PUBLIC_POSTHOG_API_KEY' | 'PUBLIC_POSTHOG_HOST' | 'PUBLIC_POSTHOG_PROXY_HOST' | 'PUBLIC_SENTRY_DSN' | 'PUBLIC_SNAPDOM_PROXY_URL' | 'PUBLIC_SITE_URL' | 'CONVEX_PROJECT_ID' | 'NODE_ADAPTER' | 'VERCEL_ENV' | 'VERCEL_URL' | 'VERCEL_GIT_COMMIT_REF' | 'WORKERS_CI' | 'WORKERS_CI_BRANCH' | 'WORKERS_CI_COMMIT_SHA' | 'WORKERS_NAME' | 'WORKERS_SUBDOMAIN' | 'CF_PAGES' | 'CF_PAGES_URL' | 'CF_PAGES_BRANCH' | 'PRODUCTION_BRANCH' | 'CI'>> {}
 }
 
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -137,9 +137,10 @@ function parseEnvFile(filePath: string): Record<string, string> {
 }
 
 /**
- * Parse a varlock .env schema and return var names marked @sensitive.
- * Also handles @defaultSensitive=inferFromPrefix(PREFIX_) — vars without
- * the prefix are treated as sensitive by default.
+ * Parse a varlock .env schema and return var names treated as sensitive.
+ * Handles @defaultSensitive=inferFromPrefix(PREFIX_): vars without the prefix
+ * are sensitive by default. An explicit @public comment opts a var back out,
+ * matching varlock's own classification.
  */
 function parseSensitiveVarNames(schemaPath: string): Set<string> {
 	if (!fs.existsSync(schemaPath)) return new Set();
@@ -162,6 +163,7 @@ function parseSensitiveVarNames(schemaPath: string): Set<string> {
 		const trimmed = line.trim();
 		if (trimmed.startsWith('#')) {
 			if (trimmed.includes('@sensitive')) nextIsSensitive = true;
+			else if (trimmed.includes('@public')) nextIsSensitive = false;
 			continue;
 		}
 


### PR DESCRIPTION
Closes #442

Running `bun run dev:cloud` aborted with `🚨 DETECTED LEAKED SENSITIVE CONFIG - CONVEX_DEPLOYMENT`. The schema treats every non-`PUBLIC_` var as sensitive (`@defaultSensitive=inferFromPrefix(PUBLIC_)`), and `CONVEX_DEPLOYMENT` was never marked `@public`, so `@preventLeaks` scans every SSR response for its value. The Convex deployment slug is also embedded in the public `PUBLIC_CONVEX_URL` that gets rendered into the page, so a deployment value that is the bare slug or a full URL substring-matches that public URL and varlock kills the dev server. It is a false positive in our own tooling, not a Cloudflare problem.

The deployment slug is not a secret, it is already part of the public Convex URL the browser connects to. Only `CONVEX_DEPLOY_KEY` is. This marks `CONVEX_DEPLOYMENT` and the equally non-secret `CONVEX_PROJECT_ID` as `@public`, and teaches the local `parseSensitiveVarNames` helper in `vite.config.ts` to honor `@public` so the backend redaction path stays consistent with varlock. `@public` only changes varlock's classification; neither var gains a `PUBLIC_`/`VITE_` prefix, so nothing new is exposed to the browser, and the genuinely secret keys (`CONVEX_DEPLOY_KEY`, `CONVEX_INTERNAL_URL`) stay sensitive.

`varlock load` now reports `CONVEX_DEPLOYMENT` and `CONVEX_PROJECT_ID` as non-sensitive while `CONVEX_DEPLOY_KEY` stays sensitive, an isolated `scanForLeaks` repro no longer throws on a bare-slug deployment value but still catches a real leaked deploy key, and `bun scripts/static-checks.ts vite.config.ts` passes.
