### PR TITLE
fix(i18n): Translate hardcoded UI strings and validation errors

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -131,6 +131,7 @@
 			"preference_enabling": "{field} wird aktiviert...",
 			"preference_update_failed": "Einstellung konnte nicht aktualisiert werden",
 			"recipient_count": "{count, plural, other {# Empfänger}}",
+			"recipients_search_placeholder": "Benachrichtigungsempfänger durchsuchen...",
 			"save": "Einstellungen speichern",
 			"saved": "Einstellungen gespeichert",
 			"saving": "Speichern...",
@@ -255,20 +256,12 @@
 			"menu_open": "Menü öffnen",
 			"name": "Name",
 			"no_results": "Keine Ergebnisse.",
-			"page_indicator": "Seite {current} von {total}",
-			"pagination": {
-				"first": "Zur ersten Seite",
-				"last": "Zur letzten Seite",
-				"next": "Zur nächsten Seite",
-				"previous": "Zur vorherigen Seite"
-			},
 			"provider": "Anbieter",
 			"provider_email": "E-Mail",
 			"provider_github": "GitHub",
 			"provider_google": "Google",
 			"provider_passkey": "Passkey",
 			"role": "Rolle",
-			"rows_per_page": "Zeilen pro Seite",
 			"search_placeholder": "Benutzer suchen...",
 			"select_all": "Alle auswählen",
 			"select_row": "Zeile auswählen",
@@ -1133,6 +1126,16 @@
 				"placeholder_no_suggestions": "Nachricht eingeben..."
 			}
 		}
+	},
+	"table": {
+		"page_indicator": "Seite {current} von {total}",
+		"pagination": {
+			"first": "Zur ersten Seite",
+			"last": "Zur letzten Seite",
+			"next": "Zur nächsten Seite",
+			"previous": "Zur vorherigen Seite"
+		},
+		"rows_per_page": "Zeilen pro Seite"
 	},
 	"team": {
 		"description": "Während des Arbeitsprozesses führen wir regelmäßige Anpassungen mit dem Kunden durch, denn er ist die einzige Person, die spüren kann, ob ein neuer Anzug passt oder nicht.",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -637,7 +637,10 @@
 		"adding": "Wird hinzugefügt...",
 		"cancel": "Abbrechen",
 		"confirm": "Bestätigen",
-		"save": "Speichern"
+		"confirm_input_placeholder": "Geben Sie \"{text}\" ein, um zu bestätigen.",
+		"delete": "Löschen",
+		"save": "Speichern",
+		"you": "Sie"
 	},
 	"email": {
 		"body": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -131,6 +131,7 @@
 			"preference_enabling": "Enabling {field}...",
 			"preference_update_failed": "Failed to update preference",
 			"recipient_count": "{count, plural, one {# recipient} other {# recipients}}",
+			"recipients_search_placeholder": "Search notification recipients...",
 			"save": "Save Settings",
 			"saved": "Settings saved",
 			"saving": "Saving...",
@@ -255,20 +256,12 @@
 			"menu_open": "Open menu",
 			"name": "Name",
 			"no_results": "No results.",
-			"page_indicator": "Page {current} of {total}",
-			"pagination": {
-				"first": "Go to first page",
-				"last": "Go to last page",
-				"next": "Go to next page",
-				"previous": "Go to previous page"
-			},
 			"provider": "Provider",
 			"provider_email": "Email",
 			"provider_github": "GitHub",
 			"provider_google": "Google",
 			"provider_passkey": "Passkey",
 			"role": "Role",
-			"rows_per_page": "Rows per page",
 			"search_placeholder": "Search users...",
 			"select_all": "Select all",
 			"select_row": "Select row",
@@ -1133,6 +1126,16 @@
 				"placeholder_no_suggestions": "Type a message..."
 			}
 		}
+	},
+	"table": {
+		"page_indicator": "Page {current} of {total}",
+		"pagination": {
+			"first": "Go to first page",
+			"last": "Go to last page",
+			"next": "Go to next page",
+			"previous": "Go to previous page"
+		},
+		"rows_per_page": "Rows per page"
 	},
 	"team": {
 		"description": "During the working process, we perform regular fitting with the client because he is the only person who can feel whether a new suit fits or not.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -637,7 +637,10 @@
 		"adding": "Adding...",
 		"cancel": "Cancel",
 		"confirm": "Confirm",
-		"save": "Save"
+		"confirm_input_placeholder": "Enter \"{text}\" to confirm.",
+		"delete": "Delete",
+		"save": "Save",
+		"you": "You"
 	},
 	"email": {
 		"body": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -131,6 +131,7 @@
 			"preference_enabling": "Activando {field}...",
 			"preference_update_failed": "Error al actualizar preferencia",
 			"recipient_count": "{count, plural, one {# destinatario} other {# destinatarios}}",
+			"recipients_search_placeholder": "Buscar destinatarios de notificaciones...",
 			"save": "Guardar Configuración",
 			"saved": "Configuración guardada",
 			"saving": "Guardando...",
@@ -255,20 +256,12 @@
 			"menu_open": "Abrir menú",
 			"name": "Nombre",
 			"no_results": "Sin resultados.",
-			"page_indicator": "Página {current} de {total}",
-			"pagination": {
-				"first": "Ir a la primera página",
-				"last": "Ir a la última página",
-				"next": "Ir a la siguiente página",
-				"previous": "Ir a la página anterior"
-			},
 			"provider": "Proveedor",
 			"provider_email": "Correo electrónico",
 			"provider_github": "GitHub",
 			"provider_google": "Google",
 			"provider_passkey": "Clave de acceso",
 			"role": "Rol",
-			"rows_per_page": "Filas por página",
 			"search_placeholder": "Buscar usuarios...",
 			"select_all": "Seleccionar todo",
 			"select_row": "Seleccionar fila",
@@ -1133,6 +1126,16 @@
 				"placeholder_no_suggestions": "Escribe un mensaje..."
 			}
 		}
+	},
+	"table": {
+		"page_indicator": "Página {current} de {total}",
+		"pagination": {
+			"first": "Ir a la primera página",
+			"last": "Ir a la última página",
+			"next": "Ir a la siguiente página",
+			"previous": "Ir a la página anterior"
+		},
+		"rows_per_page": "Filas por página"
 	},
 	"team": {
 		"description": "Durante el proceso de trabajo, realizamos ajustes regulares con el cliente porque él es la única persona que puede sentir si un traje nuevo le queda bien o no.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -637,7 +637,10 @@
 		"adding": "Agregando...",
 		"cancel": "Cancelar",
 		"confirm": "Confirmar",
-		"save": "Guardar"
+		"confirm_input_placeholder": "Escribe \"{text}\" para confirmar.",
+		"delete": "Eliminar",
+		"save": "Guardar",
+		"you": "Tú"
 	},
 	"email": {
 		"body": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -131,6 +131,7 @@
 			"preference_enabling": "Activation de {field}...",
 			"preference_update_failed": "Échec de la mise à jour de la préférence",
 			"recipient_count": "{count, plural, one {# destinataire} other {# destinataires}}",
+			"recipients_search_placeholder": "Rechercher des destinataires de notification...",
 			"save": "Enregistrer les Paramètres",
 			"saved": "Paramètres enregistrés",
 			"saving": "Enregistrement...",
@@ -255,20 +256,12 @@
 			"menu_open": "Ouvrir le menu",
 			"name": "Nom",
 			"no_results": "Aucun résultat.",
-			"page_indicator": "Page {current} sur {total}",
-			"pagination": {
-				"first": "Aller à la première page",
-				"last": "Aller à la dernière page",
-				"next": "Aller à la page suivante",
-				"previous": "Aller à la page précédente"
-			},
 			"provider": "Fournisseur",
 			"provider_email": "E-mail",
 			"provider_github": "GitHub",
 			"provider_google": "Google",
 			"provider_passkey": "Clé d'accès",
 			"role": "Rôle",
-			"rows_per_page": "Lignes par page",
 			"search_placeholder": "Rechercher des utilisateurs...",
 			"select_all": "Tout sélectionner",
 			"select_row": "Sélectionner la ligne",
@@ -1133,6 +1126,16 @@
 				"placeholder_no_suggestions": "Tapez un message..."
 			}
 		}
+	},
+	"table": {
+		"page_indicator": "Page {current} sur {total}",
+		"pagination": {
+			"first": "Aller à la première page",
+			"last": "Aller à la dernière page",
+			"next": "Aller à la page suivante",
+			"previous": "Aller à la page précédente"
+		},
+		"rows_per_page": "Lignes par page"
 	},
 	"team": {
 		"description": "Pendant le processus de travail, nous effectuons des ajustements réguliers avec le client car il est la seule personne qui peut sentir si un nouveau costume lui va bien ou non.",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -637,7 +637,10 @@
 		"adding": "Ajout en cours...",
 		"cancel": "Annuler",
 		"confirm": "Confirmer",
-		"save": "Enregistrer"
+		"confirm_input_placeholder": "Saisissez \"{text}\" pour confirmer.",
+		"delete": "Supprimer",
+		"save": "Enregistrer",
+		"you": "Vous"
 	},
 	"email": {
 		"body": {

--- a/src/lib/components/tables/convex-cursor-table-shell.svelte
+++ b/src/lib/components/tables/convex-cursor-table-shell.svelte
@@ -60,7 +60,7 @@
 		onNextPage,
 		onLastPage,
 		onPageSizeChange,
-		rowsPerPageLabel = 'Rows per page',
+		rowsPerPageLabel,
 		selectionText,
 		showRowsPerPage = true,
 		showSearch = true,
@@ -113,7 +113,7 @@
 		<div class="flex w-full items-center gap-8 lg:w-fit">
 			{#if showRowsPerPage}
 				<div class="hidden items-center gap-2 lg:flex">
-					<span class="text-sm font-medium">{rowsPerPageLabel}</span>
+					<span class="text-sm font-medium">{rowsPerPageLabel ?? $t('table.rows_per_page')}</span>
 					<Select.Root
 						type="single"
 						value={`${pageSize}`}
@@ -138,7 +138,7 @@
 				class="flex w-fit items-center justify-center text-sm font-medium"
 				data-testid={pageIndicatorTestId}
 			>
-				{$t('admin.users.page_indicator', { current: pageIndex + 1, total: pageCount })}
+				{$t('table.page_indicator', { current: pageIndex + 1, total: pageCount })}
 			</div>
 
 			<div class="ml-auto flex items-center gap-2 lg:ml-0">
@@ -151,7 +151,7 @@
 					}}
 					disabled={!canPreviousPage}
 				>
-					<span class="sr-only">{$t('admin.users.pagination.first')}</span>
+					<span class="sr-only">{$t('table.pagination.first')}</span>
 					<ChevronsLeftIcon />
 				</Button>
 				<Button
@@ -165,7 +165,7 @@
 					disabled={!canPreviousPage}
 					data-testid={paginationPrevTestId}
 				>
-					<span class="sr-only">{$t('admin.users.pagination.previous')}</span>
+					<span class="sr-only">{$t('table.pagination.previous')}</span>
 					<ChevronLeftIcon />
 				</Button>
 				<Button
@@ -179,7 +179,7 @@
 					disabled={!canNextPage}
 					data-testid={paginationNextTestId}
 				>
-					<span class="sr-only">{$t('admin.users.pagination.next')}</span>
+					<span class="sr-only">{$t('table.pagination.next')}</span>
 					<ChevronRightIcon />
 				</Button>
 				<Button
@@ -192,7 +192,7 @@
 					disabled={!canNextPage}
 					data-testid={paginationLastTestId}
 				>
-					<span class="sr-only">{$t('admin.users.pagination.last')}</span>
+					<span class="sr-only">{$t('table.pagination.last')}</span>
 					<ChevronsRightIcon />
 				</Button>
 			</div>

--- a/src/lib/components/ui/confirm-delete-dialog/confirm-delete-dialog.svelte
+++ b/src/lib/components/ui/confirm-delete-dialog/confirm-delete-dialog.svelte
@@ -115,7 +115,9 @@
 					<Input
 						id="confirm-delete-input"
 						bind:value={dialogState.inputText}
-						placeholder={`Enter "${dialogState.options.input.confirmationText}" to confirm.`}
+						placeholder={$t('common.confirm_input_placeholder', {
+							text: dialogState.options.input.confirmationText
+						})}
 						onkeydown={(e) => {
 							if (e.key === 'Enter') {
 								// Prevent Enter from triggering native form submit before custom confirm flow
@@ -135,7 +137,7 @@
 					}}
 					data-testid="confirm-delete-cancel"
 				>
-					{dialogState.options?.cancel?.text ?? 'Cancel'}
+					{dialogState.options?.cancel?.text ?? $t('common.cancel')}
 				</AlertDialog.Cancel>
 				<AlertDialog.Action
 					type="submit"
@@ -147,7 +149,7 @@
 					{#if dialogState.loading}
 						<LoaderCircleIcon class="size-4 motion-safe:animate-spin" />
 					{/if}
-					{dialogState.options?.confirm?.text ?? 'Delete'}
+					{dialogState.options?.confirm?.text ?? $t('common.delete')}
 				</AlertDialog.Action>
 			</AlertDialog.Footer>
 		</form>

--- a/src/lib/schemas/auth.ts
+++ b/src/lib/schemas/auth.ts
@@ -1,7 +1,7 @@
 import * as v from 'valibot';
 
 // Email validation schema (reusable across the app)
-export const emailSchema = v.pipe(v.string(), v.email());
+export const emailSchema = v.pipe(v.string(), v.email('validation.email.invalid'));
 
 // URL params schema for auth pages (redirectTo only, no tab switching)
 export const redirectParamsSchema = v.object({

--- a/src/lib/utils/validation-i18n.ts
+++ b/src/lib/utils/validation-i18n.ts
@@ -44,6 +44,34 @@ export function translateValidationErrors(
 }
 
 /**
+ * Translates SvelteKit remote-form validation issues using Tolgee.
+ *
+ * Remote forms (`form(schema, handler)`) expose `field.issues()` as
+ * `{ message, path }[]` where `message` holds the translation key from the
+ * Valibot schema (or from `invalid(issue.field(key))` in the handler).
+ *
+ * @param issues - Issues from `field.issues()` on a remote form
+ * @param t - Tolgee translate function ($t from getTranslate())
+ * @param params - Optional per-key parameters for parameterized translations
+ * @returns Array of { message: string } objects for Field.Error component, or undefined
+ *
+ * @example
+ * ```svelte
+ * <Field.Error errors={translateRemoteFormIssues(addEmailForm.fields.email.issues(), $t)} />
+ * ```
+ */
+export function translateRemoteFormIssues(
+	issues: ReadonlyArray<{ message: string }> | undefined,
+	t: TolgeeFn,
+	params?: Record<string, TolgeeParams>
+): Array<{ message: string }> | undefined {
+	if (!issues || issues.length === 0) return undefined;
+	return issues.map(({ message }) => ({
+		message: params?.[message] ? t(message, params[message]) : t(message)
+	}));
+}
+
+/**
  * Converts a single translated error to Field.Error format.
  *
  * @param error - Translation key or undefined

--- a/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
@@ -101,7 +101,7 @@
 					name="name"
 					type="text"
 					autocomplete="name"
-					placeholder="Your name"
+					placeholder={$t('settings.account.name.placeholder')}
 					disabled={isFormDisabled}
 					bind:value={signUpData.name}
 				/>

--- a/src/routes/[[lang]]/admin/settings/add-email-dialog.svelte
+++ b/src/routes/[[lang]]/admin/settings/add-email-dialog.svelte
@@ -9,6 +9,7 @@
 	import { toast } from 'svelte-sonner';
 	import { addEmailForm } from './data.remote';
 	import { emailSchema } from './email-schema';
+	import { translateRemoteFormIssues } from '$lib/utils/validation-i18n';
 
 	const { t } = getTranslate();
 
@@ -70,7 +71,10 @@
 						placeholder={$t('admin.settings.add_email_placeholder')}
 						data-testid="add-email-input"
 					/>
-					<Field.Error errors={addEmailForm.fields.email.issues()} data-testid="add-email-error" />
+					<Field.Error
+						errors={translateRemoteFormIssues(addEmailForm.fields.email.issues(), $t)}
+						data-testid="add-email-error"
+					/>
 				</Field.Field>
 			</Field.Group>
 			<Dialog.Footer>

--- a/src/routes/[[lang]]/admin/settings/data.remote.ts
+++ b/src/routes/[[lang]]/admin/settings/data.remote.ts
@@ -23,8 +23,9 @@ export const addEmailForm = form(emailSchema, async ({ email }, issue) => {
 		return { success: true };
 	} catch (err) {
 		if (err instanceof Error && err.message.includes('already exists')) {
-			// Return validation error - don't re-throw
-			return invalid(issue.email('This email already exists'));
+			// Return validation error - don't re-throw. The translation key is
+			// resolved client-side via translateRemoteFormIssues.
+			return invalid(issue.email('admin.settings.email_exists'));
 		}
 		throw err;
 	}

--- a/src/routes/[[lang]]/admin/settings/email-schema.ts
+++ b/src/routes/[[lang]]/admin/settings/email-schema.ts
@@ -6,5 +6,9 @@ import * as v from 'valibot';
  * client-side preflight validation in add-email-dialog.svelte
  */
 export const emailSchema = v.object({
-	email: v.pipe(v.string(), v.email('Please enter a valid email address'))
+	email: v.pipe(
+		v.string(),
+		v.nonEmpty('validation.email.required'),
+		v.email('validation.email.invalid')
+	)
 });

--- a/src/routes/[[lang]]/admin/settings/founder-welcome-card.svelte
+++ b/src/routes/[[lang]]/admin/settings/founder-welcome-card.svelte
@@ -11,6 +11,9 @@
 	import * as Field from '$lib/components/ui/field/index.js';
 	import { toast } from 'svelte-sonner';
 	import { tick } from 'svelte';
+	import { safeParse } from 'valibot';
+	import { emailSchema } from '$lib/schemas/auth';
+	import { translateFormError } from '$lib/utils/validation-i18n';
 	import { FOUNDER_WELCOME_DEFAULTS } from '$lib/convex/emails/helpers.js';
 
 	const { t } = getTranslate();
@@ -37,11 +40,19 @@
 		config?.enabled && config.contactUser.id !== viewer.data?._id
 	);
 
+	// Reply-to is optional: empty is valid, anything else must be a valid email
+	const replyToError = $derived.by(() => {
+		const value = editReplyTo.trim();
+		if (!value) return undefined;
+		return safeParse(emailSchema, value).success ? undefined : 'validation.email.invalid';
+	});
+
 	const canSave = $derived(
 		editName.trim() !== '' &&
 			editTitle.trim() !== '' &&
 			editSubject.trim() !== '' &&
-			editBody.trim() !== ''
+			editBody.trim() !== '' &&
+			!replyToError
 	);
 
 	// Live preview with sample data
@@ -79,7 +90,7 @@
 			await client.mutation(api.admin.founderWelcome.mutations.updateConfig, {
 				name: editName,
 				title: editTitle,
-				replyTo: editReplyTo || undefined,
+				replyTo: editReplyTo.trim() || undefined,
 				subject: editSubject,
 				body: editBody
 			});
@@ -180,6 +191,7 @@
 					placeholder={$t('admin.settings.founder_welcome.config_reply_to_placeholder')}
 					bind:value={editReplyTo}
 				/>
+				<Field.Error errors={translateFormError(replyToError, $t)} />
 			</Field.Field>
 			<Field.Field>
 				<Field.Label for="config-subject">

--- a/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
+++ b/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
@@ -255,7 +255,7 @@
 		testIdPrefix="admin-settings"
 		tableTestId="recipients-table"
 		searchValue={tableParams.search}
-		searchPlaceholder={$t('admin.users.search_placeholder')}
+		searchPlaceholder={$t('admin.settings.recipients_search_placeholder')}
 		onSearchChange={recipientsTable.setSearch}
 		pageIndex={recipientsTable.pageIndex}
 		pageCount={effectivePageCount}
@@ -268,7 +268,6 @@
 		onNextPage={recipientsTable.goNext}
 		onLastPage={recipientsTable.goLast}
 		onPageSizeChange={recipientsTable.setPageSize}
-		rowsPerPageLabel={$t('admin.users.rows_per_page')}
 		selectionText={$t('admin.settings.selected', {
 			selected: Object.keys(rowSelection).length,
 			total: totalCount

--- a/src/routes/[[lang]]/admin/users/+page.svelte
+++ b/src/routes/[[lang]]/admin/users/+page.svelte
@@ -517,7 +517,6 @@
 			onNextPage={usersTable.goNext}
 			onLastPage={usersTable.goLast}
 			onPageSizeChange={usersTable.setPageSize}
-			rowsPerPageLabel={$t('admin.users.rows_per_page')}
 			selectionText={$t('admin.users.selected', {
 				selected: Object.keys(rowSelection).length,
 				total: usersTable.hasLoadedCount

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -147,7 +147,7 @@
 								_creationTime: Date.now(),
 								userId: viewer.data!._id,
 								body: bodyToSend,
-								author: viewer.data!.name ?? 'You',
+								author: viewer.data!.name ?? $t('common.you'),
 								authorImage: viewer.data!.image ?? undefined
 							}
 						]);


### PR DESCRIPTION
Closes #467
Closes #468
Closes #470

Several surfaces bypassed Tolgee and rendered raw English in every locale. The reusable cursor table shell hardcoded `admin.users.*` keys plus an English rows-per-page prop default, so the notification recipients table showed "Search users..." and borrowed user-table labels. The signup name placeholder, the confirm-delete dialog texts and the optimistic chat author fallback were hardcoded. The admin add-email form showed untranslated validation errors at every layer, and an invalid founder welcome reply-to only failed server-side as a generic toast.

The table shell now uses a generic `table.*` namespace with a translated render-time fallback for the rows-per-page label, and the recipients table has its own search placeholder. The remaining hardcoded strings route through existing or new `common.*` keys. The add-email schema and handler return translation keys that a new `translateRemoteFormIssues` helper resolves through Tolgee at render time, following the existing `translateValidationErrors` pattern. The founder welcome reply-to field is validated client-side with the shared email schema, shows a translated inline error and disables save while invalid; empty stays valid. New keys exist in all four locales and were pushed to Tolgee tagged draft; the six superseded `admin.users.*` keys are removed locally and will be cleaned up remotely after merge.

The soft-deleted users point from #467 was already resolved by #503.

`bun run test:unit` and `bun scripts/static-checks.ts` pass.