### PR TITLE
fix(team-switcher): use cmdOrCtrl shortcut label

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ import requireMarketingRouteRegistrationRule from './eslint/rules/require-market
 import noHardcodedAriaLabelRule from './eslint/rules/no-hardcoded-aria-label.js';
 import noHardcodedSrOnlyRule from './eslint/rules/no-hardcoded-sr-only.js';
 import noDebounceInRuneRule from './eslint/rules/no-debounce-in-rune.js';
+import noHardcodedModifierKeysRule from './eslint/rules/no-hardcoded-modifier-keys.js';
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
 const localPlugin = {
@@ -21,7 +22,8 @@ const localPlugin = {
 		'require-marketing-route-registration': requireMarketingRouteRegistrationRule,
 		'no-hardcoded-aria-label': noHardcodedAriaLabelRule,
 		'no-hardcoded-sr-only': noHardcodedSrOnlyRule,
-		'no-debounce-in-rune': noDebounceInRuneRule
+		'no-debounce-in-rune': noDebounceInRuneRule,
+		'no-hardcoded-modifier-keys': noHardcodedModifierKeysRule
 	}
 };
 
@@ -186,6 +188,19 @@ export default defineConfig(
 		},
 		rules: {
 			'local/no-debounce-in-rune': 'error'
+		}
+	},
+	{
+		// Platform modifier labels (⌘ ⌃ ⌥) must come from $lib/hooks/is-mac.svelte
+		// (cmdOrCtrl/ctrlSymbol/optionOrAlt) so non-mac users see the right modifier.
+		// The hook itself is the only place allowed to define them.
+		files: ['src/**/*.svelte', 'src/**/*.ts'],
+		ignores: ['src/lib/hooks/is-mac.svelte.ts'],
+		plugins: {
+			local: localPlugin
+		},
+		rules: {
+			'local/no-hardcoded-modifier-keys': 'error'
 		}
 	},
 	// Convex best-practice rules — v2 ships ESLint 9 flat config natively

--- a/eslint/rules/no-hardcoded-modifier-keys.js
+++ b/eslint/rules/no-hardcoded-modifier-keys.js
@@ -1,0 +1,57 @@
+/**
+ * ESLint rule: no-hardcoded-modifier-keys
+ *
+ * Flags hardcoded macOS modifier symbols (⌘, ⌃, ⌥) in Svelte templates and
+ * string literals. Platform-specific modifier labels must come from
+ * $lib/hooks/is-mac.svelte (cmdOrCtrl, ctrlSymbol, optionOrAlt) so
+ * Windows/Linux users see the right modifier.
+ *
+ * ✅ <DropdownMenu.Shortcut>{cmdOrCtrl}K</DropdownMenu.Shortcut>
+ * ✅ kbd: [ctrlSymbol, '⇧', '1']        (⇧ is used cross-platform on purpose)
+ * ❌ <DropdownMenu.Shortcut>⌘K</DropdownMenu.Shortcut>
+ * ❌ const shortcut = '⌘K';
+ *
+ * Comments are not AST nodes, so JSDoc/inline comments mentioning ⌘ are fine.
+ */
+const MODIFIER_SYMBOLS = /[⌘⌃⌥]/u; // ⌘ ⌃ ⌥
+
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Disallow hardcoded macOS modifier symbols (use cmdOrCtrl/ctrlSymbol/optionOrAlt from $lib/hooks/is-mac.svelte)'
+		},
+		schema: [],
+		messages: {
+			hardcodedModifier:
+				'Hardcoded macOS modifier symbol. Use cmdOrCtrl / ctrlSymbol / optionOrAlt from $lib/hooks/is-mac.svelte so non-mac users see the right modifier.'
+		}
+	},
+	create(context) {
+		function check(node, text) {
+			if (typeof text === 'string' && MODIFIER_SYMBOLS.test(text)) {
+				context.report({ node, messageId: 'hardcodedModifier' });
+			}
+		}
+
+		return {
+			// Script string literals: const k = '⌘K'
+			Literal(node) {
+				check(node, node.value);
+			},
+			// Template literals: `Press ⌘K`
+			TemplateElement(node) {
+				check(node, node.value?.raw);
+			},
+			// Svelte template text: <span>⌘K</span>
+			SvelteText(node) {
+				check(node, node.value);
+			},
+			// Svelte attribute string parts: <Kbd label="⌘K" />
+			SvelteLiteral(node) {
+				check(node, node.value);
+			}
+		};
+	}
+};

--- a/eslint/rules/no-hardcoded-modifier-keys.test.ts
+++ b/eslint/rules/no-hardcoded-modifier-keys.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import parser from 'svelte-eslint-parser';
+import rule from './no-hardcoded-modifier-keys.js';
+
+function lint(template: string): Array<{ messageId: string }> {
+	const reports: Array<{ messageId: string }> = [];
+	const ast = parser.parseForESLint(template, {});
+
+	const context = {
+		report: (opts: { messageId: string }) => reports.push(opts),
+		getFilename: () => 'test.svelte',
+		filename: 'test.svelte'
+	};
+
+	const listeners = rule.create(context);
+
+	function walk(node: Record<string, unknown>) {
+		if (!node || typeof node !== 'object') return;
+		const type = node.type as string;
+		if (type && typeof listeners[type] === 'function') {
+			(listeners[type] as (n: unknown) => void)(node);
+		}
+		for (const key of Object.keys(node)) {
+			if (key === 'parent') continue;
+			const val = node[key];
+			if (Array.isArray(val)) val.forEach((v) => walk(v as Record<string, unknown>));
+			else if (val && typeof val === 'object' && (val as Record<string, unknown>).type)
+				walk(val as Record<string, unknown>);
+		}
+	}
+
+	walk(ast.ast as unknown as Record<string, unknown>);
+	return reports;
+}
+
+describe('no-hardcoded-modifier-keys', () => {
+	it('flags ⌘ in template text', () => {
+		const reports = lint('<span>⌘K</span>');
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('hardcodedModifier');
+	});
+
+	it('flags ⌃ and ⌥ in template text', () => {
+		expect(lint('<span>⌃⇧1</span>')).toHaveLength(1);
+		expect(lint('<span>⌥A</span>')).toHaveLength(1);
+	});
+
+	it('flags ⌘ in script string literals', () => {
+		const reports = lint("<script>const shortcut = '⌘K';</script>");
+		expect(reports).toHaveLength(1);
+	});
+
+	it('flags ⌘ in template literals', () => {
+		const reports = lint('<script>const hint = `Press ⌘K`;</script>');
+		expect(reports).toHaveLength(1);
+	});
+
+	it('flags ⌘ in attribute values', () => {
+		const reports = lint('<button title="⌘K"></button>');
+		expect(reports).toHaveLength(1);
+	});
+
+	it('allows helper variables in template', () => {
+		const reports = lint('<span>{cmdOrCtrl}K</span>');
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows ⇧ (used cross-platform on purpose)', () => {
+		const reports = lint("<script>const kbd = ['⇧', '1'];</script><span>⇧1</span>");
+		expect(reports).toHaveLength(0);
+	});
+
+	it('ignores comments', () => {
+		const reports = lint('<script>// avoids macOS ⌘⇧3 screenshot conflict</script><!-- ⌘K -->');
+		expect(reports).toHaveLength(0);
+	});
+});

--- a/src/lib/components/team-switcher.svelte
+++ b/src/lib/components/team-switcher.svelte
@@ -5,6 +5,7 @@
 	import { useSidebar } from '$lib/components/ui/sidebar/index.js';
 	import ChevronsUpDownIcon from '@lucide/svelte/icons/chevrons-up-down';
 	import PlusIcon from '@lucide/svelte/icons/plus';
+	import { onMount } from 'svelte';
 
 	// This should be `Component` after @lucide/svelte updates types
 
@@ -13,6 +14,11 @@
 
 	// svelte-ignore state_referenced_locally
 	let activeTeam = $state(teams[0]!);
+	let shortcutModifier = $state('');
+
+	onMount(() => {
+		shortcutModifier = cmdOrCtrl;
+	});
 </script>
 
 <Sidebar.Menu>
@@ -53,7 +59,7 @@
 							<team.logo class="size-3.5 shrink-0" />
 						</div>
 						{team.name}
-						<DropdownMenu.Shortcut>{cmdOrCtrl}{index + 1}</DropdownMenu.Shortcut>
+						<DropdownMenu.Shortcut>{shortcutModifier}{index + 1}</DropdownMenu.Shortcut>
 					</DropdownMenu.Item>
 				{/each}
 				<DropdownMenu.Separator />

--- a/src/lib/components/team-switcher.svelte
+++ b/src/lib/components/team-switcher.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+	import { cmdOrCtrl } from '$lib/hooks/is-mac.svelte';
 	import { useSidebar } from '$lib/components/ui/sidebar/index.js';
 	import ChevronsUpDownIcon from '@lucide/svelte/icons/chevrons-up-down';
 	import PlusIcon from '@lucide/svelte/icons/plus';
@@ -52,7 +53,7 @@
 							<team.logo class="size-3.5 shrink-0" />
 						</div>
 						{team.name}
-						<DropdownMenu.Shortcut>⌘{index + 1}</DropdownMenu.Shortcut>
+						<DropdownMenu.Shortcut>{cmdOrCtrl}{index + 1}</DropdownMenu.Shortcut>
 					</DropdownMenu.Item>
 				{/each}
 				<DropdownMenu.Separator />

--- a/src/lib/components/team-switcher.svelte
+++ b/src/lib/components/team-switcher.svelte
@@ -5,7 +5,6 @@
 	import { useSidebar } from '$lib/components/ui/sidebar/index.js';
 	import ChevronsUpDownIcon from '@lucide/svelte/icons/chevrons-up-down';
 	import PlusIcon from '@lucide/svelte/icons/plus';
-	import { onMount } from 'svelte';
 
 	// This should be `Component` after @lucide/svelte updates types
 
@@ -14,11 +13,6 @@
 
 	// svelte-ignore state_referenced_locally
 	let activeTeam = $state(teams[0]!);
-	let shortcutModifier = $state('');
-
-	onMount(() => {
-		shortcutModifier = cmdOrCtrl;
-	});
 </script>
 
 <Sidebar.Menu>
@@ -59,7 +53,7 @@
 							<team.logo class="size-3.5 shrink-0" />
 						</div>
 						{team.name}
-						<DropdownMenu.Shortcut>{shortcutModifier}{index + 1}</DropdownMenu.Shortcut>
+						<DropdownMenu.Shortcut>{cmdOrCtrl}{index + 1}</DropdownMenu.Shortcut>
 					</DropdownMenu.Item>
 				{/each}
 				<DropdownMenu.Separator />


### PR DESCRIPTION
## Summary
- replace the hardcoded `⌘` badge in the team switcher with the shared `cmdOrCtrl` helper
- align the component with the repo rule to avoid platform-specific shortcut text

Closes #476

## Test URLs
- Not applicable: this is a static shortcut label change inside the existing sidebar team switcher component, and I did not run the full app locally in this environment.

## Screenshot
- Not applicable for this small text-only shortcut badge update.

## Validation
- `bun scripts/static-checks.ts src/lib/components/team-switcher.svelte`
