### PR TITLE
refactor(hooks): Scope shared $state per request

### DIFF
--- a/src/lib/hooks/admin-support-ui.svelte.ts
+++ b/src/lib/hooks/admin-support-ui.svelte.ts
@@ -1,4 +1,13 @@
-class AdminSupportUIManager {
+import { Context } from 'runed';
+
+/**
+ * UI state for the admin support details overlay (Sheet/Drawer).
+ *
+ * Provided via context from the admin support page so each SSR request gets
+ * its own instance; `detailsOpen` is read during SSR via `bind:open`, so a
+ * module-scope singleton would be shared across concurrent requests.
+ */
+export class AdminSupportUIManager {
 	detailsOpen = $state(false);
 
 	toggle() {
@@ -10,4 +19,4 @@ class AdminSupportUIManager {
 	}
 }
 
-export const adminSupportUI = new AdminSupportUIManager();
+export const adminSupportUIContext = new Context<AdminSupportUIManager>('admin-support-ui');

--- a/src/lib/hooks/auth-flow.svelte.ts
+++ b/src/lib/hooks/auth-flow.svelte.ts
@@ -1,9 +1,14 @@
+import { Context } from 'runed';
+
 /**
  * Shared email state across auth pages (sign-in, sign-up, forgot-password)
- * This improves UX by remembering the email when switching between auth flows
+ * This improves UX by remembering the email when switching between auth flows.
+ *
+ * Provided via context from the (auth) layout so each SSR request gets its own
+ * instance instead of sharing a module-scope singleton across requests.
  */
-class AuthFlowManager {
+export class AuthFlowManager {
 	email = $state('');
 }
 
-export const authFlow = new AuthFlowManager();
+export const authFlowContext = new Context<AuthFlowManager>('auth-flow');

--- a/src/lib/hooks/use-haptic.svelte.ts
+++ b/src/lib/hooks/use-haptic.svelte.ts
@@ -97,4 +97,8 @@ export class UseHaptic {
 	}
 }
 
+// Intentional module-scope singleton: SSR-safe because every $state write is
+// browser-guarded and no field is rendered into SSR HTML, so nothing can leak
+// across requests. Kept as a singleton (instead of context) for ergonomic
+// imports across its many call sites.
 export const haptic = new UseHaptic();

--- a/src/lib/hooks/use-haptic.svelte.ts
+++ b/src/lib/hooks/use-haptic.svelte.ts
@@ -97,8 +97,10 @@ export class UseHaptic {
 	}
 }
 
-// Intentional module-scope singleton: SSR-safe because every $state write is
-// browser-guarded and no field is rendered into SSR HTML, so nothing can leak
-// across requests. Kept as a singleton (instead of context) for ergonomic
-// imports across its many call sites.
+// Intentional module-scope singleton: SSR-safe because every write of
+// caller-controlled data (trigger) is browser-guarded; the remaining writes
+// (constructor default, debug setter, cancel) set constants with no
+// per-request data, and no field is rendered into SSR HTML, so nothing can
+// leak across requests. Kept as a singleton (instead of context) for
+// ergonomic imports across its many call sites.
 export const haptic = new UseHaptic();

--- a/src/routes/[[lang]]/(auth)/+layout.svelte
+++ b/src/routes/[[lang]]/(auth)/+layout.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { AuthFlowManager, authFlowContext } from '$lib/hooks/auth-flow.svelte';
 
 	interface Props {
 		children?: Snippet;
 	}
 
 	let { children }: Props = $props();
+
+	// Per-request instance (no SSR cross-request leaks); the layout survives
+	// client-side navigation between auth pages, so the remembered email does too
+	authFlowContext.set(new AuthFlowManager());
 </script>
 
 <main id="main-content">

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -15,7 +15,7 @@
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { forgotPasswordSchema } from './schema.js';
 	import { slide } from 'svelte/transition';
-	import { authFlow } from '$lib/hooks/auth-flow.svelte';
+	import { authFlowContext } from '$lib/hooks/auth-flow.svelte';
 	import { getAuthErrorKey } from '$lib/utils/auth-messages';
 	import { translateValidationErrors } from '$lib/utils/validation-i18n.js';
 
@@ -30,8 +30,9 @@
 
 	const id = $props.id();
 
-	// Form data
-	let formData = $state({ email: '' });
+	const authFlow = authFlowContext.get();
+	// Form data, initialized once from the shared auth-flow email
+	let formData = $state({ email: authFlow.email });
 	const isFormDisabled = $derived(isLoading || !hydrated);
 
 	// Field errors
@@ -60,14 +61,7 @@
 		hydrated = true;
 	});
 
-	// Initialize email from global state
-	$effect(() => {
-		if (authFlow.email && !formData.email) {
-			formData.email = authFlow.email;
-		}
-	});
-
-	// Sync email changes back to global state
+	// Sync email changes back to the shared auth-flow state
 	$effect(() => {
 		if (formData.email) {
 			authFlow.email = formData.email;

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -13,7 +13,7 @@
 	import { resolve } from '$app/paths';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
-	import { authFlow } from '$lib/hooks/auth-flow.svelte';
+	import { authFlowContext } from '$lib/hooks/auth-flow.svelte';
 	import {
 		type LastAuthMethod,
 		type PendingOAuthProvider,
@@ -53,7 +53,9 @@
 
 	const id = $props.id();
 
-	let signInData = $state({ email: '', password: '' });
+	const authFlow = authFlowContext.get();
+	// Initialize once from the shared auth-flow email; the input owns it afterward
+	let signInData = $state({ email: authFlow.email, password: '' });
 	let signInErrors = $state<Record<string, string[]>>({});
 
 	function isLastUsedAuthMethod(method: LastAuthMethod): boolean {
@@ -86,14 +88,7 @@
 	);
 	const signInProgress = $derived((signInCompletedSteps / signInTotalSteps) * 100);
 
-	// Initialize email from global state
-	$effect(() => {
-		if (authFlow.email) {
-			signInData.email = authFlow.email;
-		}
-	});
-
-	// Sync email changes to global state
+	// Sync email changes to the shared auth-flow state
 	$effect(() => {
 		if (signInData.email) {
 			authFlow.email = signInData.email;

--- a/src/routes/[[lang]]/(auth)/signup/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signup/+page.svelte
@@ -13,7 +13,7 @@
 	import { resolve } from '$app/paths';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
-	import { authFlow } from '$lib/hooks/auth-flow.svelte';
+	import { authFlowContext } from '$lib/hooks/auth-flow.svelte';
 	import {
 		type PendingOAuthProvider,
 		lastSuccessfulAuthMethod,
@@ -51,7 +51,9 @@
 
 	const id = $props.id();
 
-	let signUpData = $state({ name: '', email: '', password: '' });
+	const authFlow = authFlowContext.get();
+	// Initialize once from the shared auth-flow email; the input owns it afterward
+	let signUpData = $state({ name: '', email: authFlow.email, password: '' });
 	let signUpErrors = $state<Record<string, string[]>>({});
 
 	function isLastUsedAuthMethod(method: LastAuthMethod): boolean {
@@ -89,14 +91,7 @@
 	);
 	const signUpProgress = $derived((signUpCompletedSteps / signUpTotalSteps) * 100);
 
-	// Initialize email from global state
-	$effect(() => {
-		if (authFlow.email) {
-			signUpData.email = authFlow.email;
-		}
-	});
-
-	// Sync email changes to global state
+	// Sync email changes to the shared auth-flow state
 	$effect(() => {
 		if (signUpData.email) {
 			authFlow.email = signUpData.email;

--- a/src/routes/[[lang]]/admin/support/+page.svelte
+++ b/src/routes/[[lang]]/admin/support/+page.svelte
@@ -17,12 +17,15 @@
 	import ThreadList from './thread-list.svelte';
 	import ThreadChat from './thread-chat.svelte';
 	import ThreadDetails from './thread-details.svelte';
-	import { adminSupportUI } from '$lib/hooks/admin-support-ui.svelte';
+	import { AdminSupportUIManager, adminSupportUIContext } from '$lib/hooks/admin-support-ui.svelte';
 	import { adminCache } from '$lib/hooks/admin-cache.svelte';
 	import { ChatDraftManager } from '$lib/chat';
 	import { browser } from '$app/environment';
 
 	const { t } = getTranslate();
+
+	// Per-request overlay state shared with thread-chat via context
+	const adminSupportUI = adminSupportUIContext.set(new AdminSupportUIManager());
 
 	// Draft persistence — lives outside {#key threadId} so drafts survive thread switches
 	const draftManager = new ChatDraftManager('drafts:admin-support');

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -18,7 +18,7 @@
 	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
 	import { useMedia } from '$lib/hooks/use-media.svelte';
 	import { SlidingHeader } from '$lib/components/ui/sliding-header';
-	import { adminSupportUI } from '$lib/hooks/admin-support-ui.svelte';
+	import { adminSupportUIContext } from '$lib/hooks/admin-support-ui.svelte';
 	import { getTranslate } from '@tolgee/svelte';
 	import { page } from '$app/state';
 
@@ -43,6 +43,7 @@
 
 	const media = useMedia();
 	const client = useConvexClient();
+	const adminSupportUI = adminSupportUIContext.get();
 
 	// Upload configuration for file attachments with locale for translated error messages
 	const uploadConfig: UploadConfig = {

--- a/src/routes/[[lang]]/app/settings/account-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/account-settings.svelte
@@ -26,15 +26,11 @@
 
 	const convexClient = useConvexClient();
 
-	let name = $state('');
-	let image = $state('');
+	// Writable deriveds: editable via bind:value/assignments, re-synced when user changes
+	let name = $derived(user?.name ?? '');
+	let image = $derived(user?.image ?? '');
 	let isUploading = $state(false);
 	let isSaving = $state(false);
-	// Update reactive values when user changes
-	$effect(() => {
-		name = user?.name ?? '';
-		image = user?.image ?? '';
-	});
 
 	async function handleFileSelect(e: Event) {
 		const target = e.target as HTMLInputElement;


### PR DESCRIPTION
Closes #500

Module-scope `$state` singletons (`authFlow` in `auth-flow.svelte.ts`, `adminSupportUI` in `admin-support-ui.svelte.ts`) live in shared module state, which the SvelteKit docs warn leaks between users during SSR. `adminSupportUI.detailsOpen` is read during SSR via `bind:open` on the support details Sheet and Drawer, so concurrent admin requests shared one value, and any fork that prefills an SSR-rendered input from `authFlow.email` would leak one user's email into another request. Separately, several components copied reactive values into editable form `$state` inside `$effect`, which re-runs on any reactive change to its source and silently overwrites unsaved typing.

Both singletons are now provided through runed `Context`. The `(auth)` layout sets a per-request `AuthFlowManager` instance. Since the layout survives client-side navigation between the auth pages, the email is still remembered when switching between sign-in, sign-up, and forgot-password. One behavior change: navigating out of the auth group and back now resets the remembered email, where the old module singleton kept it for the whole SPA session. This is an accepted, privacy-positive trade-off, since the email no longer lingers in memory after leaving the auth flow. The admin support page sets an `AdminSupportUIManager` instance that `thread-chat.svelte` reads from context, with all call sites unchanged. The inbound `$effect` blocks that copied `authFlow.email` into form state on `signin`, `signup`, and `forgot-password` are deleted; each form initializes its email field once from `authFlow.email` and owns it afterward, while the outbound sync effect keeps recording typed emails. In `account-settings.svelte` the prop-to-state `$effect` is replaced with writable `$derived` for `name` and `image`, so the form re-syncs when `user` changes and `bind:value`, the upload preview, and the remove handler keep working. The `haptic` singleton stays module-scoped with an intentional anti-pattern comment: every write of caller-controlled data is browser-guarded, the remaining writes set constants with no per-request data, and nothing is rendered into SSR HTML, so migrating its many call sites to context would add churn without removing any leak.

`bun scripts/static-checks.ts` on all changed files, `bun run test:unit` (486 tests), and the auth and support Playwright specs (`forgot-reset-password`, `invalid-auth`, `signin-invalid-credentials`, `signin-last-used-badge`, `signout`, `support-migration`) via `bun run test:e2e` all pass.

