### PR TITLE
chore(btca): Migrate from btca CLI to btca-local skill

### DIFF
--- a/.agents/skills/btca-local/SKILL.md
+++ b/.agents/skills/btca-local/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: btca-local
+description: Invoke this skill when the user says "use btca"
+---
+
+# BTCA Local
+
+BTCA Local, aka "The Better Context App Local" is a simple app defined as a skill file. The purpose of this app is to search git repos cloned onto this machine.
+
+## the BTCA Search Workflow
+
+<guidelines>
+    <guideline>
+        if the user includes a direct like to a github repo, always load and reference that
+    </guideline>
+    <guideline>
+        if the user doesn't include any specific links/repos they want you to use, do your best to guess based on the context provided
+    </guideline>
+    <guideline>
+        always include links/citations in your answers explaining what you found
+    </guideline>
+    <guideline>
+        include very clear and complete code snippets. don't leave out stuff like imports, that's important context
+    </guideline>
+    <guideline>
+        when answering use lots of bulleted/numbered lists to keep things readable and clear
+    </guideline>
+</guidelines>
+
+<workflow>
+    <step name="work dir setup">
+        use ~/.btca/agent/sandbox as the place where you clone/search repos
+    </step>
+    <step name="load">
+        if the repo(s) are already in the work dir ~/.btca/agent/sandbox update them, otherwise clone them. clone the main branch by default, unless the user asks for something else
+    </step>
+    <step name="search">
+        search the repo for the information you need. make sure to follow the guidelines
+    </step>
+<workflow>
+
+<end_goal>
+a clear, concise answer to the question with code examples
+</end_goal>
+
+## Startup Cases:
+
+This skill can be invoked in a couple different ways, and your behavior should reflect that:
+
+### user invoked without extra context/question
+
+this is the "app startup" state, almost as if a terminal app was booted up.
+
+Your job is to search the working directory ~/.btca/agent/sandbox at the top level, just to get a list of all the repos that have been previously cloned
+
+Then you should simply output the following markdown (filling in the existing repos):
+
+```md
+# BTCA Local
+
+_use your coding agent to search any git repo locally_
+
+Previously searched:
+
+- repo 1
+- ...
+
+Give me a question and the link to a git repo to get started!
+(we can also clean out or pre-load some resources to this list...)
+```
+
+### you invoked because of user's prompt
+
+in this case, your job is to answer/execute the users prompt faithfully, just while also using the btca search workflow when needed to better execute your task
+
+### user invoked while also giving a prompt/questions
+
+this one's simple, simply answer the users prompt with the btca search workflow

--- a/.claude/skills/btca-local
+++ b/.claude/skills/btca-local
@@ -1,0 +1,1 @@
+../../.agents/skills/btca-local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,25 +20,9 @@ All npm scripts must work on macOS, Linux, and Windows. Avoid `sh -c` or bash-sp
 
 ## btca
 
-When you need up-to-date information about technologies used in this project, use btca to query source repositories directly.
+When you need up-to-date information about technologies used in this project, use the `btca-local` skill to search the actual source repos. `btca.config.jsonc` is the resource registry; every resource is pre-cloned at `~/.btca/agent/sandbox/<resourceName>`. "Use btca with `<resource>` resource" means: search that clone.
 
-Run `btca resources` to get the full list of all configured resources.
-
-### Usage
-
-```bash
-btca ask -r <resource> -q "<question>"
-```
-
-Use multiple `-r` flags to query multiple resources at once:
-
-```bash
-btca ask -r svelte -r convex -q "How do I integrate Convex with SvelteKit?"
-```
-
-**Branch config:** When adding a new resource, verify the repo's default branch (`gh api repos/OWNER/REPO --jq '.default_branch'`). btca assumes `main` and fails silently on repos using `master`, `dev`, etc. Always set the `branch` field explicitly.
-
-**New dependencies:** When adding a new dependency or devDependency, always add its repo to btca and verify with a simple test question (`btca ask -r <name> -q "<test>"`). If the query fails or returns irrelevant results, check that the `branch` field matches the repo's default branch and that the model config is correct. This keeps btca comprehensive across all project deps.
+**New dependencies:** When adding a new dependency or devDependency, always add its repo to `btca.config.jsonc` (verify the default branch first: `gh api repos/OWNER/REPO --jq '.default_branch'`) and clone it into the sandbox. This keeps btca comprehensive across all project deps.
 
 ## Workflow
 

--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -1,6 +1,7 @@
 {
-	"$schema": "https://btca.dev/btca.schema.json",
-	"providerTimeoutMs": 300000,
+	// Resource manifest for the btca-local skill: repos pre-cloned into
+	// ~/.btca/agent/sandbox/<name>. The skill defaults to main, so non-main
+	// default branches must be pinned here.
 	"resources": [
 		{
 			"type": "git",
@@ -181,7 +182,7 @@
 			"type": "git",
 			"name": "convexStripe",
 			"url": "https://github.com/get-convex/stripe",
-			"branch": "master",
+			"branch": "main",
 			"specialNotes": "Stripe payments. Subscriptions, checkout, webhooks, customer portal."
 		},
 		{
@@ -435,7 +436,5 @@
 			"branch": "main",
 			"specialNotes": "WASM image codecs (WebP/AVIF/JPEG/PNG/JXL/OXIPNG/QOI). Used for client-side encode in workers. Each codec is a separate package under packages/ — @jsquash/webp at packages/webp."
 		}
-	],
-	"model": "gpt-5.4-mini",
-	"provider": "openai"
+	]
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
 	"version": 1,
 	"skills": {
+		"btca-local": {
+			"source": "davis7dotsh/better-context",
+			"sourceType": "github",
+			"skillPath": "skills/btca-local/SKILL.md",
+			"computedHash": "1888cc18192c3e0356fd8a4333b5e8ea60524f920a8dbc9c203c39d7e8de7e56"
+		},
 		"email-and-password-best-practices": {
 			"source": "better-auth/skills",
 			"sourceType": "github",


### PR DESCRIPTION
The project documented btca usage through the btca CLI (`btca ask -r <resource> -q "<question>"`). Upstream replaced the local app with a skill, so those commands no longer exist and the AGENTS.md instructions were dead.

This installs the `btca-local` skill (symlinked for Claude Code, tracked in `skills-lock.json`) and trims the AGENTS.md btca section to the skill approach: every resource is pre-cloned as a shallow clone at `~/.btca/agent/sandbox/<resourceName>`, named after its entry in `btca.config.jsonc`, so "use btca with X resource" now means searching that clone. The config file is reduced to a pure resource manifest; the CLI-only fields (`$schema`, `providerTimeoutMs`, `model`, `provider`) are removed. The `convexStripe` entry pinned branch `master`, which no longer exists on `get-convex/stripe`; it now pins `main`.

All 62 manifest resources clone successfully into the sandbox (61 shallow clones plus the `sveltekit` symlink) and the trimmed config parses. `bunx prettier --check AGENTS.md btca.config.jsonc skills-lock.json` passes.