### PR TITLE
test(i18n): Sync wrangler.toml run_worker_first with languages

### DIFF
--- a/scripts/prerender-sync.test.ts
+++ b/scripts/prerender-sync.test.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { SUPPORTED_LANGUAGES } from '../src/lib/i18n/languages';
 import { SUPPORTED_LOCALES } from '../src/lib/convex/i18n/translations';
@@ -22,5 +24,18 @@ describe('language sync', () => {
 
 	it('Tolgee translation imports match canonical SUPPORTED_LANGUAGES', () => {
 		expect([...TOLGEE_IMPORT_LANGUAGES].sort()).toEqual(canonicalCodes);
+	});
+
+	it('wrangler.toml run_worker_first matches canonical SUPPORTED_LANGUAGES', () => {
+		const content = fs.readFileSync(path.resolve('wrangler.toml'), 'utf-8');
+		const arrayMatch = content.match(/run_worker_first\s*=\s*\[([^\]]*)\]/);
+		// Fail loudly if wrangler.toml is restructured, instead of passing vacuously
+		expect(arrayMatch, 'run_worker_first array not found in wrangler.toml').not.toBeNull();
+
+		const entries = [...arrayMatch![1]!.matchAll(/"([^"]+)"/g)].map((m) => m[1]!).sort();
+		// Each language needs both the bare prefix and the wildcard so markdown
+		// content negotiation covers /<lang> and every marketing page under it.
+		const expectedEntries = canonicalCodes.flatMap((code) => [`/${code}`, `/${code}/*`]).sort();
+		expect(entries).toEqual(expectedEntries);
 	});
 });

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -14,6 +14,7 @@ const adapter = process.env.WORKERS_CI
 
 // Prerenderable marketing pages (pricing excluded — uses useCustomer() for billing UI)
 const PRERENDER_MARKETING_PAGES = ['', '/about', '/privacy', '/terms', '/impressum'];
+// Mirrors SUPPORTED_LANGUAGES in src/lib/i18n/languages.ts, kept in sync by scripts/prerender-sync.test.ts
 const LANGUAGES = ['en', 'de', 'es', 'fr'];
 const prerenderEntries = LANGUAGES.flatMap((lang) =>
 	PRERENDER_MARKETING_PAGES.map((page) => `/${lang}${page}`)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,5 +9,7 @@ minify = true
 directory = ".svelte-kit/cloudflare"
 binding = "ASSETS"
 # Route marketing pages through the worker so Accept: text/markdown
-# content negotiation works on prerendered pages (see patch-cf-worker.ts)
+# content negotiation works on prerendered pages (see patch-cf-worker.ts).
+# Entries are derived from SUPPORTED_LANGUAGES in src/lib/i18n/languages.ts
+# and kept in sync by scripts/prerender-sync.test.ts.
 run_worker_first = ["/en", "/en/*", "/de", "/de/*", "/es", "/es/*", "/fr", "/fr/*"]


### PR DESCRIPTION
Closes #472

The supported-language list lives in four places: `src/lib/i18n/languages.ts` (canonical), `svelte.config.js`, the Tolgee imports in the root layout, and the `run_worker_first` array in `wrangler.toml`. `scripts/prerender-sync.test.ts` only asserted the first three stay in sync, so adding a language would silently skip worker-first routing for the new locale and break `Accept: text/markdown` content negotiation on its prerendered marketing pages.

The sync test now reads `wrangler.toml`, regex-extracts the `run_worker_first` array, and compares the entries against the set derived from `SUPPORTED_LANGUAGES` (both the bare `/<lang>` prefix and the `/<lang>/*` wildcard per language, so a missing wildcard fails too, slightly stricter than the unique-codes check the issue proposed). The test asserts the regex matched at all, so restructuring `wrangler.toml` fails loudly instead of passing vacuously. The comment above `run_worker_first` now points at `SUPPORTED_LANGUAGES` in `src/lib/i18n/languages.ts` and at `scripts/prerender-sync.test.ts`, mirroring the pointer comment in `svelte.config.js`.

`bun run test:unit` passes (51 files, 487 tests), `bun scripts/static-checks.ts scripts/prerender-sync.test.ts` passes, and a negative check (removing `"/fr/*"` from `wrangler.toml`) makes the new test fail as expected.
