### PR TITLE
fix(seo): Bake site origin into prerendered tags

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -117,7 +117,10 @@ PUBLIC_SNAPDOM_PROXY_URL=
 # @sensitive @optional
 AUTH_E2E_TEST_SECRET=
 
-# Site URL for test requests (defaults to localhost:5173)
+# Canonical site origin (e.g. https://example.com). Baked into prerendered SEO
+# tags (canonical, hreflang, og:url, og:image) at build time; also the E2E test
+# base URL in CI (defaults to localhost:5173). The deploy script derives it from
+# the platform when unset; set it explicitly for custom domains.
 # @type=url @optional
 PUBLIC_SITE_URL=
 

--- a/scripts/deploy/platform.test.ts
+++ b/scripts/deploy/platform.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { sanitizeBranchAlias } from './platform';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { detectPlatform, sanitizeBranchAlias } from './platform';
 
 describe('sanitizeBranchAlias', () => {
 	it('uses the full alias budget for short worker names', () => {
@@ -50,5 +50,62 @@ describe('sanitizeBranchAlias', () => {
 		const branch = 'a'.repeat(56) + '-tail';
 		const alias = sanitizeBranchAlias(branch, workerName);
 		expect(alias.endsWith('-')).toBe(false);
+	});
+});
+
+describe('detectPlatform (Vercel)', () => {
+	// detectPlatform reads process.env, so isolate the vars it touches
+	const vars = [
+		'VERCEL',
+		'VERCEL_ENV',
+		'VERCEL_URL',
+		'VERCEL_PROJECT_PRODUCTION_URL',
+		'VERCEL_GIT_COMMIT_REF'
+	] as const;
+	const saved: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		for (const key of vars) {
+			saved[key] = process.env[key];
+			delete process.env[key];
+		}
+		process.env.VERCEL = '1';
+		process.env.VERCEL_URL = 'myapp-abc123xyz.vercel.app';
+	});
+
+	afterEach(() => {
+		for (const key of vars) {
+			if (saved[key] === undefined) delete process.env[key];
+			else process.env[key] = saved[key];
+		}
+	});
+
+	it('prefers the production domain over the deployment URL for production builds', () => {
+		process.env.VERCEL_ENV = 'production';
+		process.env.VERCEL_PROJECT_PRODUCTION_URL = 'myapp.vercel.app';
+		const platform = detectPlatform();
+		expect(platform.siteUrl).toBe('https://myapp.vercel.app');
+		expect(platform.deployUrl).toBe('myapp-abc123xyz.vercel.app');
+	});
+
+	it('falls back to the deployment URL for production when no production domain is set', () => {
+		process.env.VERCEL_ENV = 'production';
+		const platform = detectPlatform();
+		expect(platform.siteUrl).toBe('https://myapp-abc123xyz.vercel.app');
+	});
+
+	it('uses the deployment URL for previews even when a production domain is set', () => {
+		process.env.VERCEL_ENV = 'preview';
+		process.env.VERCEL_PROJECT_PRODUCTION_URL = 'myapp.vercel.app';
+		const platform = detectPlatform();
+		expect(platform.siteUrl).toBe('https://myapp-abc123xyz.vercel.app');
+		expect(platform.isPreview).toBe(true);
+	});
+
+	it('returns null siteUrl when no Vercel URL is available', () => {
+		process.env.VERCEL_ENV = 'production';
+		delete process.env.VERCEL_URL;
+		const platform = detectPlatform();
+		expect(platform.siteUrl).toBeNull();
 	});
 });

--- a/scripts/deploy/platform.ts
+++ b/scripts/deploy/platform.ts
@@ -40,6 +40,13 @@ export function detectPlatform(): PlatformContext {
 		const env = process.env.VERCEL_ENV as 'production' | 'preview' | 'development' | undefined;
 		const environment = env ?? 'development';
 		const vercelUrl = process.env.VERCEL_URL ?? null;
+		// VERCEL_URL is the per-deployment generated host (changes every deploy).
+		// For production builds prefer VERCEL_PROJECT_PRODUCTION_URL, the stable
+		// production domain, so baked canonical/og URLs don't point at an
+		// ephemeral deployment host.
+		const productionUrl =
+			environment === 'production' ? (process.env.VERCEL_PROJECT_PRODUCTION_URL ?? null) : null;
+		const siteHost = productionUrl ?? vercelUrl;
 
 		return {
 			platform: 'vercel',
@@ -47,8 +54,8 @@ export function detectPlatform(): PlatformContext {
 			deployUrl: vercelUrl,
 			gitRef: process.env.VERCEL_GIT_COMMIT_REF ?? null,
 			isPreview: environment === 'preview',
-			// Vercel provides hostname only (no protocol)
-			siteUrl: vercelUrl ? `https://${vercelUrl}` : null
+			// Vercel provides hostnames only (no protocol)
+			siteUrl: siteHost ? `https://${siteHost}` : null
 		};
 	}
 

--- a/scripts/deploy/steps.test.ts
+++ b/scripts/deploy/steps.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { PlatformContext } from './platform';
+import { computeBuildEnv, type ConvexDeployment } from './steps';
+
+const deployment: ConvexDeployment = {
+	urlSlug: 'curious-lark-703.eu-west-1',
+	name: 'curious-lark-703'
+};
+
+function makePlatform(overrides: Partial<PlatformContext> = {}): PlatformContext {
+	return {
+		platform: 'cloudflare',
+		environment: 'production',
+		deployUrl: null,
+		gitRef: 'main',
+		isPreview: false,
+		siteUrl: 'https://myapp.example.workers.dev',
+		...overrides
+	};
+}
+
+describe('computeBuildEnv', () => {
+	// computeBuildEnv spreads process.env, so isolate the vars it touches
+	const savedPublicSiteUrl = process.env.PUBLIC_SITE_URL;
+	const savedSiteUrl = process.env.SITE_URL;
+
+	beforeEach(() => {
+		delete process.env.PUBLIC_SITE_URL;
+		delete process.env.SITE_URL;
+	});
+
+	afterEach(() => {
+		if (savedPublicSiteUrl === undefined) delete process.env.PUBLIC_SITE_URL;
+		else process.env.PUBLIC_SITE_URL = savedPublicSiteUrl;
+		if (savedSiteUrl === undefined) delete process.env.SITE_URL;
+		else process.env.SITE_URL = savedSiteUrl;
+	});
+
+	it('sets PUBLIC_SITE_URL from platform.siteUrl when unset', () => {
+		const buildEnv = computeBuildEnv(makePlatform(), deployment);
+		expect(buildEnv.PUBLIC_SITE_URL).toBe('https://myapp.example.workers.dev');
+	});
+
+	it('does not overwrite an explicitly set PUBLIC_SITE_URL', () => {
+		process.env.PUBLIC_SITE_URL = 'https://custom-domain.example.com';
+		const buildEnv = computeBuildEnv(makePlatform(), deployment);
+		expect(buildEnv.PUBLIC_SITE_URL).toBe('https://custom-domain.example.com');
+	});
+
+	it('leaves PUBLIC_SITE_URL unset when platform.siteUrl is null', () => {
+		const buildEnv = computeBuildEnv(makePlatform({ siteUrl: null }), deployment);
+		expect(buildEnv.PUBLIC_SITE_URL).toBeUndefined();
+	});
+
+	it('sets PUBLIC_SITE_URL for preview deployments alongside SITE_URL', () => {
+		const buildEnv = computeBuildEnv(
+			makePlatform({
+				environment: 'preview',
+				isPreview: true,
+				siteUrl: 'https://branch-myapp.example.workers.dev'
+			}),
+			deployment
+		);
+		expect(buildEnv.SITE_URL).toBe('https://branch-myapp.example.workers.dev');
+		expect(buildEnv.PUBLIC_SITE_URL).toBe('https://branch-myapp.example.workers.dev');
+	});
+});

--- a/scripts/deploy/steps.ts
+++ b/scripts/deploy/steps.ts
@@ -460,6 +460,15 @@ export function computeBuildEnv(
 		console.log(`SITE_URL (for SvelteKit build): ${buildEnv.SITE_URL}`);
 	}
 
+	// Bake the real site origin into prerendered SEO tags (canonical, hreflang,
+	// og:url, og:image). Without it, SvelteKit prerenders absolute URLs with the
+	// http://sveltekit-prerender placeholder. An explicitly set PUBLIC_SITE_URL
+	// (e.g. a custom domain) always wins over the platform-derived URL.
+	if (!buildEnv.PUBLIC_SITE_URL && platform.siteUrl) {
+		buildEnv.PUBLIC_SITE_URL = platform.siteUrl;
+		console.log(`PUBLIC_SITE_URL (for SvelteKit build): ${buildEnv.PUBLIC_SITE_URL}`);
+	}
+
 	return buildEnv;
 }
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -144,7 +144,10 @@ export type CoercedEnvSchema = {
   
   /**
    * **PUBLIC_SITE_URL**  
-   * Site URL for test requests (defaults to localhost:5173)  
+   * Canonical site origin (e.g. https://example.com). Baked into prerendered SEO  
+   * tags (canonical, hreflang, og:url, og:image) at build time; also the E2E test  
+   * base URL in CI (defaults to localhost:5173). The deploy script derives it from  
+   * the platform when unset; set it explicitly for custom domains.  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M24%2021V9h-2v14h8v-2zm-4-6v-4c0-1.103-.897-2-2-2h-6v14h2v-6h1.48l2.335%206h2.145l-2.333-6H18c1.103%200%202-.897%202-2m-6-4h4v4h-4zM8%2023H4c-1.103%200-2-.897-2-2V9h2v12h4V9h2v12c0%201.103-.897%202-2%202%22%2F%3E%3C%2Fsvg%3E)   
    */
   PUBLIC_SITE_URL?: string;

--- a/src/lib/components/SEOHead.svelte
+++ b/src/lib/components/SEOHead.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { PUBLIC_SITE_URL } from '$env/static/public';
 	import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from '$lib/i18n/languages';
 	import { LEGAL_CONFIG } from '$lib/config/legal';
+
+	// During prerendering page.url.origin is SvelteKit's placeholder
+	// http://sveltekit-prerender, so absolute SEO URLs must come from the
+	// configured site origin when available. Trailing slash is stripped to
+	// avoid double slashes in `${origin}${image}` and `${origin}/${lang}`.
+	const configuredOrigin = PUBLIC_SITE_URL.replace(/\/$/, '');
 
 	interface Props {
 		/** Page title (without site name suffix) */
@@ -29,7 +36,7 @@
 	// Get current language and path
 	let currentLang = $derived(page.params.lang || DEFAULT_LANGUAGE);
 	let currentPath = $derived(page.url.pathname);
-	let origin = $derived(page.url.origin);
+	let origin = $derived(configuredOrigin || page.url.origin);
 
 	// Generate path without language prefix for alternate links
 	let pathWithoutLang = $derived.by(() => {


### PR DESCRIPTION
Closes #479

`SEOHead.svelte` derived every absolute SEO URL from `page.url.origin`, which is SvelteKit's build-time placeholder `http://sveltekit-prerender` on prerendered routes. The shipped static HTML for every prerendered marketing page therefore carried that nonexistent host in `rel=canonical`, `og:url`, `og:image`, `twitter:image` and all hreflang alternates. Crawlers read the static HTML before hydration, so Google canonicalization and hreflang targeting pointed at a dead host and social previews fetched a broken image URL, silently in any fork since the build succeeds.

`SEOHead` now imports `PUBLIC_SITE_URL` from `$env/static/public`, strips a trailing slash, and prefers it over `page.url.origin`, which stays as the runtime fallback when the var is unset. `computeBuildEnv` in `scripts/deploy/steps.ts` derives `PUBLIC_SITE_URL` from `platform.siteUrl` when it is not set explicitly, so CF Workers and Vercel builds bake the real deployment origin into the prerendered HTML while an explicitly configured value (for example a custom domain) always wins. On Vercel, `detectPlatform` prefers `VERCEL_PROJECT_PRODUCTION_URL` for production builds, since `VERCEL_URL` is the per-deployment generated host that changes on every deploy; previews keep the deployment URL. The `PUBLIC_SITE_URL` comment in `.env.schema` now documents this role, with `src/env.d.ts` regenerated via `varlock typegen`, and new tests in `scripts/deploy/steps.test.ts` and `scripts/deploy/platform.test.ts` cover the derive, no-overwrite, null `siteUrl` and Vercel production-domain cases.

`bun scripts/static-checks.ts` on the changed files, `bun run test:unit` (494 tests), and a build proof both ways pass: `PUBLIC_SITE_URL=https://example.com bun run build` produces prerendered pages with zero `sveltekit-prerender` occurrences and `https://example.com` in canonical, hreflang and `og:image`, while a plain `bun run build` without the var still succeeds with the runtime-origin fallback.

