### PR TITLE
refactor(hooks): replace manual timers/listeners with runed

### DIFF
--- a/src/lib/hooks/use-auto-scroll.svelte.ts
+++ b/src/lib/hooks/use-auto-scroll.svelte.ts
@@ -2,6 +2,9 @@
 	Installed from @ieedan/shadcn-svelte-extras
 */
 
+import { untrack } from 'svelte';
+import { useEventListener, useMutationObserver } from 'runed';
+
 /** Use this on a vertically scrollable container to ensure that it automatically scrolls to the bottom of the content.
  *
  * ## Usage
@@ -33,42 +36,51 @@ export class UseAutoScroll {
 	private lastScrollHeight = 0;
 
 	constructor() {
-		// $effect watches #ref — teardown runs automatically before re-run and on destroy
+		// Position the container when the ref binds or rebinds
 		$effect(() => {
 			const el = this.#ref;
 			if (!el) return;
 
-			this.lastScrollHeight = el.scrollHeight;
+			untrack(() => {
+				this.lastScrollHeight = el.scrollHeight;
+				el.scrollTo(0, this.#scrollY ? this.#scrollY : el.scrollHeight);
+			});
+		});
 
-			// start from bottom or start position
-			el.scrollTo(0, this.#scrollY ? this.#scrollY : el.scrollHeight);
+		useEventListener(
+			() => this.#ref,
+			'scroll',
+			() => {
+				if (!this.#ref) return;
 
-			const onScroll = () => {
-				this.#scrollY = el.scrollTop;
+				this.#scrollY = this.#ref.scrollTop;
+
 				this.disableAutoScroll();
-			};
-			el.addEventListener('scroll', onScroll);
+			}
+		);
 
-			const onResize = () => {
+		useEventListener(
+			() => (this.#ref ? window : null),
+			'resize',
+			() => {
 				this.scrollToBottom(true);
-			};
-			window.addEventListener('resize', onResize);
+			}
+		);
 
-			// should detect when something changed that effected the scroll height
-			const observer = new MutationObserver(() => {
-				if (el.scrollHeight !== this.lastScrollHeight) {
+		// should detect when something changed that effected the scroll height
+		useMutationObserver(
+			() => this.#ref,
+			() => {
+				if (!this.#ref) return;
+
+				if (this.#ref.scrollHeight !== this.lastScrollHeight) {
 					this.scrollToBottom(true);
 				}
-				this.lastScrollHeight = el.scrollHeight;
-			});
-			observer.observe(el, { childList: true, subtree: true });
 
-			return () => {
-				el.removeEventListener('scroll', onScroll);
-				window.removeEventListener('resize', onResize);
-				observer.disconnect();
-			};
-		});
+				this.lastScrollHeight = this.#ref.scrollHeight;
+			},
+			{ childList: true, subtree: true }
+		);
 	}
 
 	set ref(ref: HTMLElement | undefined) {

--- a/src/lib/hooks/use-clipboard.svelte.ts
+++ b/src/lib/hooks/use-clipboard.svelte.ts
@@ -29,16 +29,18 @@ type Options = {
  */
 export class UseClipboard {
 	#copiedStatus = $state<'success' | 'failure'>();
-	private delay: number;
+	// Reactive so useDebounce's $derived wait getter is never read before the
+	// constructor assigns it, and stays correct if the delay ever changes
+	#delay = $state(500);
 	#resetStatus = useDebounce(
 		() => {
 			this.#copiedStatus = undefined;
 		},
-		() => this.delay
+		() => this.#delay
 	);
 
 	constructor({ delay = 500 }: Partial<Options> = {}) {
-		this.delay = delay;
+		this.#delay = delay;
 	}
 
 	/** Copies the given text to the users clipboard.

--- a/src/lib/hooks/use-clipboard.svelte.ts
+++ b/src/lib/hooks/use-clipboard.svelte.ts
@@ -1,3 +1,5 @@
+import { useDebounce } from 'runed';
+
 type Options = {
 	/** The time before the copied status is reset. */
 	delay: number;
@@ -28,7 +30,12 @@ type Options = {
 export class UseClipboard {
 	#copiedStatus = $state<'success' | 'failure'>();
 	private delay: number;
-	private timeout: ReturnType<typeof setTimeout> | undefined = undefined;
+	#resetStatus = useDebounce(
+		() => {
+			this.#copiedStatus = undefined;
+		},
+		() => this.delay
+	);
 
 	constructor({ delay = 500 }: Partial<Options> = {}) {
 		this.delay = delay;
@@ -45,16 +52,16 @@ export class UseClipboard {
 	 * @returns
 	 */
 	async copy(text: string) {
-		if (this.timeout) {
+		// Re-copy while a reset is pending: clear the badge first so the
+		// success/failure transition re-fires, like the old clearTimeout path
+		if (this.#resetStatus.pending) {
 			this.#copiedStatus = undefined;
-			clearTimeout(this.timeout);
 		}
+		this.#resetStatus.cancel();
 
 		this.#copiedStatus = await copyText(text);
 
-		this.timeout = setTimeout(() => {
-			this.#copiedStatus = undefined;
-		}, this.delay);
+		void this.#resetStatus().catch(() => {});
 
 		return this.#copiedStatus;
 	}

--- a/src/lib/hooks/use-haptic.svelte.ts
+++ b/src/lib/hooks/use-haptic.svelte.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import { useDebounce } from 'runed';
 import { MediaQuery } from 'svelte/reactivity';
 import type { ActionReturn } from 'svelte/action';
 import type { defaultPatterns, HapticInput as WebHapticsInput, WebHaptics } from 'web-haptics';
@@ -18,7 +19,14 @@ export class UseHaptic {
 	#isActive = $state(false);
 	#engine: WebHaptics | null = null;
 	#reducedMotion: MediaQuery | null = null;
-	#activeTimeout: ReturnType<typeof setTimeout> | undefined;
+	// Reactive so useDebounce's wait getter picks up the per-trigger duration
+	#lastDuration = $state(100);
+	#resetActive = useDebounce(
+		() => {
+			this.#isActive = false;
+		},
+		() => this.#lastDuration
+	);
 
 	constructor(options?: { debug?: boolean }) {
 		this.#debug = options?.debug ?? false;
@@ -54,20 +62,18 @@ export class UseHaptic {
 		const engine = this.#ensureEngine();
 		if (!engine) return;
 
-		if (this.#activeTimeout) clearTimeout(this.#activeTimeout);
+		this.#resetActive.cancel();
 		this.#isActive = true;
 
-		const duration = this.#estimateDuration(input);
-		this.#activeTimeout = setTimeout(() => {
-			this.#isActive = false;
-		}, duration);
+		this.#lastDuration = this.#estimateDuration(input);
+		void this.#resetActive().catch(() => {});
 
 		engine.trigger(input as WebHapticsInput);
 	}
 
 	cancel(): void {
 		this.#engine?.cancel();
-		if (this.#activeTimeout) clearTimeout(this.#activeTimeout);
+		this.#resetActive.cancel();
 		this.#isActive = false;
 	}
 


### PR DESCRIPTION
Closes #385

Three shared hooks carried hand-rolled setTimeout, addEventListener, and MutationObserver plumbing that runed already wraps with lifecycle-aware cleanup. The vendored use-clipboard and use-auto-scroll come from @ieedan/shadcn-svelte-extras; use-haptic is local to this repo.

use-haptic and use-clipboard move their reset timers to useDebounce. In use-haptic the per-trigger duration flows through a reactive `#lastDuration` field, since useDebounce caches its wait via a `$derived` and a plain field would never recompute. Both schedule calls swallow the cancel rejection that useDebounce raises on a pending promise. use-clipboard keeps its pre-reset on rapid re-copy via the `pending` flag, so the status transition still re-fires.

use-auto-scroll adopts the upstream fix from ieedan/shadcn-svelte-extras#391. The scroll and resize listeners become useEventListener and the MutationObserver becomes useMutationObserver, all auto-disposing on unmount. The initial positioning moves into its own untracked effect so it runs when the ref binds rather than re-running on every scroll, a small intentional improvement over the previous behaviour.

`bun scripts/static-checks.ts` passes for all three files and the Svelte autofixer reports no issues.