### PR TITLE
docs: Fix AGENTS.md drift and replace stock Convex README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,7 +233,7 @@ Runtime files:
 
 - **Frontend**: SvelteKit, Svelte 5 (runes syntax!), Tailwind CSS v4, Shadcn Svelte
 - **Backend**: Convex (real-time database + serverless functions)
-- **Authentication**: Better Auth Svelte Convex Component @convex-dev/better-auth-svelte. We use the local install to get full better auth feature access like passkeys, admin, etc. See <https://labs.convex.dev/better-auth/features/local-install> for authentication documentation.
+- **Authentication**: Better Auth Svelte Convex Component `@mmailaender/convex-better-auth-svelte` (backed by the `@convex-dev/better-auth` component). We use the local install to get full better auth feature access like passkeys, admin, etc. See <https://labs.convex.dev/better-auth/features/local-install> for authentication documentation.
 - **Internationalization**: Tolgee (open source / cloud-hosted translation management with URL-based localization and in-context editing)
 - **Testing**: Playwright (E2E), Vitest (unit)
 - **Package Manager**: Bun. ALWAYS use bun instead of npm to run commands.
@@ -269,7 +269,7 @@ Runtime files:
 
 - Every new `+page.svelte` route must include `SEOHead`.
 - For localized routes under `src/routes/[[lang]]/`, `SEOHead` title and description must use translated `meta.*` keys in all 4 locale files (`en`, `de`, `es`, `fr`).
-- `meta.*.title` values must be page-title only and must NOT include the site suffix or brand name. `SEOHead` appends `| SaaS Starter` automatically (use `"Settings"`, not `"Settings - SaaS Starter"`).
+- `meta.*.title` values must be page-title only and must NOT include the site suffix or brand name. `SEOHead` appends `| ${LEGAL_CONFIG.brandName}` automatically (default `"SaaS Starter"`, configured in `src/lib/config/legal.ts`; use `"Settings"`, not `"Settings - SaaS Starter"`).
 - Public marketing routes under `src/routes/[[lang]]/(marketing)/` can expose agent-facing markdown from the same URL via `Accept: text/markdown`. Keep the markdown source in a sibling `page.md.ts` file, not a `+page.*` file, and keep it in sync with the marketing page content. `/llms.txt` is the discovery entrypoint, and v1 markdown content is English-only.
 - If a marketing/legal page obfuscates contact email in HTML, keep the agent-facing `page.md.ts` variant obfuscated too. Do not expose the raw email address only via `Accept: text/markdown`.
 
@@ -281,11 +281,13 @@ Use the @convex-dev/resend email system for production-ready email delivery. Use
 
 ```text
 src/lib/convex/emails/
+├── __tests__/             # Unit tests for the send helpers
+├── _generated/            # Build output of `bun run build:emails` (gitignored)
 ├── resend.ts              # Resend client configuration
 ├── events.ts              # Webhook event handlers
 ├── send.ts                # Email sending mutations
-├── queries.ts             # Email status queries
-└── mutations.ts           # Email management (cancel, status)
+├── helpers.ts             # Shared send helpers (test-email skip, founder welcome delay)
+└── templates.ts           # Renders templates from _generated/ ({{var}} interpolation)
 ```
 
 Emails are sent via internal mutations using the Resend component.
@@ -300,13 +302,7 @@ Email events are automatically stored in the `emailEvents` table:
 - `email.opened` - Email opened (requires tracking enabled in Resend)
 - `email.clicked` - Link clicked (requires tracking enabled in Resend)
 
-Query email events using:
-
-```typescript
-const events = await ctx.runQuery(api.emails.queries.getEmailEvents, {
-	emailId: 'email-id'
-});
-```
+There is currently no query over `emailEvents`; inspect events via the Convex dashboard, or add a query on the `by_email_id` index when needed.
 
 ### PostHog Analytics
 

--- a/src/lib/convex/README.md
+++ b/src/lib/convex/README.md
@@ -1,88 +1,13 @@
-# Welcome to your Convex functions directory!
+# Convex backend
 
-Write your Convex functions here.
-See https://docs.convex.dev/functions for more.
+Backend functions, schema, and auth config.
 
-A query function that takes two arguments looks like:
+Before writing or reviewing any code in this directory, read the
+`convex-guidelines` skill (`skills/convex-guidelines/SKILL.md`), it has the
+canonical patterns for this project (validators, function registration,
+pagination, indexes, Better Auth integration).
 
-```ts
-// functions.js
-import { query } from './_generated/server';
-import { v } from 'convex/values';
+The frontend consumes these functions via `@mmailaender/convex-svelte`
+(`useQuery`), see "Rendering & Data Strategy" in `AGENTS.md`.
 
-export const myQueryFunction = query({
-	// Validators for arguments.
-	args: {
-		first: v.number(),
-		second: v.string()
-	},
-
-	// Function implementation.
-	handler: async (ctx, args) => {
-		// Read the database as many times as you need here.
-		// See https://docs.convex.dev/database/reading-data.
-		const documents = await ctx.db.query('tablename').collect();
-
-		// Arguments passed from the client are properties of the args object.
-		console.log(args.first, args.second);
-
-		// Write arbitrary JavaScript here: filter, aggregate, build derived data,
-		// remove non-public properties, or create new objects.
-		return documents;
-	}
-});
-```
-
-Using this query function in a React component looks like:
-
-```ts
-const data = useQuery(api.functions.myQueryFunction, {
-	first: 10,
-	second: 'hello'
-});
-```
-
-A mutation function looks like:
-
-```ts
-// functions.js
-import { mutation } from './_generated/server';
-import { v } from 'convex/values';
-
-export const myMutationFunction = mutation({
-	// Validators for arguments.
-	args: {
-		first: v.string(),
-		second: v.string()
-	},
-
-	// Function implementation.
-	handler: async (ctx, args) => {
-		// Insert or modify documents in the database here.
-		// Mutations can also read from the database like queries.
-		// See https://docs.convex.dev/database/writing-data.
-		const message = { body: args.first, author: args.second };
-		const id = await ctx.db.insert('messages', message);
-
-		// Optionally, return a value from your mutation.
-		return await ctx.db.get(id);
-	}
-});
-```
-
-Using this mutation function in a React component looks like:
-
-```ts
-const mutation = useMutation(api.functions.myMutationFunction);
-function handleButtonPress() {
-	// fire and forget, the most common way to use mutations
-	mutation({ first: 'Hello!', second: 'me' });
-	// OR
-	// use the result once the mutation has completed
-	mutation({ first: 'Hello!', second: 'me' }).then((result) => console.log(result));
-}
-```
-
-Use the Convex CLI to push your functions to a deployment. See everything
-the Convex CLI can do by running `bunx convex -h` in your project root
-directory. To learn more, launch the docs with `bunx convex docs`.
+Convex docs: https://docs.convex.dev/functions


### PR DESCRIPTION
Closes #474

AGENTS.md drifted from the code in three places. The email architecture section listed `emails/queries.ts` and `emails/mutations.ts` and documented an `api.emails.queries.getEmailEvents` query, none of which exist. The Tech Stack section named `@convex-dev/better-auth-svelte` although every import uses `@mmailaender/convex-better-auth-svelte`. The SEOHead bullet described the title suffix as a hardcoded `| SaaS Starter` although it comes from `LEGAL_CONFIG.brandName`, the rebranding knob for forks. Additionally, `src/lib/convex/README.md` was still the stock Convex scaffold with React `useQuery`/`useMutation` examples, no returns validators and an unbounded `.collect()`, contradicting the project's convex-guidelines skill.

The email architecture tree now matches the actual directory contents, the event tracking section states that no query over `emailEvents` exists yet, the Tech Stack names the installed package, and the SEOHead bullet references `LEGAL_CONFIG.brandName` in `src/lib/config/legal.ts` with its default. The Convex README is replaced by a short pointer to the convex-guidelines skill and the data strategy section in AGENTS.md. This covers item 1 of #496 (the remaining items there are code changes), and the missing `getEmailEvents` query stays open as a code decision in #463.

`bun scripts/static-checks.ts AGENTS.md src/lib/convex/README.md` passes.