### PR TITLE
fix(scripts): Harden build script error handling

### DIFF
--- a/scripts/build-emails.ts
+++ b/scripts/build-emails.ts
@@ -166,4 +166,7 @@ ${exportStatements}
 	}
 }
 
-buildEmails();
+buildEmails().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -58,4 +58,7 @@ async function main(): Promise<void> {
 	console.log(`${colors.green}Deployment complete!${colors.reset}`);
 }
 
-main();
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/scripts/generate-convex.ts
+++ b/scripts/generate-convex.ts
@@ -205,6 +205,7 @@ async function main() {
 			const stateId = computeLocalConvexStateId(PROJECT_DIR);
 			const keysPath = path.join(CONVEX_STATE_DIR, stateId, 'keys.json');
 
+			let keys: { adminKey: string } | null = null;
 			if (!fs.existsSync(keysPath)) {
 				console.warn(
 					`Warning: Local backend is running but no keys found at .convex/${stateId}/keys.json.`
@@ -213,7 +214,19 @@ async function main() {
 					'This can happen after switching branches. Falling back to offline validation.'
 				);
 			} else {
-				const keys = JSON.parse(fs.readFileSync(keysPath, 'utf-8'));
+				try {
+					keys = JSON.parse(fs.readFileSync(keysPath, 'utf-8'));
+				} catch {
+					console.warn(
+						`Warning: Could not parse .convex/${stateId}/keys.json (corrupt or truncated).`
+					);
+					console.warn(
+						'This can happen if the dev server was killed mid-write. Falling back to offline validation.'
+					);
+				}
+			}
+
+			if (keys) {
 				const { code, output } = runCommand('bunx', [
 					'convex',
 					'codegen',

--- a/scripts/patch-cf-worker.test.ts
+++ b/scripts/patch-cf-worker.test.ts
@@ -30,6 +30,18 @@ const WORKER_FIXTURE_NO_CACHE = `
     }
 `;
 
+// Fixture where the worktop cache call drifted to take extra args, so
+// CACHE_LOOKUP_PATTERN no longer matches but a cache lookup clearly exists
+const WORKER_FIXTURE_DRIFTED_CACHE = `
+    let pragma = req.headers.get("cache-control") || "";
+    let res = !pragma.includes("no-cache") && await r2(req, opts);
+    if (res) return res;
+    let is_static_asset = false;
+    if (is_static_asset || prerendered.has(pathname) || pathname === version_file || pathname.startsWith(immutable)) {
+      res = await env2.ASSETS.fetch(req);
+    }
+`;
+
 describe('patch-cf-worker', () => {
 	it('patches both cache lookup and static-serving condition', () => {
 		const result = applyMarkdownPatch(WORKER_FIXTURE);
@@ -86,5 +98,11 @@ describe('patch-cf-worker', () => {
 		expect(result).not.toBeNull();
 		expect(result).toContain('__wantsMarkdown');
 		expect(result).toContain('!__wantsMarkdown && (is_static_asset');
+	});
+
+	it('throws when a cache lookup exists but the pattern drifted', () => {
+		expect(() => applyMarkdownPatch(WORKER_FIXTURE_DRIFTED_CACHE)).toThrow(
+			/CACHE_LOOKUP_PATTERN did not match/
+		);
 	});
 });

--- a/scripts/patch-cf-worker.ts
+++ b/scripts/patch-cf-worker.ts
@@ -36,6 +36,8 @@ export const CACHE_LOOKUP_PATTERN =
 /**
  * Apply the markdown passthrough patch to a worker source string.
  * Returns the patched source, or null if the pattern wasn't found.
+ * Throws when a cache-like lookup exists but CACHE_LOOKUP_PATTERN no longer
+ * matches it (pattern drift), so a build with lost cache-bypass fails loud.
  */
 export function applyMarkdownPatch(source: string): string | null {
 	if (!STATIC_SERVING_PATTERN.test(source)) {
@@ -51,15 +53,18 @@ export function applyMarkdownPatch(source: string): string | null {
 			`const __wantsMarkdown = /\\btext\\/markdown\\b/i.test(req.headers.get("accept") || "");\n$1!__wantsMarkdown && $2`
 		);
 	} else {
-		// Warn if cache-like code exists but didn't match (pattern drift)
-		if (/await \w+\(req\)/.test(patched)) {
-			console.warn(
-				'[patch-cf-worker] WARNING: Detected a cache lookup but CACHE_LOOKUP_PATTERN did not match. ' +
-					'The worktop cache will NOT be bypassed for markdown requests. ' +
+		// Fail loud if cache-like code exists but didn't match (pattern drift).
+		// \w+ excludes dotted calls like server.respond(req, ...), so this only
+		// fires for worktop-style cache lookups (e.g. `await r2(req, opts)`).
+		if (/await \w+\(req\b/.test(patched)) {
+			throw new Error(
+				'Detected a worktop cache lookup but CACHE_LOOKUP_PATTERN did not match. ' +
+					'Without the cache bypass, cached HTML is served for Accept: text/markdown ' +
+					'requests on non-prerendered pages. ' +
 					'Update CACHE_LOOKUP_PATTERN to match the new adapter output.'
 			);
 		}
-		// Fallback: inject before static serving (prerendered pages still fixed, cache bypass skipped)
+		// Fallback: inject before static serving (prerendered pages still fixed, no cache layer to bypass)
 		patched = patched.replace(
 			STATIC_SERVING_PATTERN,
 			`const __wantsMarkdown = /\\btext\\/markdown\\b/i.test(req.headers.get("accept") || "");\n$1!__wantsMarkdown && ($2))`
@@ -83,7 +88,13 @@ if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.met
 	}
 
 	const original = fs.readFileSync(WORKER_PATH, 'utf-8');
-	const patched = applyMarkdownPatch(original);
+	let patched: string | null;
+	try {
+		patched = applyMarkdownPatch(original);
+	} catch (err) {
+		console.error(`[patch-cf-worker] ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(1);
+	}
 
 	if (patched === null) {
 		console.error(

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -316,4 +316,7 @@ async function main() {
 	rl?.close();
 }
 
-main();
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
Closes #499

The build scripts had three robustness gaps. `scripts/deploy.ts`, `scripts/template-setup.ts` and `scripts/build-emails.ts` called their async entrypoints bare, so a reachable throw (for example `sanitizeBranchAlias()` via `detectPlatform()`) surfaced as an unhandled rejection instead of the explicit `process.exit(1)` used elsewhere. `scripts/generate-convex.ts` ran `JSON.parse` on `keys.json` without a guard, so a truncated file (dev server killed mid-write) crashed the script instead of degrading to offline validation like the adjacent missing-keys branch. And `scripts/patch-cf-worker.ts` lost the markdown cache-bypass silently when the worktop cache call drifted to a multi-arg shape, because both `CACHE_LOOKUP_PATTERN` and the single-arg drift-warning regex failed to match, so the build exited 0 with `Accept: text/markdown` negotiation broken on non-prerendered pages.

The three entrypoints are now wrapped in `.catch((err) => { console.error(err); process.exit(1); })`, matching `generate-convex.ts` and `model-eval.ts`. The `keys.json` read is hoisted into a try/catch that warns about a corrupt or truncated file and falls through to offline validation. In `applyMarkdownPatch`, the drift-detection regex is loosened from `await \w+\(req\)` to `await \w+\(req\b` so it catches multi-arg calls like `await r2(req, opts)` while still ignoring dotted calls like `server.respond(req, ...)`, and a detected drift now throws instead of warning and soft-falling back. The CLI entrypoint catches that error and exits 1 with the message. The silent static-serving fallback is preserved for workers without a cache layer, and a new test fixture with a drifted multi-arg cache call asserts the loud failure.

`bun scripts/static-checks.ts` on the six changed files passes, `bun run test:unit` passes (including the new drifted-cache fixture), and `bun run build:emails` and `bun run generate` both still exit 0.
