### PR TITLE
fix(convex): Rate-limit chat mutations and enforce community quota server-side

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -605,6 +605,7 @@
 			"upgrade_tooltip": "Auf Pro upgraden für unbegrenzte Nachrichten"
 		},
 		"messages": {
+			"rate_limited": "Sie senden zu schnell Nachrichten. Versuchen Sie es in {seconds}s erneut.",
 			"send_failed": "Nachricht konnte nicht gesendet werden",
 			"sent_success": "Nachricht gesendet!"
 		},

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -928,6 +928,7 @@
 		"account": {
 			"avatar": {
 				"alt": "Profilvorschau",
+				"rate_limited": "Zu viele Upload-Versuche. Versuchen Sie es in {seconds}s erneut.",
 				"ready": "Bild bereit zum Speichern",
 				"removed": "Bild entfernt - klicken Sie auf Speichern zur Bestätigung",
 				"select_error": "Bitte wählen Sie eine Bilddatei aus",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -928,6 +928,7 @@
 		"account": {
 			"avatar": {
 				"alt": "Profile preview",
+				"rate_limited": "Too many upload attempts. Try again in {seconds}s.",
 				"ready": "Image ready to save",
 				"removed": "Image removed - click Save to confirm",
 				"select_error": "Please select an image file",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -605,6 +605,7 @@
 			"upgrade_tooltip": "Upgrade to Pro for unlimited messages"
 		},
 		"messages": {
+			"rate_limited": "You're sending messages too fast. Try again in {seconds}s.",
 			"send_failed": "Failed to send message",
 			"sent_success": "Message sent!"
 		},

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -605,6 +605,7 @@
 			"upgrade_tooltip": "Actualiza a Pro para mensajes ilimitados"
 		},
 		"messages": {
+			"rate_limited": "Estás enviando mensajes demasiado rápido. Vuelve a intentarlo en {seconds}s.",
 			"send_failed": "Error al enviar mensaje",
 			"sent_success": "¡Mensaje enviado!"
 		},

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -928,6 +928,7 @@
 		"account": {
 			"avatar": {
 				"alt": "Vista previa del perfil",
+				"rate_limited": "Demasiados intentos de subida. Vuelve a intentarlo en {seconds}s.",
 				"ready": "Imagen lista para guardar",
 				"removed": "Imagen eliminada - haz clic en Guardar para confirmar",
 				"select_error": "Por favor selecciona un archivo de imagen",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -605,6 +605,7 @@
 			"upgrade_tooltip": "Passez à Pro pour des messages illimités"
 		},
 		"messages": {
+			"rate_limited": "Vous envoyez des messages trop vite. Réessayez dans {seconds}s.",
 			"send_failed": "Échec de l'envoi du message",
 			"sent_success": "Message envoyé !"
 		},

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -928,6 +928,7 @@
 		"account": {
 			"avatar": {
 				"alt": "Aperçu du profil",
+				"rate_limited": "Trop de tentatives d'envoi. Réessayez dans {seconds}s.",
 				"ready": "Image prête à enregistrer",
 				"removed": "Image supprimée - cliquez sur Enregistrer pour confirmer",
 				"select_error": "Veuillez sélectionner un fichier image",

--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -38,6 +38,9 @@
 	// A warm support thread is acquired on first keystroke and reused until submit.
 	let pendingThreadId = $state<string | null>(null);
 	let threadCreationPromise: Promise<string> | null = null;
+	// After a failed creation (e.g. rate limited), passive keystroke retries
+	// are suppressed until this timestamp; an explicit submit always retries.
+	let threadCreationBlockedUntil = 0;
 
 	// Query subscription for pre-warming cache (enables optimistic updates)
 	// The onUpdate return type is a function that can be called to unsubscribe
@@ -54,8 +57,10 @@
 		threadContext.requestWidgetOpen();
 
 		try {
-			// Wait for pending thread if still creating
-			const threadId = pendingThreadId || (await threadCreationPromise!);
+			// Wait for pending thread if still creating; if the first-keystroke
+			// attempt failed earlier, retry creation now instead of re-awaiting
+			// a cached rejection
+			const threadId = pendingThreadId ?? (await (threadCreationPromise ?? createWarmThread()));
 
 			// Update shared context (selectThread sets view='chat' + URL sync)
 			threadContext.selectThread(threadId);
@@ -80,6 +85,9 @@
 		} catch (error) {
 			console.error('[AI Chatbar] handleSubmit Error:', error);
 
+			// Restore the cleared input so the visitor's message is not lost
+			if (!input) input = trimmedPrompt;
+
 			// Handle rate limit errors with user-friendly toast
 			if (error instanceof ConvexError) {
 				const data = error.data as { code?: string; retryAfter?: number } | undefined;
@@ -97,41 +105,60 @@
 		}
 	}
 
+	function createWarmThread(): Promise<string> {
+		threadCreationPromise = client
+			.mutation(api.support.threads.getOrCreateWarmThread, {
+				anonymousUserId,
+				pageUrl: typeof window !== 'undefined' ? window.location.href : undefined
+			})
+			.then((result) => {
+				pendingThreadId = result.threadId;
+
+				// Pre-subscribe to messages query so it's cached by submit time
+				// This ensures optimistic update finds the query in cache
+				const preSubscribeArgs = {
+					threadId: result.threadId,
+					...(anonymousUserId ? { anonymousUserId } : {}),
+					paginationOpts: { numItems: 50, cursor: null },
+					streamArgs: { kind: 'list' as const, startOrder: 0 }
+				};
+				queryUnsubscribe = client.onUpdate(
+					api.support.messages.listMessages,
+					preSubscribeArgs,
+					() => {
+						// Query cache warmed
+					}
+				);
+
+				return result.threadId;
+			})
+			.catch((error) => {
+				console.error('[AI Chatbar] Thread creation failed:', error);
+				// Don't cache the rejection: clear the promise so a later submit or
+				// keystroke (after the cooldown) can retry instead of re-awaiting it
+				threadCreationPromise = null;
+				const data =
+					error instanceof ConvexError
+						? (error.data as { retryAfter?: number } | undefined)
+						: undefined;
+				threadCreationBlockedUntil = Date.now() + (data?.retryAfter ?? 30000);
+				throw error;
+			});
+		return threadCreationPromise;
+	}
+
 	function handleValueChange(value: string) {
 		input = value;
 
 		// Acquire a warm thread on first keystroke (or reuse the existing pending one)
-		if (value.trim() && !pendingThreadId && !threadCreationPromise) {
-			threadCreationPromise = client
-				.mutation(api.support.threads.getOrCreateWarmThread, {
-					anonymousUserId,
-					pageUrl: typeof window !== 'undefined' ? window.location.href : undefined
-				})
-				.then((result) => {
-					pendingThreadId = result.threadId;
-
-					// Pre-subscribe to messages query so it's cached by submit time
-					// This ensures optimistic update finds the query in cache
-					const preSubscribeArgs = {
-						threadId: result.threadId,
-						...(anonymousUserId ? { anonymousUserId } : {}),
-						paginationOpts: { numItems: 50, cursor: null },
-						streamArgs: { kind: 'list' as const, startOrder: 0 }
-					};
-					queryUnsubscribe = client.onUpdate(
-						api.support.messages.listMessages,
-						preSubscribeArgs,
-						() => {
-							// Query cache warmed
-						}
-					);
-
-					return result.threadId;
-				})
-				.catch((error) => {
-					console.error('[AI Chatbar] Thread creation failed:', error);
-					throw error;
-				});
+		if (
+			value.trim() &&
+			!pendingThreadId &&
+			!threadCreationPromise &&
+			Date.now() >= threadCreationBlockedUntil
+		) {
+			// Keystroke-time failure is non-fatal: submit retries and surfaces errors
+			createWarmThread().catch(() => {});
 		}
 	}
 

--- a/src/lib/convex/__tests__/messages.test.ts
+++ b/src/lib/convex/__tests__/messages.test.ts
@@ -27,10 +27,14 @@ vi.mock('../_generated/api', () => ({
 	}
 }));
 
+import { authComponent } from '../auth';
 import { getAutumnSdk } from '../autumn';
-import { enforceAndTrackMessageUsage, removeMessage } from '../messages';
+import { appRateLimiter } from '../rateLimit';
+import { enforceAndTrackMessageUsage, removeMessage, send } from '../messages';
 
+const getAuthUserMock = authComponent.getAuthUser as unknown as ReturnType<typeof vi.fn>;
 const getAutumnSdkMock = getAutumnSdk as unknown as ReturnType<typeof vi.fn>;
+const limitMock = appRateLimiter.limit as unknown as ReturnType<typeof vi.fn>;
 
 type RegisteredFunction<TArgs, TResult> = {
 	_handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
@@ -41,6 +45,7 @@ const enforceHandler = enforceAndTrackMessageUsage as unknown as RegisteredFunct
 	null
 >;
 const removeHandler = removeMessage as unknown as RegisteredFunction<{ messageId: string }, null>;
+const sendHandler = send as unknown as RegisteredFunction<{ body: string }, { messageId: string }>;
 
 // The quota backstop deletes user messages in a silent at-most-once scheduled
 // action, so its keep/remove decision must never regress: only a definitive
@@ -125,5 +130,43 @@ describe('removeMessage', () => {
 		await removeHandler._handler(ctx, { messageId: 'msg_1' });
 
 		expect(del).not.toHaveBeenCalled();
+	});
+});
+
+describe('send', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getAuthUserMock.mockResolvedValue({ _id: 'user_1' });
+		limitMock.mockResolvedValue({ ok: true, retryAfter: 0 });
+	});
+
+	it('rejects with a structured error when the rate limit is exhausted', async () => {
+		limitMock.mockResolvedValue({ ok: false, retryAfter: 12000 });
+		const insert = vi.fn();
+		const runAfter = vi.fn();
+		const ctx = { db: { insert }, scheduler: { runAfter } };
+
+		await expect(sendHandler._handler(ctx, { body: 'hello' })).rejects.toMatchObject({
+			data: { code: 'RATE_LIMITED', retryAfter: 12000 }
+		});
+		expect(insert).not.toHaveBeenCalled();
+		expect(runAfter).not.toHaveBeenCalled();
+	});
+
+	it('inserts the message and schedules the quota backstop with its id', async () => {
+		const insert = vi.fn().mockResolvedValue('msg_1');
+		const runAfter = vi.fn().mockResolvedValue(undefined);
+		const ctx = { db: { insert }, scheduler: { runAfter } };
+
+		const result = await sendHandler._handler(ctx, { body: 'hello' });
+
+		expect(result).toEqual({ messageId: 'msg_1' });
+		expect(limitMock).toHaveBeenCalledWith(expect.anything(), 'communityMessage', {
+			key: 'user_1'
+		});
+		expect(runAfter).toHaveBeenCalledWith(0, 'internal.messages.enforceAndTrackMessageUsage', {
+			userId: 'user_1',
+			messageId: 'msg_1'
+		});
 	});
 });

--- a/src/lib/convex/__tests__/messages.test.ts
+++ b/src/lib/convex/__tests__/messages.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../auth', () => ({
+	authComponent: {
+		getAuthUser: vi.fn(),
+		safeGetAuthUser: vi.fn()
+	}
+}));
+
+vi.mock('../autumn', () => ({
+	getAutumnSdk: vi.fn()
+}));
+
+vi.mock('../rateLimit', () => ({
+	appRateLimiter: {
+		limit: vi.fn().mockResolvedValue({ ok: true, retryAfter: 0 })
+	}
+}));
+
+vi.mock('../_generated/api', () => ({
+	components: {},
+	internal: {
+		messages: {
+			removeMessage: 'internal.messages.removeMessage',
+			enforceAndTrackMessageUsage: 'internal.messages.enforceAndTrackMessageUsage'
+		}
+	}
+}));
+
+import { getAutumnSdk } from '../autumn';
+import { enforceAndTrackMessageUsage, removeMessage } from '../messages';
+
+const getAutumnSdkMock = getAutumnSdk as unknown as ReturnType<typeof vi.fn>;
+
+type RegisteredFunction<TArgs, TResult> = {
+	_handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const enforceHandler = enforceAndTrackMessageUsage as unknown as RegisteredFunction<
+	{ userId: string; messageId: string },
+	null
+>;
+const removeHandler = removeMessage as unknown as RegisteredFunction<{ messageId: string }, null>;
+
+// The quota backstop deletes user messages in a silent at-most-once scheduled
+// action, so its keep/remove decision must never regress: only a definitive
+// not-allowed response from Autumn may remove a message. Missing data (HTTP
+// error) or a thrown network error must keep it.
+describe('enforceAndTrackMessageUsage', () => {
+	let check: ReturnType<typeof vi.fn>;
+	let track: ReturnType<typeof vi.fn>;
+	let runMutation: ReturnType<typeof vi.fn>;
+	let ctx: { runMutation: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		check = vi.fn();
+		track = vi.fn().mockResolvedValue(undefined);
+		runMutation = vi.fn().mockResolvedValue(null);
+		ctx = { runMutation };
+		getAutumnSdkMock.mockResolvedValue({ check, track });
+	});
+
+	it('tracks usage when the check allows the message', async () => {
+		check.mockResolvedValue({ data: { allowed: true } });
+
+		await enforceHandler._handler(ctx, { userId: 'user_1', messageId: 'msg_1' });
+
+		expect(track).toHaveBeenCalledWith({ customer_id: 'user_1', feature_id: 'messages', value: 1 });
+		expect(runMutation).not.toHaveBeenCalled();
+	});
+
+	it('removes the message only on a definitive not-allowed response', async () => {
+		check.mockResolvedValue({ data: { allowed: false } });
+
+		await enforceHandler._handler(ctx, { userId: 'user_1', messageId: 'msg_1' });
+
+		expect(runMutation).toHaveBeenCalledWith('internal.messages.removeMessage', {
+			messageId: 'msg_1'
+		});
+		expect(track).not.toHaveBeenCalled();
+	});
+
+	it('keeps and tracks the message when the check returns no data (HTTP error)', async () => {
+		check.mockResolvedValue({ data: null });
+
+		await enforceHandler._handler(ctx, { userId: 'user_1', messageId: 'msg_1' });
+
+		expect(runMutation).not.toHaveBeenCalled();
+		expect(track).toHaveBeenCalledWith({ customer_id: 'user_1', feature_id: 'messages', value: 1 });
+	});
+
+	it('keeps the message and skips tracking when the check throws (network error)', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		check.mockRejectedValue(new Error('network down'));
+
+		await expect(
+			enforceHandler._handler(ctx, { userId: 'user_1', messageId: 'msg_1' })
+		).resolves.toBeNull();
+
+		expect(runMutation).not.toHaveBeenCalled();
+		expect(track).not.toHaveBeenCalled();
+		warn.mockRestore();
+	});
+});
+
+describe('removeMessage', () => {
+	it('deletes an existing message', async () => {
+		const del = vi.fn().mockResolvedValue(undefined);
+		const ctx = {
+			db: { get: vi.fn().mockResolvedValue({ _id: 'msg_1' }), delete: del }
+		};
+
+		await removeHandler._handler(ctx, { messageId: 'msg_1' });
+
+		expect(del).toHaveBeenCalledWith('msg_1');
+	});
+
+	it('is a no-op when the message is already gone', async () => {
+		const del = vi.fn();
+		const ctx = {
+			db: { get: vi.fn().mockResolvedValue(null), delete: del }
+		};
+
+		await removeHandler._handler(ctx, { messageId: 'msg_1' });
+
+		expect(del).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/convex/aiChat/rateLimit.ts
+++ b/src/lib/convex/aiChat/rateLimit.ts
@@ -33,5 +33,14 @@ export const aiChatRateLimiter = new RateLimiter(components.rateLimiter, {
 		rate: 120,
 		period: HOUR,
 		capacity: 30
+	},
+
+	// Per-user thread creation (createThread + getOrCreateWarmThread)
+	// Token bucket: 10-thread burst, sustained 10/hour
+	aiChatThreadCreate: {
+		kind: 'token bucket',
+		rate: 10,
+		period: HOUR,
+		capacity: 10
 	}
 });

--- a/src/lib/convex/aiChat/threads.ts
+++ b/src/lib/convex/aiChat/threads.ts
@@ -1,10 +1,11 @@
-import { v } from 'convex/values';
+import { v, ConvexError } from 'convex/values';
 import { internalMutation } from '../_generated/server';
 import { authedQuery, authedMutation } from '../functions';
 import { aiChatAgent } from './agent';
 import { components } from '../_generated/api';
 import { requireAiChatThreadRecord } from './ownership';
 import { isVisibleAiChatThread } from './visibility';
+import { aiChatRateLimiter } from './rateLimit';
 
 // aiChatThreads is the feature registry for AI chat access and sidebar state.
 // agent:threads remains generic conversation storage/runtime shared across features.
@@ -61,6 +62,11 @@ export const createThread = authedMutation({
 	args: {},
 	handler: async (ctx) => {
 		const userId = ctx.user._id;
+
+		const status = await aiChatRateLimiter.limit(ctx, 'aiChatThreadCreate', { key: userId });
+		if (!status.ok) {
+			throw new ConvexError('Too many new chats. Please wait a moment.');
+		}
 
 		const { threadId } = await aiChatAgent.createThread(ctx, {
 			userId,
@@ -137,6 +143,12 @@ export const getOrCreateWarmThread = authedMutation({
 
 		if (existingWarm) {
 			return { threadId: existingWarm.threadId };
+		}
+
+		// Only the creation branch consumes a token; idempotent reads above don't
+		const status = await aiChatRateLimiter.limit(ctx, 'aiChatThreadCreate', { key: userId });
+		if (!status.ok) {
+			throw new ConvexError('Too many new chats. Please wait a moment.');
 		}
 
 		// No warm thread exists — create one

--- a/src/lib/convex/aiChat/threads.ts
+++ b/src/lib/convex/aiChat/threads.ts
@@ -1,4 +1,4 @@
-import { v, ConvexError } from 'convex/values';
+import { v } from 'convex/values';
 import { internalMutation } from '../_generated/server';
 import { authedQuery, authedMutation } from '../functions';
 import { aiChatAgent } from './agent';
@@ -6,6 +6,7 @@ import { components } from '../_generated/api';
 import { requireAiChatThreadRecord } from './ownership';
 import { isVisibleAiChatThread } from './visibility';
 import { aiChatRateLimiter } from './rateLimit';
+import { createRateLimitError } from '../support/types';
 
 // aiChatThreads is the feature registry for AI chat access and sidebar state.
 // agent:threads remains generic conversation storage/runtime shared across features.
@@ -65,7 +66,7 @@ export const createThread = authedMutation({
 
 		const status = await aiChatRateLimiter.limit(ctx, 'aiChatThreadCreate', { key: userId });
 		if (!status.ok) {
-			throw new ConvexError('Too many new chats. Please wait a moment.');
+			throw createRateLimitError(status.retryAfter, 'Too many new chats. Please wait a moment.');
 		}
 
 		const { threadId } = await aiChatAgent.createThread(ctx, {
@@ -148,7 +149,7 @@ export const getOrCreateWarmThread = authedMutation({
 		// Only the creation branch consumes a token; idempotent reads above don't
 		const status = await aiChatRateLimiter.limit(ctx, 'aiChatThreadCreate', { key: userId });
 		if (!status.ok) {
-			throw new ConvexError('Too many new chats. Please wait a moment.');
+			throw createRateLimitError(status.retryAfter, 'Too many new chats. Please wait a moment.');
 		}
 
 		// No warm thread exists — create one

--- a/src/lib/convex/messages.ts
+++ b/src/lib/convex/messages.ts
@@ -1,8 +1,10 @@
-import { internalAction } from './_generated/server';
+import { internalAction, internalMutation } from './_generated/server';
 import { v, ConvexError } from 'convex/values';
 import { components, internal } from './_generated/api';
 import { authedQuery, authedMutation } from './functions';
 import { getAutumnSdk } from './autumn';
+import { appRateLimiter } from './rateLimit';
+import { createRateLimitError } from './support/types';
 
 export const list = authedQuery({
 	args: {},
@@ -56,9 +58,12 @@ export const list = authedQuery({
 /**
  * Send a community chat message.
  *
- * Mutation (not action) so Convex optimistic updates work.
- * Billing is enforced client-side via Autumn customer balance;
- * usage tracking is scheduled as a fire-and-forget internalAction.
+ * Mutation (not action) so Convex optimistic updates work. The Autumn
+ * entitlement check needs an action context, so the message-quota
+ * backstop runs in the scheduled follow-up: it removes the inserted
+ * message when the sender is over their limit (only reachable by a
+ * direct API call that bypasses the client guard). A per-user rate
+ * limiter caps send frequency here in the mutation.
  */
 export const send = authedMutation({
 	args: { body: v.string() },
@@ -67,13 +72,19 @@ export const send = authedMutation({
 			throw new ConvexError('Message is too long (max 2000 characters)');
 		}
 
+		const status = await appRateLimiter.limit(ctx, 'communityMessage', { key: ctx.user._id });
+		if (!status.ok) {
+			throw createRateLimitError(status.retryAfter, 'Too many messages. Please wait a moment.');
+		}
+
 		const messageId = await ctx.db.insert('messages', {
 			body,
 			userId: ctx.user._id
 		});
 
-		await ctx.scheduler.runAfter(0, internal.messages.trackMessageUsage, {
-			userId: ctx.user._id
+		await ctx.scheduler.runAfter(0, internal.messages.enforceAndTrackMessageUsage, {
+			userId: ctx.user._id,
+			messageId
 		});
 
 		return { messageId };
@@ -81,17 +92,53 @@ export const send = authedMutation({
 });
 
 /**
- * Track community chat message usage via Autumn SDK.
- * Scheduled from the send mutation (fire-and-forget).
+ * Delete a community chat message. Internal only, used by the quota
+ * backstop to roll back an over-limit message.
  */
-export const trackMessageUsage = internalAction({
-	args: { userId: v.string() },
-	handler: async (_ctx, { userId }) => {
+export const removeMessage = internalMutation({
+	args: { messageId: v.id('messages') },
+	returns: v.null(),
+	handler: async (ctx, { messageId }) => {
+		const message = await ctx.db.get(messageId);
+		if (message) {
+			await ctx.db.delete(messageId);
+		}
+		return null;
+	}
+});
+
+/**
+ * Enforce the community chat message quota and track usage via Autumn.
+ * Scheduled from the send mutation. The entitlement check needs an
+ * action (HTTP), so enforcement happens here rather than in the
+ * mutation: over-limit messages are removed, allowed ones are tracked.
+ */
+export const enforceAndTrackMessageUsage = internalAction({
+	args: { userId: v.string(), messageId: v.id('messages') },
+	returns: v.null(),
+	handler: async (ctx, { userId, messageId }) => {
 		const sdk = await getAutumnSdk();
-		await sdk.track({
-			customer_id: userId,
-			feature_id: 'messages',
-			value: 1
-		});
+
+		let allowed = true;
+		try {
+			const result = await sdk.check({ customer_id: userId, feature_id: 'messages' });
+			// Only a definitive not-allowed response removes the message. A
+			// missing `data` (HTTP error) or a thrown network error keeps the
+			// message — never delete a legitimate message on a transient fault.
+			if (result.data && !result.data.allowed) {
+				allowed = false;
+			}
+		} catch (error) {
+			console.warn('[enforceAndTrackMessageUsage] Autumn check failed, keeping message:', error);
+			return null;
+		}
+
+		if (!allowed) {
+			await ctx.runMutation(internal.messages.removeMessage, { messageId });
+			return null;
+		}
+
+		await sdk.track({ customer_id: userId, feature_id: 'messages', value: 1 });
+		return null;
 	}
 });

--- a/src/lib/convex/messages.ts
+++ b/src/lib/convex/messages.ts
@@ -61,9 +61,12 @@ export const list = authedQuery({
  * Mutation (not action) so Convex optimistic updates work. The Autumn
  * entitlement check needs an action context, so the message-quota
  * backstop runs in the scheduled follow-up: it removes the inserted
- * message when the sender is over their limit (only reachable by a
- * direct API call that bypasses the client guard). A per-user rate
- * limiter caps send frequency here in the mutation.
+ * message when the sender is over their limit. That path is reached
+ * by direct API calls and by legitimate sends right at the quota
+ * boundary (the client guard reads a balance that only updates after
+ * the scheduled track lands), in which case the message briefly
+ * appears and is then removed. A per-user rate limiter caps send
+ * frequency here in the mutation.
  */
 export const send = authedMutation({
 	args: { body: v.string() },

--- a/src/lib/convex/rateLimit.ts
+++ b/src/lib/convex/rateLimit.ts
@@ -1,0 +1,36 @@
+import { RateLimiter, MINUTE, HOUR } from '@convex-dev/rate-limiter';
+import { components } from './_generated/api';
+
+/**
+ * Rate limiter for top-level app mutations (community chat, profile image).
+ *
+ * Per-user limits keyed by the authenticated user ID.
+ */
+export const appRateLimiter = new RateLimiter(components.rateLimiter, {
+	// Per-user community chat message rate
+	// Token bucket: 5-message burst, then 1 every 12s sustained
+	communityMessage: {
+		kind: 'token bucket',
+		rate: 5,
+		period: MINUTE,
+		capacity: 5
+	},
+
+	// Per-user profile image upload-URL minting
+	// Token bucket: 10-call burst, sustained 10/hour
+	profileImageUpload: {
+		kind: 'token bucket',
+		rate: 10,
+		period: HOUR,
+		capacity: 10
+	},
+
+	// Per-user profile image finalize/update
+	// Separate bucket from the upload-URL step (both are directly reachable)
+	profileImageUpdate: {
+		kind: 'token bucket',
+		rate: 10,
+		period: HOUR,
+		capacity: 10
+	}
+});

--- a/src/lib/convex/storage.ts
+++ b/src/lib/convex/storage.ts
@@ -4,6 +4,7 @@ import { PROFILE_IMAGE_ALLOWED_TYPES, PROFILE_IMAGE_MAX_SIZE } from './constants
 import { authComponent } from './auth';
 import { components } from './_generated/api';
 import { appRateLimiter } from './rateLimit';
+import { createRateLimitError } from './support/types';
 
 /**
  * Generate an upload URL for file uploads
@@ -23,7 +24,10 @@ export const generateUploadUrl = mutation({
 		}
 		const status = await appRateLimiter.limit(ctx, 'profileImageUpload', { key: user._id });
 		if (!status.ok) {
-			throw new ConvexError('Too many upload requests. Please try again later.');
+			throw createRateLimitError(
+				status.retryAfter,
+				'Too many upload requests. Please try again later.'
+			);
 		}
 		return await ctx.runMutation(components.convexFilesControl.upload.generateUploadUrl, {
 			provider: 'convex'
@@ -55,11 +59,14 @@ export const updateProfileImage = mutation({
 			throw new ConvexError('Unauthorized');
 		}
 
+		// No storage cleanup here: the throw aborts the transaction, so a delete
+		// would be rolled back anyway. The blob stays orphaned like any abandoned upload.
 		const status = await appRateLimiter.limit(ctx, 'profileImageUpdate', { key: user._id });
 		if (!status.ok) {
-			// Clean up orphaned storage before rejecting
-			await ctx.storage.delete(args.storageId);
-			throw new ConvexError('Too many upload requests. Please try again later.');
+			throw createRateLimitError(
+				status.retryAfter,
+				'Too many upload requests. Please try again later.'
+			);
 		}
 
 		const metadata = await ctx.db.system.get(args.storageId);

--- a/src/lib/convex/storage.ts
+++ b/src/lib/convex/storage.ts
@@ -3,6 +3,7 @@ import { v, ConvexError } from 'convex/values';
 import { PROFILE_IMAGE_ALLOWED_TYPES, PROFILE_IMAGE_MAX_SIZE } from './constants';
 import { authComponent } from './auth';
 import { components } from './_generated/api';
+import { appRateLimiter } from './rateLimit';
 
 /**
  * Generate an upload URL for file uploads
@@ -19,6 +20,10 @@ export const generateUploadUrl = mutation({
 		const user = await authComponent.getAuthUser(ctx);
 		if (!user) {
 			throw new ConvexError('Unauthorized');
+		}
+		const status = await appRateLimiter.limit(ctx, 'profileImageUpload', { key: user._id });
+		if (!status.ok) {
+			throw new ConvexError('Too many upload requests. Please try again later.');
 		}
 		return await ctx.runMutation(components.convexFilesControl.upload.generateUploadUrl, {
 			provider: 'convex'
@@ -48,6 +53,13 @@ export const updateProfileImage = mutation({
 			// Clean up orphaned storage before rejecting
 			await ctx.storage.delete(args.storageId);
 			throw new ConvexError('Unauthorized');
+		}
+
+		const status = await appRateLimiter.limit(ctx, 'profileImageUpdate', { key: user._id });
+		if (!status.ok) {
+			// Clean up orphaned storage before rejecting
+			await ctx.storage.delete(args.storageId);
+			throw new ConvexError('Too many upload requests. Please try again later.');
 		}
 
 		const metadata = await ctx.db.system.get(args.storageId);

--- a/src/lib/convex/support/__tests__/warmThread.test.ts
+++ b/src/lib/convex/support/__tests__/warmThread.test.ts
@@ -36,10 +36,12 @@ vi.mock('../../_generated/api', () => ({
 
 import { authComponent } from '../../auth';
 import { supportAgent } from '../agent';
+import { supportRateLimiter } from '../rateLimit';
 import { getOrCreateWarmThread } from '../threads';
 
 const safeGetAuthUserMock = authComponent.safeGetAuthUser as unknown as ReturnType<typeof vi.fn>;
 const createThreadMock = supportAgent.createThread as unknown as ReturnType<typeof vi.fn>;
+const limitMock = supportRateLimiter.limit as unknown as ReturnType<typeof vi.fn>;
 
 type MutationHandler<TArgs, TResult> = {
 	_handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
@@ -87,6 +89,9 @@ describe('support warm thread acquisition', () => {
 			notificationEmail: undefined
 		});
 		expect(createThreadMock).not.toHaveBeenCalled();
+		// The reuse branch must not consume a rate-limit token, otherwise
+		// warm-thread polling would drain the thread-creation bucket
+		expect(limitMock).not.toHaveBeenCalled();
 		expect(patch).toHaveBeenCalledWith('support_doc_1', {
 			pageUrl: 'https://example.com/new',
 			updatedAt: expect.any(Number)
@@ -122,6 +127,10 @@ describe('support warm thread acquisition', () => {
 			userId: 'anon_456',
 			title: 'Customer Support',
 			summary: 'New support conversation'
+		});
+		// The creation branch is rate limited; anonymous callers share a global bucket
+		expect(limitMock).toHaveBeenCalledWith(ctx, 'supportThreadCreateAnon', {
+			key: 'anonymous-global'
 		});
 		expect(insert).toHaveBeenCalledWith(
 			'supportThreads',

--- a/src/lib/convex/support/__tests__/warmThread.test.ts
+++ b/src/lib/convex/support/__tests__/warmThread.test.ts
@@ -12,6 +12,12 @@ vi.mock('../agent', () => ({
 	}
 }));
 
+vi.mock('../rateLimit', () => ({
+	supportRateLimiter: {
+		limit: vi.fn().mockResolvedValue({ ok: true, retryAfter: 0 })
+	}
+}));
+
 vi.mock('../../_generated/api', () => ({
 	components: {
 		betterAuth: {

--- a/src/lib/convex/support/rateLimit.ts
+++ b/src/lib/convex/support/rateLimit.ts
@@ -78,5 +78,23 @@ export const supportRateLimiter = new RateLimiter(components.rateLimiter, {
 		rate: 500,
 		period: MINUTE,
 		shards: 5
+	},
+
+	// Authenticated thread creation (createThread + getOrCreateWarmThread)
+	// Token bucket: 5-thread burst, sustained 10/hour
+	supportThreadCreate: {
+		kind: 'token bucket',
+		rate: 10,
+		period: HOUR,
+		capacity: 5
+	},
+
+	// Anonymous thread creation — GLOBAL shared bucket (spoofable client IDs)
+	// Token bucket: 10-thread burst, sustained 20/hour
+	supportThreadCreateAnon: {
+		kind: 'token bucket',
+		rate: 20,
+		period: HOUR,
+		capacity: 10
 	}
 });

--- a/src/lib/convex/support/rateLimit.ts
+++ b/src/lib/convex/support/rateLimit.ts
@@ -89,12 +89,16 @@ export const supportRateLimiter = new RateLimiter(components.rateLimiter, {
 		capacity: 5
 	},
 
-	// Anonymous thread creation — GLOBAL shared bucket (spoofable client IDs)
-	// Token bucket: 10-thread burst, sustained 20/hour
+	// Anonymous thread creation — GLOBAL shared bucket (spoofable client IDs).
+	// Sized for legitimate traffic: the marketing-page chatbar creates a warm
+	// thread on the first keystroke of every NEW anonymous visitor, so this
+	// gates the anon support entry point, not a rare secondary action. Thread
+	// creation is a cheap DB insert; LLM cost is capped separately (globalLLM).
+	// Token bucket: 30-thread burst, sustained 100/hour
 	supportThreadCreateAnon: {
 		kind: 'token bucket',
-		rate: 20,
+		rate: 100,
 		period: HOUR,
-		capacity: 10
+		capacity: 30
 	}
 });

--- a/src/lib/convex/support/threads.ts
+++ b/src/lib/convex/support/threads.ts
@@ -23,6 +23,28 @@ import {
 	buildSupportSearchText,
 	type SupportLatestThreadMessage
 } from './denormalization';
+import { supportRateLimiter } from './rateLimit';
+import { createRateLimitError } from './types';
+
+/**
+ * Rate-limit a support thread-creation path. Anonymous callers share a
+ * global bucket because their IDs are client-generated and spoofable.
+ */
+async function limitSupportThreadCreate(
+	ctx: MutationCtx,
+	owner: { ownerId: string; isAnonymous: boolean },
+	pageUrl?: string
+) {
+	const limitName = owner.isAnonymous ? 'supportThreadCreateAnon' : 'supportThreadCreate';
+	const key = owner.isAnonymous ? 'anonymous-global' : owner.ownerId;
+	const status = await supportRateLimiter.limit(ctx, limitName, { key });
+	if (!status.ok) {
+		throw createRateLimitError(
+			status.retryAfter,
+			t(extractLocaleFromUrl(pageUrl), 'backend.support.rate_limit.user')
+		);
+	}
+}
 
 // supportThreads is the source of truth for support thread membership and list rendering.
 // agent:threads remains shared runtime/storage used only for generic conversation metadata.
@@ -148,6 +170,7 @@ export const createThread = mutation({
 	}),
 	handler: async (ctx, args) => {
 		const owner = await requireSupportOwnerIdentity(ctx, args.anonymousUserId);
+		await limitSupportThreadCreate(ctx, owner, args.pageUrl);
 		return await createSupportThreadRecord(ctx, {
 			resolvedUserId: owner.ownerId,
 			isAnonymous: owner.isAnonymous,
@@ -195,6 +218,9 @@ export const getOrCreateWarmThread = mutation({
 				notificationEmail: existingWarm.notificationEmail
 			};
 		}
+
+		// Only the creation branch consumes a token; the idempotent read above doesn't
+		await limitSupportThreadCreate(ctx, owner, args.pageUrl);
 
 		return await createSupportThreadRecord(ctx, {
 			resolvedUserId: owner.ownerId,

--- a/src/lib/convex/support/threads.ts
+++ b/src/lib/convex/support/threads.ts
@@ -39,10 +39,12 @@ async function limitSupportThreadCreate(
 	const key = owner.isAnonymous ? 'anonymous-global' : owner.ownerId;
 	const status = await supportRateLimiter.limit(ctx, limitName, { key });
 	if (!status.ok) {
-		throw createRateLimitError(
-			status.retryAfter,
-			t(extractLocaleFromUrl(pageUrl), 'backend.support.rate_limit.user')
-		);
+		// Anonymous callers share a global bucket, so exhaustion is high demand,
+		// not the visitor's own message rate — use the global message for them.
+		const messageKey = owner.isAnonymous
+			? 'backend.support.rate_limit.global'
+			: 'backend.support.rate_limit.user';
+		throw createRateLimitError(status.retryAfter, t(extractLocaleFromUrl(pageUrl), messageKey));
 	}
 }
 

--- a/src/routes/[[lang]]/app/+layout.svelte
+++ b/src/routes/[[lang]]/app/+layout.svelte
@@ -6,7 +6,7 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { tick } from 'svelte';
+	import { tick, onDestroy } from 'svelte';
 	import { localizedHref } from '$lib/utils/i18n';
 	import { useQuery, useConvexClient } from '@mmailaender/convex-svelte';
 	import { api } from '$lib/convex/_generated/api';
@@ -40,6 +40,7 @@
 
 	let ensureWarmInFlight = $state(false);
 	let ensureWarmBlocked = $state(false);
+	let ensureWarmUnblockTimer: ReturnType<typeof setTimeout> | undefined;
 
 	$effect(() => {
 		if (warmThreadQuery.data === null && !ensureWarmInFlight && !ensureWarmBlocked && viewer) {
@@ -56,7 +57,7 @@
 						error instanceof ConvexError
 							? ((error.data as { retryAfter?: number })?.retryAfter ?? 60000)
 							: 60000;
-					setTimeout(() => {
+					ensureWarmUnblockTimer = setTimeout(() => {
 						ensureWarmBlocked = false;
 					}, retryAfter);
 				})
@@ -65,6 +66,8 @@
 				});
 		}
 	});
+
+	onDestroy(() => clearTimeout(ensureWarmUnblockTimer));
 
 	// Chat pages need fullControl (manage own scroll containers)
 	const fullControl = $derived(

--- a/src/routes/[[lang]]/app/+layout.svelte
+++ b/src/routes/[[lang]]/app/+layout.svelte
@@ -10,6 +10,7 @@
 	import { localizedHref } from '$lib/utils/i18n';
 	import { useQuery, useConvexClient } from '@mmailaender/convex-svelte';
 	import { api } from '$lib/convex/_generated/api';
+	import { ConvexError } from 'convex/values';
 	import { getTranslate } from '@tolgee/svelte';
 	import type { LayoutData } from './$types';
 	import type { Snippet } from 'svelte';
@@ -38,13 +39,30 @@
 	const warmThreadId = $derived(warmThreadQuery.data?.threadId ?? null);
 
 	let ensureWarmInFlight = $state(false);
+	let ensureWarmBlocked = $state(false);
 
 	$effect(() => {
-		if (warmThreadQuery.data === null && !ensureWarmInFlight && viewer) {
+		if (warmThreadQuery.data === null && !ensureWarmInFlight && !ensureWarmBlocked && viewer) {
 			ensureWarmInFlight = true;
-			client.mutation(api.aiChat.threads.getOrCreateWarmThread, {}).finally(() => {
-				ensureWarmInFlight = false;
-			});
+			client
+				.mutation(api.aiChat.threads.getOrCreateWarmThread, {})
+				.catch((error) => {
+					// Back off instead of retrying at network pace: the effect re-runs
+					// when ensureWarmInFlight resets while data is still null, so a
+					// deterministic failure (e.g. thread-create rate limit) would loop.
+					console.error('[app] Failed to ensure warm thread:', error);
+					ensureWarmBlocked = true;
+					const retryAfter =
+						error instanceof ConvexError
+							? ((error.data as { retryAfter?: number })?.retryAfter ?? 60000)
+							: 60000;
+					setTimeout(() => {
+						ensureWarmBlocked = false;
+					}, retryAfter);
+				})
+				.finally(() => {
+					ensureWarmInFlight = false;
+				});
 		}
 	});
 

--- a/src/routes/[[lang]]/app/ai-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/+page.svelte
@@ -5,6 +5,7 @@
 	import { resolve } from '$app/paths';
 	import { useQuery, useConvexClient } from '@mmailaender/convex-svelte';
 	import { api } from '$lib/convex/_generated/api';
+	import { ConvexError } from 'convex/values';
 	import { useCustomer, useAutumnOperation } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
 	import { getTranslate } from '@tolgee/svelte';
 	import { toast } from 'svelte-sonner';
@@ -41,9 +42,10 @@
 	// Fallback: if navigated to /ai-chat without ?thread= (e.g. direct URL), get warm thread.
 	// The common path (sidebar click) already includes ?thread=warmId, so this rarely fires.
 	let resolvingThread = $state(false);
+	let resolveThreadBlocked = $state(false);
 
 	$effect(() => {
-		if (!threadId && !resolvingThread && viewer.data) {
+		if (!threadId && !resolvingThread && !resolveThreadBlocked && viewer.data) {
 			resolvingThread = true;
 			client
 				.mutation(api.aiChat.threads.getOrCreateWarmThread, {})
@@ -53,7 +55,18 @@
 					goto(resolve(url.pathname + url.search), { noScroll: true, replaceState: true });
 				})
 				.catch((err) => {
+					// Back off instead of retrying at network pace: the effect re-runs
+					// when resolvingThread resets while threadId is still empty, so a
+					// deterministic failure (e.g. thread-create rate limit) would loop.
 					console.error('[ai-chat] Failed to resolve warm thread:', err);
+					resolveThreadBlocked = true;
+					const retryAfter =
+						err instanceof ConvexError
+							? ((err.data as { retryAfter?: number })?.retryAfter ?? 60000)
+							: 60000;
+					setTimeout(() => {
+						resolveThreadBlocked = false;
+					}, retryAfter);
 				})
 				.finally(() => {
 					resolvingThread = false;

--- a/src/routes/[[lang]]/app/ai-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import SEOHead from '$lib/components/SEOHead.svelte';
+	import { onDestroy } from 'svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
@@ -43,6 +44,7 @@
 	// The common path (sidebar click) already includes ?thread=warmId, so this rarely fires.
 	let resolvingThread = $state(false);
 	let resolveThreadBlocked = $state(false);
+	let resolveThreadUnblockTimer: ReturnType<typeof setTimeout> | undefined;
 
 	$effect(() => {
 		if (!threadId && !resolvingThread && !resolveThreadBlocked && viewer.data) {
@@ -64,7 +66,7 @@
 						err instanceof ConvexError
 							? ((err.data as { retryAfter?: number })?.retryAfter ?? 60000)
 							: 60000;
-					setTimeout(() => {
+					resolveThreadUnblockTimer = setTimeout(() => {
 						resolveThreadBlocked = false;
 					}, retryAfter);
 				})
@@ -73,6 +75,8 @@
 				});
 		}
 	});
+
+	onDestroy(() => clearTimeout(resolveThreadUnblockTimer));
 
 	async function handleUpgrade() {
 		haptic.trigger('light');

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -29,6 +29,7 @@
 	import { page } from '$app/state';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import type { OptimisticLocalStore } from 'convex/browser';
+	import { ConvexError } from 'convex/values';
 	import type { Id } from '$lib/convex/_generated/dataModel';
 
 	const { t } = getTranslate();
@@ -158,7 +159,15 @@
 		} catch (error) {
 			console.error('Failed to send message:', error);
 			haptic.trigger('error');
-			toast.error($t('chat.messages.send_failed'));
+			if (
+				error instanceof ConvexError &&
+				(error.data as { code?: string })?.code === 'RATE_LIMITED'
+			) {
+				const retryAfter = (error.data as { retryAfter?: number }).retryAfter ?? 60000;
+				toast.error($t('chat.messages.rate_limited', { seconds: Math.ceil(retryAfter / 1000) }));
+			} else {
+				toast.error($t('chat.messages.send_failed'));
+			}
 		} finally {
 			isSending = false;
 		}

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -159,6 +159,8 @@
 		} catch (error) {
 			console.error('Failed to send message:', error);
 			haptic.trigger('error');
+			// Restore the draft so the user can retry without retyping
+			if (!inputValue) inputValue = bodyToSend;
 			if (
 				error instanceof ConvexError &&
 				(error.data as { code?: string })?.code === 'RATE_LIMITED'

--- a/src/routes/[[lang]]/app/settings/account-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/account-settings.svelte
@@ -9,6 +9,7 @@
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { useConvexClient } from '@mmailaender/convex-svelte';
 	import { api } from '$lib/convex/_generated/api.js';
+	import { ConvexError } from 'convex/values';
 	import { PROFILE_IMAGE_MAX_SIZE, PROFILE_IMAGE_MAX_SIZE_LABEL } from '$lib/convex/constants.js';
 
 	const { t } = getTranslate();
@@ -84,10 +85,20 @@
 			haptic.trigger('success');
 			toast.success($t('settings.account.avatar.ready'));
 		} catch (error) {
-			const message =
-				error instanceof Error ? error.message : $t('settings.account.avatar.upload_failed');
 			haptic.trigger('error');
-			toast.error(message);
+			if (
+				error instanceof ConvexError &&
+				(error.data as { code?: string })?.code === 'RATE_LIMITED'
+			) {
+				const retryAfter = (error.data as { retryAfter?: number }).retryAfter ?? 60000;
+				toast.error(
+					$t('settings.account.avatar.rate_limited', { seconds: Math.ceil(retryAfter / 1000) })
+				);
+			} else {
+				const message =
+					error instanceof Error ? error.message : $t('settings.account.avatar.upload_failed');
+				toast.error(message);
+			}
 			target.value = '';
 		} finally {
 			isUploading = false;


### PR DESCRIPTION
Closes #451
Closes #495

The community chat send mutation enforced the free-tier message quota only on the client and, unlike its AI chat and support siblings, had no rate limiter, so a direct `api.messages.send` call could flood the shared channel and bypass the limit entirely. The same missing-rate-limiter gap existed in five more mutations: both profile image storage mutations, and `createThread` plus `getOrCreateWarmThread` in both the support and AI chat features, where the warm-thread variant would otherwise sidestep a createThread-only limit.

Every one of these mutations now calls a per-user rate limiter at the top, keyed on the authenticated user (a shared global bucket for spoofable anonymous support callers, sized for the marketing-page chatbar that creates a warm thread on a new visitor's first keystroke). Thread-creation limits only consume a token on the actual creation branch so idempotent warm-thread reads stay free. The Autumn entitlement check needs an action context, so community chat quota enforcement runs in the already-scheduled follow-up rather than the mutation: it removes an over-limit message and tracks usage only when the send is allowed. That backstop is reached by direct API calls and by legitimate sends right at the quota boundary, where the message briefly appears and is then removed; a failed Autumn check never deletes a legitimate message, and the decision logic is unit-tested.

All rate-limit errors are structured with a retryAfter so clients can react: community chat and the avatar settings show translated toasts with the retry time and restore the user's input, the warm-thread auto-creation effects in the app layout and the ai-chat page back off instead of retrying at network pace, and the support chatbar clears its cached creation promise on failure so one rejected thread creation no longer disables it until reload.

`bun run check:convex`, `bun run test:unit` (including locale parity and the new backstop tests) and `bun scripts/static-checks.ts` pass.