### PR TITLE
fix(ci): Pass CF check-run summary via env block

### DIFF
--- a/.github/workflows/e2e-preview-cf.yml
+++ b/.github/workflows/e2e-preview-cf.yml
@@ -50,8 +50,9 @@ jobs:
           ref: ${{ github.event.check_run.head_sha }}
 
       - name: Extract preview URL
+        env:
+          SUMMARY: ${{ github.event.check_run.output.summary }}
         run: |
-          SUMMARY="${{ github.event.check_run.output.summary }}"
           PREVIEW_URL=$(echo "$SUMMARY" | grep 'Preview Alias URL:' | sed 's/.*Preview Alias URL: //' | tr -d '[:space:]')
           if [ -z "$PREVIEW_URL" ]; then
             echo "::error::No Preview Alias URL found in check_run output"


### PR DESCRIPTION
Closes #481

The `Extract preview URL` step in `.github/workflows/e2e-preview-cf.yml` assigned `SUMMARY="${{ github.event.check_run.output.summary }}"` inline, so GitHub Actions substituted the Cloudflare check-run summary into the script text before bash parsed it. The summary embeds branch and deployment data that anyone who can push a branch controls, and a double quote or `$(...)` in it would break out of the assignment and run arbitrary commands in a job that holds `statuses: write` and exposes `AUTH_E2E_TEST_SECRET`, `CF_ACCESS_CLIENT_ID`, and `CF_ACCESS_CLIENT_SECRET`. The `check_run` trigger runs with base-repo secrets regardless of fork origin, so fork PRs reach this sink too.

The summary is now passed to the step through an `env:` block and the script reads the quoted `"$SUMMARY"` variable, so the value never enters the parsed script body and expansion is injection-safe. The remaining `run:` interpolations in the file are `github.repository`, `check_run.head_sha`, `job.status`, and `github.run_id`, all GitHub-generated values (a GitHub-generated hex SHA), and the other `github.event` uses sit in `if:` conditions and a `with: ref:` input, none of which are shell sinks.

`bun scripts/static-checks.ts .github/workflows/e2e-preview-cf.yml` passes, and `actionlint` reports no new findings beyond the pre-existing runner-label and SC2086/SC2129 notes already present on `main`. The extraction itself runs unchanged on the next CF preview build that triggers this workflow.

