### PR TITLE
refactor(ui): Use semantic status color tokens

### DIFF
--- a/src/lib/chat/ui/InlineEmailPrompt.svelte
+++ b/src/lib/chat/ui/InlineEmailPrompt.svelte
@@ -113,7 +113,7 @@
 		/>
 		{#if showConfirmed}
 			<InputGroup.Addon align="inline-end">
-				<CircleCheckIcon class="h-4 w-4 text-green-600" />
+				<CircleCheckIcon class="h-4 w-4 text-success" />
 			</InputGroup.Addon>
 		{/if}
 	</InputGroup.Root>

--- a/src/lib/components/prompt-kit/tool/ToolDetails.svelte
+++ b/src/lib/components/prompt-kit/tool/ToolDetails.svelte
@@ -51,10 +51,8 @@
 
 	{#if state === 'output-error' && errorText}
 		<div>
-			<h4 class="mb-2 text-sm font-medium text-red-500">Error</h4>
-			<div
-				class="rounded border border-red-200 bg-background p-2 text-sm dark:border-red-950 dark:bg-red-900/20"
-			>
+			<h4 class="mb-2 text-sm font-medium text-destructive">Error</h4>
+			<div class="rounded border border-destructive/20 bg-destructive/10 p-2 text-sm">
 				{errorText}
 			</div>
 		</div>
@@ -65,7 +63,7 @@
 	{/if}
 
 	{#if toolCallId}
-		<div class="border-t border-blue-200 pt-2 text-xs text-muted-foreground">
+		<div class="border-t pt-2 text-xs text-muted-foreground">
 			<span class="font-mono">Call ID: {toolCallId}</span>
 		</div>
 	{/if}

--- a/src/lib/components/prompt-kit/tool/ToolHeader.svelte
+++ b/src/lib/components/prompt-kit/tool/ToolHeader.svelte
@@ -35,13 +35,13 @@
 	function getStateIconClass(): string {
 		switch (toolPart.state) {
 			case 'input-streaming':
-				return 'h-4 w-4 motion-safe:animate-spin text-blue-500';
+				return 'h-4 w-4 motion-safe:animate-spin text-info';
 			case 'input-available':
-				return 'h-4 w-4 text-orange-500';
+				return 'h-4 w-4 text-warning';
 			case 'output-available':
-				return 'h-4 w-4 text-green-500';
+				return 'h-4 w-4 text-success';
 			case 'output-error':
-				return 'h-4 w-4 text-red-500';
+				return 'h-4 w-4 text-destructive';
 			default:
 				return 'text-muted-foreground h-4 w-4';
 		}

--- a/src/lib/components/ui/metric-card.svelte
+++ b/src/lib/components/ui/metric-card.svelte
@@ -69,7 +69,7 @@
 					variant="outline"
 					class={cn(
 						trend.direction === 'down' && 'text-destructive',
-						trend.direction === 'up' && 'text-emerald-600 dark:text-emerald-500'
+						trend.direction === 'up' && 'text-success'
 					)}
 				>
 					{#if trend.direction === 'up'}

--- a/src/lib/components/ui/password/password-strength.svelte
+++ b/src/lib/components/ui/password/password-strength.svelte
@@ -19,11 +19,11 @@
 		base: '',
 		variants: {
 			score: {
-				0: 'bg-red-500',
-				1: 'bg-red-500',
-				2: 'bg-yellow-500',
-				3: 'bg-yellow-500',
-				4: 'bg-green-500'
+				0: 'bg-destructive',
+				1: 'bg-destructive',
+				2: 'bg-warning',
+				3: 'bg-warning',
+				4: 'bg-success'
 			}
 		}
 	});

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -180,7 +180,7 @@
 								<div
 									data-testid="forgot-password-success-message"
 									transition:slide={{ duration: 200 }}
-									class="rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400"
+									class="rounded-md bg-success/10 p-3 text-sm text-success"
 								>
 									<T keyName={message} />
 								</div>

--- a/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
@@ -199,7 +199,7 @@
 								<div
 									data-testid="reset-password-success-message"
 									transition:slide={{ duration: 200 }}
-									class="rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400"
+									class="rounded-md bg-success/10 p-3 text-sm text-success"
 								>
 									<T keyName={message} />
 									<a href={resolve(localizedHref('/signin'))} class="underline">

--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -241,10 +241,10 @@
 										<Badge
 											variant="outline"
 											class="text-xs capitalize {thread.supportMetadata.priority === 'low'
-												? 'border-green-500 bg-green-500/10 text-green-700 dark:text-green-400'
+												? 'border-success bg-success/10 text-success'
 												: thread.supportMetadata.priority === 'medium'
-													? 'border-yellow-500 bg-yellow-500/10 text-yellow-700 dark:text-yellow-400'
-													: 'border-red-500 bg-red-500/10 text-red-700 dark:text-red-400'}"
+													? 'border-warning bg-warning/10 text-warning'
+													: 'border-destructive bg-destructive/10 text-destructive'}"
 										>
 											{thread.supportMetadata.priority}
 										</Badge>

--- a/src/routes/[[lang]]/admin/users/status-badge.svelte
+++ b/src/routes/[[lang]]/admin/users/status-badge.svelte
@@ -19,7 +19,7 @@
 	</span>
 {:else if emailVerified}
 	<span
-		class="inline-flex items-center rounded-md border border-green-600 px-2 py-1 text-xs font-medium text-green-600 ring-1 ring-green-600/20 ring-inset"
+		class="inline-flex items-center rounded-md border border-success px-2 py-1 text-xs font-medium text-success ring-1 ring-success/20 ring-inset"
 		data-testid={testId}
 	>
 		<T keyName="admin.users.verified" />

--- a/src/routes/[[lang]]/app/settings/email-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/email-settings.svelte
@@ -128,7 +128,7 @@
 						<InputGroup.Input id="currentEmail" value={currentEmail} disabled />
 						<InputGroup.Addon align="inline-end">
 							{#if isEmailVerified}
-								<div class="flex items-center gap-1 text-green-600">
+								<div class="flex items-center gap-1 text-success">
 									<CircleCheckIcon class="h-3 w-3" />
 									<InputGroup.Text>
 										<T keyName="settings.email.verified_badge" />

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -74,11 +74,14 @@
 	--sidebar-accent-hover: var(--sidebar-accent);
 	--sidebar-border: oklch(0.92 0.004 286.32);
 	--sidebar-ring: oklch(0.705 0.015 286.067);
-	--success: oklch(0.723 0.191 149.579);
+	/* Status tokens are mode-aware like --destructive: dark 600/700 shades here keep
+	   text-success/warning/info readable on light backgrounds; .dark uses the
+	   brighter 500 shades. */
+	--success: oklch(0.527 0.154 150.069);
 	--success-foreground: oklch(1 0 0);
-	--warning: oklch(0.795 0.184 86.047);
-	--warning-foreground: oklch(0.21 0.006 285.885);
-	--info: oklch(0.623 0.214 259.815);
+	--warning: oklch(0.554 0.135 66.442);
+	--warning-foreground: oklch(1 0 0);
+	--info: oklch(0.546 0.245 262.881);
 	--info-foreground: oklch(1 0 0);
 }
 


### PR DESCRIPTION
Closes #469

Status colors across the app hardcoded Tailwind palette classes (`text-green-500`, `bg-yellow-500`, `text-emerald-600`, `border-red-200`, and similar) although the theme defines semantic tokens (`--color-success`, `--color-warning`, `--color-info`, `--color-destructive`). This made positive and negative states asymmetric (for example `metric-card.svelte` paired `text-emerald-600` with `text-destructive`), required manual `dark:` shade variants per call site, and would silently ignore any theme customization of the status colors.

This maps every cited call site to the semantic tokens: green and emerald become `success`, yellow and orange become `warning`, blue becomes `info`, and red becomes `destructive`. Affected files are `ToolHeader.svelte` (state icons), `ToolDetails.svelte` (error heading and container, now `border-destructive/20 bg-destructive/10` matching the existing badge and button destructive pattern, plus the call ID divider which drops `border-blue-200` for the default border token), `metric-card.svelte`, `password-strength.svelte`, `InlineEmailPrompt.svelte`, `status-badge.svelte`, `email-settings.svelte`, the success banners in `reset-password` and `forgot-password`, and the priority badges in `thread-list.svelte`. The `dark:` shade variants are removed since the tokens are now mode-aware in `layout.css`, mirroring `--destructive`: `:root` uses dark shades (green-700, yellow-700, blue-600) so light-mode text keeps at least the contrast of the shades these call sites used before, and `.dark` keeps the brighter 500 shades. `:root` `--warning-foreground` flips to white so it stays readable on the darker warning color. `ToolBadge.svelte` was already deleted in #502, so the dead code part of the issue needs no change here. The yellow noscript banners and email template inline colors are intentionally untouched, noscript is light-theme-only and email clients need inline colors.

`bun scripts/static-checks.ts` with all changed files passes, and a grep over the touched files confirms no palette status classes remain outside the noscript banners. Dark mode was not visually spot-checked in a browser.

