### PR TITLE
refactor(chat): runed listeners for drag-and-drop

### DIFF
--- a/src/lib/components/ai-elements/prompt-input/PromptInput.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInput.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import type { Snippet } from 'svelte';
-	import { watch } from 'runed';
+	import { useEventListener, watch } from 'runed';
 	import { onMount } from 'svelte';
 	import {
 		AttachmentsContext,
@@ -53,67 +53,29 @@
 		}
 	});
 
-	// Attach drop handlers on nearest form
-	watch(
-		() => formRef,
-		(formRef) => {
-			if (!formRef) return;
-
-			let onDragOver = (e: DragEvent) => {
-				if (e.dataTransfer?.types?.includes('Files')) {
-					e.preventDefault();
-				}
-			};
-
-			let onDrop = (e: DragEvent) => {
-				if (e.dataTransfer?.types?.includes('Files')) {
-					e.preventDefault();
-				}
-				if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
-					attachments.add(e.dataTransfer.files);
-				}
-			};
-
-			formRef.addEventListener('dragover', onDragOver);
-			formRef.addEventListener('drop', onDrop);
-
-			return () => {
-				formRef?.removeEventListener('dragover', onDragOver);
-				formRef?.removeEventListener('drop', onDrop);
-			};
+	// Files-only drag & drop handlers, shared between form-scoped and global drop
+	const onDragOver = (e: DragEvent) => {
+		if (e.dataTransfer?.types?.includes('Files')) {
+			e.preventDefault();
 		}
-	);
+	};
 
-	// Global drop handlers
-	watch(
-		() => globalDrop,
-		(globalDrop) => {
-			if (!globalDrop) return;
-
-			let onDragOver = (e: DragEvent) => {
-				if (e.dataTransfer?.types?.includes('Files')) {
-					e.preventDefault();
-				}
-			};
-
-			let onDrop = (e: DragEvent) => {
-				if (e.dataTransfer?.types?.includes('Files')) {
-					e.preventDefault();
-				}
-				if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
-					attachments.add(e.dataTransfer.files);
-				}
-			};
-
-			document.addEventListener('dragover', onDragOver);
-			document.addEventListener('drop', onDrop);
-
-			return () => {
-				document.removeEventListener('dragover', onDragOver);
-				document.removeEventListener('drop', onDrop);
-			};
+	const onDrop = (e: DragEvent) => {
+		if (e.dataTransfer?.types?.includes('Files')) {
+			e.preventDefault();
 		}
-	);
+		if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
+			attachments.add(e.dataTransfer.files);
+		}
+	};
+
+	// Scope drop handlers to the nearest form; null target until onMount finds it
+	useEventListener(() => formRef, 'dragover', onDragOver);
+	useEventListener(() => formRef, 'drop', onDrop);
+
+	// Global drop handlers, only while enabled
+	useEventListener(() => (globalDrop ? document : null), 'dragover', onDragOver);
+	useEventListener(() => (globalDrop ? document : null), 'drop', onDrop);
 
 	// Note: File input cannot be programmatically set for security reasons
 	// The syncHiddenInput prop is no longer functional


### PR DESCRIPTION
Closes #389

The prompt-input registered its drag-and-drop handlers through two hand-rolled watch blocks that called addEventListener and removeEventListener directly, with the Files-only dragover and drop handlers duplicated across both blocks. The asymmetry between the four add and four remove calls is the kind of thing a later refactor can quietly break, and the listeners do not auto-dispose against the component lifecycle the way the rest of the codebase now does.

This swaps both blocks for runed's useEventListener. The handlers are defined once and bound via reactive target getters: `() => formRef` for the form scope and `() => (globalDrop ? document : null)` for the global listeners, so the global handlers attach only while globalDrop is set and detach as soon as it clears. Cleanup runs automatically on unmount and when a target getter changes, matching the existing useMutationObserver usage elsewhere. The third watch block (file-input sync) is untouched.

`bun scripts/static-checks.ts` passes and the Svelte autofixer reports no issues on the changed file.