### PR TITLE
feat(dev): deterministic per-project vite ports

### DIFF
--- a/.env.convex.example
+++ b/.env.convex.example
@@ -76,9 +76,11 @@ AUTH_GITHUB_SECRET=
 # Base URL for OAuth redirects and deep links (can be preview URL)
 # Auto-derived from VERCEL_URL for preview deployments
 # Note: For email images, use EMAIL_ASSET_URL (always production)
-# Local dev default: http://localhost:5173 (matches `bun run dev`)
+# Local dev: auto-derived from the running Vite port (per-project, see
+# scripts/dev-ports.ts). Leave SITE_URL unset locally so a copied value can't pin
+# the trusted origin to a wrong port and break the admin sign-in.
 # For cloud/prod, set via: bunx convex env set SITE_URL https://yourapp.com
-SITE_URL=http://localhost:5173
+# SITE_URL=https://yourapp.com
 
 # ====================================
 # E2E Testing (REQUIRED for test setup)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,8 @@ Local dev notes (`bun run dev`):
 - Local seeded admin credentials: `admin@local.dev` / `LocalDevAdmin123!`
 - Convex backend env vars are loaded from `.env.convex.local` (optional services like email, OAuth, billing, AI).
 - `RESEND_API_KEY` and `AUTH_EMAIL` in `.env.convex.local` are only needed for real signup, verification, and password reset email flows.
-- `SITE_URL` in `.env.convex.local` must point to your local dev origin (`http://localhost:5173`). The default in `.env.convex.example` is already set for this. A production URL here breaks the admin sign-in via Better Auth.
+- `SITE_URL` is auto-derived locally from the running Vite port (per-project, see `scripts/dev-ports.ts`); leave it unset in `.env.convex.local` for local dev and only set it for cloud/prod. A hardcoded or production URL here breaks the admin sign-in via Better Auth.
+- Dev and test Vite ports are deterministic per project/worktree (separate ranges in `scripts/dev-ports.ts`, so dev can't creep into the test port). Override with `DEV_VITE_PORT` / `TEST_VITE_PORT`, or set `PORTLESS_SITE_URL` to front the local stack with vercel-labs/portless.
 - Local Convex state is isolated per branch/worktree under `.convex/`.
 - `RESET_LOCAL_BACKEND=true bun run dev` clears the existing local Convex state before startup and restores the default seeded admin credentials.
 
@@ -323,9 +324,9 @@ This project uses **PostHog** for product analytics with an optional **Cloudflar
 
 #### Local e2e isolation
 
-- `bun run test:e2e` spawns an isolated test stack via `bun run dev:test`: separate vite port (`:5174`), separate local Convex backend (different port + state dir under `.convex/<branch>...e2e-<hash>/`), and a separate BetterAuth secret file. Safe to run alongside `bun run dev` on `:5173`.
+- `bun run test:e2e` spawns an isolated test stack via `bun run dev:test`: a deterministic per-project vite test port (see `scripts/dev-ports.ts`), a separate local Convex backend (different port + state dir under `.convex/<branch>...e2e-<hash>/`), and a separate BetterAuth secret file. Safe to run alongside `bun run dev` (dev and test ports live in separate ranges).
 - `AUTH_E2E_TEST_SECRET` is sourced from `.env.test` and **auto-propagated into the test Convex backend** by `vite.config.ts`. You no longer need to mirror it into `.env.convex.local`.
-- Local test mode forces `baseURL` and `SITE_URL` to `http://localhost:5174` regardless of what `.env.test` contains, so a stale gitignored `PUBLIC_SITE_URL` can't silently misroute signups. The wrapper `scripts/dev-test.ts` warns loudly if leftover `PUBLIC_CONVEX_URL` / `PUBLIC_SITE_URL` are still set.
+- Local test mode forces `baseURL` and `SITE_URL` to the computed per-project test URL (`http://localhost:<testPort>`) regardless of what `.env.test` contains, so a stale gitignored `PUBLIC_SITE_URL` can't silently misroute signups. The wrapper `scripts/dev-test.ts` warns loudly if leftover `PUBLIC_CONVEX_URL` / `PUBLIC_SITE_URL` are still set.
 - `globalSetup` polls `api.tests.health` before the first signup, so a cold backend boot doesn't surface as a flaky 500.
 - `RESET_LOCAL_BACKEND=true bun run test:e2e` resets only the test state dir; dev's BetterAuth secret and DB are untouched.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ bun install
 bun run dev
 ```
 
-Visit `http://localhost:5173` and sign in:
+Visit the URL printed by `bun run dev` (a stable per-project port) and sign in:
 
 ```text
 admin@local.dev
@@ -50,6 +50,24 @@ bunx convex init                              # creates a Convex project
 bun run dev:cloud                             # frontend + cloud Convex backend
 bunx convex env set KEY value                 # set backend env vars (see .env-convex.schema / env matrix below)
 ```
+
+</details>
+
+<details>
+<summary><strong>Optional: stable named URLs with portless</strong></summary>
+
+`bun run dev` and `bun run test:e2e` already pick stable per-project ports (derived from the project path in `scripts/dev-ports.ts`), so several projects or worktrees run at once without clashing. If you'd rather use names than remember ports, [vercel-labs/portless](https://github.com/vercel-labs/portless) fronts the dev server with a `.localhost` URL and gives each git worktree its own branch subdomain.
+
+Run portless with `--no-tls` so everything stays on HTTP. The Convex backend reaches the browser over a WebSocket on its own local port; an HTTPS frontend would block that as mixed content, plain HTTP does not.
+
+Point the harness at the named URL with `PORTLESS_SITE_URL`. The dev/test wrappers then hand port control to portless, and the same URL flows into the Convex `SITE_URL`/trusted origin and Playwright's base URL:
+
+```bash
+PORTLESS_SITE_URL=http://myapp.localhost bun run dev
+PORTLESS_SITE_URL=http://myapp.localhost bun run test:e2e
+```
+
+This stays optional: a plain clone needs nothing extra and never has to install portless or grant it the privileged ports it binds.
 
 </details>
 

--- a/docs/setup/customer-support/screenshot-proxy-worker.js
+++ b/docs/setup/customer-support/screenshot-proxy-worker.js
@@ -36,7 +36,7 @@ const ALLOWED_DOMAINS = [
 const ALLOWED_ORIGINS = [
 	'https://yourdomain.com', // Your production domain
 	'https://www.yourdomain.com', // Your www domain
-	'http://localhost:5173', // Local development (remove in production)
+	'http://localhost:5173', // Local dev. Your dev port is now per-project (see scripts/dev-ports.ts); add the URL 'bun run dev' prints. Remove in production.
 	'http://localhost:4173' // Local preview (remove in production)
 ];
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,8 +7,9 @@ bun run test:e2e
 ```
 
 Spawns `bun run dev:test`, which boots an isolated local Convex backend on a separate
-state dir (`.convex/<branch>...e2e-<hash>/`) and a separate vite port (`:5174`). Safe to
-run alongside `bun run dev`. Requires `AUTH_E2E_TEST_SECRET` in `.env.test`. See
+state dir (`.convex/<branch>...e2e-<hash>/`) and a deterministic per-project vite test
+port (see `scripts/dev-ports.ts`). Safe to run alongside `bun run dev`. Requires
+`AUTH_E2E_TEST_SECRET` in `.env.test`. See
 `AGENTS.md` → Testing Guidelines → "Local e2e isolation".
 
 ## Targeting a developer-managed deployment

--- a/e2e/utils/site-url.ts
+++ b/e2e/utils/site-url.ts
@@ -1,25 +1,34 @@
+import { resolveTestPort } from '../../scripts/dev-ports';
+
 /**
  * Single source of truth for the local test stack's vite port.
+ * Computed per-project (per cwd) by scripts/dev-ports.ts so parallel
+ * projects/worktrees never collide; override with the TEST_VITE_PORT env var.
  * Imported by scripts/dev-test.ts (where vite is spawned), playwright.config.ts
- * (webServer + baseURL), and resolveSiteUrl below. Don't hardcode 5174 elsewhere.
+ * (webServer + baseURL), and resolveSiteUrl below. Don't hardcode the port elsewhere.
  */
-export const TEST_VITE_PORT = 5174;
+export const TEST_VITE_PORT = resolveTestPort();
 const TEST_BASE_URL = `http://localhost:${TEST_VITE_PORT}`;
 
 /**
  * Resolve the site URL e2e tests should hit.
  *
  * Order:
- *   1. `E2E_OVERRIDE_SITE_URL` — explicit escape hatch for running the suite against a
- *      developer-managed deployment (CF preview, staging, custom convex). Skips the local
- *      dev:test stack entirely; pair with `PUBLIC_CONVEX_URL` for the matching backend.
- *   2. Local test mode (no CI): hard-code the test vite port. Deliberately ignores
+ *   1. `E2E_OVERRIDE_SITE_URL` — escape hatch for running the suite against a
+ *      developer-managed deployment (CF preview, staging, custom convex). SKIPS the
+ *      local dev:test stack entirely; pair with `PUBLIC_CONVEX_URL` for the matching backend.
+ *   2. `PORTLESS_SITE_URL` — front the LOCAL stack with a vercel-labs/portless named
+ *      `.localhost` URL. The local Convex stack still runs; the dev:test wrapper yields
+ *      port control to portless. Becomes the baseURL and the setup Origin header, and
+ *      vite.config.ts forwards it as SITE_URL/trustedOrigin so the origins match.
+ *   3. Local test mode (no CI): the computed per-project test port. Deliberately ignores
  *      `PUBLIC_SITE_URL` so a stale gitignored .env.test can't asymmetrically misroute
  *      signups while the Convex resolver points at the local backend.
- *   3. CI: workflow injects the real preview URL via `PUBLIC_SITE_URL`.
+ *   4. CI: workflow injects the real preview URL via `PUBLIC_SITE_URL`.
  */
 export function resolveSiteUrl(): string {
 	if (process.env.E2E_OVERRIDE_SITE_URL) return process.env.E2E_OVERRIDE_SITE_URL;
+	if (process.env.PORTLESS_SITE_URL) return process.env.PORTLESS_SITE_URL;
 	if (!process.env.CI) return TEST_BASE_URL;
 	return process.env.PUBLIC_SITE_URL || 'http://localhost:5173';
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"license": "MIT",
 	"type": "module",
 	"scripts": {
-		"dev": "vite dev",
-		"dev:frontend": "vite dev",
+		"dev": "bun scripts/dev.ts",
+		"dev:frontend": "bun scripts/dev.ts",
 		"dev:backend:cloud": "convex dev",
 		"dev:cloud": "bun-tasks dev:frontend ::: dev:backend:cloud",
 		"dev:test": "VARLOCK_ENV=test bun scripts/dev-test.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ import { defineConfig, devices } from '@playwright/test';
 import 'varlock/auto-load';
 import { getPreviewBypass } from './e2e/utils/preview-bypass';
 import { resolveSiteUrl, TEST_VITE_PORT } from './e2e/utils/site-url';
+import { portlessOwnsPort } from './scripts/dev-ports';
 
 // CI: tests run against actual preview deployment (PUBLIC_SITE_URL set by workflow).
 // Local default: forced to the test vite port spawned by `bun run dev:test`.
@@ -122,7 +123,9 @@ export default defineConfig({
 			? undefined
 			: {
 					command: 'bun run dev:test',
-					port: TEST_VITE_PORT,
+					// When portless fronts vite, poll the named URL (vite sits behind portless
+					// on an internal port); otherwise poll the computed per-project test port.
+					...(portlessOwnsPort() ? { url: baseURL } : { port: TEST_VITE_PORT }),
 					reuseExistingServer: false,
 					timeout: 90000
 				}

--- a/scripts/dev-ports.test.ts
+++ b/scripts/dev-ports.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	BAD_FETCH_PORTS,
+	computeDevPort,
+	computeTestPort,
+	parsePortOverride,
+	portlessOwnsPort,
+	resolveDevPort,
+	resolveTestPort
+} from './dev-ports';
+
+// A spread of synthetic cwds, including worktree-style sibling paths and a
+// relative path. None need to exist on disk: normalizeCwd falls back to
+// path.resolve when realpathSync throws ENOENT.
+const SAMPLE_CWDS = [
+	'/a',
+	'/b',
+	'/Users/x/saas-starter',
+	'/Users/x/saas-starter.worktrees/feat-dark-mode',
+	'/Users/x/saas-starter.worktrees/fix-422',
+	'/tmp/some/other/project',
+	'relative/path'
+];
+
+describe('dev-ports: deterministic ranges', () => {
+	it('dev port is stable per cwd and in [20000, 21000)', () => {
+		for (const cwd of SAMPLE_CWDS) {
+			expect(computeDevPort(cwd)).toBe(computeDevPort(cwd));
+			expect(computeDevPort(cwd)).toBeGreaterThanOrEqual(20000);
+			expect(computeDevPort(cwd)).toBeLessThan(21000);
+		}
+	});
+
+	it('test port is stable per cwd and in [21000, 22000)', () => {
+		for (const cwd of SAMPLE_CWDS) {
+			expect(computeTestPort(cwd)).toBe(computeTestPort(cwd));
+			expect(computeTestPort(cwd)).toBeGreaterThanOrEqual(21000);
+			expect(computeTestPort(cwd)).toBeLessThan(22000);
+		}
+	});
+
+	it('test port = dev port + 1000 (shared offset, predictable)', () => {
+		for (const cwd of SAMPLE_CWDS) {
+			expect(computeTestPort(cwd)).toBe(computeDevPort(cwd) + 1000);
+		}
+	});
+
+	it('dev and test ranges never overlap', () => {
+		const maxDev = Math.max(...SAMPLE_CWDS.map(computeDevPort));
+		const minTest = Math.min(...SAMPLE_CWDS.map(computeTestPort));
+		expect(maxDev).toBeLessThan(21000);
+		expect(minTest).toBeGreaterThanOrEqual(21000);
+	});
+
+	it('distinct cwds map to distinct ports (no trivial collapse)', () => {
+		const devPorts = new Set(SAMPLE_CWDS.map(computeDevPort));
+		expect(devPorts.size).toBeGreaterThan(1);
+	});
+
+	it('no computed port is a WHATWG bad-fetch port', () => {
+		for (const cwd of SAMPLE_CWDS) {
+			expect(BAD_FETCH_PORTS.has(computeDevPort(cwd))).toBe(false);
+			expect(BAD_FETCH_PORTS.has(computeTestPort(cwd))).toBe(false);
+		}
+	});
+});
+
+describe('dev-ports: override + portless env handling', () => {
+	const ENV_KEYS = [
+		'DEV_VITE_PORT',
+		'TEST_VITE_PORT',
+		'PORTLESS_SITE_URL',
+		'E2E_OVERRIDE_SITE_URL'
+	];
+	let saved: Record<string, string | undefined>;
+
+	beforeEach(() => {
+		saved = {};
+		for (const key of ENV_KEYS) {
+			saved[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of ENV_KEYS) {
+			if (saved[key] === undefined) delete process.env[key];
+			else process.env[key] = saved[key];
+		}
+	});
+
+	it('a valid override wins over the computed port', () => {
+		process.env.DEV_VITE_PORT = '20500';
+		expect(resolveDevPort()).toBe(20500);
+		process.env.TEST_VITE_PORT = '21500';
+		expect(resolveTestPort()).toBe(21500);
+	});
+
+	it('unset/empty override falls back to the computed port', () => {
+		expect(resolveDevPort()).toBe(computeDevPort());
+		process.env.TEST_VITE_PORT = '   ';
+		expect(resolveTestPort()).toBe(computeTestPort());
+	});
+
+	it('invalid override values fail loud', () => {
+		for (const bad of ['abc', '0', '99999', '3.14', '5060']) {
+			process.env.DEV_VITE_PORT = bad;
+			expect(() => resolveDevPort(), `expected "${bad}" to throw`).toThrow(/DEV_VITE_PORT/);
+		}
+	});
+
+	it('portlessOwnsPort: true only when PORTLESS_SITE_URL is set without E2E_OVERRIDE_SITE_URL', () => {
+		expect(portlessOwnsPort()).toBe(false);
+
+		process.env.PORTLESS_SITE_URL = 'http://myapp.localhost';
+		expect(portlessOwnsPort()).toBe(true);
+
+		process.env.E2E_OVERRIDE_SITE_URL = 'https://preview.example.com';
+		expect(portlessOwnsPort()).toBe(false);
+	});
+
+	it('parsePortOverride returns undefined when unset', () => {
+		expect(parsePortOverride('DEV_VITE_PORT')).toBeUndefined();
+	});
+});

--- a/scripts/dev-ports.ts
+++ b/scripts/dev-ports.ts
@@ -31,17 +31,26 @@ export const BAD_FETCH_PORTS = new Set([
 	6669, 6679, 6697, 10080
 ]);
 
-export async function isPortAvailable(port: number): Promise<boolean> {
-	return await new Promise((resolve) => {
+type PortProbe = 'free' | 'in-use' | 'unsupported';
+
+// Probe a single address family. Distinguishes a real collision (EADDRINUSE)
+// from a family that simply isn't bindable on this host (e.g. ::1 on an
+// IPv6-disabled box), which must NOT be treated as a collision.
+function probePortFamily(port: number, host: string): Promise<PortProbe> {
+	return new Promise((resolve) => {
 		const server = net.createServer();
 		server.unref();
-		server.once('error', () => {
-			resolve(false);
+		server.once('error', (err: NodeJS.ErrnoException) => {
+			resolve(err.code === 'EADDRINUSE' ? 'in-use' : 'unsupported');
 		});
-		server.listen(port, '127.0.0.1', () => {
-			server.close(() => resolve(true));
+		server.listen(port, host, () => {
+			server.close(() => resolve('free'));
 		});
 	});
+}
+
+export async function isPortAvailable(port: number, host = '127.0.0.1'): Promise<boolean> {
+	return (await probePortFamily(port, host)) !== 'in-use';
 }
 
 export async function findAvailablePort(startPort: number, maxAttempts = 100): Promise<number> {
@@ -137,7 +146,15 @@ export function portlessOwnsPort(): boolean {
  * EADDRINUSE stack from Vite.
  */
 export async function preflightOrExit(port: number, label: 'dev' | 'dev:test'): Promise<void> {
-	if (await isPortAvailable(port)) return;
+	// The wrappers run vite without --host, so it binds its default `localhost`,
+	// which resolves to ::1 and/or 127.0.0.1 depending on the platform (and Node
+	// version). Probe both loopback families so a sibling vite is caught whichever
+	// one it grabbed; a family that can't be bound at all is not a collision.
+	const [v4, v6] = await Promise.all([
+		probePortFamily(port, '127.0.0.1'),
+		probePortFamily(port, '::1')
+	]);
+	if (v4 !== 'in-use' && v6 !== 'in-use') return;
 	const overrideVar = label === 'dev:test' ? 'TEST_VITE_PORT' : 'DEV_VITE_PORT';
 	const runCmd = label === 'dev:test' ? 'bun run test:e2e' : 'bun run dev';
 	console.error(

--- a/scripts/dev-ports.ts
+++ b/scripts/dev-ports.ts
@@ -1,0 +1,150 @@
+import { createHash } from 'node:crypto';
+import { realpathSync } from 'node:fs';
+import * as net from 'node:net';
+import * as path from 'node:path';
+
+/**
+ * Single source of truth for the deterministic per-project Vite frontend ports.
+ *
+ * Each forked project and each git worktree has a distinct absolute cwd, so the
+ * dev and test servers get stable, non-colliding ports with zero coordination.
+ * Convex backend ports stay dynamic (see vite.config.ts); only the two frontend
+ * ports are derived here.
+ *
+ * Imported by scripts/dev.ts and scripts/dev-test.ts (where vite is spawned),
+ * playwright.config.ts + e2e/utils/site-url.ts (baseURL/webServer), and
+ * vite.config.ts (which reuses the port helpers + the portless predicate). Keep
+ * this file free of Vite/varlock imports so it stays safe to import from a bare
+ * `bun scripts/*` wrapper and from the Playwright config.
+ */
+
+// WHATWG fetch "bad port" list. Node's fetch (undici) refuses to connect to
+// these, so a Convex backend or site proxy that binds one is unreachable: the
+// SvelteKit -> Convex proxy fails with `TypeError: fetch failed` / cause
+// `bad port` even though the port was free to bind. Skip them here.
+// https://fetch.spec.whatwg.org/#port-blocking
+export const BAD_FETCH_PORTS = new Set([
+	1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87, 95, 101, 102,
+	103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137, 139, 143, 161, 179, 389, 427, 465,
+	512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993,
+	995, 1719, 1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668,
+	6669, 6679, 6697, 10080
+]);
+
+export async function isPortAvailable(port: number): Promise<boolean> {
+	return await new Promise((resolve) => {
+		const server = net.createServer();
+		server.unref();
+		server.once('error', () => {
+			resolve(false);
+		});
+		server.listen(port, '127.0.0.1', () => {
+			server.close(() => resolve(true));
+		});
+	});
+}
+
+export async function findAvailablePort(startPort: number, maxAttempts = 100): Promise<number> {
+	// Blocked ports don't count toward maxAttempts, so the limit always reflects
+	// how many connectable ports were actually probed.
+	let checked = 0;
+	for (let offset = 0; checked < maxAttempts; offset += 1) {
+		const port = startPort + offset;
+		if (BAD_FETCH_PORTS.has(port)) continue;
+		checked += 1;
+		if (await isPortAvailable(port)) {
+			return port;
+		}
+	}
+
+	throw new Error(`Could not find an available port after ${maxAttempts} attempts`);
+}
+
+// Deterministic per-cwd frontend ports. Two non-overlapping ranges keep the dev
+// server from ever creeping into the test port. Both ranges sit clear of the
+// WHATWG bad-fetch ports (max 10080) and below the OS ephemeral range.
+const DEV_BASE = 20000;
+const TEST_BASE = 21000;
+const SPAN = 1000;
+
+/**
+ * Resolve a cwd to a stable absolute string. realpath keeps symlinked worktrees
+ * stable, but falls back to path.resolve when the path does not exist on disk
+ * (realpathSync throws ENOENT) so the helper is testable with synthetic paths.
+ */
+function normalizeCwd(cwd: string): string {
+	try {
+		return realpathSync(cwd);
+	} catch {
+		return path.resolve(cwd);
+	}
+}
+
+function hashOffset(cwd: string): number {
+	const hex = createHash('sha256').update(normalizeCwd(cwd)).digest('hex').slice(0, 8);
+	return parseInt(hex, 16) % SPAN;
+}
+
+export function computeDevPort(cwd: string = process.cwd()): number {
+	return DEV_BASE + hashOffset(cwd);
+}
+
+export function computeTestPort(cwd: string = process.cwd()): number {
+	return TEST_BASE + hashOffset(cwd);
+}
+
+/**
+ * Parse a numeric port override env var. Returns undefined when unset/empty.
+ * Throws a clear error for invalid values (non-integer, out of 1..65535, or a
+ * WHATWG bad-fetch port). These overrides are the documented collision escape
+ * hatch, so a bad value must fail loud rather than silently fall back to the
+ * computed port (which `Number(x) || fallback` would do).
+ */
+export function parsePortOverride(name: string): number | undefined {
+	const raw = process.env[name];
+	if (raw === undefined || raw.trim() === '') return undefined;
+	const port = Number(raw);
+	if (!Number.isInteger(port) || port < 1 || port > 65535 || BAD_FETCH_PORTS.has(port)) {
+		throw new Error(
+			`${name}="${raw}" is not a valid port. Expected an integer in 1..65535 that is not a WHATWG bad-fetch port.`
+		);
+	}
+	return port;
+}
+
+export function resolveDevPort(): number {
+	return parsePortOverride('DEV_VITE_PORT') ?? computeDevPort();
+}
+
+export function resolveTestPort(): number {
+	return parsePortOverride('TEST_VITE_PORT') ?? computeTestPort();
+}
+
+/**
+ * True when a vercel-labs/portless `.localhost` URL should be the source of
+ * truth AND the local stack still runs (so the wrappers must yield port control
+ * to portless and skip --port). Distinct from E2E_OVERRIDE_SITE_URL, which
+ * points the suite at an external deployment and skips the local stack entirely.
+ */
+export function portlessOwnsPort(): boolean {
+	return !!process.env.PORTLESS_SITE_URL && !process.env.E2E_OVERRIDE_SITE_URL;
+}
+
+/**
+ * Preflight a deterministic port before spawning Vite with --strictPort. On a
+ * collision (another project/worktree hashed to the same port, or a stale
+ * server) print an actionable message and exit, instead of dumping a raw
+ * EADDRINUSE stack from Vite.
+ */
+export async function preflightOrExit(port: number, label: 'dev' | 'dev:test'): Promise<void> {
+	if (await isPortAvailable(port)) return;
+	const overrideVar = label === 'dev:test' ? 'TEST_VITE_PORT' : 'DEV_VITE_PORT';
+	const runCmd = label === 'dev:test' ? 'bun run test:e2e' : 'bun run dev';
+	console.error(
+		`\n[${label}] port ${port} is already in use.\n` +
+			`  Another project/worktree may have hashed to the same port, or a stale server is holding it.\n` +
+			`  Find it:  lsof -nP -iTCP:${port} -sTCP:LISTEN\n` +
+			`  Override: ${overrideVar}=<port> ${runCmd}\n`
+	);
+	process.exit(1);
+}

--- a/scripts/dev-test.ts
+++ b/scripts/dev-test.ts
@@ -11,10 +11,13 @@ if (process.env.PUBLIC_CONVEX_URL) {
 			`Remove PUBLIC_CONVEX_URL from .env.test to silence this warning.`
 	);
 }
-if (process.env.PUBLIC_SITE_URL && process.env.PUBLIC_SITE_URL !== TEST_BASE_URL) {
+// In portless mode the forced origin is the named .localhost URL, not the local
+// port, so name the URL the suite will actually use.
+const forcedSiteUrl = portlessOwnsPort() ? process.env.PORTLESS_SITE_URL! : TEST_BASE_URL;
+if (process.env.PUBLIC_SITE_URL && process.env.PUBLIC_SITE_URL !== forcedSiteUrl) {
 	console.warn(
 		`[dev:test] WARNING: PUBLIC_SITE_URL=${process.env.PUBLIC_SITE_URL} is set. ` +
-			`Local test mode forces ${TEST_BASE_URL} — see e2e/utils/site-url.ts.`
+			`Local test mode forces ${forcedSiteUrl} — see e2e/utils/site-url.ts.`
 	);
 }
 

--- a/scripts/dev-test.ts
+++ b/scripts/dev-test.ts
@@ -1,7 +1,8 @@
 import 'varlock/auto-load';
-import { TEST_VITE_PORT } from '../e2e/utils/site-url';
+import { portlessOwnsPort, preflightOrExit, resolveTestPort } from './dev-ports';
 
-const TEST_BASE_URL = `http://localhost:${TEST_VITE_PORT}`;
+const testPort = resolveTestPort();
+const TEST_BASE_URL = `http://localhost:${testPort}`;
 
 if (process.env.PUBLIC_CONVEX_URL) {
 	console.warn(
@@ -17,18 +18,29 @@ if (process.env.PUBLIC_SITE_URL && process.env.PUBLIC_SITE_URL !== TEST_BASE_URL
 	);
 }
 
-process.env.npm_lifecycle_event = 'dev:test';
-
-// --strictPort: vite's default is to find the next free port if TEST_VITE_PORT is taken;
+// --strictPort: vite's default is to find the next free port if testPort is taken;
 // that would silently start a second test backend on a different port and break
-// playwright's port expectation.
+// playwright's port expectation. Preflight first so a collision (sibling project,
+// stale server) surfaces as an actionable message instead of a raw EADDRINUSE.
+// When portless owns the port, yield control (no --port/--strictPort) so portless
+// can front vite on its named .localhost URL.
 // We deliberately do NOT pass --host. Vite's default host is `localhost`, which makes
 // resolvedUrls.local[0] resolve to `${TEST_BASE_URL}/`. That value is forwarded as
 // SITE_URL into the Convex backend (vite.config.ts envVars callback) and becomes the
 // trustedOrigin for BetterAuth. Test setup sends Origin: ${TEST_BASE_URL} — the
 // hostnames must match. Forcing --host 127.0.0.1 here breaks BetterAuth's origin check.
-const child = Bun.spawn(['vite', 'dev', '--port', String(TEST_VITE_PORT), '--strictPort'], {
-	stdio: ['inherit', 'inherit', 'inherit']
+let portArgs: string[] = [];
+if (!portlessOwnsPort()) {
+	await preflightOrExit(testPort, 'dev:test');
+	portArgs = ['--port', String(testPort), '--strictPort'];
+}
+
+const child = Bun.spawn(['vite', 'dev', ...portArgs], {
+	stdio: ['inherit', 'inherit', 'inherit'],
+	// Pin npm_lifecycle_event in the explicit env: Bun.spawn does NOT forward
+	// runtime mutations of process.env to the child, so vite.config.ts only sees
+	// test mode reliably when it is set here (not via a bare assignment above).
+	env: { ...process.env, npm_lifecycle_event: 'dev:test' }
 });
 
 const onSignal = (signal: NodeJS.Signals) => {

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,39 @@
+import { portlessOwnsPort, preflightOrExit, resolveDevPort } from './dev-ports';
+
+// Wrapper for `bun run dev` and `bun run dev:frontend`. Spawns vite on a
+// deterministic per-project port (see scripts/dev-ports.ts) so parallel
+// projects/worktrees never collide. --strictPort + preflight turn a collision
+// into a clear message instead of a silent port bump (which previously let the
+// dev server creep into the E2E port). When portless owns the port, yield
+// control: skip --port so portless can front vite on its named .localhost URL.
+let portArgs: string[] = [];
+if (!portlessOwnsPort()) {
+	const port = resolveDevPort();
+	await preflightOrExit(port, 'dev');
+	portArgs = ['--port', String(port), '--strictPort'];
+}
+
+// We deliberately do NOT pass --host (see scripts/dev-test.ts for the reasoning):
+// vite's default host `localhost` keeps resolvedUrls.local[0] aligned with the
+// BetterAuth trustedOrigin derived from it.
+const child = Bun.spawn(['vite', 'dev', ...portArgs], {
+	stdio: ['inherit', 'inherit', 'inherit'],
+	// Pass env explicitly: Bun.spawn forwards inherited shell env vars but NOT
+	// runtime mutations of process.env. vite.config.ts branches on
+	// npm_lifecycle_event (`dev` starts the local Convex backend; `dev:frontend`,
+	// used by `dev:cloud`, skips it), so forward the current env verbatim.
+	env: { ...process.env }
+});
+
+const onSignal = (signal: NodeJS.Signals) => {
+	try {
+		child.kill(signal);
+	} catch {
+		/* already dead */
+	}
+};
+process.on('SIGINT', () => onSignal('SIGINT'));
+process.on('SIGTERM', () => onSignal('SIGTERM'));
+
+const code = await child.exited;
+process.exit(code ?? 0);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,12 @@
 import * as childProcess from 'node:child_process';
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
-import * as net from 'node:net';
 import * as path from 'node:path';
 import { varlockLoadedEnv, varlockVitePlugin } from '@varlock/vite-integration';
 import { convexLocal } from 'convex-vite-plugin';
 import { resetRedactionMap } from 'varlock/env';
 import { DEV_FEATURES, type DevFeature } from './src/lib/dev/features';
+import { findAvailablePort, portlessOwnsPort } from './scripts/dev-ports';
 import { sentrySvelteKit } from '@sentry/sveltekit';
 import devtoolsJson from 'vite-plugin-devtools-json';
 import tailwindcss from '@tailwindcss/vite';
@@ -14,48 +14,6 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { loadEnv, type PluginOption } from 'vite';
-
-async function isPortAvailable(port: number): Promise<boolean> {
-	return await new Promise((resolve) => {
-		const server = net.createServer();
-		server.unref();
-		server.once('error', () => {
-			resolve(false);
-		});
-		server.listen(port, '127.0.0.1', () => {
-			server.close(() => resolve(true));
-		});
-	});
-}
-
-// WHATWG fetch "bad port" list. Node's fetch (undici) refuses to connect to
-// these, so a Convex backend or site proxy that binds one is unreachable: the
-// SvelteKit -> Convex proxy fails with `TypeError: fetch failed` / cause
-// `bad port` even though the port was free to bind. Skip them here.
-// https://fetch.spec.whatwg.org/#port-blocking
-const BAD_FETCH_PORTS = new Set([
-	1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87, 95, 101, 102,
-	103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137, 139, 143, 161, 179, 389, 427, 465,
-	512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993,
-	995, 1719, 1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668,
-	6669, 6679, 6697, 10080
-]);
-
-async function findAvailablePort(startPort: number, maxAttempts = 100): Promise<number> {
-	// Blocked ports don't count toward maxAttempts, so the limit always reflects
-	// how many connectable ports were actually probed.
-	let checked = 0;
-	for (let offset = 0; checked < maxAttempts; offset += 1) {
-		const port = startPort + offset;
-		if (BAD_FETCH_PORTS.has(port)) continue;
-		checked += 1;
-		if (await isPortAvailable(port)) {
-			return port;
-		}
-	}
-
-	throw new Error(`Could not find an available port after ${maxAttempts} attempts`);
-}
 
 function computeLocalConvexStateId(projectDir: string, suffix?: string): string {
 	let gitBranch = 'unknown';
@@ -318,7 +276,13 @@ export default defineConfig(async ({ mode }) => {
 				reset: resetLocalBackend,
 				onReady: [{ name: 'localDev:ensureSeededAdmin' }],
 				envVars: ({ vitePort, resolvedUrls }) => {
-					const siteUrl = resolvedUrls?.local[0] ?? `http://localhost:${vitePort}`;
+					// When portless fronts vite, resolvedUrls.local[0] is vite's own
+					// localhost URL, not the .localhost named origin -- so the trustedOrigin
+					// would mismatch. Use the SAME predicate as the dev/test wrappers so the
+					// wrapper-bound port, Playwright baseURL, and Convex SITE_URL always agree.
+					const siteUrl = portlessOwnsPort()
+						? process.env.PORTLESS_SITE_URL!
+						: (resolvedUrls?.local[0] ?? `http://localhost:${vitePort}`);
 					return {
 						// Auto-generated defaults for local dev
 						BETTER_AUTH_SECRET: betterAuthSecret,


### PR DESCRIPTION
Closes #331

Running several projects or worktrees from this template at once was painful: the dev and E2E vite servers were pinned to 5173/5174, so siblings collided, and a plain `vite dev` would silently increment into the pinned E2E port and break a parallel test run.

Both frontend ports are now derived per project from a hash of the working directory in `scripts/dev-ports.ts`, the single source consumed by the dev and dev:test wrappers, the Playwright config, and the e2e site-url resolver. Each fork and worktree lands on its own stable, bookmarkable port in two non-overlapping ranges (dev 20000-20999, test 21000-21999), so they never clash and the dev server can no longer creep into the test port. `--strictPort` stays, now with a friendly preflight that names the port and the lsof command on a collision, and `DEV_VITE_PORT`/`TEST_VITE_PORT` are escape hatches that fail loudly on an invalid value instead of silently falling back. The Convex backend ports were already dynamic, so they are untouched.

The harness is also portless-ready for anyone who prefers named URLs: set `PORTLESS_SITE_URL` to a vercel-labs/portless `.localhost` URL and the wrappers yield port control while the same origin flows into the Convex SITE_URL/trusted origin and Playwright's base URL. This stays optional, a plain clone needs nothing extra and never has to install portless. The README documents the `--no-tls` setup.

A vitest guard covers range membership, determinism, and override validation.

`bun run test:unit` passes (new dev-ports guard, 11 assertions). `bun scripts/static-checks.ts` is green including the project type-check. A full `bun run test:e2e` ran against the computed port (vite on :21184, backend on a random port) with signin/admin setup and the admin-users-table suite green, confirming the SITE_URL/Origin/trustedOrigin chain holds; the only residual failures were the known axe "execution context destroyed" dev-server flakes, unrelated to ports.
