### PR TITLE
refactor(convex): Remove unused schema indexes

### DIFF
--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -58,10 +58,7 @@ export default defineSchema({
 		adminUserId: v.string(), // Admin who created the note
 		content: v.string(), // Note content
 		createdAt: v.number() // Timestamp when note was created
-	})
-		.index('by_user', ['userId'])
-		.index('by_admin', ['adminUserId'])
-		.index('by_created', ['createdAt']),
+	}).index('by_user', ['userId']),
 
 	// Support feature registry.
 	// Source of truth for support thread membership, access, and denormalized list/search data.
@@ -71,10 +68,8 @@ export default defineSchema({
 		.index('by_user', ['userId'])
 		.index('by_user_warm', ['userId', 'isWarm'])
 		.index('by_user_and_updated', ['userId', 'updatedAt'])
-		.index('by_status', ['status'])
 		.index('by_assigned', ['assignedTo'])
 		.index('by_status_and_assigned', ['status', 'assignedTo'])
-		.index('by_created', ['createdAt'])
 		.index('by_handed_off_and_status', ['isHandedOff', 'status'])
 		.index('by_needs_response', ['isHandedOff', 'status', 'awaitingAdminResponse'])
 		.searchIndex('search_all', {
@@ -140,10 +135,7 @@ export default defineSchema({
 		width: v.optional(v.number()),
 		height: v.optional(v.number()),
 		createdAt: v.number()
-	})
-		.index('by_fileId', ['fileId'])
-		.index('by_storageId', ['storageId'])
-		.index('by_url', ['url']),
+	}).index('by_url', ['url']),
 
 	// Dashboard counters - singleton for materialized user metrics
 	// Updated atomically via auth triggers (onCreate, onUpdate) to avoid


### PR DESCRIPTION
Closes #462

The Convex schema defined six indexes that no query ever reads: `by_admin` and `by_created` on `internalUserNotes` (only `by_user` is queried in `admin/support/queries.ts`), `by_fileId` and `by_storageId` on `fileMetadata` (all three lookup sites in `aiChat/messages.ts`, `support/messages.ts`, and `support/files.ts` use `by_url`), and `by_status` and `by_created` on `supportThreads` (`by_status_and_assigned` covers status lookups, and the cleanup path orders by the built-in `by_creation_time`). Every dead index adds write-time maintenance cost on each insert and patch, and as a reference repo this normalizes speculative indexing.

This PR removes those six indexes from `src/lib/convex/schema.ts`. No query code changes are needed since nothing referenced them, and Convex drops removed indexes automatically on the next deploy, so there is no migration. The write-only `adminAuditLogs` table from the issue is deferred because its disposition (build an audit view, remove the table, or keep it dashboard-inspectable) is a maintainer decision entangled with #484. The `fileMetadata` indexes can be re-added if the row cleanup for #460 ends up needing `by_fileId` or `by_storageId`.

`bun scripts/static-checks.ts src/lib/convex/schema.ts`, `bun run check:convex`, and `bun run test:unit` (486 tests) all pass.
