### PR TITLE
fix(support): Remove dead streaming state guards

### DIFF
--- a/src/lib/chat/core/ChatCore.svelte.ts
+++ b/src/lib/chat/core/ChatCore.svelte.ts
@@ -213,7 +213,8 @@ export class ChatCore {
 				threadId = result.threadId;
 				threadCreated = result;
 
-				// Update threadId without clearing messages (for optimistic updates)
+				// Update threadId directly (setThread would clear streamCache, error,
+				// and the pagination cursors)
 				this.threadId = threadId;
 				this.isNewConversation = false;
 			}

--- a/src/lib/chat/core/ChatCore.svelte.ts
+++ b/src/lib/chat/core/ChatCore.svelte.ts
@@ -8,7 +8,6 @@
 import type { ConvexClient } from 'convex/browser';
 import type { FunctionReference } from 'convex/server';
 import type {
-	ChatMessage,
 	SendMessageOptions,
 	SendMessageResult,
 	ChatConfig,
@@ -66,9 +65,6 @@ export class ChatCore {
 	 *  Used as a {#key} to replay chip entrance animations. */
 	threadGeneration = $state(0);
 
-	// Messages state
-	messages = $state<ChatMessage[]>([]);
-
 	// Loading states
 	isLoading = $state(false);
 	isSending = $state(false);
@@ -105,21 +101,12 @@ export class ChatCore {
 		return this.threadId !== null;
 	}
 
-	get streamingMessages(): ChatMessage[] {
-		return this.messages.filter((m) => m.status === 'pending' || m.status === 'streaming');
-	}
-
-	get isStreaming(): boolean {
-		return this.streamingMessages.length > 0;
-	}
-
 	/**
 	 * Initialize or load a thread
 	 */
 	setThread(threadId: string | null): void {
 		this.threadId = threadId;
 		this.isNewConversation = threadId === null;
-		this.messages = [];
 		this.hasMore = false;
 		this.continueCursor = null;
 		this.error = null;
@@ -315,7 +302,6 @@ export class ChatCore {
 	reset(): void {
 		this.threadId = null;
 		this.isNewConversation = false;
-		this.messages = [];
 		this.isLoading = false;
 		this.isSending = false;
 		this.error = null;

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -33,8 +33,8 @@
  * });
  *
  * // Access reactive state
- * core.messages
- * core.isStreaming
+ * core.isSending
+ * core.error
  * core.sendMessage(client, 'Hello!')
  * ```
  */

--- a/src/lib/chat/ui/ChatRoot.svelte
+++ b/src/lib/chat/ui/ChatRoot.svelte
@@ -3,7 +3,7 @@
 	import type { Snippet } from 'svelte';
 	import type { UIMessage } from '@convex-dev/agent';
 	import { ChatCore, type ChatCoreAPI } from '../core/ChatCore.svelte.js';
-	import type { ChatMessage, DisplayMessage } from '../core/types.js';
+	import type { DisplayMessage } from '../core/types.js';
 	import {
 		ChatUIContext,
 		setChatUIContext,
@@ -31,7 +31,6 @@
 	 */
 	export interface ExternalCoreAdapter {
 		threadId: string | null;
-		messages: ChatMessage[];
 		isLoading: boolean;
 		isSending: boolean;
 		error: string | null;

--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -213,7 +213,7 @@
 					size="icon"
 					class="h-8 w-8 rounded-full text-muted-foreground"
 					onclick={handleSubmit}
-					disabled={!input.trim() || threadContext.isSending || threadContext.hasPendingToolCalls}
+					disabled={!input.trim() || threadContext.isSending}
 					aria-label={$t('chat.aria.send')}
 				>
 					{#if threadContext.isSending}

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -277,11 +277,7 @@
 						if (!prompt?.trim()) return;
 						// In AI mode, block while processing (sending, awaiting stream, or streaming)
 						// In handed-off mode, allow fire-and-forget like admin view
-						const isProcessing =
-							threadContext.isSending ||
-							threadContext.isAwaitingStream ||
-							threadContext.isStreaming;
-						if (!threadContext.isHandedOff && isProcessing) return;
+						if (!threadContext.isHandedOff && chatUIContext.isProcessing) return;
 
 						try {
 							await threadContext.sendMessage(client, prompt, {

--- a/src/lib/components/customer-support/support-thread-context.svelte.ts
+++ b/src/lib/components/customer-support/support-thread-context.svelte.ts
@@ -1,10 +1,8 @@
 import { Context } from 'runed';
 import { ChatDraftManager } from '$lib/chat/core/ChatDraftManager.svelte';
 import type { ConvexClient } from 'convex/browser';
-import type { UIMessagePart, UIDataTypes, UITools } from 'ai';
-import { isToolUIPart } from 'ai';
 import { api } from '$lib/convex/_generated/api';
-import type { Attachment, ChatMessage } from '$lib/chat';
+import type { Attachment } from '$lib/chat';
 import { StreamCacheManager } from '$lib/chat/core/stream-cache.js';
 import { createOptimisticUpdate, type ListMessagesArgs } from '$lib/chat/core/optimistic.js';
 import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';
@@ -61,7 +59,6 @@ export class SupportThreadContext {
 	assignedAdmin = $state<{ name?: string; image: string | null } | undefined>(undefined);
 	notificationEmail = $state<string | null>(null); // Email for admin reply notifications
 	isEmailPending = $state(false); // True while email mutation is in flight (green check hidden)
-	messages = $state<ChatMessage[]>([]);
 	isLoading = $state(false);
 	isSending = $state(false);
 	error = $state<string | null>(null);
@@ -169,30 +166,8 @@ export class SupportThreadContext {
 		return this.threadId !== null;
 	}
 
-	get streamingMessages() {
-		return this.messages.filter((m) => m.status === 'pending');
-	}
-
-	get isStreaming() {
-		return this.streamingMessages.length > 0;
-	}
-
 	get currentAgentName(): string | undefined {
 		return this.threadAgentName;
-	}
-
-	/**
-	 * Check if any message has pending tool calls awaiting user response
-	 */
-	get hasPendingToolCalls(): boolean {
-		return this.messages.some((msg) =>
-			msg.parts?.some((p) => {
-				// Cast needed: MessagePart's catch-all { type: string; [key: string]: unknown }
-				// is structurally compatible but not assignable to UIMessagePart union
-				const part = p as UIMessagePart<UIDataTypes, UITools>;
-				return isToolUIPart(part) && part.state === 'input-available' && !part.output;
-			})
-		);
 	}
 
 	/**
@@ -217,7 +192,6 @@ export class SupportThreadContext {
 		this.isHandedOff = isHandedOff ?? false;
 		this.assignedAdmin = assignedAdmin;
 		this.notificationEmail = notificationEmail ?? null;
-		this.messages = [];
 		this.hasMore = false;
 		this.continueCursor = null;
 	}
@@ -385,7 +359,7 @@ export class SupportThreadContext {
 
 		// In AI mode (not handed off), block multiple sends until AI responds
 		// In handed-off mode, allow fire-and-forget like admin view
-		if (!this.isHandedOff && (this.isSending || this.isAwaitingStream || this.isStreaming)) {
+		if (!this.isHandedOff && (this.isSending || this.isAwaitingStream)) {
 			throw new Error('Cannot send message: waiting for AI response');
 		}
 
@@ -616,7 +590,6 @@ export class SupportThreadContext {
 		this.assignedAdmin = undefined;
 		this.notificationEmail = null;
 		this.isEmailPending = false;
-		this.messages = [];
 		this.isLoading = false;
 		this.isSending = false;
 		this.error = null;
@@ -640,7 +613,7 @@ export class SupportThreadContext {
  *   const thread = supportThreadContext.get();
  *
  *   // Access thread state
- *   const { threadId, messages, isStreaming } = $derived(thread);
+ *   const { threadId, isSending } = $derived(thread);
  * </script>
  * ```
  */

--- a/src/lib/components/customer-support/support-thread-context.svelte.ts
+++ b/src/lib/components/customer-support/support-thread-context.svelte.ts
@@ -390,7 +390,8 @@ export class SupportThreadContext {
 				threadId = result.threadId;
 				threadCreated = true;
 
-				// Update context state (don't call setThread which clears messages)
+				// Update context state directly (setThread would reset isHandedOff,
+				// assignedAdmin, and the pagination cursors)
 				this.threadId = threadId;
 				this.notificationEmail = result.notificationEmail ?? null;
 				this.currentView = 'chat';


### PR DESCRIPTION
Closes #456

In `src/lib/components/customer-support/support-thread-context.svelte.ts` the `messages` field was only ever assigned `[]`, so the `hasPendingToolCalls`, `streamingMessages`, and `isStreaming` getters derived from it were constant false. The chatbar send button (`ai-chatbar.svelte`) carried a tool-call guard that could never engage, the widget send handler (`feedback-widget.svelte`) consumed the dead `isStreaming` getter, and `ChatCore.svelte.ts` duplicated the same vestigial messages-based getters with filter drift between the two copies, while live streaming detection already exists in `ChatUIContext.isStreaming`.

This removes the write-only `messages` fields and the dead getters from both `SupportThreadContext` and `ChatCore`, drops the constant `hasPendingToolCalls` clause from the chatbar send button, and tightens the `sendMessage` guard to `isSending || isAwaitingStream`. The widget send guard now uses `chatUIContext.isProcessing`, the same guard `ChatInput.svelte` already uses, which combines `isSending`, `isAwaitingStream`, and the live display-message based `ChatUIContext.isStreaming`, so streaming detection has one canonical source. `messages` is also removed from the `ExternalCoreAdapter` interface in `ChatRoot.svelte`, and the headless-core doc examples in `src/lib/chat/index.ts` and the context class doc no longer reference the removed members. All removed guard terms were constant false, so behavior is unchanged except the widget send guard now also catches the live streaming window.

`bun scripts/static-checks.ts` on the six changed files and `bun run test:unit` (486 tests) pass; a manual dev-server smoke test of the widget send flow was not run.
