### PR TITLE
fix(ui): Add error branches to useQuery consumers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,11 +440,21 @@ For each data need in a new route, pick the right pattern:
 3. **Real-time data that can show a loading state?**
    → Skip server fetch, use `useQuery` directly (no `initialData`):
 
-   ```ts
-   const metrics = useQuery(api.admin.queries.getDashboardMetrics, {});
+   ```svelte
+   <script lang="ts">
+   	const metrics = useQuery(api.admin.queries.getDashboardMetrics, {});
+   	const isLoading = $derived(metrics.isLoading);
+   </script>
+
+   {#if metrics.error}
+   	<p class="text-destructive"><T keyName="common.load_error" /></p>
+   {:else}
+   	<!-- skeleton while isLoading, data when resolved -->
+   {/if}
    ```
 
    Shows skeleton/loading state until data arrives. Use for admin panels, secondary data.
+   Always render an error branch from `metrics.error` (localized via Tolgee) and derive loading from `isLoading`, never from `!metrics.data`: on a query throw `data` stays `undefined` forever, so a `!data` loading state shows infinite skeletons. No retry plumbing needed, the Convex subscription stays live and the error state self-heals when the query recovers.
 
 4. **Billing/subscription checks?**
    → `useCustomer()` from `@stickerdaniel/convex-autumn-svelte/sveltekit`

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -636,6 +636,7 @@
 		"confirm": "Bestätigen",
 		"confirm_input_placeholder": "Geben Sie \"{text}\" ein, um zu bestätigen.",
 		"delete": "Löschen",
+		"load_error": "Daten konnten nicht geladen werden. Bitte versuchen Sie es später erneut.",
 		"save": "Speichern",
 		"you": "Sie"
 	},
@@ -1086,6 +1087,7 @@
 			"question_text": "Warum SaaS Starter?"
 		},
 		"thread": {
+			"load_error": "Unterhaltungen konnten nicht geladen werden. Bitte versuchen Sie es später erneut.",
 			"new_conversation": "Neue Unterhaltung"
 		},
 		"time": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -636,6 +636,7 @@
 		"confirm": "Confirm",
 		"confirm_input_placeholder": "Enter \"{text}\" to confirm.",
 		"delete": "Delete",
+		"load_error": "Failed to load data. Please try again later.",
 		"save": "Save",
 		"you": "You"
 	},
@@ -1086,6 +1087,7 @@
 			"question_text": "Why SaaS Starter?"
 		},
 		"thread": {
+			"load_error": "Failed to load conversations. Please try again later.",
 			"new_conversation": "New conversation"
 		},
 		"time": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -636,6 +636,7 @@
 		"confirm": "Confirmar",
 		"confirm_input_placeholder": "Escribe \"{text}\" para confirmar.",
 		"delete": "Eliminar",
+		"load_error": "No se pudieron cargar los datos. Por favor, inténtalo de nuevo más tarde.",
 		"save": "Guardar",
 		"you": "Tú"
 	},
@@ -1086,6 +1087,7 @@
 			"question_text": "¿Por qué SaaS Starter?"
 		},
 		"thread": {
+			"load_error": "No se pudieron cargar las conversaciones. Por favor, inténtalo de nuevo más tarde.",
 			"new_conversation": "Nueva conversación"
 		},
 		"time": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -636,6 +636,7 @@
 		"confirm": "Confirmer",
 		"confirm_input_placeholder": "Saisissez \"{text}\" pour confirmer.",
 		"delete": "Supprimer",
+		"load_error": "Échec du chargement des données. Veuillez réessayer plus tard.",
 		"save": "Enregistrer",
 		"you": "Vous"
 	},
@@ -1086,6 +1087,7 @@
 			"question_text": "Pourquoi SaaS Starter ?"
 		},
 		"thread": {
+			"load_error": "Échec du chargement des conversations. Veuillez réessayer plus tard.",
 			"new_conversation": "Nouvelle conversation"
 		},
 		"time": {

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -40,6 +40,9 @@
 	// Filter out threads with no messages (e.g., eagerly created but never used threads)
 	const threads = $derived((threadsQuery.data?.page ?? []).filter((t) => t.lastMessage));
 	const isLoading = $derived(!ctx.userId ? true : threadsQuery.isLoading);
+	// Query error: without this branch the greeting/empty state would swallow it
+	// (self-heals when the live Convex subscription recovers)
+	const loadError = $derived(threadsQuery.error);
 
 	// Query admin avatars for the welcome screen
 	const adminAvatarsQuery = useQuery(api.support.threads.getAdminAvatars, {});
@@ -216,7 +219,14 @@
 <div class="flex h-full flex-col" inert={ctx.currentView !== 'overview' ? true : undefined}>
 	<!-- Thread List -->
 	<div class="min-h-0 flex-1 overflow-y-auto">
-		{#if !isLoading && threads.length === 0}
+		{#if loadError}
+			<div
+				class="flex h-full items-center justify-center p-8 text-center text-balance text-destructive"
+				data-testid="support-threads-error"
+			>
+				{$t('support.thread.load_error')}
+			</div>
+		{:else if !isLoading && threads.length === 0}
 			<!-- Empty state with greeting (only shown after query completes) -->
 			<div class="flex h-full flex-col justify-start">
 				<div class="m-10 flex flex-col items-start">

--- a/src/lib/tables/convex/create-convex-cursor-table.svelte.ts
+++ b/src/lib/tables/convex/create-convex-cursor-table.svelte.ts
@@ -401,8 +401,11 @@ export function createConvexCursorTable<
 			isResolvingPreviousPage ||
 			(currentPageData === undefined && listQuery.isLoading)
 	);
-	// Reactive query error: when set, isLoading is false and rows is empty, so
-	// consumers must render an error branch or the empty state swallows it.
+	// Reactive query error: when set, isLoading is false. On a first-load failure
+	// rows is empty, so consumers must render an error branch or the empty state
+	// swallows it. After a successful load, rows can stay non-empty from pageCache
+	// while the live subscription errors; consumers rendering the error ahead of
+	// those stale rows is intentional and transient.
 	// Self-heals: the Convex subscription stays live and clears the error on recovery.
 	const error = $derived(listQuery.error ?? countQuery.error);
 

--- a/src/lib/tables/convex/create-convex-cursor-table.svelte.ts
+++ b/src/lib/tables/convex/create-convex-cursor-table.svelte.ts
@@ -21,6 +21,7 @@ export type ConvexCursorTableState<TItem, TSortField extends string, TFilterKeys
 	readonly urlState: TableUrlState<TFilterKeys>;
 	readonly rows: TItem[];
 	readonly isLoading: boolean;
+	readonly error: Error | undefined;
 	readonly totalCount: number;
 	readonly hasLoadedCount: boolean;
 	readonly pageCount: number;
@@ -400,6 +401,10 @@ export function createConvexCursorTable<
 			isResolvingPreviousPage ||
 			(currentPageData === undefined && listQuery.isLoading)
 	);
+	// Reactive query error: when set, isLoading is false and rows is empty, so
+	// consumers must render an error branch or the empty state swallows it.
+	// Self-heals: the Convex subscription stays live and clears the error on recovery.
+	const error = $derived(listQuery.error ?? countQuery.error);
 
 	function cachePage(index: number, data: CursorListResult<TItem> | undefined) {
 		if (!data) return;
@@ -669,6 +674,9 @@ export function createConvexCursorTable<
 		},
 		get isLoading() {
 			return isLoading;
+		},
+		get error() {
+			return error;
 		},
 		get totalCount() {
 			return totalCount;

--- a/src/routes/[[lang]]/admin/dashboard/+page.svelte
+++ b/src/routes/[[lang]]/admin/dashboard/+page.svelte
@@ -22,8 +22,9 @@
 	// Fetch dashboard metrics
 	const metrics = useQuery(api.admin.queries.getDashboardMetrics, {});
 
-	// Derive loading state
-	let isLoading = $derived(!metrics.data);
+	// Derive loading state from isLoading, not !data: on a query throw data
+	// stays undefined while isLoading turns false, which would freeze skeletons
+	let isLoading = $derived(metrics.isLoading);
 
 	// Update user count context when metrics load
 	$effect(() => {
@@ -40,45 +41,56 @@
 
 <div class="flex flex-col gap-6">
 	<!-- Metrics Cards -->
-	<div
-		class="grid grid-cols-1 gap-4 px-4 *:data-[slot=card]:bg-linear-to-t *:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card *:data-[slot=card]:shadow-xs lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4 dark:*:data-[slot=card]:bg-card"
-	>
-		<MetricCard
-			label={$t('admin.metrics.total_users')}
-			value={metrics.data?.totalUsers ?? 0}
-			description={$t('admin.metrics.total_users_desc')}
-			subtitle={$t('admin.metrics.registered_users')}
-			icon={UsersIcon}
-			loading={isLoading}
-		/>
+	{#if metrics.error}
+		<div class="px-4 lg:px-6">
+			<p
+				class="rounded-md border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive"
+				data-testid="admin-dashboard-error"
+			>
+				<T keyName="common.load_error" />
+			</p>
+		</div>
+	{:else}
+		<div
+			class="grid grid-cols-1 gap-4 px-4 *:data-[slot=card]:bg-linear-to-t *:data-[slot=card]:from-primary/5 *:data-[slot=card]:to-card *:data-[slot=card]:shadow-xs lg:px-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4 dark:*:data-[slot=card]:bg-card"
+		>
+			<MetricCard
+				label={$t('admin.metrics.total_users')}
+				value={metrics.data?.totalUsers ?? 0}
+				description={$t('admin.metrics.total_users_desc')}
+				subtitle={$t('admin.metrics.registered_users')}
+				icon={UsersIcon}
+				loading={isLoading}
+			/>
 
-		<MetricCard
-			label={$t('admin.metrics.active_sessions')}
-			value={metrics.data?.activeIn24h ?? 0}
-			description={$t('admin.metrics.active_sessions_desc')}
-			subtitle={$t('admin.metrics.currently_active')}
-			icon={ActivityIcon}
-			loading={isLoading}
-		/>
+			<MetricCard
+				label={$t('admin.metrics.active_sessions')}
+				value={metrics.data?.activeIn24h ?? 0}
+				description={$t('admin.metrics.active_sessions_desc')}
+				subtitle={$t('admin.metrics.currently_active')}
+				icon={ActivityIcon}
+				loading={isLoading}
+			/>
 
-		<MetricCard
-			label={$t('admin.metrics.recent_signups')}
-			value={metrics.data?.recentSignups ?? 0}
-			description={$t('admin.metrics.recent_signups_desc')}
-			subtitle={$t('admin.metrics.last_7_days')}
-			icon={UserPlusIcon}
-			loading={isLoading}
-		/>
+			<MetricCard
+				label={$t('admin.metrics.recent_signups')}
+				value={metrics.data?.recentSignups ?? 0}
+				description={$t('admin.metrics.recent_signups_desc')}
+				subtitle={$t('admin.metrics.last_7_days')}
+				icon={UserPlusIcon}
+				loading={isLoading}
+			/>
 
-		<MetricCard
-			label={$t('admin.metrics.admins')}
-			value={metrics.data?.adminCount ?? 0}
-			description={$t('admin.metrics.admins_desc')}
-			subtitle={$t('admin.metrics.admin_users')}
-			icon={ShieldCheckIcon}
-			loading={isLoading}
-		/>
-	</div>
+			<MetricCard
+				label={$t('admin.metrics.admins')}
+				value={metrics.data?.adminCount ?? 0}
+				description={$t('admin.metrics.admins_desc')}
+				subtitle={$t('admin.metrics.admin_users')}
+				icon={ShieldCheckIcon}
+				loading={isLoading}
+			/>
+		</div>
+	{/if}
 
 	<!-- External Service Links -->
 	<div class="flex flex-col gap-4 px-4 lg:px-6">

--- a/src/routes/[[lang]]/admin/settings/founder-welcome-card.svelte
+++ b/src/routes/[[lang]]/admin/settings/founder-welcome-card.svelte
@@ -135,7 +135,11 @@
 		</Item.Description>
 	</Item.Content>
 	<Item.Footer>
-		{#if !result.data}
+		{#if result.error}
+			<p class="text-sm text-destructive" data-testid="founder-welcome-error">
+				<T keyName="common.load_error" />
+			</p>
+		{:else if !result.data}
 			<Button size="sm" variant="outline" class="invisible">&nbsp;</Button>
 		{:else if !isEnabled}
 			<Button size="sm" onclick={openDialog}>

--- a/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
+++ b/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
@@ -110,6 +110,7 @@
 	const pageIndex = $derived(recipientsTable.pageIndex);
 	const pageSize = $derived(recipientsTable.pageSize);
 	const isLoading = $derived(recipientsTable.isLoading);
+	const loadError = $derived(recipientsTable.error);
 	const typeFilter = $derived(recipientsTable.filters.type as RecipientTypeFilter);
 	const sorting = $derived.by<SortingState>(() => {
 		const sortBy = recipientsTable.sortBy;
@@ -341,6 +342,15 @@
 								</Table.Cell>
 							</Table.Row>
 						{/each}
+					{:else if loadError}
+						<Table.Row data-testid="recipients-error">
+							<Table.Cell
+								colspan={columns.length}
+								class="h-24 text-center text-destructive hover:!bg-transparent"
+							>
+								<T keyName="common.load_error" />
+							</Table.Cell>
+						</Table.Row>
 					{:else if table.getRowModel().rows.length === 0 || (isLoading && skeletonCount === 0)}
 						<Table.Row data-testid="recipients-empty">
 							<Table.Cell

--- a/src/routes/[[lang]]/admin/support/+page.svelte
+++ b/src/routes/[[lang]]/admin/support/+page.svelte
@@ -77,6 +77,7 @@
 	const allThreads = $derived(threadsQuery.results);
 	const isLoading = $derived(threadsQuery.isLoading);
 	const isDone = $derived(threadsQuery.status === 'Exhausted');
+	const loadError = $derived(threadsQuery.error);
 
 	// Selected thread from already-loaded list (for instant header display)
 	const selectedThread = $derived(allThreads.find((t) => t._id === threadId));
@@ -155,6 +156,7 @@
 					threads={allThreads}
 					selectedThreadId={threadId}
 					{isLoading}
+					error={loadError}
 					{isDone}
 					cachedCount={cachedThreadCount}
 					onFilterChange={(mode) => (filters.mode = mode)}
@@ -211,6 +213,7 @@
 					threads={allThreads}
 					selectedThreadId={threadId}
 					{isLoading}
+					error={loadError}
 					{isDone}
 					cachedCount={cachedThreadCount}
 					onFilterChange={(mode) => (filters.mode = mode)}
@@ -251,6 +254,7 @@
 				threads={allThreads}
 				selectedThreadId={threadId}
 				{isLoading}
+				error={loadError}
 				{isDone}
 				cachedCount={cachedThreadCount}
 				onFilterChange={(mode) => (filters.mode = mode)}

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -98,8 +98,11 @@
 	}));
 	const thread = $derived(threadQuery.data);
 
-	// Loading state: true when no initial data and query hasn't resolved yet
-	const isLoading = $derived(!initialThread && !thread);
+	// Loading state: true when no initial data and query hasn't resolved or failed yet
+	const isLoading = $derived(!initialThread && !thread && !threadQuery.error);
+	// Error state: query threw and there is no data to fall back to (self-heals
+	// when the live Convex subscription recovers)
+	const showLoadError = $derived(!initialThread && !thread && !!threadQuery.error);
 
 	// Derived display values: prefer initialThread (instant), fallback to query data
 	const displayName = $derived(
@@ -159,6 +162,27 @@
 					</span>
 				</Button>
 			</header>
+		{:else if showLoadError}
+			<!-- Error header (back button stays functional) -->
+			<header class="flex shrink-0 items-center gap-2 border-b border-border/50 p-4">
+				<div class="relative flex size-10 items-center justify-center">
+					<Button
+						variant="ghost"
+						size="icon"
+						class="h-10 w-10 rounded-full hover:!bg-muted-foreground/10"
+						onclick={onBackClick}
+					>
+						<ChevronLeft class="size-5" />
+					</Button>
+				</div>
+				<div class="min-w-0 flex-1 py-1">
+					<div class="flex h-10 items-center">
+						<p class="text-sm text-destructive" data-testid="thread-chat-error">
+							{$t('common.load_error')}
+						</p>
+					</div>
+				</div>
+			</header>
 		{:else}
 			<SlidingHeader
 				isBackView={true}
@@ -208,6 +232,11 @@
 								<Skeleton class="h-3.5 w-40" />
 							</div>
 						</div>
+					{:else if showLoadError}
+						<!-- Error state -->
+						<p class="text-sm text-destructive" data-testid="thread-chat-error">
+							{$t('common.load_error')}
+						</p>
 					{:else}
 						<!-- Resolved state -->
 						<AvatarHeading image={userImage} title={displayName} subtitle={displayEmail} />

--- a/src/routes/[[lang]]/admin/support/thread-details.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-details.svelte
@@ -289,6 +289,13 @@
 					{/if}
 				</Field.Group>
 			</div>
+		{:else if threadQuery.error}
+			<div
+				class="flex h-full items-center justify-center text-center text-balance text-destructive"
+				data-testid="thread-details-error"
+			>
+				<T keyName="common.load_error" />
+			</div>
 		{/if}
 	</div>
 </div>

--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -57,6 +57,7 @@
 		threads = [],
 		selectedThreadId,
 		isLoading = false,
+		error,
 		isDone = false,
 		cachedCount,
 		onFilterChange,
@@ -71,6 +72,7 @@
 		threads?: Thread[];
 		selectedThreadId: string | null | undefined;
 		isLoading?: boolean;
+		error?: Error | undefined;
 		isDone?: boolean;
 		cachedCount?: number;
 		onFilterChange: (mode: 'all' | 'unassigned' | 'my-inbox') => void;
@@ -170,7 +172,15 @@
 
 	<!-- Thread List -->
 	<div class="relative flex-1">
-		{#if isLoading}
+		{#if error && threads.length === 0}
+			<!-- Query error with nothing loaded (load-more errors are handled by InfiniteLoader's error snippet) -->
+			<div
+				class="absolute inset-0 flex items-center justify-center p-8 text-center text-destructive"
+				data-testid="admin-support-threads-error"
+			>
+				<T keyName="common.load_error" />
+			</div>
+		{:else if isLoading}
 			<!-- Loading skeletons -->
 			<div class="scrollbar-thin absolute inset-0 overflow-y-auto">
 				{#each Array(skeletonCount) as _, i (i)}

--- a/src/routes/[[lang]]/admin/users/+page.svelte
+++ b/src/routes/[[lang]]/admin/users/+page.svelte
@@ -188,6 +188,7 @@
 			: (usersTable.filters.provider as ProviderFilter)
 	);
 	const isLoading = $derived(usersTable.isLoading);
+	const loadError = $derived(usersTable.error);
 
 	// TanStack Table state (only client-side concerns remain)
 	let rowSelection = $state<RowSelectionState>({});
@@ -602,6 +603,16 @@
 									</Table.Cell>
 								</Table.Row>
 							{/each}
+						{:else if loadError}
+							<Table.Row class="hover:!bg-transparent">
+								<Table.Cell
+									colspan={columns.length}
+									class="h-24 text-center text-destructive"
+									data-testid="admin-users-error"
+								>
+									<T keyName="common.load_error" />
+								</Table.Cell>
+							</Table.Row>
 						{:else if table.getRowModel().rows.length === 0 || (isLoading && skeletonCount === 0)}
 							<Table.Row class="hover:!bg-transparent">
 								<Table.Cell


### PR DESCRIPTION
Closes #488

convex-svelte's `useQuery` and `usePaginatedQuery` expose an `error` field, but no consumer in `src/routes` read it. Every consumer derived its loading state from `!data` or from `isLoading` alone, so a transient Convex or network throw left `data` undefined forever and the UI stayed on skeletons (admin dashboard, users table, notification recipients table, support inbox, thread chat header) or went silently blank (thread details, founder welcome card, customer support widget) with no message and no recovery path.

The cursor-table factory `create-convex-cursor-table.svelte.ts` now derives an `error` from `listQuery.error ?? countQuery.error` and exposes it on the returned state. Both table consumers render a localized full-width error row (`admin-users-error`, `recipients-error`) ahead of the empty state, which previously swallowed a first-load failure because `isLoading` turns false on a throw while `rows` is still empty. After a successful load `rows` can stay non-empty from the page cache, so on a later subscription error the error row intentionally takes priority over the stale rows. The standalone consumers read `.error` directly: the admin dashboard replaces the metric cards with an inline error and derives loading from `metrics.isLoading` instead of `!metrics.data`, the support inbox passes the paginated query error into the thread list (only when nothing is loaded yet, since load-more failures already have the `InfiniteLoader` retry snippet), the thread chat header and the details panel swap their skeleton or blank state for an error message, the founder welcome card footer shows the error instead of its invisible placeholder button, and the customer support widget shows it instead of the greeting. No retry plumbing is added because the Convex subscription stays live after an error, so every error state self-heals once the query recovers. The copy is localized in all four locales via `common.load_error` and `support.thread.load_error`, and the `AGENTS.md` pattern-3 example now includes the error branch so forks copy it.

`bun scripts/static-checks.ts` on all changed files passes, `bun run test:unit` passes (486 tests), and `bun run test:e2e e2e/admin-users-table.spec.ts e2e/admin-settings-table.spec.ts e2e/admin-settings.spec.ts` passes.

