### PR TITLE
fix(convex): Count Autumn usage atomically with the entitlement check

### DIFF
--- a/src/lib/convex/__tests__/autumn.test.ts
+++ b/src/lib/convex/__tests__/autumn.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../env', () => ({
+	requireEnv: vi.fn(() => 'sk_test')
+}));
+
+vi.mock('../auth', () => ({
+	authComponent: {
+		getAuthUser: vi.fn()
+	}
+}));
+
+vi.mock('../_generated/api', () => ({
+	components: { autumn: {} },
+	internal: {}
+}));
+
+vi.mock('@useautumn/convex', () => ({
+	Autumn: class {
+		api() {
+			return {};
+		}
+	}
+}));
+
+const check = vi.fn();
+const track = vi.fn();
+
+// The autumn-js factory only runs when getAutumnSdk() dynamically
+// imports it inside a test, so the mocks above are initialized by then
+vi.mock('autumn-js', () => ({
+	Autumn: class {
+		check = check;
+		track = track;
+	}
+}));
+
+import { checkAndCountUsage, refundUsage } from '../autumn';
+
+// checkAndCountUsage wraps Autumn's atomic check-with-send_event. The
+// outcome mapping is the single place that decides between counted,
+// denied, and fail-open behavior for every metered feature, so each
+// branch is pinned here. Call sites only branch on the outcome
+// (covered in messages.test.ts and createAIResponse.test.ts).
+describe('checkAndCountUsage', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('sends an atomic check and maps allowed to counted', async () => {
+		check.mockResolvedValue({ data: { allowed: true } });
+
+		const outcome = await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages' });
+
+		expect(outcome).toBe('counted');
+		expect(check).toHaveBeenCalledWith({
+			customer_id: 'user_1',
+			feature_id: 'messages',
+			required_balance: 1,
+			send_event: true
+		});
+	});
+
+	it('maps a definitive not-allowed response to denied', async () => {
+		check.mockResolvedValue({ data: { allowed: false } });
+
+		const outcome = await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages' });
+
+		expect(outcome).toBe('denied');
+	});
+
+	it('maps a missing data payload (non-2xx response) to unavailable', async () => {
+		check.mockResolvedValue({ data: null });
+
+		const outcome = await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages' });
+
+		expect(outcome).toBe('unavailable');
+	});
+
+	it('maps a thrown network error to unavailable', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		check.mockRejectedValue(new Error('network down'));
+
+		const outcome = await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages' });
+
+		expect(outcome).toBe('unavailable');
+		warn.mockRestore();
+	});
+
+	it('passes a custom value as the deducted amount', async () => {
+		check.mockResolvedValue({ data: { allowed: true } });
+
+		await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages', value: 3 });
+
+		expect(check).toHaveBeenCalledWith(expect.objectContaining({ required_balance: 3 }));
+	});
+});
+
+describe('refundUsage', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('credits the balance with a negative track value', async () => {
+		track.mockResolvedValue({ data: {} });
+
+		await refundUsage({ customerId: 'user_1', featureId: 'ai_chat_messages' });
+
+		expect(track).toHaveBeenCalledWith({
+			customer_id: 'user_1',
+			feature_id: 'ai_chat_messages',
+			value: -1
+		});
+	});
+
+	it('never throws: a failed refund is logged, not propagated', async () => {
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		track.mockRejectedValue(new Error('network down'));
+
+		await expect(
+			refundUsage({ customerId: 'user_1', featureId: 'ai_chat_messages', value: 2 })
+		).resolves.toBeUndefined();
+
+		expect(track).toHaveBeenCalledWith(expect.objectContaining({ value: -2 }));
+		error.mockRestore();
+	});
+});

--- a/src/lib/convex/__tests__/messages.test.ts
+++ b/src/lib/convex/__tests__/messages.test.ts
@@ -8,7 +8,7 @@ vi.mock('../auth', () => ({
 }));
 
 vi.mock('../autumn', () => ({
-	getAutumnSdk: vi.fn()
+	checkAndCountUsage: vi.fn()
 }));
 
 vi.mock('../rateLimit', () => ({
@@ -28,12 +28,12 @@ vi.mock('../_generated/api', () => ({
 }));
 
 import { authComponent } from '../auth';
-import { getAutumnSdk } from '../autumn';
+import { checkAndCountUsage } from '../autumn';
 import { appRateLimiter } from '../rateLimit';
 import { enforceAndTrackMessageUsage, removeMessage, send } from '../messages';
 
 const getAuthUserMock = authComponent.getAuthUser as unknown as ReturnType<typeof vi.fn>;
-const getAutumnSdkMock = getAutumnSdk as unknown as ReturnType<typeof vi.fn>;
+const checkAndCountUsageMock = checkAndCountUsage as unknown as ReturnType<typeof vi.fn>;
 const limitMock = appRateLimiter.limit as unknown as ReturnType<typeof vi.fn>;
 
 type RegisteredFunction<TArgs, TResult> = {
@@ -49,63 +49,49 @@ const sendHandler = send as unknown as RegisteredFunction<{ body: string }, { me
 
 // The quota backstop deletes user messages in a silent at-most-once scheduled
 // action, so its keep/remove decision must never regress: only a definitive
-// not-allowed response from Autumn may remove a message. Missing data (HTTP
-// error) or a thrown network error must keep it.
+// 'denied' outcome may remove a message. 'unavailable' (Autumn outage) must
+// keep it. The outcome mapping itself is covered in __tests__/autumn.test.ts;
+// usage is counted by the atomic check, so no separate track call exists.
 describe('enforceAndTrackMessageUsage', () => {
-	let check: ReturnType<typeof vi.fn>;
-	let track: ReturnType<typeof vi.fn>;
 	let runMutation: ReturnType<typeof vi.fn>;
 	let ctx: { runMutation: ReturnType<typeof vi.fn> };
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		check = vi.fn();
-		track = vi.fn().mockResolvedValue(undefined);
 		runMutation = vi.fn().mockResolvedValue(null);
 		ctx = { runMutation };
-		getAutumnSdkMock.mockResolvedValue({ check, track });
 	});
 
-	it('tracks usage when the check allows the message', async () => {
-		check.mockResolvedValue({ data: { allowed: true } });
+	it('keeps a counted message without any follow-up call', async () => {
+		checkAndCountUsageMock.mockResolvedValue('counted');
 
 		await enforceHandler._handler(ctx, { userId: 'user_1', messageId: 'msg_1' });
 
-		expect(track).toHaveBeenCalledWith({ customer_id: 'user_1', feature_id: 'messages', value: 1 });
+		expect(checkAndCountUsageMock).toHaveBeenCalledWith({
+			customerId: 'user_1',
+			featureId: 'messages'
+		});
 		expect(runMutation).not.toHaveBeenCalled();
 	});
 
-	it('removes the message only on a definitive not-allowed response', async () => {
-		check.mockResolvedValue({ data: { allowed: false } });
+	it('removes the message only on a definitive denial', async () => {
+		checkAndCountUsageMock.mockResolvedValue('denied');
 
 		await enforceHandler._handler(ctx, { userId: 'user_1', messageId: 'msg_1' });
 
 		expect(runMutation).toHaveBeenCalledWith('internal.messages.removeMessage', {
 			messageId: 'msg_1'
 		});
-		expect(track).not.toHaveBeenCalled();
 	});
 
-	it('keeps and tracks the message when the check returns no data (HTTP error)', async () => {
-		check.mockResolvedValue({ data: null });
-
-		await enforceHandler._handler(ctx, { userId: 'user_1', messageId: 'msg_1' });
-
-		expect(runMutation).not.toHaveBeenCalled();
-		expect(track).toHaveBeenCalledWith({ customer_id: 'user_1', feature_id: 'messages', value: 1 });
-	});
-
-	it('keeps the message and skips tracking when the check throws (network error)', async () => {
-		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-		check.mockRejectedValue(new Error('network down'));
+	it('keeps the message uncounted when Autumn is unavailable', async () => {
+		checkAndCountUsageMock.mockResolvedValue('unavailable');
 
 		await expect(
 			enforceHandler._handler(ctx, { userId: 'user_1', messageId: 'msg_1' })
 		).resolves.toBeNull();
 
 		expect(runMutation).not.toHaveBeenCalled();
-		expect(track).not.toHaveBeenCalled();
-		warn.mockRestore();
 	});
 });
 

--- a/src/lib/convex/aiChat/__tests__/createAIResponse.test.ts
+++ b/src/lib/convex/aiChat/__tests__/createAIResponse.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../auth', () => ({
+	authComponent: {
+		getAuthUser: vi.fn(),
+		safeGetAuthUser: vi.fn()
+	}
+}));
+
+vi.mock('../../autumn', () => ({
+	checkAndCountUsage: vi.fn(),
+	refundUsage: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('../agent', () => ({
+	aiChatAgent: {
+		streamText: vi.fn()
+	}
+}));
+
+vi.mock('../rateLimit', () => ({
+	aiChatRateLimiter: {
+		limit: vi.fn().mockResolvedValue({ ok: true, retryAfter: 0 })
+	}
+}));
+
+vi.mock('../ownership', () => ({
+	requireAiChatThreadRecord: vi.fn()
+}));
+
+vi.mock('../../support/messageListing', () => ({
+	listMessagesForThread: vi.fn()
+}));
+
+vi.mock('@convex-dev/agent', () => ({
+	getFile: vi.fn()
+}));
+
+vi.mock('@convex-dev/agent/validators', async () => {
+	const { v } = await import('convex/values');
+	return { vStreamArgs: v.optional(v.any()) };
+});
+
+vi.mock('../../_generated/api', () => ({
+	components: {},
+	internal: {
+		aiChat: {
+			threads: {
+				updateThreadMetadata: 'internal.aiChat.threads.updateThreadMetadata'
+			},
+			messages: {
+				createAIResponse: 'internal.aiChat.messages.createAIResponse'
+			}
+		}
+	}
+}));
+
+import { checkAndCountUsage, refundUsage } from '../../autumn';
+import { aiChatAgent } from '../agent';
+import { createAIResponse } from '../messages';
+
+const checkAndCountUsageMock = checkAndCountUsage as unknown as ReturnType<typeof vi.fn>;
+const refundUsageMock = refundUsage as unknown as ReturnType<typeof vi.fn>;
+const streamTextMock = aiChatAgent.streamText as unknown as ReturnType<typeof vi.fn>;
+
+type RegisteredFunction<TArgs> = {
+	_handler: (ctx: unknown, args: TArgs) => Promise<unknown>;
+};
+
+const handler = createAIResponse as unknown as RegisteredFunction<{
+	threadId: string;
+	promptMessageId: string;
+	userId?: string;
+}>;
+
+const args = { threadId: 'thread_1', promptMessageId: 'prompt_1', userId: 'user_1' };
+
+// The AI chat usage unit is counted atomically BEFORE the multi-second
+// stream (see checkAndCountUsage), so the failure path must refund it:
+// a failed generation never costs a message, and a delivered response
+// is never refunded by later denormalization errors.
+describe('createAIResponse', () => {
+	let runMutation: ReturnType<typeof vi.fn>;
+	let ctx: { runMutation: ReturnType<typeof vi.fn> };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		refundUsageMock.mockResolvedValue(undefined);
+		runMutation = vi.fn().mockResolvedValue(null);
+		ctx = { runMutation };
+		streamTextMock.mockResolvedValue({
+			consumeStream: vi.fn().mockResolvedValue(undefined),
+			text: Promise.resolve('Hello there')
+		});
+	});
+
+	it('skips generation entirely when the quota is denied', async () => {
+		checkAndCountUsageMock.mockResolvedValue('denied');
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		await handler._handler(ctx, args);
+
+		expect(streamTextMock).not.toHaveBeenCalled();
+		expect(refundUsageMock).not.toHaveBeenCalled();
+		warn.mockRestore();
+	});
+
+	it('generates and keeps the counted unit on success', async () => {
+		checkAndCountUsageMock.mockResolvedValue('counted');
+
+		await handler._handler(ctx, args);
+
+		expect(checkAndCountUsageMock).toHaveBeenCalledWith({
+			customerId: 'user_1',
+			featureId: 'ai_chat_messages'
+		});
+		expect(streamTextMock).toHaveBeenCalled();
+		expect(refundUsageMock).not.toHaveBeenCalled();
+		expect(runMutation).toHaveBeenCalledWith(
+			'internal.aiChat.threads.updateThreadMetadata',
+			expect.objectContaining({ threadId: 'thread_1', lastMessage: 'Hello there' })
+		);
+	});
+
+	it('refunds the counted unit when generation fails', async () => {
+		checkAndCountUsageMock.mockResolvedValue('counted');
+		streamTextMock.mockRejectedValue(new Error('model exploded'));
+
+		await expect(handler._handler(ctx, args)).rejects.toThrow('model exploded');
+
+		expect(refundUsageMock).toHaveBeenCalledWith({
+			customerId: 'user_1',
+			featureId: 'ai_chat_messages'
+		});
+	});
+
+	it('does not refund a failed generation that was never counted (outage)', async () => {
+		checkAndCountUsageMock.mockResolvedValue('unavailable');
+		streamTextMock.mockRejectedValue(new Error('model exploded'));
+
+		await expect(handler._handler(ctx, args)).rejects.toThrow('model exploded');
+
+		// Fail-open path: generation ran uncounted, so there is nothing to credit back
+		expect(refundUsageMock).not.toHaveBeenCalled();
+	});
+
+	it('does not refund when only denormalization fails after a delivered response', async () => {
+		checkAndCountUsageMock.mockResolvedValue('counted');
+		runMutation.mockRejectedValue(new Error('metadata write failed'));
+
+		await expect(handler._handler(ctx, args)).rejects.toThrow('metadata write failed');
+
+		// The stream was consumed, the response is saved: the unit is earned
+		expect(refundUsageMock).not.toHaveBeenCalled();
+	});
+
+	it('skips billing entirely without a userId', async () => {
+		await handler._handler(ctx, { threadId: 'thread_1', promptMessageId: 'prompt_1' });
+
+		expect(checkAndCountUsageMock).not.toHaveBeenCalled();
+		expect(streamTextMock).toHaveBeenCalled();
+	});
+});

--- a/src/lib/convex/aiChat/messages.ts
+++ b/src/lib/convex/aiChat/messages.ts
@@ -11,7 +11,7 @@ import { aiChatRateLimiter } from './rateLimit';
 import { listMessagesForThread } from '../support/messageListing';
 import { authedMutation } from '../functions';
 import { authComponent } from '../auth';
-import { getAutumnSdk } from '../autumn';
+import { checkAndCountUsage, refundUsage } from '../autumn';
 import { requireAiChatThreadRecord } from './ownership';
 
 const THREAD_PREVIEW_LENGTH = 100;
@@ -121,8 +121,12 @@ export const sendMessage = authedMutation({
 /**
  * Internal action to generate AI response with streaming.
  *
- * Checks Autumn billing before generating (action can make HTTP calls).
- * Tracks usage after successful response.
+ * Counts the AI chat message in one atomic Autumn call before
+ * generating (see `checkAndCountUsage` for the concurrency semantics;
+ * a separate check-before plus track-after pair would let concurrent
+ * sends race past the limit during the multi-second stream). If
+ * generation fails after the unit was counted, the unit is refunded
+ * so a failed response never costs a message.
  */
 export const createAIResponse = internalAction({
 	args: {
@@ -131,33 +135,48 @@ export const createAIResponse = internalAction({
 		userId: v.optional(v.string())
 	},
 	handler: async (ctx, args) => {
-		// Check AI chat message allowance via direct SDK (no auth context in internalAction).
-		// See: https://github.com/useautumn/autumn-js/issues/51
+		// Direct SDK path with explicit customer_id (no auth context in
+		// internalAction). See: https://github.com/useautumn/autumn-js/issues/51
+		let usageCounted = false;
 		if (args.userId) {
-			const sdk = await getAutumnSdk();
-			const checkResult = await sdk.check({
-				customer_id: args.userId,
-				feature_id: 'ai_chat_messages'
+			const outcome = await checkAndCountUsage({
+				customerId: args.userId,
+				featureId: 'ai_chat_messages'
 			});
-			if (checkResult.data && !checkResult.data.allowed) {
+			if (outcome === 'denied') {
 				console.warn(`[createAIResponse] AI chat limit reached for user ${args.userId}`);
 				return;
 			}
+			// 'unavailable' fails open: generate uncounted rather than blocking
+			// a legitimate user on a billing outage
+			usageCounted = outcome === 'counted';
 		}
 
-		const result = await aiChatAgent.streamText(
-			ctx,
-			{ threadId: args.threadId, userId: args.userId },
-			{ promptMessageId: args.promptMessageId },
-			{
-				saveStreamDeltas: {
-					chunking: 'line',
-					throttleMs: 100
+		let result;
+		try {
+			result = await aiChatAgent.streamText(
+				ctx,
+				{ threadId: args.threadId, userId: args.userId },
+				{ promptMessageId: args.promptMessageId },
+				{
+					saveStreamDeltas: {
+						chunking: 'line',
+						throttleMs: 100
+					}
 				}
-			}
-		);
+			);
 
-		await result.consumeStream();
+			await result.consumeStream();
+		} catch (error) {
+			// The unit was counted up front; a failed generation must not cost
+			// a message. The refund window ends here: once the stream is
+			// consumed the response is saved, so later denormalization errors
+			// don't refund a delivered message.
+			if (args.userId && usageCounted) {
+				await refundUsage({ customerId: args.userId, featureId: 'ai_chat_messages' });
+			}
+			throw error;
+		}
 
 		// Denormalize: update thread sidebar metadata with the AI's response.
 		// Trim and skip an empty preview so a whitespace-only response never lands
@@ -169,16 +188,6 @@ export const createAIResponse = internalAction({
 				threadId: args.threadId,
 				lastMessage: responsePreview,
 				lastMessageAt: Date.now()
-			});
-		}
-
-		// Track usage after successful AI response
-		if (args.userId) {
-			const sdk = await getAutumnSdk();
-			await sdk.track({
-				customer_id: args.userId,
-				feature_id: 'ai_chat_messages',
-				value: 1
 			});
 		}
 	}

--- a/src/lib/convex/autumn.ts
+++ b/src/lib/convex/autumn.ts
@@ -52,3 +52,87 @@ export async function getAutumnSdk() {
 	const { Autumn: AutumnSDK } = await import('autumn-js');
 	return new AutumnSDK({ secretKey });
 }
+
+/** Outcome of an atomic check-and-count usage call. */
+export type UsageCheckOutcome = 'counted' | 'denied' | 'unavailable';
+
+/**
+ * Atomically check access to a metered feature and count its usage.
+ *
+ * Wraps Autumn's `check` with `send_event: true`, which deducts `value`
+ * units and computes `allowed` in one server-side operation with
+ * overage behavior "reject". Deciding and deducting are a single
+ * atomic step on Autumn's side, so concurrent calls serialize there:
+ * with N units left, exactly N calls get 'counted' and the rest get
+ * 'denied'. A separate check-then-track pair would race instead (all
+ * concurrent checks read the same stale balance before any track
+ * lands, letting every one of them pass).
+ *
+ * Outcomes:
+ * - 'counted': access granted, `value` units were deducted. The usage
+ *   is recorded; no separate track call must follow.
+ * - 'denied': access denied, nothing was deducted.
+ * - 'unavailable': Autumn errored (the SDK returns `data: null` on a
+ *   non-2xx response and throws on network failures). Nothing was
+ *   deducted. Callers fail open: grant access uncounted rather than
+ *   punishing legitimate users for a billing outage.
+ *
+ * Only valid for metered features with a usage amount known up front
+ * (Autumn rejects `send_event` for boolean features and publishable
+ * keys). If the operation the usage pays for can still fail afterwards,
+ * compensate with `refundUsage` in the failure path.
+ */
+export async function checkAndCountUsage({
+	customerId,
+	featureId,
+	value = 1
+}: {
+	customerId: string;
+	featureId: string;
+	value?: number;
+}): Promise<UsageCheckOutcome> {
+	const sdk = await getAutumnSdk();
+	let result;
+	try {
+		result = await sdk.check({
+			customer_id: customerId,
+			feature_id: featureId,
+			// Doubles as the deducted amount when send_event is true
+			required_balance: value,
+			send_event: true
+		});
+	} catch (error) {
+		console.warn(`[checkAndCountUsage] Autumn unreachable for ${featureId}:`, error);
+		return 'unavailable';
+	}
+	if (!result.data) {
+		return 'unavailable';
+	}
+	return result.data.allowed ? 'counted' : 'denied';
+}
+
+/**
+ * Credit back usage previously counted by `checkAndCountUsage`, for
+ * when the operation the usage paid for failed afterwards. Negative
+ * track values credit the balance (documented Autumn behavior).
+ *
+ * Best effort: a failed refund is logged, never thrown, so it cannot
+ * mask the original failure. The cost of a lost refund is one unit on
+ * a double fault (operation AND refund both failed).
+ */
+export async function refundUsage({
+	customerId,
+	featureId,
+	value = 1
+}: {
+	customerId: string;
+	featureId: string;
+	value?: number;
+}): Promise<void> {
+	try {
+		const sdk = await getAutumnSdk();
+		await sdk.track({ customer_id: customerId, feature_id: featureId, value: -value });
+	} catch (error) {
+		console.error(`[refundUsage] Failed to refund ${value} ${featureId} for ${customerId}:`, error);
+	}
+}

--- a/src/lib/convex/messages.ts
+++ b/src/lib/convex/messages.ts
@@ -2,7 +2,7 @@ import { internalAction, internalMutation } from './_generated/server';
 import { v, ConvexError } from 'convex/values';
 import { components, internal } from './_generated/api';
 import { authedQuery, authedMutation } from './functions';
-import { getAutumnSdk } from './autumn';
+import { checkAndCountUsage } from './autumn';
 import { appRateLimiter } from './rateLimit';
 import { createRateLimitError } from './support/types';
 
@@ -60,13 +60,13 @@ export const list = authedQuery({
  *
  * Mutation (not action) so Convex optimistic updates work. The Autumn
  * entitlement check needs an action context, so the message-quota
- * backstop runs in the scheduled follow-up: it removes the inserted
- * message when the sender is over their limit. That path is reached
- * by direct API calls and by legitimate sends right at the quota
- * boundary (the client guard reads a balance that only updates after
- * the scheduled track lands), in which case the message briefly
- * appears and is then removed. A per-user rate limiter caps send
- * frequency here in the mutation.
+ * backstop runs in the scheduled follow-up: it atomically counts the
+ * message and removes it when the sender is over their limit. That
+ * path is reached by direct API calls and by legitimate sends right
+ * at the quota boundary (the client guard reads a balance that only
+ * updates after the scheduled enforcement lands), in which case the
+ * message briefly appears and is then removed. A per-user rate
+ * limiter caps send frequency here in the mutation.
  */
 export const send = authedMutation({
 	args: { body: v.string() },
@@ -111,37 +111,25 @@ export const removeMessage = internalMutation({
 });
 
 /**
- * Enforce the community chat message quota and track usage via Autumn.
+ * Enforce the community chat message quota and count the usage.
+ *
  * Scheduled from the send mutation. The entitlement check needs an
  * action (HTTP), so enforcement happens here rather than in the
- * mutation: over-limit messages are removed, allowed ones are tracked.
+ * mutation. Counting and deciding happen in one atomic Autumn call
+ * (see `checkAndCountUsage` for the concurrency semantics):
+ * - 'counted': the message was within quota and is now recorded.
+ * - 'denied': nothing was deducted, remove the over-limit message.
+ * - 'unavailable': nothing was deducted, keep the message uncounted.
+ *   Never delete a legitimate message on a transient billing fault.
  */
 export const enforceAndTrackMessageUsage = internalAction({
 	args: { userId: v.string(), messageId: v.id('messages') },
 	returns: v.null(),
 	handler: async (ctx, { userId, messageId }) => {
-		const sdk = await getAutumnSdk();
-
-		let allowed = true;
-		try {
-			const result = await sdk.check({ customer_id: userId, feature_id: 'messages' });
-			// Only a definitive not-allowed response removes the message. A
-			// missing `data` (HTTP error) or a thrown network error keeps the
-			// message — never delete a legitimate message on a transient fault.
-			if (result.data && !result.data.allowed) {
-				allowed = false;
-			}
-		} catch (error) {
-			console.warn('[enforceAndTrackMessageUsage] Autumn check failed, keeping message:', error);
-			return null;
-		}
-
-		if (!allowed) {
+		const outcome = await checkAndCountUsage({ customerId: userId, featureId: 'messages' });
+		if (outcome === 'denied') {
 			await ctx.runMutation(internal.messages.removeMessage, { messageId });
-			return null;
 		}
-
-		await sdk.track({ customer_id: userId, feature_id: 'messages', value: 1 });
 		return null;
 	}
 });


### PR DESCRIPTION
The community chat quota backstop and the AI chat response action both enforced metered features with a read-only Autumn check followed by a separate track call. Between the two HTTP calls every concurrent request reads the same stale balance, so with one unit left, N parallel sends all pass and overshoot the limit. For AI chat the window spans the entire multi-second stream.

Autumn closes this server-side: a check with send_event deducts the usage and computes allowed in one atomic operation with overage behavior reject, so concurrent calls serialize and exactly the remaining quota passes. The new checkAndCountUsage helper in autumn.ts wraps this and documents the semantics once: counted (usage recorded), denied (nothing deducted), or unavailable (Autumn errored, nothing deducted, callers fail open). refundUsage credits a unit back via a negative track value, which Autumn documents for exactly this purpose.

The community backstop now removes a message only on a definitive denied outcome. createAIResponse counts the unit before generating and refunds it when generation fails, so a failed response never costs a message. The refund window ends once the stream is consumed, so a delivered response is never refunded by later denormalization errors. A thrown check now also fails open for AI chat and generation proceeds uncounted instead of the action dying before the stream.

The remaining Autumn call sites were audited: the title generation check stays intentionally check-only (its usage unit is tracked by the response path) and the client-side useCustomer gates are advisory UI state.

See also: #451, #507

`bun run check:convex`, `bun run test:unit` and `bun scripts/static-checks.ts` pass.