### PR TITLE
test(e2e): Replace conditional skips with auto-waits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,7 @@ This project uses **PostHog** for product analytics with an optional **Cloudflar
 - Requires `.env.test` with `AUTH_E2E_TEST_SECRET` only. The Convex backend URL is auto-resolved from `.convex/.test-backend-url`; no `PUBLIC_CONVEX_URL` needed locally.
 - `AuthenticatedLayout` sets `data-hydrated` on `<html>` in `onMount`; `waitForAuthenticated` in `e2e/utils/auth.ts` waits for it so clicks happen after Svelte hydration, not on inert SSR markup.
 - See `.env.schema` for all available env vars with types and descriptions
+- **Never `test.skip()` to dodge a timing race.** Make tests deterministic with auto-waiting assertions (`expect(locator).toBeVisible()`, `expect.poll`) instead of one-shot `count()`/`isVisible()` snapshots followed by a skip. `test.skip()` is only for genuinely unsupported environments (a feature switched off, an external dependency absent), always with a reason string (good example: `e2e/signin-last-used-badge.spec.ts` gating on `hasGoogleOAuth`).
 - **CI E2E timing (CF Workers):** E2E tests only start after the CF Workers Build preview deployment completes (~2-3 min). The `e2e-preview-cf.yml` workflow triggers on the CF `check_run` event, extracts the preview URL, then runs Playwright against it. Results are posted as a commit status, not a check run. Total time from push to E2E result is ~7-8 min.
 
 #### Local e2e isolation

--- a/e2e/admin-settings.spec.ts
+++ b/e2e/admin-settings.spec.ts
@@ -113,15 +113,9 @@ test.describe('Admin Settings Page', () => {
 		// Wait for table to load
 		await expect.poll(async () => page.getByTestId('recipients-loading').count()).toBe(0);
 
-		// Get initial row count
+		// Auto-wait for at least one recipient row (the admin user always exists)
 		const allRows = page.locator('[data-testid^="recipient-row-"]');
-		const initialCount = await allRows.count();
-
-		// Skip if not enough data to test filtering
-		if (initialCount < 1) {
-			test.skip();
-			return;
-		}
+		await expect(allRows.first()).toBeVisible();
 
 		// Open filter dropdown
 		await page.getByTestId('admin-settings-type-filter-trigger').click();
@@ -147,22 +141,14 @@ test.describe('Admin Settings Page', () => {
 		const firstRow = page.locator('[data-testid^="recipient-row-"]').first();
 		await expect(firstRow).toBeVisible();
 
-		// Get the email from the row's data-testid
+		// Get the email from the row's data-testid (row is visible, so the testid must exist)
 		const rowTestId = await firstRow.getAttribute('data-testid');
 		const email = rowTestId?.replace('recipient-row-', '');
+		expect(email).toBeTruthy();
 
-		if (!email) {
-			test.skip();
-			return;
-		}
-
-		// Find a toggle checkbox for this recipient
+		// Find a toggle checkbox for this recipient (the toggle column renders unconditionally)
 		const toggle = page.getByTestId(`toggle-notifyNewSupportTickets-${email}`);
-
-		if (!(await toggle.isVisible())) {
-			test.skip();
-			return;
-		}
+		await expect(toggle).toBeVisible();
 
 		// Get initial state
 		const initialChecked = await toggle.isChecked();


### PR DESCRIPTION
Closes #508

Two tests in `e2e/admin-settings.spec.ts` called `test.skip()` when a non-retrying snapshot read came back empty: `filters recipients by type` skipped when a one-shot `allRows.count()` returned 0, and `toggles notification preference` skipped when `toggle.isVisible()` was false. Both reads can land in the window right after the `recipients-loading` flag clears but before the reactive table paints its rows, so on a slow run the tests silently skip and produce no signal instead of catching regressions.

The skip blocks are replaced with web-first auto-waiting assertions. The filter test now waits with `await expect(allRows.first()).toBeVisible()`, the unused `initialCount` snapshot is removed. The toggle test asserts `expect(email).toBeTruthy()` after extracting it from the row testid (the row is already auto-waited into view, so a missing testid is a real failure) and waits with `await expect(toggle).toBeVisible()` since the toggle column renders unconditionally. `AGENTS.md` gains a convention bullet in the E2E Playwright Tests section: never `test.skip()` to dodge a timing race, use auto-waiting assertions instead, and reserve `test.skip()` for genuinely unsupported environments with a reason string, pointing to the `hasGoogleOAuth` gate in `e2e/signin-last-used-badge.spec.ts` as the good example. The issue's optional lint rule flagging `test.skip()` next to one-shot `count()`/`isVisible()` reads is deferred as a follow-up since it needs heuristic AST matching.

`bun scripts/static-checks.ts e2e/admin-settings.spec.ts AGENTS.md` passes, and `bun run test:e2e -- e2e/admin-settings.spec.ts` passes with 0 skipped (8 passed, previously up to 2 conditional skips), stable across `--repeat-each=3` (22 passed).
