### PR TITLE
refactor(convex): Align schema userId conventions

### DIFF
--- a/src/lib/convex/admin/founderWelcome/mutations.ts
+++ b/src/lib/convex/admin/founderWelcome/mutations.ts
@@ -74,7 +74,7 @@ export const updateConfig = adminMutation({
 		// Upsert per-user profile (name, title, replyTo)
 		const existingProfile = await ctx.db
 			.query('adminProfiles')
-			.withIndex('by_userId', (q) => q.eq('userId', adminUserId))
+			.withIndex('by_user', (q) => q.eq('userId', adminUserId))
 			.unique();
 
 		if (existingProfile) {

--- a/src/lib/convex/admin/founderWelcome/queries.ts
+++ b/src/lib/convex/admin/founderWelcome/queries.ts
@@ -63,7 +63,7 @@ async function readFounderWelcomeConfig(ctx: QueryCtx): Promise<FounderWelcomeCo
 	// Read per-user profile for contact person
 	const profile = await ctx.db
 		.query('adminProfiles')
-		.withIndex('by_userId', (q) => q.eq('userId', contactUserId))
+		.withIndex('by_user', (q) => q.eq('userId', contactUserId))
 		.unique();
 
 	// Read global email config
@@ -110,7 +110,7 @@ export const getFounderWelcomeConfig = adminQuery({
 		// Read viewer's own profile for form pre-fill
 		const viewerProfile = await ctx.db
 			.query('adminProfiles')
-			.withIndex('by_userId', (q) => q.eq('userId', ctx.user._id))
+			.withIndex('by_user', (q) => q.eq('userId', ctx.user._id))
 			.unique();
 
 		const viewerUser = await ctx.runQuery(components.betterAuth.adapter.findOne, {

--- a/src/lib/convex/admin/support/queries.ts
+++ b/src/lib/convex/admin/support/queries.ts
@@ -45,7 +45,7 @@ export const listThreadsForAdmin = adminQuery({
 			v.object({
 				_id: v.string(),
 				_creationTime: v.number(),
-				userId: v.optional(v.string()),
+				userId: v.string(),
 				title: v.optional(v.string()),
 				summary: v.optional(v.string()),
 				status: v.union(v.literal('active'), v.literal('archived')),
@@ -248,7 +248,7 @@ export const getThreadForAdmin = adminQuery({
 	returns: v.object({
 		_id: v.string(),
 		_creationTime: v.number(),
-		userId: v.optional(v.string()),
+		userId: v.string(),
 		title: v.optional(v.string()),
 		summary: v.optional(v.string()),
 		status: v.union(v.literal('active'), v.literal('archived')),

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -129,7 +129,7 @@ export default defineSchema({
 		founderWelcomeName: v.optional(v.string()),
 		founderWelcomeTitle: v.optional(v.string()),
 		founderWelcomeReplyTo: v.optional(v.string())
-	}).index('by_userId', ['userId']),
+	}).index('by_user', ['userId']),
 
 	// File metadata - stores image dimensions for proper dialog sizing
 	// (agent component strips unknown fields from file parts, so we store dimensions separately)

--- a/src/lib/convex/support/supportThreadFields.ts
+++ b/src/lib/convex/support/supportThreadFields.ts
@@ -8,7 +8,7 @@ import { v } from 'convex/values';
  */
 export const supportThreadFields = {
 	threadId: v.string(), // Reference to agent:threads
-	userId: v.optional(v.string()), // Denormalized for quick lookups
+	userId: v.string(), // Denormalized for quick lookups; every write path sets it (auth or anon_* owner)
 	isWarm: v.optional(v.boolean()), // true = pre-warmed empty support thread awaiting first message
 	status: v.union(v.literal('open'), v.literal('done')),
 	isHandedOff: v.optional(v.boolean()), // true = human-only mode, undefined/false = AI responds

--- a/src/lib/convex/support/threads.ts
+++ b/src/lib/convex/support/threads.ts
@@ -255,7 +255,7 @@ export const listThreads = query({
 			v.object({
 				_id: v.string(),
 				_creationTime: v.number(),
-				userId: v.optional(v.string()),
+				userId: v.string(),
 				title: v.optional(v.string()),
 				summary: v.optional(v.string()),
 				status: v.union(v.literal('active'), v.literal('archived')),
@@ -340,7 +340,7 @@ export const listThreads = query({
 				return {
 					_id: supportThread.threadId,
 					_creationTime: supportThread.createdAt,
-					userId: supportThread.userId ?? thread.userId,
+					userId: supportThread.userId,
 					title: supportThread.title,
 					summary: supportThread.summary,
 					status: thread.status,


### PR DESCRIPTION
Closes #464

The schema had two inconsistencies that get copied as-is by anyone extending the template. `adminProfiles` named its index `by_userId` while every other userId index in the schema is `by_user`, and `supportThreads.userId` was declared optional even though every write path (`createSupportThreadRecord`, the E2E test seeder, and the anonymous-ticket migration) always sets it to an authenticated or `anon_*` owner ID. The misleading optionality forced workarounds like the `?? thread.userId` fallback in `listThreads` and wider return validators than the actual data contract.

This renames the `adminProfiles` index to `by_user` and updates the three `withIndex` call sites in `admin/founderWelcome`. `supportThreads.userId` is now `v.string()` in `supportThreadFields.ts`, which also tightens the shared `vSupportMetadata` admin validator that spreads these fields. The dead `supportThread.userId ?? thread.userId` fallback in `listThreads` is simplified to `supportThread.userId`, and the return validators that surface this field (`listThreads`, `listThreadsForAdmin`, `getThreadForAdmin`) are narrowed to `v.string()`. `getThread` keeps an optional `userId` because it spreads the agent component thread, whose `userId` is optional upstream.

Index renames are code-only and need no migration. Every insert and migration path at HEAD sets `userId`, but between January and March 2026 `createThread` was a public mutation that accepted an optional `userId` and inserted it verbatim, so a production deployment from that window could still hold rows without it. Before merging into such a deployment, check the dashboard for `supportThreads` rows missing `userId` (the schema push fails validation if any exist) and backfill or delete them first.

Verification: `bun scripts/static-checks.ts` on the changed files, `bun run check:convex`, and `bun run test:unit` (486 tests) all pass.
