### PR TITLE
fix(auth): Revoke sessions on password reset

### DIFF
--- a/e2e/forgot-reset-password.spec.ts
+++ b/e2e/forgot-reset-password.spec.ts
@@ -1,7 +1,23 @@
 import { test, expect } from '@playwright/test';
+import 'varlock/auto-load';
+import { ConvexHttpClient } from 'convex/browser';
+import { api } from '../src/lib/convex/_generated/api';
+import { resolveConvexUrl } from './utils/convex-url';
+import { resolveSiteUrl } from './utils/site-url';
+import { getPreviewBypass } from './utils/preview-bypass';
 
 // This test runs without auth state - tests unauthenticated behavior
 test.use({ storageState: { cookies: [], origins: [] } });
+
+const testSecret = process.env.AUTH_E2E_TEST_SECRET!;
+
+const getConvexClient = () => {
+	const convexUrl = resolveConvexUrl();
+	if (!convexUrl) {
+		throw new Error('Convex URL not configured (set PUBLIC_CONVEX_URL or start local dev server)');
+	}
+	return new ConvexHttpClient(convexUrl);
+};
 
 test.describe('Forgot Password', () => {
 	test('shows validation error for invalid email', async ({ page }) => {
@@ -135,5 +151,79 @@ test.describe('Reset Password', () => {
 
 		// Should navigate to signin
 		await expect(page).toHaveURL(/signin/);
+	});
+
+	test('resetting the password revokes other active sessions', async ({ page, playwright }) => {
+		const client = getConvexClient();
+		const siteUrl = resolveSiteUrl();
+		const bypass = getPreviewBypass();
+
+		// Dedicated user: resetting the shared test user's password would break other specs
+		const email = `test-reset-revoke-${Date.now()}@e2e.example.com`;
+		const password = 'OldPassword123!';
+		const newPassword = 'NewPassword456!';
+
+		// Separate cookie jar simulating another device's session that the reset must revoke
+		const otherSession = await playwright.request.newContext({
+			baseURL: siteUrl,
+			extraHTTPHeaders: { Origin: siteUrl, ...bypass.headers }
+		});
+
+		try {
+			const signUp = await otherSession.post('/api/auth/sign-up/email', {
+				data: { email, password, name: 'E2E Reset Revoke' }
+			});
+			expect(signUp.ok()).toBeTruthy();
+
+			const verifyResult = await client.mutation(api.tests.verifyTestUserEmail, {
+				email,
+				secret: testSecret
+			});
+			expect(verifyResult.success).toBeTruthy();
+
+			// Establish the session that should be revoked by the password reset
+			const signIn = await otherSession.post('/api/auth/sign-in/email', {
+				data: { email, password }
+			});
+			expect(signIn.ok()).toBeTruthy();
+
+			const sessionBefore = await otherSession.get('/api/auth/get-session');
+			expect(await sessionBefore.json()).not.toBeNull();
+
+			// Request a reset token. Delivery is skipped for @e2e.example.com addresses,
+			// so the token is read from the backend's verification model instead.
+			const resetRequest = await otherSession.post('/api/auth/request-password-reset', {
+				data: { email, redirectTo: '/reset-password' }
+			});
+			expect(resetRequest.ok()).toBeTruthy();
+
+			const { token } = await client.mutation(api.tests.getPasswordResetToken, {
+				email,
+				secret: testSecret
+			});
+			expect(token).toBeTruthy();
+
+			// Complete the reset through the UI in a fresh browser session
+			await page.goto(`/reset-password?token=${token}`);
+			await page.waitForLoadState('domcontentloaded');
+			await expect(page.getByTestId('reset-password-password-input')).toBeEnabled({
+				timeout: 30000
+			});
+			await page.getByTestId('reset-password-password-input').fill(newPassword);
+			await page.getByTestId('reset-password-confirm-input').fill(newPassword);
+			await page.getByTestId('reset-password-submit-button').click();
+			await expect(page.getByTestId('reset-password-success-message')).toBeVisible({
+				timeout: 10000
+			});
+
+			// revokeSessionsOnPasswordReset must have invalidated the other session
+			const sessionAfter = await otherSession.get('/api/auth/get-session');
+			expect(await sessionAfter.json()).toBeNull();
+		} finally {
+			await otherSession.dispose();
+			await client
+				.mutation(api.tests.deleteTestUser, { email, secret: testSecret })
+				.catch(() => {});
+		}
 	});
 });

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -321,6 +321,10 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>): BetterAuthOptions
 		emailAndPassword: {
 			enabled: true,
 			minPasswordLength: 10,
+			// Raise Better Auth's default 128 cap to allow long passphrases
+			maxPasswordLength: 256,
+			// Invalidate all other sessions after a password reset (e.g. account recovery after takeover)
+			revokeSessionsOnPasswordReset: true,
 			requireEmailVerification: true,
 			// Password reset email
 			sendResetPassword: async ({ user, url }: SendResetPasswordArgs) => {

--- a/src/lib/convex/tests.ts
+++ b/src/lib/convex/tests.ts
@@ -262,6 +262,49 @@ export const getAuthUserIdByEmail = mutation({
 	}
 });
 
+// Get the most recent password reset token for a test user
+// Note: This mutation requires AUTH_E2E_TEST_SECRET for security
+// Reset emails are skipped for @e2e.example.com addresses (emails/helpers.ts),
+// so E2E tests read the token Better Auth stored in the verification model.
+export const getPasswordResetToken = mutation({
+	args: { email: v.string(), secret: v.string() },
+	returns: v.object({ token: v.union(v.string(), v.null()) }),
+	handler: async (ctx, { email, secret }) => {
+		requireTestSecret(secret);
+
+		const user = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+			model: 'user',
+			where: [{ field: 'email', value: email }]
+		});
+
+		if (!user) {
+			return { token: null };
+		}
+
+		const RESET_PREFIX = 'reset-password:';
+
+		// Unindexed scan over the verification model (test-only, table stays tiny on e2e backends)
+		const result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+			model: 'verification',
+			where: [
+				{ field: 'value', value: user._id },
+				{ field: 'identifier', operator: 'starts_with', value: RESET_PREFIX }
+			],
+			paginationOpts: { numItems: 100, cursor: null }
+		});
+
+		const latest = (result.page as Array<{ identifier?: string; _creationTime?: number }>).sort(
+			(a, b) => (b._creationTime ?? 0) - (a._creationTime ?? 0)
+		)[0];
+
+		const token = latest?.identifier?.startsWith(RESET_PREFIX)
+			? latest.identifier.slice(RESET_PREFIX.length)
+			: null;
+
+		return { token };
+	}
+});
+
 // Clean up anonymous support threads created in E2E tests
 // Note: This mutation requires AUTH_E2E_TEST_SECRET for security
 export const cleanupAnonymousSupportThreads = mutation({


### PR DESCRIPTION
Closes #453

The `emailAndPassword` block in `src/lib/convex/auth.ts` only set `minPasswordLength: 10`. Better Auth's `revokeSessionsOnPasswordReset` defaults to false, so completing a password reset after an account takeover left the attacker's existing sessions alive, while the settings change-password flow already opts into `revokeOtherSessions: true`. Nothing pinned the reset behavior in tests either.

This sets `revokeSessionsOnPasswordReset: true` so a completed reset deletes all of the user's sessions (verified against better-auth 1.6.9: the reset route calls `internalAdapter.deleteSessions`, which the Convex adapter backs with `deleteMany`). It also sets `maxPasswordLength: 256`. Better Auth already caps passwords at 128 by default, so this raises the cap for long passphrases and aligns with the `email-and-password-best-practices` skill example rather than fixing unbounded hashing as the issue suggested. A new E2E test in `e2e/forgot-reset-password.spec.ts` pins the revocation: it signs up a dedicated user, establishes a second session in a separate cookie jar, completes the reset through the UI, and asserts `/api/auth/get-session` returns null for the other session afterwards. Since reset emails are skipped for `@e2e.example.com` addresses, a new secret-gated mutation `getPasswordResetToken` in `src/lib/convex/tests.ts` reads the token Better Auth stored in the verification model, dead code in production like the other `AUTH_E2E_TEST_SECRET` helpers. Whether the uppercase/lowercase/digit complexity rules should be enforced server-side or documented as advisory is left open, as the issue explicitly defers that decision.

`bun scripts/static-checks.ts` on the changed files, `bun run check:convex`, `bun run test:unit` (486 tests), and `bun run test:e2e -- e2e/forgot-reset-password.spec.ts` (9 tests, including the new revocation test) all pass locally.
