### PR TITLE
fix(pricing): Sync free-tier copy with config and preserve checkout locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Sign in with email/password, Google, GitHub, or passkeys. Powered by [Better Aut
 
 ### Billing
 
-[Autumn](https://docs.useautumn.com/welcome) sits on top of Stripe and lets you define pricing tiers and usage gates without writing webhook handlers. Configure your products in `autumn.config.ts` or generate a starter config at [app.useautumn.com/sandbox/quickstart](https://app.useautumn.com/sandbox/quickstart). Ships with a Free tier (10 messages/month) and a Pro tier ($10/month, unlimited). The community chat enforces quotas, warns users when they are running low, and offers an upgrade flow.
+[Autumn](https://docs.useautumn.com/welcome) sits on top of Stripe and lets you define pricing tiers and usage gates without writing webhook handlers. Configure your products in `autumn.config.ts` or generate a starter config at [app.useautumn.com/sandbox/quickstart](https://app.useautumn.com/sandbox/quickstart). Ships with a Free tier (3 messages/month) and a Pro tier ($10/month, unlimited). The community chat enforces quotas, warns users when they are running low, and offers an upgrade flow.
 
 ### Admin Panel
 

--- a/autumn.config.ts
+++ b/autumn.config.ts
@@ -43,7 +43,7 @@ export const free = plan({
 });
 
 /**
- * Pro tier with unlimited community chat and 200 AI chat messages/month.
+ * Pro tier with unlimited community chat and 500 AI chat messages/month.
  */
 export const pro = plan({
 	id: 'pro',

--- a/src/blocks/pricing/pricing-three.svelte
+++ b/src/blocks/pricing/pricing-three.svelte
@@ -70,9 +70,11 @@
 		}
 
 		// Proceed with checkout for authenticated users
+		const successUrl = new URL(localizedHref('/app/community-chat'), page.url.origin);
+		successUrl.searchParams.set('upgraded', 'true');
 		const result = await upgradeOperation.execute({
 			productId,
-			successUrl: page.url.origin + '/app/community-chat?upgraded=true'
+			successUrl: successUrl.href
 		});
 
 		if (result?.url) {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -313,10 +313,6 @@
 			"placeholder": "Nachricht eingeben..."
 		},
 		"new_chat": "Neuer Chat",
-		"pro_required": {
-			"description": "Upgraden Sie auf Pro für 30 KI-Chat-Nachrichten pro Monat. Testen Sie kostenlos mit der Testkarte 4242 4242 4242 4242.",
-			"title": "Pro-Funktion"
-		},
 		"select_chat": "Wählen Sie eine Unterhaltung oder starten Sie einen neuen Chat",
 		"suggestion": {
 			"explain": "Erkläre etwas",
@@ -866,32 +862,18 @@
 				"2": "SLA-Garantien",
 				"3": "Erweiterte Sicherheitsfunktionen"
 			},
-			"enterprise[0]": "Individuelle Nachrichtenlimits",
-			"enterprise[1]": "Dedizierter Account Manager",
-			"enterprise[2]": "SLA-Garantien",
-			"enterprise[3]": "Erweiterte Sicherheitsfunktionen",
-			"enterprise[4]": "Benutzerdefinierte Integrationen",
-			"enterprise[5]": "White-Label-Optionen",
 			"free": {
 				"0": "3 Nachrichten pro Monat",
 				"1": "Vollständiger Quellcode-Zugriff",
 				"2": "Alle Funktionen enthalten",
 				"3": "MIT-Lizenz"
 			},
-			"free[0]": "10 Nachrichten pro Monat",
-			"free[1]": "Vollständiger Quellcode-Zugriff",
-			"free[2]": "Alle Funktionen enthalten",
-			"free[3]": "MIT-Lizenz",
 			"pro": {
 				"0": "Unbegrenzte Nachrichten",
 				"1": "Vollständiger Quellcode-Zugriff",
 				"2": "Alle Funktionen enthalten",
 				"3": "Priority-Support"
-			},
-			"pro[0]": "Unbegrenzte Nachrichten",
-			"pro[1]": "Vollständiger Quellcode-Zugriff",
-			"pro[2]": "Alle Funktionen enthalten",
-			"pro[3]": "Priority-Support"
+			}
 		},
 		"popular_badge": "Beliebt",
 		"section_label": "Preise",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -873,7 +873,7 @@
 			"enterprise[4]": "Benutzerdefinierte Integrationen",
 			"enterprise[5]": "White-Label-Optionen",
 			"free": {
-				"0": "10 Nachrichten pro Monat",
+				"0": "3 Nachrichten pro Monat",
 				"1": "Vollständiger Quellcode-Zugriff",
 				"2": "Alle Funktionen enthalten",
 				"3": "MIT-Lizenz"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -873,7 +873,7 @@
 			"enterprise[4]": "Custom integrations",
 			"enterprise[5]": "White-label options",
 			"free": {
-				"0": "10 messages per month",
+				"0": "3 messages per month",
 				"1": "Full source code access",
 				"2": "All features included",
 				"3": "MIT License"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -313,10 +313,6 @@
 			"placeholder": "Type a message..."
 		},
 		"new_chat": "New Chat",
-		"pro_required": {
-			"description": "Upgrade to Pro for 30 AI chat messages per month. Try it free with test card 4242 4242 4242 4242.",
-			"title": "Pro Feature"
-		},
 		"select_chat": "Select a conversation or start a new chat",
 		"suggestion": {
 			"explain": "Explain something",
@@ -866,32 +862,18 @@
 				"2": "SLA guarantees",
 				"3": "Advanced security features"
 			},
-			"enterprise[0]": "Custom message limits",
-			"enterprise[1]": "Dedicated account manager",
-			"enterprise[2]": "SLA guarantees",
-			"enterprise[3]": "Advanced security features",
-			"enterprise[4]": "Custom integrations",
-			"enterprise[5]": "White-label options",
 			"free": {
 				"0": "3 messages per month",
 				"1": "Full source code access",
 				"2": "All features included",
 				"3": "MIT License"
 			},
-			"free[0]": "10 messages per month",
-			"free[1]": "Full source code access",
-			"free[2]": "All features included",
-			"free[3]": "MIT License",
 			"pro": {
 				"0": "Unlimited messages",
 				"1": "Full source code access",
 				"2": "All features included",
 				"3": "Priority support"
-			},
-			"pro[0]": "Unlimited messages",
-			"pro[1]": "Full source code access",
-			"pro[2]": "All features included",
-			"pro[3]": "Priority support"
+			}
 		},
 		"popular_badge": "Popular",
 		"section_label": "Pricing",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -873,7 +873,7 @@
 			"enterprise[4]": "Integraciones personalizadas",
 			"enterprise[5]": "Opciones de marca blanca",
 			"free": {
-				"0": "10 mensajes por mes",
+				"0": "3 mensajes por mes",
 				"1": "Acceso completo al código fuente",
 				"2": "Todas las funciones incluidas",
 				"3": "Licencia MIT"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -313,10 +313,6 @@
 			"placeholder": "Escribe un mensaje..."
 		},
 		"new_chat": "Nuevo chat",
-		"pro_required": {
-			"description": "Actualiza a Pro para 30 mensajes de Chat IA al mes. Prueba gratis con la tarjeta de prueba 4242 4242 4242 4242.",
-			"title": "Función Pro"
-		},
 		"select_chat": "Selecciona una conversación o inicia un nuevo chat",
 		"suggestion": {
 			"explain": "Explica algo",
@@ -866,32 +862,18 @@
 				"2": "Garantías de SLA",
 				"3": "Funciones de seguridad avanzadas"
 			},
-			"enterprise[0]": "Límites de mensajes personalizados",
-			"enterprise[1]": "Gestor de cuenta dedicado",
-			"enterprise[2]": "Garantías de SLA",
-			"enterprise[3]": "Funciones de seguridad avanzadas",
-			"enterprise[4]": "Integraciones personalizadas",
-			"enterprise[5]": "Opciones de marca blanca",
 			"free": {
 				"0": "3 mensajes por mes",
 				"1": "Acceso completo al código fuente",
 				"2": "Todas las funciones incluidas",
 				"3": "Licencia MIT"
 			},
-			"free[0]": "10 mensajes por mes",
-			"free[1]": "Acceso completo al código fuente",
-			"free[2]": "Todas las funciones incluidas",
-			"free[3]": "Licencia MIT",
 			"pro": {
 				"0": "Mensajes ilimitados",
 				"1": "Acceso completo al código fuente",
 				"2": "Todas las funciones incluidas",
 				"3": "Soporte prioritario"
-			},
-			"pro[0]": "Mensajes ilimitados",
-			"pro[1]": "Acceso completo al código fuente",
-			"pro[2]": "Todas las funciones incluidas",
-			"pro[3]": "Soporte prioritario"
+			}
 		},
 		"popular_badge": "Popular",
 		"section_label": "Precios",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -313,10 +313,6 @@
 			"placeholder": "Tapez un message..."
 		},
 		"new_chat": "Nouveau chat",
-		"pro_required": {
-			"description": "Passez à Pro pour 30 messages Chat IA par mois. Essayez gratuitement avec la carte test 4242 4242 4242 4242.",
-			"title": "Fonction Pro"
-		},
 		"select_chat": "Sélectionnez une conversation ou démarrez un nouveau chat",
 		"suggestion": {
 			"explain": "Explique quelque chose",
@@ -866,32 +862,18 @@
 				"2": "Garanties SLA",
 				"3": "Fonctionnalités de sécurité avancées"
 			},
-			"enterprise[0]": "Limites de messages personnalisées",
-			"enterprise[1]": "Gestionnaire de compte dédié",
-			"enterprise[2]": "Garanties SLA",
-			"enterprise[3]": "Fonctionnalités de sécurité avancées",
-			"enterprise[4]": "Intégrations personnalisées",
-			"enterprise[5]": "Options de marque blanche",
 			"free": {
 				"0": "3 messages par mois",
 				"1": "Accès complet au code source",
 				"2": "Toutes les fonctionnalités incluses",
 				"3": "Licence MIT"
 			},
-			"free[0]": "10 messages par mois",
-			"free[1]": "Accès complet au code source",
-			"free[2]": "Toutes les fonctionnalités incluses",
-			"free[3]": "Licence MIT",
 			"pro": {
 				"0": "Messages illimités",
 				"1": "Accès complet au code source",
 				"2": "Toutes les fonctionnalités incluses",
 				"3": "Support prioritaire"
-			},
-			"pro[0]": "Messages illimités",
-			"pro[1]": "Accès complet au code source",
-			"pro[2]": "Toutes les fonctionnalités incluses",
-			"pro[3]": "Support prioritaire"
+			}
 		},
 		"popular_badge": "Populaire",
 		"section_label": "Tarifs",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -873,7 +873,7 @@
 			"enterprise[4]": "Intégrations personnalisées",
 			"enterprise[5]": "Options de marque blanche",
 			"free": {
-				"0": "10 messages par mois",
+				"0": "3 messages par mois",
 				"1": "Accès complet au code source",
 				"2": "Toutes les fonctionnalités incluses",
 				"3": "Licence MIT"

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -51,9 +51,11 @@
 
 	async function handleUpgrade() {
 		haptic.trigger('light');
+		const successUrl = new URL(localizedHref('/app/community-chat'), page.url.origin);
+		successUrl.searchParams.set('upgraded', 'true');
 		const result = await upgradeOperation.execute({
 			productId: 'pro',
-			successUrl: page.url.origin + '/app/community-chat?upgraded=true'
+			successUrl: successUrl.href
 		});
 		if (result?.url) {
 			window.location.href = result.url;

--- a/src/routes/[[lang]]/(marketing)/pricing/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/pricing/page.md.ts
@@ -16,7 +16,7 @@ export const marketingMarkdown: MarketingMarkdownDocument = {
 			heading: 'Free tier',
 			bullets: [
 				'Price: $0 per month',
-				'10 messages per month',
+				'3 messages per month',
 				'Full source code access',
 				'All features included',
 				'MIT License'


### PR DESCRIPTION
Closes #455
Closes #494

The pricing surfaces and the billing config disagreed, and two checkout call sites dropped the user's locale on return. The free tier copy advertised "10 messages per month" in all four locales, the agent-facing pricing markdown and the README, while `autumn.config.ts` grants only 3. The Pro docstring claimed "200 AI chat messages" while the item grants 500, and an orphaned `ai_chat.pro_required` key (claiming 30) was rendered nowhere. Separately, `nav-user.svelte` and the pricing block built the Autumn `successUrl` by concatenating the origin with a hardcoded `/app/community-chat`, so the post-checkout redirect lost the `[[lang]]` prefix and bounced through a 307 based on the browser's accept-language header.

The config is the enforced source of truth, so the free-tier count now reads 3 everywhere and the Pro docstring reads 500. The dead `ai_chat.pro_required` key and a parallel set of unused flat `free[n]`/`pro[n]`/`enterprise[n]` pricing keys (the component renders the nested tier objects via `getFeatureKeys`, never the flat ones) are removed from all four locale files. Both checkout call sites now build the success URL through `localizedHref('/app/community-chat')`, keeping the active locale and the existing community-chat destination, matching the in-page chat upgrade flows. The locale files are pushed to Tolgee after merge.

`bun run test:unit` (including locale parity) and `bun scripts/static-checks.ts` pass.