### PR TITLE
docs(autumn): Note atmn push stays a manual step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ After modifying `autumn.config.ts`, ALWAYS push changes to Autumn:
 - `bunx atmn push` — Push config to sandbox
 - `bunx atmn push -p` — Push config to production
 
-Without pushing, the config change only exists locally and has no effect.
+Without pushing, the config change only exists locally and has no effect. Pre-commit/static-checks only runs `atmn preview` (a local render that never diffs against or pushes to the live deployment), so no automated check covers pushing; it stays a manual step.
 
 ### Tolgee CLI
 

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -342,8 +342,10 @@ async function main(): Promise<void> {
 		// `atmn preview` only renders plans from the local autumn.config.ts; it never
 		// diffs against or pushes to the live deployment. After any config edit,
 		// `bunx atmn push` (sandbox) / `bunx atmn push -p` (prod) is a required manual
-		// step that no automated check covers (the CLI has no read-only diff primitive
-		// to build a drift guard from, and auto-pushing from CI would be worse).
+		// step that no automated check covers (the CLI's only diff is the hidden
+		// debug-only `test-diff`, which requires auth, always exits 0, and prints
+		// human-readable output, so there is no stable primitive to build a drift
+		// guard from; auto-pushing from CI would be worse).
 		printHeader(step, 'Autumn config');
 		runCommand('bun', ['atmn', 'preview']);
 		console.log('\n');

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -338,7 +338,12 @@ async function main(): Promise<void> {
 		}
 		console.log('\n');
 
-		// Autumn billing config validation (no auth needed, runs locally)
+		// Autumn billing config validation (no auth needed, runs locally).
+		// `atmn preview` only renders plans from the local autumn.config.ts; it never
+		// diffs against or pushes to the live deployment. After any config edit,
+		// `bunx atmn push` (sandbox) / `bunx atmn push -p` (prod) is a required manual
+		// step that no automated check covers (the CLI has no read-only diff primitive
+		// to build a drift guard from, and auto-pushing from CI would be worse).
 		printHeader(step, 'Autumn config');
 		runCommand('bun', ['atmn', 'preview']);
 		console.log('\n');


### PR DESCRIPTION
Closes #493

`AGENTS.md` requires `bunx atmn push` after any `autumn.config.ts` edit because the config stays inert until pushed, but the only automated touchpoint is `bun atmn preview` in `scripts/static-checks.ts`, a local render that never diffs against or pushes to the live deployment. Nothing in the docs or the script says so, which makes it easy for a fork to edit limits, commit, pass all checks, and silently run against stale live entitlements.

This expands the comment above the `atmn preview` call in `scripts/static-checks.ts` to state that it only renders the local config and that `bunx atmn push` (sandbox) and `bunx atmn push -p` (prod) remain a required manual step no automated check covers, and adds the same caveat to the `AGENTS.md` Autumn Billing Config section. Per the issue, no auto-push or drift guard is added: the only diff the Autumn CLI ships is the hidden debug-only `test-diff` command, which requires auth, always exits 0, and prints human-readable output, so there is no stable primitive to build a guard from, and auto-pushing from CI would be its own anti-pattern. The third Pro allowance number in the dead `ai_chat.pro_required` locale copy and the 200-message docstring were already removed in #506, so no locale or config changes are needed here.

`bun scripts/static-checks.ts scripts/static-checks.ts AGENTS.md` passes, including the unchanged `atmn preview` step.

