### PR TITLE
fix(convex): Delete fileMetadata in file vacuum

### DIFF
--- a/src/lib/convex/files/__tests__/vacuum.test.ts
+++ b/src/lib/convex/files/__tests__/vacuum.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../_generated/api', () => ({
+	components: {
+		agent: {
+			files: {
+				getFilesToDelete: 'components.agent.files.getFilesToDelete',
+				deleteFiles: 'components.agent.files.deleteFiles'
+			}
+		}
+	},
+	internal: {
+		files: {
+			vacuum: {
+				deleteUnusedFiles: 'internal.files.vacuum.deleteUnusedFiles'
+			}
+		}
+	}
+}));
+
+import { deleteUnusedFiles } from '../vacuum';
+
+type MutationHandler<TArgs, TResult> = {
+	_handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const deleteUnusedFilesHandler = deleteUnusedFiles as unknown as MutationHandler<
+	{ cursor?: string },
+	void
+>;
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+type MetadataRow = { _id: string; storageId: string };
+
+function createCtx(options: {
+	page: Array<{ _id: string; storageId: string; lastTouchedAt: number }>;
+	isDone?: boolean;
+	metadataRows?: MetadataRow[];
+}) {
+	const metadataRows = options.metadataRows ?? [];
+	const deletedMetadataIds: string[] = [];
+
+	const ctx = {
+		runQuery: vi.fn().mockResolvedValue({
+			page: options.page,
+			isDone: options.isDone ?? true,
+			continueCursor: 'cursor_1'
+		}),
+		runMutation: vi.fn().mockResolvedValue(undefined),
+		storage: { delete: vi.fn().mockResolvedValue(undefined) },
+		scheduler: { runAfter: vi.fn().mockResolvedValue(undefined) },
+		db: {
+			query: vi.fn(() => ({
+				withIndex: vi.fn(
+					(
+						_name: string,
+						cb: (q: { eq: (field: string, value: string) => unknown }) => unknown
+					) => {
+						let requestedStorageId = '';
+						cb({
+							eq: (_field, value) => {
+								requestedStorageId = value;
+								return {};
+							}
+						});
+						return {
+							collect: vi
+								.fn()
+								.mockResolvedValue(
+									metadataRows.filter((row) => row.storageId === requestedStorageId)
+								)
+						};
+					}
+				)
+			})),
+			delete: vi.fn(async (id: string) => {
+				deletedMetadataIds.push(id);
+			})
+		}
+	};
+
+	return { ctx, deletedMetadataIds };
+}
+
+describe('files vacuum', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('cascade-deletes fileMetadata rows for vacuumed files', async () => {
+		const staleFile = {
+			_id: 'agent_file_1',
+			storageId: 'storage_1',
+			lastTouchedAt: Date.now() - 2 * DAY_MS
+		};
+		const { ctx, deletedMetadataIds } = createCtx({
+			page: [staleFile],
+			metadataRows: [
+				{ _id: 'meta_1', storageId: 'storage_1' },
+				{ _id: 'meta_2', storageId: 'storage_1' },
+				{ _id: 'meta_other', storageId: 'storage_other' }
+			]
+		});
+
+		await deleteUnusedFilesHandler._handler(ctx, {});
+
+		expect(ctx.storage.delete).toHaveBeenCalledWith('storage_1');
+		expect(deletedMetadataIds).toEqual(['meta_1', 'meta_2']);
+		expect(ctx.runMutation).toHaveBeenCalledWith('components.agent.files.deleteFiles', {
+			fileIds: ['agent_file_1']
+		});
+	});
+
+	it('keeps fileMetadata for recently touched files', async () => {
+		const freshFile = {
+			_id: 'agent_file_1',
+			storageId: 'storage_1',
+			lastTouchedAt: Date.now()
+		};
+		const { ctx, deletedMetadataIds } = createCtx({
+			page: [freshFile],
+			metadataRows: [{ _id: 'meta_1', storageId: 'storage_1' }]
+		});
+
+		await deleteUnusedFilesHandler._handler(ctx, {});
+
+		expect(ctx.storage.delete).not.toHaveBeenCalled();
+		expect(deletedMetadataIds).toEqual([]);
+		expect(ctx.runMutation).toHaveBeenCalledWith('components.agent.files.deleteFiles', {
+			fileIds: []
+		});
+	});
+
+	it('schedules a continuation when pagination is not done', async () => {
+		const { ctx } = createCtx({ page: [], isDone: false });
+
+		await deleteUnusedFilesHandler._handler(ctx, {});
+
+		expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+			0,
+			'internal.files.vacuum.deleteUnusedFiles',
+			{ cursor: 'cursor_1' }
+		);
+	});
+});

--- a/src/lib/convex/files/vacuum.ts
+++ b/src/lib/convex/files/vacuum.ts
@@ -22,6 +22,18 @@ export const deleteUnusedFiles = internalMutation({
 			console.debug(`Deleting ${toDelete.length} files...`);
 		}
 		await Promise.all(toDelete.map((f) => ctx.storage.delete(f.storageId as Id<'_storage'>)));
+		// Cascade-delete fileMetadata rows (image dimensions) for the vacuumed files.
+		// The vacuum is the cascade point on purpose: agent files are hash-deduped and
+		// refcounted, and thread deletion only decrements refcounts, so metadata must
+		// outlive any single thread and die with the file itself.
+		// Bounded: <=100 files per batch, fileMetadata is deduped by URL (~1 row per file)
+		for (const f of toDelete) {
+			const metadataRows = await ctx.db
+				.query('fileMetadata')
+				.withIndex('by_storageId', (q) => q.eq('storageId', f.storageId))
+				.collect();
+			await Promise.all(metadataRows.map((row) => ctx.db.delete(row._id)));
+		}
 		// Also mark them as deleted in the component.
 		// This is in a transaction (mutation), so there's no races.
 		await ctx.runMutation(components.agent.files.deleteFiles, {


### PR DESCRIPTION
Closes #460

`fileMetadata` rows (image dimensions keyed off agent files) are inserted by `storeFileMetadata` in `src/lib/convex/support/files.ts` but no code path ever deleted them. Thread deletion and the e2e cleanup mutations remove threads and files while leaving the metadata behind, so rows accumulated unboundedly after every thread or file removal.

The hourly file vacuum (`deleteUnusedFiles` in `src/lib/convex/files/vacuum.ts`) now cascade-deletes matching `fileMetadata` rows via the existing `by_storageId` index before marking the files deleted in the agent component. The vacuum is the correct cascade point rather than thread deletion: agent files are hash-deduped and refcounted, and `deleteThreadAsync` only decrements refcounts, so metadata must outlive any single thread and die with the file itself. The sweep is bounded at 100 files per batch with roughly one metadata row per file (deduped by URL), matching the documented anti-pattern comment style. A mocked-ctx unit test covers the cascade, the 24 hour freshness filter, and the pagination continuation. Pre-existing orphaned rows from files deleted before this change are not retro-cleaned; a one-off backfill is intentionally out of scope for the template.

`bun scripts/static-checks.ts src/lib/convex/files/vacuum.ts src/lib/convex/files/__tests__/vacuum.test.ts`, `bun run check:convex`, and `bun run test:unit` (489 tests) all pass.
