### PR TITLE
fix(chat): stop reasoning indicator flicker

### DIFF
--- a/src/lib/chat/ui/ChatMessage.svelte
+++ b/src/lib/chat/ui/ChatMessage.svelte
@@ -2,13 +2,12 @@
 	import { Message } from '$lib/components/prompt-kit/message';
 	import { Response } from '$lib/components/ai-elements/response';
 	import { ToolComposed } from '$lib/components/prompt-kit/tool';
-	import type { ToolPart } from '$lib/components/prompt-kit/tool/types.js';
 	import ChatAttachments from './ChatAttachments.svelte';
 	import ChatReasoning from './ChatReasoning.svelte';
 	import MessageBubble from './MessageBubble.svelte';
 	import InlineEmailPrompt from './InlineEmailPrompt.svelte';
 	import { getChatUIContext } from './ChatContext.svelte.js';
-	import { getActiveStreamingReasoningIndex, getReasoningPartKey } from './reasoning-parts.js';
+	import { deriveOrderedParts, LEADING_REASONING_KEY, type OrderedPart } from './ordered-parts.js';
 	import { type DisplayMessage, type Attachment } from '../core/types.js';
 
 	let {
@@ -52,23 +51,12 @@
 	);
 	const usesFilledBubble = $derived(isUser || isAdminMessage);
 	const align = $derived(ctx.getAlignment(message.role));
-	function isReasoningPartOpen(partKey: string): boolean {
-		return ctx.isReasoningOpen(`${message.id}:${partKey}`);
+	function handleReasoningOpenChange(stateKey: string, open: boolean) {
+		ctx.setReasoningOpen(stateKey, open);
+		ctx.markUserToggled(stateKey);
 	}
 
-	function handleReasoningPartOpenChange(partKey: string, open: boolean) {
-		const fullKey = `${message.id}:${partKey}`;
-		ctx.setReasoningOpen(fullKey, open);
-		ctx.markUserToggled(fullKey);
-	}
-
-	// Fallback: single reasoning open state for messages without parts
-	const isReasoningOpen = $derived(ctx.isReasoningOpen(message.id));
-
-	// Whether this message has interleaved parts (reasoning/tool/text in order)
-	const hasParts = $derived(!!(message.parts && message.parts.length > 0));
-
-	// Fallback deriveds for messages without parts (pending state, old messages)
+	// Fallback deriveds for messages without renderable parts (pending state, old messages)
 	const showReasoningFallback = $derived(
 		message.displayReasoning ||
 			message.hasReasoningStream ||
@@ -76,61 +64,57 @@
 	);
 	const shimmerFallback = $derived(!!message.displayReasoning && !message.displayText);
 
-	type OrderedPart =
-		| { kind: 'reasoning'; text: string; isStreaming: boolean; hasContent: boolean; key: string }
-		| { kind: 'tool'; toolPart: ToolPart; key: string }
-		| { kind: 'text'; text: string; key: string };
+	// Renderable parts in chronological order (step-start etc. are dropped)
+	const orderedParts = $derived(deriveOrderedParts(message.parts, message.status));
 
-	// Derive ordered parts for chronological rendering
-	const orderedParts: OrderedPart[] = $derived.by(() => {
-		const parts = message.parts ?? [];
-		const isMessageInProgress = message.status === 'pending' || message.status === 'streaming';
-		const activeReasoningIndex = getActiveStreamingReasoningIndex(parts, isMessageInProgress);
-		return parts
-			.map((p, idx): OrderedPart | null => {
-				if (p.type === 'reasoning') {
-					const text = (p as { text?: string }).text ?? '';
-					return {
-						kind: 'reasoning',
-						text,
-						isStreaming: idx === activeReasoningIndex,
-						hasContent: !!text,
-						key: getReasoningPartKey(p, idx)
-					};
-				}
-				if (p.type === 'text') {
-					return {
-						kind: 'text',
-						text: (p as { text?: string }).text ?? '',
-						key: `text-${idx}`
-					};
-				}
-				if (typeof p.type === 'string' && p.type.startsWith('tool-') && 'state' in p) {
-					return {
-						kind: 'tool',
-						toolPart: {
-							type: p.type,
-							state: (p as { state: ToolPart['state'] }).state,
-							input: (p as { input?: Record<string, unknown> }).input,
-							output: (p as { output?: unknown }).output as Record<string, unknown> | undefined,
-							toolCallId: (p as { toolCallId?: string }).toolCallId,
-							errorText: (p as { errorText?: string }).errorText
-						},
-						key:
-							(p as { toolCallId?: string }).toolCallId ??
-							(p as { streamId?: string }).streamId ??
-							`tool-${idx}`
-					};
-				}
-				return null;
-			})
-			.filter((p): p is OrderedPart => p !== null);
+	// Reasoning items carry a resolved accordion open-state key. The leading reasoning and
+	// its connecting placeholder share a stable Svelte key (LEADING_REASONING_KEY), so the
+	// component instance survives the connecting -> thinking transition without remounting.
+	type RenderItem =
+		| {
+				kind: 'reasoning';
+				text: string;
+				isStreaming: boolean;
+				hasContent: boolean;
+				key: string;
+				stateKey: string;
+		  }
+		| Exclude<OrderedPart, { kind: 'reasoning' }>;
+
+	const renderItems: RenderItem[] = $derived.by(() => {
+		if (orderedParts.length > 0) {
+			return orderedParts.map(
+				(part): RenderItem =>
+					part.kind === 'reasoning'
+						? {
+								kind: 'reasoning',
+								text: part.text,
+								isStreaming: part.isStreaming,
+								hasContent: part.hasContent,
+								key: part.key,
+								stateKey: `${message.id}:${part.partKey}`
+							}
+						: part
+			);
+		}
+
+		// No renderable parts yet: keep a single connecting indicator mounted, plus legacy text.
+		const items: RenderItem[] = [];
+		if (showReasoningFallback) {
+			items.push({
+				kind: 'reasoning',
+				text: message.displayReasoning,
+				isStreaming: shimmerFallback,
+				hasContent: !!message.displayReasoning,
+				key: LEADING_REASONING_KEY,
+				stateKey: message.id
+			});
+		}
+		if (message.displayText) {
+			items.push({ kind: 'text', text: message.displayText, key: 'text-0' });
+		}
+		return items;
 	});
-
-	function handleReasoningOpenChange(open: boolean) {
-		ctx.setReasoningOpen(message.id, open);
-		ctx.markUserToggled(message.id);
-	}
 </script>
 
 <div
@@ -151,37 +135,21 @@
 		{:else}
 			<!-- AI messages: ghost/prose style with interleaved reasoning/tools/text -->
 			<MessageBubble {align} variant="ghost">
-				{#if hasParts}
-					{#each orderedParts as part (part.key)}
-						{#if part.kind === 'reasoning'}
-							<ChatReasoning
-								open={isReasoningPartOpen(part.key)}
-								onOpenChange={(open) => handleReasoningPartOpenChange(part.key, open)}
-								isStreaming={part.isStreaming}
-								hasContent={part.hasContent}
-								content={part.text}
-							/>
-						{:else if part.kind === 'tool'}
-							<ToolComposed toolPart={part.toolPart} />
-						{:else if part.kind === 'text'}
-							<Response content={part.text} animation={{ enabled: true }} />
-						{/if}
-					{/each}
-				{:else}
-					<!-- Fallback for messages without parts (pending, old messages) -->
-					{#if showReasoningFallback}
+				{#each renderItems as item (item.key)}
+					{#if item.kind === 'reasoning'}
 						<ChatReasoning
-							open={isReasoningOpen}
-							onOpenChange={handleReasoningOpenChange}
-							isStreaming={shimmerFallback}
-							hasContent={!!message.displayReasoning}
-							content={message.displayReasoning}
+							open={ctx.isReasoningOpen(item.stateKey)}
+							onOpenChange={(open) => handleReasoningOpenChange(item.stateKey, open)}
+							isStreaming={item.isStreaming}
+							hasContent={item.hasContent}
+							content={item.text}
 						/>
+					{:else if item.kind === 'tool'}
+						<ToolComposed toolPart={item.toolPart} />
+					{:else if item.kind === 'text'}
+						<Response content={item.text} animation={{ enabled: true }} />
 					{/if}
-					{#if message.displayText}
-						<Response content={message.displayText} animation={{ enabled: true }} />
-					{/if}
-				{/if}
+				{/each}
 				{#if isHandoffMessage && showEmailPrompt && onSubmitEmail}
 					<InlineEmailPrompt {currentEmail} {isEmailPending} {defaultEmail} {onSubmitEmail} />
 				{/if}

--- a/src/lib/chat/ui/ChatMessage.svelte
+++ b/src/lib/chat/ui/ChatMessage.svelte
@@ -92,7 +92,7 @@
 								isStreaming: part.isStreaming,
 								hasContent: part.hasContent,
 								key: part.key,
-								stateKey: `${message.id}:${part.partKey}`
+								stateKey: `${message.id}:${part.key}`
 							}
 						: part
 			);
@@ -107,7 +107,7 @@
 				isStreaming: shimmerFallback,
 				hasContent: !!message.displayReasoning,
 				key: LEADING_REASONING_KEY,
-				stateKey: message.id
+				stateKey: `${message.id}:${LEADING_REASONING_KEY}`
 			});
 		}
 		if (message.displayText) {

--- a/src/lib/chat/ui/ordered-parts.test.ts
+++ b/src/lib/chat/ui/ordered-parts.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { MessagePart } from '../core/types.js';
+import { deriveOrderedParts, LEADING_REASONING_KEY } from './ordered-parts.js';
+
+describe('deriveOrderedParts', () => {
+	// Regression guard: a step-start-only parts array must yield no renderable parts, so the
+	// caller keeps the "Connecting…" fallback mounted instead of rendering an empty list and
+	// blinking the reasoning indicator out between connecting and thinking.
+	it('returns [] for a step-start-only parts array', () => {
+		expect(deriveOrderedParts([{ type: 'step-start' }] as MessagePart[], 'streaming')).toEqual([]);
+	});
+
+	it('returns one reasoning entry once a reasoning part follows step-start', () => {
+		const result = deriveOrderedParts(
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Hi', streamPartId: 'r1' }
+			] as MessagePart[],
+			'streaming'
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			kind: 'reasoning',
+			text: 'Hi',
+			hasContent: true,
+			key: LEADING_REASONING_KEY,
+			partKey: 'reasoning-r1'
+		});
+	});
+
+	it('keys the leading reasoning with LEADING_REASONING_KEY even without a preceding part', () => {
+		const result = deriveOrderedParts(
+			[{ type: 'reasoning', text: 'thinking', streamPartId: 'r1' }] as MessagePart[],
+			'streaming'
+		);
+		expect(result[0]).toMatchObject({ key: LEADING_REASONING_KEY, partKey: 'reasoning-r1' });
+	});
+
+	it('keeps the real part key for a non-leading reasoning block', () => {
+		const result = deriveOrderedParts(
+			[
+				{ type: 'reasoning', text: 'First', streamPartId: 'r1' },
+				{ type: 'tool-getWeather', toolCallId: 't1', state: 'output-available' },
+				{ type: 'reasoning', text: 'Second', streamPartId: 'r2' }
+			] as MessagePart[],
+			'streaming'
+		);
+		const reasoning = result.filter((p) => p.kind === 'reasoning');
+		expect(reasoning[0]).toMatchObject({ key: LEADING_REASONING_KEY, partKey: 'reasoning-r1' });
+		expect(reasoning[1]).toMatchObject({ key: 'reasoning-r2', partKey: 'reasoning-r2' });
+	});
+
+	it('marks the trailing reasoning part as streaming only while in progress', () => {
+		const parts = [
+			{ type: 'reasoning', text: 'a', streamPartId: 'r1' },
+			{ type: 'reasoning', text: 'b', streamPartId: 'r2' }
+		] as MessagePart[];
+
+		const streaming = deriveOrderedParts(parts, 'streaming');
+		expect(streaming[0]).toMatchObject({ isStreaming: false });
+		expect(streaming[1]).toMatchObject({ isStreaming: true });
+
+		const done = deriveOrderedParts(parts, 'success');
+		expect(done[0]).toMatchObject({ isStreaming: false });
+		expect(done[1]).toMatchObject({ isStreaming: false });
+	});
+
+	it('orders interleaved reasoning/tool/text and drops step-start', () => {
+		const result = deriveOrderedParts(
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'think', streamPartId: 'r1' },
+				{ type: 'tool-getWeather', toolCallId: 't1', state: 'output-available' },
+				{ type: 'text', text: 'answer' }
+			] as MessagePart[],
+			'streaming'
+		);
+		expect(result.map((p) => p.kind)).toEqual(['reasoning', 'tool', 'text']);
+	});
+
+	it('handles undefined and empty parts', () => {
+		expect(deriveOrderedParts(undefined, 'success')).toEqual([]);
+		expect(deriveOrderedParts([], 'pending')).toEqual([]);
+	});
+});

--- a/src/lib/chat/ui/ordered-parts.test.ts
+++ b/src/lib/chat/ui/ordered-parts.test.ts
@@ -23,8 +23,7 @@ describe('deriveOrderedParts', () => {
 			kind: 'reasoning',
 			text: 'Hi',
 			hasContent: true,
-			key: LEADING_REASONING_KEY,
-			partKey: 'reasoning-r1'
+			key: LEADING_REASONING_KEY
 		});
 	});
 
@@ -33,7 +32,7 @@ describe('deriveOrderedParts', () => {
 			[{ type: 'reasoning', text: 'thinking', streamPartId: 'r1' }] as MessagePart[],
 			'streaming'
 		);
-		expect(result[0]).toMatchObject({ key: LEADING_REASONING_KEY, partKey: 'reasoning-r1' });
+		expect(result[0]).toMatchObject({ key: LEADING_REASONING_KEY });
 	});
 
 	it('keeps the real part key for a non-leading reasoning block', () => {
@@ -46,8 +45,8 @@ describe('deriveOrderedParts', () => {
 			'streaming'
 		);
 		const reasoning = result.filter((p) => p.kind === 'reasoning');
-		expect(reasoning[0]).toMatchObject({ key: LEADING_REASONING_KEY, partKey: 'reasoning-r1' });
-		expect(reasoning[1]).toMatchObject({ key: 'reasoning-r2', partKey: 'reasoning-r2' });
+		expect(reasoning[0]).toMatchObject({ key: LEADING_REASONING_KEY });
+		expect(reasoning[1]).toMatchObject({ key: 'reasoning-r2' });
 	});
 
 	it('marks the trailing reasoning part as streaming only while in progress', () => {

--- a/src/lib/chat/ui/ordered-parts.ts
+++ b/src/lib/chat/ui/ordered-parts.ts
@@ -1,33 +1,24 @@
 import type { ToolPart } from '$lib/components/prompt-kit/tool/types.js';
 import type { MessagePart, MessageStatus } from '../core/types.js';
-import { getActiveStreamingReasoningIndex, getReasoningPartKey } from './reasoning-parts.js';
+import {
+	getActiveStreamingReasoningIndex,
+	getReasoningKey,
+	LEADING_REASONING_KEY
+} from './reasoning-parts.js';
 
-/**
- * Stable Svelte `{#each}` key for the leading reasoning block (the first reasoning
- * part of a message) and its "Connecting…" placeholder. Decoupling DOM identity from
- * the accordion open/close key (which still uses the real part key) keeps a single
- * reasoning component instance mounted across the connecting → thinking transition,
- * so the indicator never blinks out or restarts its shimmer.
- */
-export const LEADING_REASONING_KEY = 'reasoning-lead';
+export { LEADING_REASONING_KEY };
 
 /**
  * A renderable message part in chronological order.
  *
- * `key` is the Svelte `{#each}` identity. `partKey` (reasoning only) is the unprefixed
- * accordion part key (`${message.id}:${partKey}` is the open-state key consumed by
- * `reasoning-accordion-sync.ts`). For the leading reasoning block `key` is stabilised to
- * `LEADING_REASONING_KEY` while `partKey` stays the real part key.
+ * `key` is both the Svelte `{#each}` identity and the suffix of the accordion open-state
+ * key (`${message.id}:${key}`). The leading reasoning block keys to
+ * {@link LEADING_REASONING_KEY} (see `getReasoningKey`), so it stays mounted and keeps its
+ * open-state across the connecting → thinking transition; later reasoning blocks keep their
+ * per-part key.
  */
 export type OrderedPart =
-	| {
-			kind: 'reasoning';
-			text: string;
-			isStreaming: boolean;
-			hasContent: boolean;
-			key: string;
-			partKey: string;
-	  }
+	| { kind: 'reasoning'; text: string; isStreaming: boolean; hasContent: boolean; key: string }
 	| { kind: 'tool'; toolPart: ToolPart; key: string }
 	| { kind: 'text'; text: string; key: string };
 
@@ -45,21 +36,17 @@ export function deriveOrderedParts(
 	const messageParts = parts ?? [];
 	const isMessageInProgress = status === 'pending' || status === 'streaming';
 	const activeReasoningIndex = getActiveStreamingReasoningIndex(messageParts, isMessageInProgress);
-	const firstReasoningIndex = messageParts.findIndex((p) => p.type === 'reasoning');
 
 	return messageParts
 		.map((p, idx): OrderedPart | null => {
 			if (p.type === 'reasoning') {
 				const text = (p as { text?: string }).text ?? '';
-				const partKey = getReasoningPartKey(p, idx);
 				return {
 					kind: 'reasoning',
 					text,
 					isStreaming: idx === activeReasoningIndex,
 					hasContent: !!text,
-					// Leading reasoning keeps a stable DOM identity for instance continuity.
-					key: idx === firstReasoningIndex ? LEADING_REASONING_KEY : partKey,
-					partKey
+					key: getReasoningKey(messageParts, idx)
 				};
 			}
 			if (p.type === 'text') {

--- a/src/lib/chat/ui/ordered-parts.ts
+++ b/src/lib/chat/ui/ordered-parts.ts
@@ -1,0 +1,92 @@
+import type { ToolPart } from '$lib/components/prompt-kit/tool/types.js';
+import type { MessagePart, MessageStatus } from '../core/types.js';
+import { getActiveStreamingReasoningIndex, getReasoningPartKey } from './reasoning-parts.js';
+
+/**
+ * Stable Svelte `{#each}` key for the leading reasoning block (the first reasoning
+ * part of a message) and its "Connecting…" placeholder. Decoupling DOM identity from
+ * the accordion open/close key (which still uses the real part key) keeps a single
+ * reasoning component instance mounted across the connecting → thinking transition,
+ * so the indicator never blinks out or restarts its shimmer.
+ */
+export const LEADING_REASONING_KEY = 'reasoning-lead';
+
+/**
+ * A renderable message part in chronological order.
+ *
+ * `key` is the Svelte `{#each}` identity. `partKey` (reasoning only) is the unprefixed
+ * accordion part key (`${message.id}:${partKey}` is the open-state key consumed by
+ * `reasoning-accordion-sync.ts`). For the leading reasoning block `key` is stabilised to
+ * `LEADING_REASONING_KEY` while `partKey` stays the real part key.
+ */
+export type OrderedPart =
+	| {
+			kind: 'reasoning';
+			text: string;
+			isStreaming: boolean;
+			hasContent: boolean;
+			key: string;
+			partKey: string;
+	  }
+	| { kind: 'tool'; toolPart: ToolPart; key: string }
+	| { kind: 'text'; text: string; key: string };
+
+/**
+ * Derive renderable parts for chronological rendering.
+ *
+ * Non-renderable parts (e.g. `step-start`) are dropped, so a message whose only part is
+ * `step-start` returns `[]` and the caller keeps the connecting fallback mounted instead
+ * of rendering an empty list.
+ */
+export function deriveOrderedParts(
+	parts: MessagePart[] | undefined,
+	status: MessageStatus
+): OrderedPart[] {
+	const messageParts = parts ?? [];
+	const isMessageInProgress = status === 'pending' || status === 'streaming';
+	const activeReasoningIndex = getActiveStreamingReasoningIndex(messageParts, isMessageInProgress);
+	const firstReasoningIndex = messageParts.findIndex((p) => p.type === 'reasoning');
+
+	return messageParts
+		.map((p, idx): OrderedPart | null => {
+			if (p.type === 'reasoning') {
+				const text = (p as { text?: string }).text ?? '';
+				const partKey = getReasoningPartKey(p, idx);
+				return {
+					kind: 'reasoning',
+					text,
+					isStreaming: idx === activeReasoningIndex,
+					hasContent: !!text,
+					// Leading reasoning keeps a stable DOM identity for instance continuity.
+					key: idx === firstReasoningIndex ? LEADING_REASONING_KEY : partKey,
+					partKey
+				};
+			}
+			if (p.type === 'text') {
+				return {
+					kind: 'text',
+					text: (p as { text?: string }).text ?? '',
+					key: `text-${idx}`
+				};
+			}
+			if (typeof p.type === 'string' && p.type.startsWith('tool-') && 'state' in p) {
+				return {
+					kind: 'tool',
+					toolPart: {
+						type: p.type,
+						state: (p as { state: ToolPart['state'] }).state,
+						input: (p as { input?: Record<string, unknown> }).input,
+						output: (p as { output?: unknown }).output as Record<string, unknown> | undefined,
+						toolCallId: (p as { toolCallId?: string }).toolCallId,
+						errorText: (p as { errorText?: string }).errorText
+					},
+					key:
+						(p as { toolCallId?: string }).toolCallId ??
+						(p as { streamId?: string }).streamId ??
+						`tool-${idx}`
+				};
+			}
+			return null;
+		})
+		.filter((p): p is OrderedPart => p !== null);
+}

--- a/src/lib/chat/ui/reasoning-accordion-sync.test.ts
+++ b/src/lib/chat/ui/reasoning-accordion-sync.test.ts
@@ -74,14 +74,14 @@ describe('syncReasoningAccordionState', () => {
 			controller
 		);
 
-		expect(openState.has('msg-1:reasoning-reason-1')).toBe(true);
-		expect(autoOpened.has('msg-1:reasoning-reason-1')).toBe(true);
+		expect(openState.has('msg-1:reasoning-lead')).toBe(true);
+		expect(autoOpened.has('msg-1:reasoning-lead')).toBe(true);
 	});
 
 	it('closes previously auto-opened reasoning parts once a later part appears', () => {
 		const { controller, openState, autoOpened } = createController(
-			['msg-1:reasoning-reason-1'],
-			['msg-1:reasoning-reason-1']
+			['msg-1:reasoning-lead'],
+			['msg-1:reasoning-lead']
 		);
 
 		syncReasoningAccordionState(
@@ -97,8 +97,8 @@ describe('syncReasoningAccordionState', () => {
 			controller
 		);
 
-		expect(openState.has('msg-1:reasoning-reason-1')).toBe(false);
-		expect(autoOpened.has('msg-1:reasoning-reason-1')).toBe(false);
+		expect(openState.has('msg-1:reasoning-lead')).toBe(false);
+		expect(autoOpened.has('msg-1:reasoning-lead')).toBe(false);
 	});
 
 	it('opens only the latest reasoning block across multiple reasoning and tool phases', () => {
@@ -112,7 +112,7 @@ describe('syncReasoningAccordionState', () => {
 			],
 			controller
 		);
-		expect(openState.has('msg-1:reasoning-reason-1')).toBe(true);
+		expect(openState.has('msg-1:reasoning-lead')).toBe(true);
 
 		syncReasoningAccordionState(
 			[
@@ -126,7 +126,7 @@ describe('syncReasoningAccordionState', () => {
 			],
 			controller
 		);
-		expect(openState.has('msg-1:reasoning-reason-1')).toBe(false);
+		expect(openState.has('msg-1:reasoning-lead')).toBe(false);
 
 		syncReasoningAccordionState(
 			[
@@ -140,7 +140,7 @@ describe('syncReasoningAccordionState', () => {
 			],
 			controller
 		);
-		expect(openState.has('msg-1:reasoning-reason-1')).toBe(false);
+		expect(openState.has('msg-1:reasoning-lead')).toBe(false);
 		expect(openState.has('msg-1:reasoning-reason-2')).toBe(true);
 
 		syncReasoningAccordionState(
@@ -173,7 +173,7 @@ describe('syncReasoningAccordionState', () => {
 			],
 			controller
 		);
-		expect(openState.has('msg-1:reasoning-reason-1')).toBe(false);
+		expect(openState.has('msg-1:reasoning-lead')).toBe(false);
 		expect(openState.has('msg-1:reasoning-reason-2')).toBe(false);
 		expect(openState.has('msg-1:reasoning-reason-3')).toBe(true);
 	});
@@ -193,7 +193,7 @@ describe('syncReasoningAccordionState', () => {
 			controller
 		);
 
-		expect(openState.has('msg-legacy')).toBe(true);
+		expect(openState.has('msg-legacy:reasoning-lead')).toBe(true);
 	});
 
 	it('removes stale auto-opened keys that are no longer present in the current message parts', () => {
@@ -224,27 +224,27 @@ describe('syncReasoningAccordionState', () => {
 		});
 
 		syncReasoningAccordionState([streamingMsg], controller);
-		expect(openState.has('msg-1:reasoning-reason-1')).toBe(true);
+		expect(openState.has('msg-1:reasoning-lead')).toBe(true);
 
 		// Step 2: simulate user close (setReasoningOpen + markUserToggled from ChatMessage handler)
 		// Recreate controller with the post-user-close state: closed, auto-opened, user-dismissed
 		const { controller: c2, openState: os2 } = createController(
 			[],
-			['msg-1:reasoning-reason-1'],
-			['msg-1:reasoning-reason-1']
+			['msg-1:reasoning-lead'],
+			['msg-1:reasoning-lead']
 		);
 
 		// Step 3: next stream update — should NOT reopen
 		syncReasoningAccordionState([streamingMsg], c2);
-		expect(os2.has('msg-1:reasoning-reason-1')).toBe(false);
+		expect(os2.has('msg-1:reasoning-lead')).toBe(false);
 	});
 
 	it('respects user reopen during streaming — does not auto-close on completion', () => {
 		// User closed then reopened — userToggled is set, accordion is open
 		const { controller, openState, autoOpened, userToggled } = createController(
-			['msg-1:reasoning-reason-1'],
-			['msg-1:reasoning-reason-1'],
-			['msg-1:reasoning-reason-1']
+			['msg-1:reasoning-lead'],
+			['msg-1:reasoning-lead'],
+			['msg-1:reasoning-lead']
 		);
 
 		// Streaming ends: reasoning is no longer the active part
@@ -262,10 +262,10 @@ describe('syncReasoningAccordionState', () => {
 		);
 
 		// User-dismissed blocks should not be auto-closed
-		expect(openState.has('msg-1:reasoning-reason-1')).toBe(true);
+		expect(openState.has('msg-1:reasoning-lead')).toBe(true);
 		// But tracking flags should be cleaned up
-		expect(autoOpened.has('msg-1:reasoning-reason-1')).toBe(false);
-		expect(userToggled.has('msg-1:reasoning-reason-1')).toBe(false);
+		expect(autoOpened.has('msg-1:reasoning-lead')).toBe(false);
+		expect(userToggled.has('msg-1:reasoning-lead')).toBe(false);
 	});
 
 	it('does not reopen a legacy fallback the user closed during streaming', () => {
@@ -282,10 +282,14 @@ describe('syncReasoningAccordionState', () => {
 			],
 			controller
 		);
-		expect(openState.has('msg-legacy')).toBe(true);
+		expect(openState.has('msg-legacy:reasoning-lead')).toBe(true);
 
 		// Step 2: user closes, simulate with dismissed state
-		const { controller: c2, openState: os2 } = createController([], ['msg-legacy'], ['msg-legacy']);
+		const { controller: c2, openState: os2 } = createController(
+			[],
+			['msg-legacy:reasoning-lead'],
+			['msg-legacy:reasoning-lead']
+		);
 
 		// Step 3: next sync — should NOT reopen
 		syncReasoningAccordionState(
@@ -299,15 +303,15 @@ describe('syncReasoningAccordionState', () => {
 			],
 			c2
 		);
-		expect(os2.has('msg-legacy')).toBe(false);
+		expect(os2.has('msg-legacy:reasoning-lead')).toBe(false);
 	});
 
 	it('opens a new reasoning block even after user closed a previous one', () => {
 		// reason-1 was auto-opened then user-dismissed
 		const { controller, openState } = createController(
 			[],
-			['msg-1:reasoning-reason-1'],
-			['msg-1:reasoning-reason-1']
+			['msg-1:reasoning-lead'],
+			['msg-1:reasoning-lead']
 		);
 
 		// New streaming message with reason-1 (done) + tool + reason-2 (active)
@@ -325,7 +329,7 @@ describe('syncReasoningAccordionState', () => {
 		);
 
 		// reason-1 should stay as user left it (closed), reason-2 should auto-open
-		expect(openState.has('msg-1:reasoning-reason-1')).toBe(false);
+		expect(openState.has('msg-1:reasoning-lead')).toBe(false);
 		expect(openState.has('msg-1:reasoning-reason-2')).toBe(true);
 	});
 

--- a/src/lib/chat/ui/reasoning-accordion-sync.ts
+++ b/src/lib/chat/ui/reasoning-accordion-sync.ts
@@ -1,5 +1,9 @@
 import type { DisplayMessage } from '../core/types.js';
-import { getActiveStreamingReasoningIndex, getReasoningPartKey } from './reasoning-parts.js';
+import {
+	getActiveStreamingReasoningIndex,
+	getReasoningKey,
+	LEADING_REASONING_KEY
+} from './reasoning-parts.js';
 
 export interface ReasoningAccordionController {
 	isReasoningOpen(messageId: string): boolean;
@@ -28,7 +32,7 @@ export function syncReasoningAccordionState(
 
 			parts.forEach((part, index) => {
 				if (part.type !== 'reasoning') return;
-				const partKey = `${message.id}:${getReasoningPartKey(part, index)}`;
+				const partKey = `${message.id}:${getReasoningKey(parts, index)}`;
 				validReasoningKeys.add(partKey);
 
 				if (index === activeReasoningIndex) {
@@ -49,24 +53,27 @@ export function syncReasoningAccordionState(
 			return;
 		}
 
+		// No renderable parts yet: the connecting fallback / cached reasoning shares the leading
+		// reasoning key, so a user toggle here carries over once the real reasoning part arrives.
+		const legacyKey = `${message.id}:${LEADING_REASONING_KEY}`;
 		const hasReasoning = !!message.displayReasoning;
 		const hasResponse = !!message.displayText;
 
 		if (hasReasoning && !hasResponse) {
-			validReasoningKeys.add(message.id);
-			if (!controller.wasUserToggled(message.id)) {
-				if (!controller.isReasoningOpen(message.id)) {
-					controller.setReasoningOpen(message.id, true);
-					controller.markAutoOpened(message.id);
+			validReasoningKeys.add(legacyKey);
+			if (!controller.wasUserToggled(legacyKey)) {
+				if (!controller.isReasoningOpen(legacyKey)) {
+					controller.setReasoningOpen(legacyKey, true);
+					controller.markAutoOpened(legacyKey);
 				}
 			}
-		} else if (hasResponse && controller.wasAutoOpened(message.id)) {
-			validReasoningKeys.add(message.id);
-			if (!controller.wasUserToggled(message.id)) {
-				controller.setReasoningOpen(message.id, false);
+		} else if (hasResponse && controller.wasAutoOpened(legacyKey)) {
+			validReasoningKeys.add(legacyKey);
+			if (!controller.wasUserToggled(legacyKey)) {
+				controller.setReasoningOpen(legacyKey, false);
 			}
-			controller.clearAutoOpened(message.id);
-			controller.clearUserToggled(message.id);
+			controller.clearAutoOpened(legacyKey);
+			controller.clearUserToggled(legacyKey);
 		}
 	});
 

--- a/src/lib/chat/ui/reasoning-parts.ts
+++ b/src/lib/chat/ui/reasoning-parts.ts
@@ -1,5 +1,14 @@
 import type { MessagePart } from '../core/types.js';
 
+/**
+ * Stable key for the leading reasoning block (the first reasoning part of a message)
+ * and its "Connecting…" placeholder. Used both as the Svelte `{#each}` identity (so the
+ * component instance survives the connecting → thinking transition without remounting) and
+ * as the accordion open-state key, so a user toggle made on the placeholder carries over to
+ * the real leading reasoning part instead of being dropped when the part materializes.
+ */
+export const LEADING_REASONING_KEY = 'reasoning-lead';
+
 export function getReasoningPartKey(part: MessagePart, index: number): string {
 	if (part.type === 'reasoning') {
 		const record = part as { streamPartId?: unknown; id?: unknown };
@@ -10,6 +19,21 @@ export function getReasoningPartKey(part: MessagePart, index: number): string {
 	}
 
 	return `reasoning-${index}`;
+}
+
+/**
+ * Key for a reasoning part at `index` within `parts`. The first reasoning part gets the
+ * stable {@link LEADING_REASONING_KEY}; later reasoning blocks keep their per-part key.
+ * Single source of truth shared by rendering (ordered-parts) and accordion sync, so both
+ * agree on the leading reasoning key.
+ */
+export function getReasoningKey(parts: MessagePart[] | undefined, index: number): string {
+	const list = parts ?? [];
+	const firstReasoningIndex = list.findIndex((p) => p.type === 'reasoning');
+	if (index === firstReasoningIndex) {
+		return LEADING_REASONING_KEY;
+	}
+	return getReasoningPartKey(list[index]!, index);
 }
 
 export function getActiveStreamingReasoningIndex(

--- a/src/lib/components/ai-elements/reasoning/ReasoningTrigger.svelte
+++ b/src/lib/components/ai-elements/reasoning/ReasoningTrigger.svelte
@@ -48,12 +48,12 @@
 		{@render children()}
 	{:else}
 		<BotIcon class="size-4" />
-		{#if !hasContent}
-			<!-- State 1: Connecting - waiting for first reasoning content -->
-			<ReasoningShimmerLoader text={$t('chat.reasoning.connecting')} />
-		{:else if isStreaming}
-			<!-- State 2: Thinking - receiving reasoning data -->
-			<ReasoningShimmerLoader text={$t('chat.reasoning.thinking')} />
+		{#if !hasContent || isStreaming}
+			<!-- States 1 & 2: Connecting (no content yet) then Thinking (receiving data).
+			     One shimmer instance keeps the animation from restarting across the transition. -->
+			<ReasoningShimmerLoader
+				text={!hasContent ? $t('chat.reasoning.connecting') : $t('chat.reasoning.thinking')}
+			/>
 		{:else}
 			<!-- State 3: Finished - show duration -->
 			<p>{durationMessage}</p>


### PR DESCRIPTION
The reasoning indicator briefly disappeared between "Connecting" and "Thinking" at the start of a streamed assistant reply.

ChatMessage rendered the reasoning block through two mutually exclusive branches gated on `message.parts.length`. When a `step-start` part arrived before the first `reasoning` part, the parts branch took over while `orderedParts` still filtered `step-start` out, so it rendered nothing and the fallback was already gone. The whole block blinked out until the first reasoning delta arrived.

The reasoning parts now render through one chronological list gated on renderable content, so a step-start-only window keeps the connecting indicator mounted. The leading reasoning block and its connecting placeholder share a stable each-key while the accordion open-state key keeps the real part key, so the same component instance survives the connecting to thinking transition without a remount or shimmer restart, and the auto-open logic in `reasoning-accordion-sync.ts` is untouched. `ReasoningTrigger` drives the connecting and thinking states from one shimmer instance so the animation no longer resets on the label change. A new pure helper `deriveOrderedParts` carries the ordering logic.

`bun scripts/static-checks.ts` passes on the changed files and `bun run test:unit` passes, including a new ordered-parts regression test that asserts a step-start-only parts array yields nothing to render.
