### PR TITLE
refactor(convex): Remove dead emailEvents indexes

### DIFF
--- a/src/lib/convex/emails/send.ts
+++ b/src/lib/convex/emails/send.ts
@@ -272,7 +272,7 @@ export const sendNewUserSignupNotification = internalMutation({
 		// (5 retries, 30s backoff). Its idempotency key is the per-enqueue email record id,
 		// so it only dedupes retries of an already-enqueued email. Duplicate-send safety
 		// across re-runs of this loop comes from Convex's exactly-once scheduled-mutation
-		// execution (scheduled from the auth onCreate trigger, auth.ts).
+		// execution (scheduled from the auth onCreate/onUpdate triggers, auth.ts).
 		let sentCount = 0;
 		for (const email of recipients) {
 			try {

--- a/src/lib/convex/emails/send.ts
+++ b/src/lib/convex/emails/send.ts
@@ -268,8 +268,11 @@ export const sendNewUserSignupNotification = internalMutation({
 		});
 
 		// Send to each recipient
-		// Note: The Resend component handles retries internally via workpool (5 retries, 30s backoff)
-		// and uses idempotency keys for exactly-once delivery
+		// Note: The Resend component retries transient failures internally via workpool
+		// (5 retries, 30s backoff). Its idempotency key is the per-enqueue email record id,
+		// so it only dedupes retries of an already-enqueued email. Duplicate-send safety
+		// across re-runs of this loop comes from Convex's exactly-once scheduled-mutation
+		// execution (scheduled from the auth onCreate trigger, auth.ts).
 		let sentCount = 0;
 		for (const email of recipients) {
 			try {

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -14,15 +14,15 @@ export default defineSchema({
 	}).index('by_user', ['userId']),
 
 	// Email event tracking - stores webhook events from Resend
+	// Intentionally write-only for now: inspect events via the Convex dashboard.
+	// by_email_id is the documented read path (AGENTS.md Email Event Tracking);
+	// add a query on it when needed.
 	emailEvents: defineTable({
 		emailId: v.string(), // Resend email ID
 		eventType: v.string(), // 'email.delivered', 'email.bounced', etc.
 		timestamp: v.number(), // When the event occurred
 		data: vEmailEvent // Full event payload from Resend
-	})
-		.index('by_email_id', ['emailId'])
-		.index('by_event_type', ['eventType'])
-		.index('by_timestamp', ['timestamp']),
+	}).index('by_email_id', ['emailId']),
 
 	// Admin audit logs - tracks admin actions for accountability
 	adminAuditLogs: defineTable({


### PR DESCRIPTION
Closes #463

The `emailEvents` table stores Resend webhook events but nothing reads it. Its schema declared three indexes (`by_email_id`, `by_event_type`, `by_timestamp`) for a documented `getEmailEvents` query that never existed, so two of the indexes are pure write overhead on every webhook event. In the same module, the comment above the multi-recipient signup-notification loop in `src/lib/convex/emails/send.ts` claimed the Resend idempotency key makes the loop safe to re-run, which misattributes the actual safety mechanism.

This removes the unused `by_event_type` and `by_timestamp` indexes from `emailEvents` and keeps `by_email_id`, which `AGENTS.md` already documents as the read path to use when a query is added. A schema comment marks the table as intentionally write-only so the missing query is not re-flagged. The send comment now explains that the Resend idempotency key only dedupes workpool retries of an already-enqueued email, and that re-run safety of the loop comes from Convex's exactly-once execution of scheduled mutations (scheduled from the auth `onCreate`/`onUpdate` triggers in `auth.ts`). Adding a real `getEmailEvents` query is deferred until something needs it, matching the `AGENTS.md` wording from #501.

`bun scripts/static-checks.ts src/lib/convex/schema.ts src/lib/convex/emails/send.ts`, `bun run check:convex`, and `bun run test:unit` (486 tests) all pass.

