### PR TITLE
feat(ai-chat): Generate thread titles from first message

### DIFF
--- a/src/lib/components/authenticated/configs/ai-chat-thread-label.test.ts
+++ b/src/lib/components/authenticated/configs/ai-chat-thread-label.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { aiChatThreadLabel } from './ai-chat-thread-label';
+
+describe('aiChatThreadLabel', () => {
+	it('prefers the title (trimmed) over the preview', () => {
+		expect(
+			aiChatThreadLabel(
+				{ title: '  Postgres Indexing  ', lastMessage: 'raw text' },
+				'New conversation'
+			)
+		).toBe('Postgres Indexing');
+	});
+
+	it('falls back to a short last-message preview unchanged', () => {
+		expect(aiChatThreadLabel({ lastMessage: 'Short message' }, 'New conversation')).toBe(
+			'Short message'
+		);
+	});
+
+	it('truncates a long preview to 30 chars + ellipsis', () => {
+		const long = 'a'.repeat(40);
+		expect(aiChatThreadLabel({ lastMessage: long }, 'New conversation')).toBe(
+			'a'.repeat(30) + '...'
+		);
+	});
+
+	it('uses the localized empty label when there is no title or preview', () => {
+		expect(aiChatThreadLabel({}, 'Neue Unterhaltung')).toBe('Neue Unterhaltung');
+	});
+
+	it('treats a whitespace-only title as no title', () => {
+		expect(
+			aiChatThreadLabel({ title: '   ', lastMessage: 'real preview' }, 'New conversation')
+		).toBe('real preview');
+	});
+
+	it('treats an empty preview as no preview (file-only thread)', () => {
+		expect(aiChatThreadLabel({ lastMessage: '' }, 'New conversation')).toBe('New conversation');
+	});
+
+	it('falls back to the hardcoded default when no label is provided', () => {
+		expect(aiChatThreadLabel({})).toBe('New conversation');
+	});
+});

--- a/src/lib/components/authenticated/configs/ai-chat-thread-label.ts
+++ b/src/lib/components/authenticated/configs/ai-chat-thread-label.ts
@@ -1,0 +1,27 @@
+const MAX_PREVIEW_LABEL_LENGTH = 30;
+
+/**
+ * Sidebar label for an AI chat thread: prefer the LLM-generated title (the
+ * rendering span CSS-truncates it), fall back to a truncated last-message
+ * preview, then the localized empty-thread label. The empty-thread fallback is
+ * reachable for a file-only thread that has no title or text preview yet.
+ *
+ * Import-light so it can be unit-tested without the $app/state dependency that
+ * the surrounding sidebar config pulls in via localizedHref.
+ */
+export function aiChatThreadLabel(
+	thread: { title?: string; lastMessage?: string },
+	newConversationLabel?: string
+): string {
+	const title = thread.title?.trim();
+	if (title) return title;
+
+	const preview = thread.lastMessage;
+	if (preview) {
+		return preview.length > MAX_PREVIEW_LABEL_LENGTH
+			? preview.slice(0, MAX_PREVIEW_LABEL_LENGTH) + '...'
+			: preview;
+	}
+
+	return newConversationLabel || 'New conversation';
+}

--- a/src/lib/components/authenticated/configs/app-sidebar-config.ts
+++ b/src/lib/components/authenticated/configs/app-sidebar-config.ts
@@ -5,6 +5,7 @@ import BotMessageSquareIcon from '@lucide/svelte/icons/bot-message-square';
 import ServerCogIcon from '@lucide/svelte/icons/server-cog';
 import Logo from '$lib/components/icons/logo.svelte';
 import { LEGAL_CONFIG } from '$lib/config/legal';
+import { aiChatThreadLabel } from './ai-chat-thread-label';
 import type { SidebarConfig, NavSubItem } from '../types';
 
 interface PageState {
@@ -33,26 +34,13 @@ export function getAppSidebarConfig(
 		? new URLSearchParams(search).get('thread')
 		: null;
 
-	const aiChatSubItems: NavSubItem[] = (aiChatThreads ?? []).map((thread) => {
-		// Prefer the LLM-generated title; the rendering span CSS-truncates it.
-		// Fall back to a truncated last-message preview, then the empty label.
-		const title = thread.title?.trim();
-		const label = title
-			? title
-			: thread.lastMessage
-				? thread.lastMessage.length > 30
-					? thread.lastMessage.slice(0, 30) + '...'
-					: thread.lastMessage
-				: newConversationLabel || 'New conversation';
-
-		return {
-			id: thread._id,
-			label,
-			url: localizedHref(`/app/ai-chat?thread=${thread._id}`),
-			isActive: activeThreadId === thread._id,
-			timestamp: thread.lastMessageAt
-		};
-	});
+	const aiChatSubItems: NavSubItem[] = (aiChatThreads ?? []).map((thread) => ({
+		id: thread._id,
+		label: aiChatThreadLabel(thread, newConversationLabel),
+		url: localizedHref(`/app/ai-chat?thread=${thread._id}`),
+		isActive: activeThreadId === thread._id,
+		timestamp: thread.lastMessageAt
+	}));
 
 	// Point "AI Chat" to the pre-warmed thread when available
 	const aiChatUrl = warmThreadId

--- a/src/lib/components/authenticated/configs/app-sidebar-config.ts
+++ b/src/lib/components/authenticated/configs/app-sidebar-config.ts
@@ -15,6 +15,7 @@ interface PageState {
 
 interface AiChatThread {
 	_id: string;
+	title?: string;
 	lastMessage?: string;
 	lastMessageAt?: number;
 }
@@ -32,17 +33,26 @@ export function getAppSidebarConfig(
 		? new URLSearchParams(search).get('thread')
 		: null;
 
-	const aiChatSubItems: NavSubItem[] = (aiChatThreads ?? []).map((thread) => ({
-		id: thread._id,
-		label: thread.lastMessage
-			? thread.lastMessage.length > 30
-				? thread.lastMessage.slice(0, 30) + '...'
-				: thread.lastMessage
-			: newConversationLabel || 'New conversation',
-		url: localizedHref(`/app/ai-chat?thread=${thread._id}`),
-		isActive: activeThreadId === thread._id,
-		timestamp: thread.lastMessageAt
-	}));
+	const aiChatSubItems: NavSubItem[] = (aiChatThreads ?? []).map((thread) => {
+		// Prefer the LLM-generated title; the rendering span CSS-truncates it.
+		// Fall back to a truncated last-message preview, then the empty label.
+		const title = thread.title?.trim();
+		const label = title
+			? title
+			: thread.lastMessage
+				? thread.lastMessage.length > 30
+					? thread.lastMessage.slice(0, 30) + '...'
+					: thread.lastMessage
+				: newConversationLabel || 'New conversation';
+
+		return {
+			id: thread._id,
+			label,
+			url: localizedHref(`/app/ai-chat?thread=${thread._id}`),
+			isActive: activeThreadId === thread._id,
+			timestamp: thread.lastMessageAt
+		};
+	});
 
 	// Point "AI Chat" to the pre-warmed thread when available
 	const aiChatUrl = warmThreadId

--- a/src/lib/convex/_generated/api.d.ts
+++ b/src/lib/convex/_generated/api.d.ts
@@ -29,6 +29,7 @@ import type * as aiChat_rateLimit from "../aiChat/rateLimit.js";
 import type * as aiChat_threads from "../aiChat/threads.js";
 import type * as aiChat_titles from "../aiChat/titles.js";
 import type * as aiChat_tools_weather from "../aiChat/tools/weather.js";
+import type * as aiChat_visibility from "../aiChat/visibility.js";
 import type * as auth from "../auth.js";
 import type * as autumn from "../autumn.js";
 import type * as constants from "../constants.js";
@@ -100,6 +101,7 @@ declare const fullApi: ApiFromModules<{
   "aiChat/threads": typeof aiChat_threads;
   "aiChat/titles": typeof aiChat_titles;
   "aiChat/tools/weather": typeof aiChat_tools_weather;
+  "aiChat/visibility": typeof aiChat_visibility;
   auth: typeof auth;
   autumn: typeof autumn;
   constants: typeof constants;

--- a/src/lib/convex/_generated/api.d.ts
+++ b/src/lib/convex/_generated/api.d.ts
@@ -27,6 +27,7 @@ import type * as aiChat_messages from "../aiChat/messages.js";
 import type * as aiChat_ownership from "../aiChat/ownership.js";
 import type * as aiChat_rateLimit from "../aiChat/rateLimit.js";
 import type * as aiChat_threads from "../aiChat/threads.js";
+import type * as aiChat_titles from "../aiChat/titles.js";
 import type * as aiChat_tools_weather from "../aiChat/tools/weather.js";
 import type * as auth from "../auth.js";
 import type * as autumn from "../autumn.js";
@@ -97,6 +98,7 @@ declare const fullApi: ApiFromModules<{
   "aiChat/ownership": typeof aiChat_ownership;
   "aiChat/rateLimit": typeof aiChat_rateLimit;
   "aiChat/threads": typeof aiChat_threads;
+  "aiChat/titles": typeof aiChat_titles;
   "aiChat/tools/weather": typeof aiChat_tools_weather;
   auth: typeof auth;
   autumn: typeof autumn;

--- a/src/lib/convex/aiChat/__tests__/visibility.test.ts
+++ b/src/lib/convex/aiChat/__tests__/visibility.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { isVisibleAiChatThread } from '../visibility';
+
+describe('isVisibleAiChatThread', () => {
+	it('hides a warm thread even when it has a timestamp', () => {
+		expect(isVisibleAiChatThread({ isWarm: true, lastMessageAt: 123 })).toBe(false);
+	});
+
+	it('hides a never-used thread (no timestamp, no preview)', () => {
+		expect(isVisibleAiChatThread({})).toBe(false);
+	});
+
+	it('shows a thread that has only lastMessageAt (file-only send, no preview text)', () => {
+		expect(isVisibleAiChatThread({ lastMessageAt: 1717000000000 })).toBe(true);
+	});
+
+	it('treats lastMessageAt 0 as a real "has been used" signal', () => {
+		expect(isVisibleAiChatThread({ lastMessageAt: 0 })).toBe(true);
+	});
+
+	it('shows a legacy thread that has a preview but no timestamp', () => {
+		expect(isVisibleAiChatThread({ lastMessage: 'hi' })).toBe(true);
+	});
+
+	it('shows a normal thread with both signals', () => {
+		expect(isVisibleAiChatThread({ lastMessage: 'hi', lastMessageAt: 1717000000000 })).toBe(true);
+	});
+
+	it('does not count an empty-string preview on its own', () => {
+		expect(isVisibleAiChatThread({ lastMessage: '' })).toBe(false);
+	});
+});

--- a/src/lib/convex/aiChat/messages.ts
+++ b/src/lib/convex/aiChat/messages.ts
@@ -88,12 +88,12 @@ export const sendMessage = authedMutation({
 			messageId = result.messageId;
 		}
 
-		// Denormalize: update lastMessage on the thread record for sidebar display
+		// Denormalize for the sidebar. lastMessageAt is the "thread has been used"
+		// signal (drives visibility + first-send); lastMessage is a display-only
+		// preview, so skip it for a file-only send rather than persisting ''.
+		const preview = args.prompt.trim().slice(0, THREAD_PREVIEW_LENGTH);
 		await ctx.db.patch(record._id, {
-			lastMessage:
-				args.prompt.length > THREAD_PREVIEW_LENGTH
-					? args.prompt.slice(0, THREAD_PREVIEW_LENGTH)
-					: args.prompt,
+			...(preview ? { lastMessage: preview } : {}),
 			lastMessageAt: Date.now()
 		});
 
@@ -159,15 +159,15 @@ export const createAIResponse = internalAction({
 
 		await result.consumeStream();
 
-		// Denormalize: update thread sidebar metadata with the AI's response
+		// Denormalize: update thread sidebar metadata with the AI's response.
+		// Trim and skip an empty preview so a whitespace-only response never lands
+		// as the sidebar label (mirrors the user-message path in sendMessage).
 		const responseText = await result.text;
-		if (responseText) {
+		const responsePreview = responseText.trim().slice(0, THREAD_PREVIEW_LENGTH);
+		if (responsePreview) {
 			await ctx.runMutation(internal.aiChat.threads.updateThreadMetadata, {
 				threadId: args.threadId,
-				lastMessage:
-					responseText.length > THREAD_PREVIEW_LENGTH
-						? responseText.slice(0, THREAD_PREVIEW_LENGTH)
-						: responseText,
+				lastMessage: responsePreview,
 				lastMessageAt: Date.now()
 			});
 		}

--- a/src/lib/convex/aiChat/messages.ts
+++ b/src/lib/convex/aiChat/messages.ts
@@ -41,9 +41,11 @@ export const sendMessage = authedMutation({
 			userId
 		});
 
-		// First message in this thread (no denormalized lastMessage yet) → derive
-		// a descriptive title from it. Captured before we patch lastMessage below.
-		const isFirstMessage = !record.lastMessage;
+		// First send in this thread → derive a descriptive title from it. Uses
+		// lastMessageAt (written on every send, never an empty string) rather than
+		// lastMessage, which can be '' for a file-only first message and would
+		// misidentify later sends as the first. Captured before the patch below.
+		const isFirstMessage = record.lastMessageAt === undefined;
 
 		// Consume warm thread on first message (backend-driven, no client coordination needed)
 		if (record.isWarm) {
@@ -107,7 +109,8 @@ export const sendMessage = authedMutation({
 		if (isFirstMessage && args.prompt.trim().length > 0) {
 			await ctx.scheduler.runAfter(0, internal.aiChat.titles.generateThreadTitle, {
 				threadId: args.threadId,
-				prompt: args.prompt
+				prompt: args.prompt,
+				userId
 			});
 		}
 

--- a/src/lib/convex/aiChat/messages.ts
+++ b/src/lib/convex/aiChat/messages.ts
@@ -41,6 +41,10 @@ export const sendMessage = authedMutation({
 			userId
 		});
 
+		// First message in this thread (no denormalized lastMessage yet) → derive
+		// a descriptive title from it. Captured before we patch lastMessage below.
+		const isFirstMessage = !record.lastMessage;
+
 		// Consume warm thread on first message (backend-driven, no client coordination needed)
 		if (record.isWarm) {
 			await ctx.db.patch(record._id, { isWarm: false });
@@ -97,6 +101,15 @@ export const sendMessage = authedMutation({
 			promptMessageId: messageId,
 			userId
 		});
+
+		// Generate a descriptive thread title from the first user message (LLM,
+		// fire-and-forget). Skipped for file-only first messages with no text.
+		if (isFirstMessage && args.prompt.trim().length > 0) {
+			await ctx.scheduler.runAfter(0, internal.aiChat.titles.generateThreadTitle, {
+				threadId: args.threadId,
+				prompt: args.prompt
+			});
+		}
 
 		return { messageId };
 	}

--- a/src/lib/convex/aiChat/threads.ts
+++ b/src/lib/convex/aiChat/threads.ts
@@ -4,6 +4,7 @@ import { authedQuery, authedMutation } from '../functions';
 import { aiChatAgent } from './agent';
 import { components } from '../_generated/api';
 import { requireAiChatThreadRecord } from './ownership';
+import { isVisibleAiChatThread } from './visibility';
 
 // aiChatThreads is the feature registry for AI chat access and sidebar state.
 // agent:threads remains generic conversation storage/runtime shared across features.
@@ -36,7 +37,7 @@ export const listThreads = authedQuery({
 			.take(fetchLimit);
 
 		const validThreads = records
-			.filter((r) => !r.isWarm && r.lastMessage)
+			.filter(isVisibleAiChatThread)
 			.sort((a, b) => (b.lastMessageAt ?? 0) - (a.lastMessageAt ?? 0));
 
 		return {

--- a/src/lib/convex/aiChat/threads.ts
+++ b/src/lib/convex/aiChat/threads.ts
@@ -195,8 +195,7 @@ export const updateThreadMetadata = internalMutation({
 	args: {
 		threadId: v.string(),
 		lastMessage: v.optional(v.string()),
-		lastMessageAt: v.optional(v.number()),
-		title: v.optional(v.string())
+		lastMessageAt: v.optional(v.number())
 	},
 	handler: async (ctx, args) => {
 		const record = await ctx.db
@@ -208,11 +207,34 @@ export const updateThreadMetadata = internalMutation({
 		const patch: Record<string, unknown> = {};
 		if (args.lastMessage !== undefined) patch.lastMessage = args.lastMessage;
 		if (args.lastMessageAt !== undefined) patch.lastMessageAt = args.lastMessageAt;
-		if (args.title !== undefined) patch.title = args.title;
 
 		if (Object.keys(patch).length > 0) {
 			await ctx.db.patch(record._id, patch);
 		}
+	}
+});
+
+/**
+ * Set the thread title only if one is not already stored (first-write-wins).
+ *
+ * Used by generateThreadTitle so a duplicate or late title generation can never
+ * overwrite an existing title.
+ */
+export const setThreadTitleIfEmpty = internalMutation({
+	args: {
+		threadId: v.string(),
+		title: v.string()
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const record = await ctx.db
+			.query('aiChatThreads')
+			.withIndex('by_thread', (q) => q.eq('threadId', args.threadId))
+			.first();
+		if (!record || record.title) return null;
+
+		await ctx.db.patch(record._id, { title: args.title });
+		return null;
 	}
 });
 

--- a/src/lib/convex/aiChat/titles.ts
+++ b/src/lib/convex/aiChat/titles.ts
@@ -1,0 +1,63 @@
+import { internalAction } from '../_generated/server';
+import { v } from 'convex/values';
+import { internal } from '../_generated/api';
+import { generateText } from 'ai';
+import { openrouter } from '@openrouter/ai-sdk-provider';
+import { CHAT_MODEL_ID } from '../utils/chatModel';
+
+// Clamp the stored title; the sidebar span also CSS-truncates for display.
+const MAX_TITLE_LENGTH = 60;
+// Only the opening of the first message matters for a title; cap tokens sent.
+const MAX_PROMPT_CHARS = 500;
+
+/**
+ * Generate a short, descriptive thread title from the first user message.
+ *
+ * Scheduled (fire-and-forget) from `sendMessage` on the first message of a
+ * thread. Runs a single non-reasoning LLM call (no reasoning extraBody, unlike
+ * the chat agent) and writes the result to `aiChatThreads.title` via
+ * `updateThreadMetadata`. The sidebar prefers this title over the last-message
+ * preview. On any failure we keep no title and the UI falls back gracefully, so
+ * errors are swallowed (logged only).
+ */
+export const generateThreadTitle = internalAction({
+	args: {
+		threadId: v.string(),
+		prompt: v.string()
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		const source = args.prompt.trim().slice(0, MAX_PROMPT_CHARS);
+		if (!source) return null;
+
+		let raw: string;
+		try {
+			const { text } = await generateText({
+				model: openrouter(CHAT_MODEL_ID),
+				temperature: 0.3,
+				prompt: `Summarize the following user message into a short, descriptive conversation title of 3 to 6 words. Use title case. Do not use quotation marks or trailing punctuation. Respond with the title only, nothing else.\n\nMessage:\n${source}`
+			});
+			raw = text;
+		} catch (err) {
+			console.warn('[generateThreadTitle] LLM call failed', err);
+			return null;
+		}
+
+		// Sanitize: first line only, strip wrapping quotes/backticks, clamp length.
+		let title = (raw.split('\n')[0] ?? '')
+			.trim()
+			.replace(/^["'`]+|["'`]+$/g, '')
+			.trim();
+		if (!title) return null;
+		if (title.length > MAX_TITLE_LENGTH) {
+			title = title.slice(0, MAX_TITLE_LENGTH).trim();
+		}
+
+		await ctx.runMutation(internal.aiChat.threads.updateThreadMetadata, {
+			threadId: args.threadId,
+			title
+		});
+
+		return null;
+	}
+});

--- a/src/lib/convex/aiChat/titles.ts
+++ b/src/lib/convex/aiChat/titles.ts
@@ -4,6 +4,7 @@ import { internal } from '../_generated/api';
 import { generateText } from 'ai';
 import { openrouter } from '@openrouter/ai-sdk-provider';
 import { CHAT_MODEL_ID } from '../utils/chatModel';
+import { getAutumnSdk } from '../autumn';
 
 // Clamp the stored title; the sidebar span also CSS-truncates for display.
 const MAX_TITLE_LENGTH = 60;
@@ -16,19 +17,36 @@ const MAX_PROMPT_CHARS = 500;
  * Scheduled (fire-and-forget) from `sendMessage` on the first message of a
  * thread. Runs a single non-reasoning LLM call (no reasoning extraBody, unlike
  * the chat agent) and writes the result to `aiChatThreads.title` via
- * `updateThreadMetadata`. The sidebar prefers this title over the last-message
- * preview. On any failure we keep no title and the UI falls back gracefully, so
- * errors are swallowed (logged only).
+ * `setThreadTitleIfEmpty` (first-write-wins, so a late/duplicate run can never
+ * overwrite an existing title). The sidebar prefers this title over the
+ * last-message preview. On any failure we keep no title and the UI falls back
+ * gracefully, so errors are swallowed (logged only).
+ *
+ * Gated by the same Autumn `ai_chat_messages` allowance as the AI response, so a
+ * client bypassing the frontend billing check can't trigger unmetered title LLM
+ * calls. We only check (never track) — the response path tracks the usage unit.
  */
 export const generateThreadTitle = internalAction({
 	args: {
 		threadId: v.string(),
-		prompt: v.string()
+		prompt: v.string(),
+		userId: v.optional(v.string())
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
 		const source = args.prompt.trim().slice(0, MAX_PROMPT_CHARS);
 		if (!source) return null;
+
+		// Billing gate (check only): skip when the user is out of AI chat
+		// allowance, matching createAIResponse. Autumn fails open on 5xx/network.
+		if (args.userId) {
+			const sdk = await getAutumnSdk();
+			const checkResult = await sdk.check({
+				customer_id: args.userId,
+				feature_id: 'ai_chat_messages'
+			});
+			if (checkResult.data && !checkResult.data.allowed) return null;
+		}
 
 		let raw: string;
 		try {
@@ -53,7 +71,7 @@ export const generateThreadTitle = internalAction({
 			title = title.slice(0, MAX_TITLE_LENGTH).trim();
 		}
 
-		await ctx.runMutation(internal.aiChat.threads.updateThreadMetadata, {
+		await ctx.runMutation(internal.aiChat.threads.setThreadTitleIfEmpty, {
 			threadId: args.threadId,
 			title
 		});

--- a/src/lib/convex/aiChat/visibility.ts
+++ b/src/lib/convex/aiChat/visibility.ts
@@ -1,0 +1,17 @@
+/**
+ * A thread belongs in the sidebar once it has actually been used. Visibility keys
+ * on lastMessageAt (written on every send, the same signal as first-send
+ * detection), not on lastMessage, which is a display-only preview and is unset
+ * for a file-only send. The lastMessage disjunct keeps any legacy row that has a
+ * preview but no timestamp visible.
+ *
+ * Kept in its own import-light module so it can be unit-tested without pulling in
+ * the Convex runtime graph (mirrors ownership.ts).
+ */
+export function isVisibleAiChatThread(r: {
+	isWarm?: boolean;
+	lastMessage?: string;
+	lastMessageAt?: number;
+}): boolean {
+	return !r.isWarm && (r.lastMessageAt !== undefined || !!r.lastMessage);
+}


### PR DESCRIPTION
Threads previously showed a truncated last-message preview as their
sidebar label. Now the first user message is summarized into a short
descriptive title via a single non-reasoning LLM call (fire-and-forget,
scheduled from sendMessage) and stored in aiChatThreads.title.

The sidebar prefers this title and falls back to the last-message
preview when no title exists yet (generation pending or failed), so the
UI degrades gracefully. Title generation errors are logged and swallowed.