### PR TITLE
refactor(chat): Extract shared quota banner

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -295,13 +295,6 @@
 		}
 	},
 	"ai_chat": {
-		"alerts": {
-			"limit_reached": "Sie haben alle Ihre KI-Chat-Nachrichten diesen Monat aufgebraucht. Upgraden Sie auf Pro für mehr.",
-			"limit_reached_free": "Upgraden Sie auf Pro für mehr KI-Chat-Nachrichten pro Monat.",
-			"limit_reached_pro": "Sie haben alle Ihre KI-Chat-Nachrichten diesen Monat aufgebraucht. Sie werden nächsten Monat zurückgesetzt.",
-			"low_messages": "{remaining} von {total} KI-Chat-Nachricht verbleibend diesen Monat.",
-			"low_messages_plural": "{remaining} von {total} KI-Chat-Nachrichten verbleibend diesen Monat."
-		},
 		"delete_thread": "Unterhaltung löschen",
 		"delete_thread_confirm": "Sind Sie sicher, dass Sie diese Unterhaltung löschen möchten?",
 		"description": "Chatten Sie mit unserem KI-Assistenten",
@@ -541,15 +534,10 @@
 			"talk_to_human": "Mit Experte sprechen"
 		},
 		"alerts": {
-			"limit_reached": {
-				"description": "Sie haben alle {total} kostenlosen Nachrichten für diesen Monat verbraucht.",
-				"title": "Nachrichtenlimit erreicht"
-			},
-			"low_messages": {
-				"description": "Sie haben noch {remaining} von {total} Nachricht für diesen Monat.",
-				"description_plural": "Sie haben noch {remaining} von {total} Nachrichten für diesen Monat.",
-				"title": "Wenig Nachrichten übrig"
-			}
+			"limit_reached_free": "Upgraden Sie auf Pro für mehr Nachrichten pro Monat.",
+			"limit_reached_pro": "Sie haben alle Ihre Nachrichten für diesen Monat aufgebraucht. Sie werden nächsten Monat zurückgesetzt.",
+			"low_messages": "{remaining} von {total} Nachricht verbleibend diesen Monat.",
+			"low_messages_plural": "{remaining} von {total} Nachrichten verbleibend diesen Monat."
 		},
 		"aria": {
 			"remove_attachment": "{filename} entfernen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -295,13 +295,6 @@
 		}
 	},
 	"ai_chat": {
-		"alerts": {
-			"limit_reached": "You've used all your AI chat messages this month. Upgrade to Pro for more.",
-			"limit_reached_free": "Upgrade to Pro for more AI chat messages per month.",
-			"limit_reached_pro": "You've used all your AI chat messages this month. They reset next month.",
-			"low_messages": "{remaining} of {total} AI chat message remaining this month.",
-			"low_messages_plural": "{remaining} of {total} AI chat messages remaining this month."
-		},
 		"delete_thread": "Delete conversation",
 		"delete_thread_confirm": "Are you sure you want to delete this conversation?",
 		"description": "Chat with our AI assistant",
@@ -541,15 +534,10 @@
 			"talk_to_human": "Talk to a human"
 		},
 		"alerts": {
-			"limit_reached": {
-				"description": "You've used all {total} of your free messages this month.",
-				"title": "Message Limit Reached"
-			},
-			"low_messages": {
-				"description": "You have {remaining} of {total} message remaining this month.",
-				"description_plural": "You have {remaining} of {total} messages remaining this month.",
-				"title": "Low on Messages"
-			}
+			"limit_reached_free": "Upgrade to Pro for more messages per month.",
+			"limit_reached_pro": "You've used all your messages this month. They reset next month.",
+			"low_messages": "{remaining} of {total} message remaining this month.",
+			"low_messages_plural": "{remaining} of {total} messages remaining this month."
 		},
 		"aria": {
 			"remove_attachment": "Remove {filename}",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -295,13 +295,6 @@
 		}
 	},
 	"ai_chat": {
-		"alerts": {
-			"limit_reached": "Has usado todos tus mensajes de chat con IA este mes. Actualiza a Pro para obtener más.",
-			"limit_reached_free": "Actualiza a Pro para más mensajes de chat con IA al mes.",
-			"limit_reached_pro": "Has usado todos tus mensajes de chat con IA este mes. Se reinician el mes que viene.",
-			"low_messages": "{remaining} de {total} mensaje de chat con IA restante este mes.",
-			"low_messages_plural": "{remaining} de {total} mensajes de chat con IA restantes este mes."
-		},
 		"delete_thread": "Eliminar conversación",
 		"delete_thread_confirm": "¿Estás seguro de que quieres eliminar esta conversación?",
 		"description": "Chatea con nuestro asistente de IA",
@@ -541,15 +534,10 @@
 			"talk_to_human": "Hablar con una persona"
 		},
 		"alerts": {
-			"limit_reached": {
-				"description": "Has usado todos los {total} mensajes gratuitos de este mes.",
-				"title": "Límite de Mensajes Alcanzado"
-			},
-			"low_messages": {
-				"description": "Tienes {remaining} de {total} mensaje restante este mes.",
-				"description_plural": "Tienes {remaining} de {total} mensajes restantes este mes.",
-				"title": "Pocos Mensajes"
-			}
+			"limit_reached_free": "Actualiza a Pro para más mensajes al mes.",
+			"limit_reached_pro": "Has usado todos tus mensajes este mes. Se reinician el mes que viene.",
+			"low_messages": "{remaining} de {total} mensaje restante este mes.",
+			"low_messages_plural": "{remaining} de {total} mensajes restantes este mes."
 		},
 		"aria": {
 			"remove_attachment": "Eliminar {filename}",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -295,13 +295,6 @@
 		}
 	},
 	"ai_chat": {
-		"alerts": {
-			"limit_reached": "Vous avez utilisé tous vos messages de chat IA ce mois-ci. Passez à Pro pour en obtenir plus.",
-			"limit_reached_free": "Passez à Pro pour plus de messages de chat IA par mois.",
-			"limit_reached_pro": "Vous avez utilisé tous vos messages de chat IA ce mois-ci. Ils seront réinitialisés le mois prochain.",
-			"low_messages": "{remaining} sur {total} message de chat IA restant ce mois-ci.",
-			"low_messages_plural": "{remaining} sur {total} messages de chat IA restants ce mois-ci."
-		},
 		"delete_thread": "Supprimer la conversation",
 		"delete_thread_confirm": "Êtes-vous sûr de vouloir supprimer cette conversation ?",
 		"description": "Discutez avec notre assistant IA",
@@ -541,15 +534,10 @@
 			"talk_to_human": "Parler à un humain"
 		},
 		"alerts": {
-			"limit_reached": {
-				"description": "Vous avez utilisé tous vos {total} messages gratuits de ce mois.",
-				"title": "Limite de Messages Atteinte"
-			},
-			"low_messages": {
-				"description": "Il vous reste {remaining} message sur {total} pour ce mois.",
-				"description_plural": "Il vous reste {remaining} messages sur {total} pour ce mois.",
-				"title": "Peu de Messages"
-			}
+			"limit_reached_free": "Passez à Pro pour plus de messages par mois.",
+			"limit_reached_pro": "Vous avez utilisé tous vos messages ce mois-ci. Ils seront réinitialisés le mois prochain.",
+			"low_messages": "{remaining} sur {total} message restant ce mois-ci.",
+			"low_messages_plural": "{remaining} sur {total} messages restants ce mois-ci."
 		},
 		"aria": {
 			"remove_attachment": "Supprimer {filename}",

--- a/src/lib/components/message-quota-banner.svelte
+++ b/src/lib/components/message-quota-banner.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import LockIcon from '@lucide/svelte/icons/lock';
+	import { T, getTranslate } from '@tolgee/svelte';
+
+	const { t } = getTranslate();
+
+	let {
+		isPro = false,
+		hasMessagesAvailable = false,
+		remaining = 0,
+		total = 0,
+		onUpgrade,
+		isUpgrading = false
+	}: {
+		isPro?: boolean;
+		hasMessagesAvailable?: boolean;
+		remaining?: number;
+		total?: number;
+		onUpgrade?: () => void;
+		isUpgrading?: boolean;
+	} = $props();
+
+	// Low when a third or less of the quota remains. The isFinite guard makes
+	// this a no-op for unlimited quotas (total = Infinity).
+	const isLow = $derived(
+		Number.isFinite(total) && total > 0 && remaining > 0 && remaining / total <= 1 / 3
+	);
+</script>
+
+{#if !hasMessagesAvailable}
+	<!-- Out of messages: free users get an upgrade CTA, Pro users an info notice -->
+	<div
+		class="mx-4 mb-2 flex items-center justify-between rounded-lg border border-border/50 bg-muted/50 px-4 py-3 backdrop-blur-sm"
+	>
+		<div class="flex items-center gap-2 text-sm text-muted-foreground">
+			<LockIcon class="size-4 shrink-0" />
+			<span>
+				<T keyName={isPro ? 'chat.alerts.limit_reached_pro' : 'chat.alerts.limit_reached_free'} />
+			</span>
+		</div>
+		{#if !isPro}
+			<Button size="sm" variant="default" onclick={onUpgrade} disabled={isUpgrading}>
+				{isUpgrading ? $t('chat.buttons.processing') : $t('chat.buttons.upgrade')}
+			</Button>
+		{/if}
+	</div>
+{:else if isLow}
+	<!-- Low on messages: nudge free users to upgrade, inform Pro users -->
+	<div
+		class="mx-4 mb-2 flex items-center justify-between rounded-lg border border-border/50 bg-muted/50 px-4 py-3 backdrop-blur-sm"
+	>
+		<div class="flex items-center gap-2 text-sm text-muted-foreground">
+			<span>
+				<T
+					keyName={remaining !== 1 ? 'chat.alerts.low_messages_plural' : 'chat.alerts.low_messages'}
+					params={{ remaining, total }}
+				/>
+			</span>
+		</div>
+		{#if !isPro}
+			<Button size="sm" variant="outline" onclick={onUpgrade} disabled={isUpgrading}>
+				{isUpgrading ? $t('chat.buttons.processing') : $t('chat.buttons.upgrade')}
+			</Button>
+		{/if}
+	</div>
+{/if}

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -10,9 +10,8 @@
 	import { ChatUIContext, type UploadConfig } from '$lib/chat/ui/ChatContext.svelte';
 	import { ChatCore } from '$lib/chat/core/ChatCore.svelte';
 	import { ChatDraftManager } from '$lib/chat/core/ChatDraftManager.svelte';
-	import { Button } from '$lib/components/ui/button';
-	import LockIcon from '@lucide/svelte/icons/lock';
-	import { T, getTranslate } from '@tolgee/svelte';
+	import MessageQuotaBanner from '$lib/components/message-quota-banner.svelte';
+	import { getTranslate } from '@tolgee/svelte';
 	import { page } from '$app/state';
 	import { tick } from 'svelte';
 
@@ -159,65 +158,14 @@
 					{/key}
 				</div>
 			{/if}
-			{#if !hasMessagesAvailable && !isPro}
-				<!-- Free user, out of messages: upgrade banner -->
-				<div
-					class="mx-4 mb-2 flex items-center justify-between rounded-lg border border-border/50 bg-muted/50 px-4 py-3 backdrop-blur-sm"
-				>
-					<div class="flex items-center gap-2 text-sm text-muted-foreground">
-						<LockIcon class="size-4 shrink-0" />
-						<span><T keyName="ai_chat.alerts.limit_reached_free" /></span>
-					</div>
-					<Button size="sm" variant="default" onclick={onUpgrade} disabled={isUpgrading}>
-						{isUpgrading ? $t('chat.buttons.processing') : $t('chat.buttons.upgrade')}
-					</Button>
-				</div>
-			{:else if !hasMessagesAvailable && isPro}
-				<!-- Pro user, out of messages -->
-				<div
-					class="mx-4 mb-2 flex items-center justify-between rounded-lg border border-border/50 bg-muted/50 px-4 py-3 backdrop-blur-sm"
-				>
-					<div class="flex items-center gap-2 text-sm text-muted-foreground">
-						<LockIcon class="size-4 shrink-0" />
-						<span><T keyName="ai_chat.alerts.limit_reached_pro" /></span>
-					</div>
-				</div>
-			{:else if !isPro && Number.isFinite(totalMessages) && totalMessages > 0 && remainingMessages > 0 && remainingMessages / totalMessages <= 1 / 3}
-				<!-- Free user, low messages: upgrade nudge -->
-				<div
-					class="mx-4 mb-2 flex items-center justify-between rounded-lg border border-border/50 bg-muted/50 px-4 py-3 backdrop-blur-sm"
-				>
-					<div class="flex items-center gap-2 text-sm text-muted-foreground">
-						<span>
-							<T
-								keyName={remainingMessages !== 1
-									? 'ai_chat.alerts.low_messages_plural'
-									: 'ai_chat.alerts.low_messages'}
-								params={{ remaining: remainingMessages, total: totalMessages }}
-							/>
-						</span>
-					</div>
-					<Button size="sm" variant="outline" onclick={onUpgrade} disabled={isUpgrading}>
-						{isUpgrading ? $t('chat.buttons.processing') : $t('chat.buttons.upgrade')}
-					</Button>
-				</div>
-			{:else if isPro && Number.isFinite(totalMessages) && totalMessages > 0 && remainingMessages > 0 && remainingMessages / totalMessages <= 1 / 3}
-				<!-- Pro user, low messages -->
-				<div
-					class="mx-4 mb-2 flex items-center justify-between rounded-lg border border-border/50 bg-muted/50 px-4 py-3 backdrop-blur-sm"
-				>
-					<div class="flex items-center gap-2 text-sm text-muted-foreground">
-						<span>
-							<T
-								keyName={remainingMessages !== 1
-									? 'ai_chat.alerts.low_messages_plural'
-									: 'ai_chat.alerts.low_messages'}
-								params={{ remaining: remainingMessages, total: totalMessages }}
-							/>
-						</span>
-					</div>
-				</div>
-			{/if}
+			<MessageQuotaBanner
+				{isPro}
+				{hasMessagesAvailable}
+				remaining={remainingMessages}
+				total={totalMessages}
+				{onUpgrade}
+				{isUpgrading}
+			/>
 			<ChatInput
 				class="mx-4"
 				placeholder={$t('ai_chat.input.placeholder')}

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -20,14 +20,14 @@
 	import ProgressiveBlur from '$blocks/magic/ProgressiveBlur.svelte';
 	import { FadeOnLoad } from '$lib/utils/fade-on-load.svelte.js';
 	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
-	import LockIcon from '@lucide/svelte/icons/lock';
+	import MessageQuotaBanner from '$lib/components/message-quota-banner.svelte';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { toast } from 'svelte-sonner';
 	import { mode } from 'mode-watcher';
 	import { tick, onMount } from 'svelte';
 
 	import { page } from '$app/state';
-	import { T, getTranslate } from '@tolgee/svelte';
+	import { getTranslate } from '@tolgee/svelte';
 	import type { OptimisticLocalStore } from 'convex/browser';
 	import { ConvexError } from 'convex/values';
 	import type { Id } from '$lib/convex/_generated/dataModel';
@@ -290,51 +290,16 @@
 
 		<!-- Input area -->
 		<div class="relative z-20 mx-auto w-full max-w-3xl -translate-y-4">
-			{#if !isPro && !hasMessagesAvailable}
-				<div
-					class="mx-4 mb-2 flex items-center justify-between rounded-lg border border-border/50 bg-muted/50 px-4 py-3 backdrop-blur-sm"
-				>
-					<div class="flex items-center gap-2 text-sm text-muted-foreground">
-						<LockIcon class="size-4 shrink-0" />
-						<span><T keyName="chat.alerts.limit_reached.title" /></span>
-					</div>
-					<Button
-						size="sm"
-						variant="default"
-						onclick={handleUpgrade}
-						disabled={upgradeOperation.isLoading}
-					>
-						{upgradeOperation.isLoading
-							? $t('chat.buttons.processing')
-							: $t('chat.buttons.upgrade')}
-					</Button>
-				</div>
-			{:else if !isPro && remainingMessages <= 3 && remainingMessages > 0}
-				<div
-					class="mx-4 mb-2 flex items-center justify-between rounded-lg border border-border/50 bg-muted/50 px-4 py-3 backdrop-blur-sm"
-				>
-					<div class="flex items-center gap-2 text-sm text-muted-foreground">
-						<span>
-							<T
-								keyName={remainingMessages !== 1
-									? 'chat.alerts.low_messages.description_plural'
-									: 'chat.alerts.low_messages.description'}
-								params={{ remaining: remainingMessages, total: totalMessages }}
-							/>
-						</span>
-					</div>
-					<Button
-						size="sm"
-						variant="outline"
-						onclick={handleUpgrade}
-						disabled={upgradeOperation.isLoading}
-					>
-						{upgradeOperation.isLoading
-							? $t('chat.buttons.processing')
-							: $t('chat.buttons.upgrade')}
-					</Button>
-				</div>
-			{/if}
+			<!-- Pro community chat is unlimited (hasMessagesAvailable is always true and
+			     total is Infinity), so the banner's Pro branches never fire here -->
+			<MessageQuotaBanner
+				{isPro}
+				{hasMessagesAvailable}
+				remaining={remainingMessages}
+				total={totalMessages}
+				onUpgrade={handleUpgrade}
+				isUpgrading={upgradeOperation.isLoading}
+			/>
 
 			<PromptInput
 				class="mx-4 bg-popover p-0"


### PR DESCRIPTION
Closes #466

`community-chat/+page.svelte` and `ai-chat/thread-chat.svelte` rendered a visually identical out-of-messages / low-messages banner twice, with two parallel translation namespaces (`chat.alerts.*` vs `ai_chat.alerts.*`) and two different low-message thresholds (absolute `<= 3` vs ratio `<= 1/3`). A user crossing features got inconsistent warnings, and every key existed twice in all four locales.

This extracts one shared `message-quota-banner.svelte` component taking `isPro`, `hasMessagesAvailable`, `remaining`, `total`, `onUpgrade` and `isUpgrading`, with a single ratio threshold (`remaining / total <= 1/3`, guarded by `Number.isFinite(total)` so unlimited Pro quotas never trigger it). Both routes now render this component, and the locale files carry one unified key set (`chat.alerts.limit_reached_free`, `chat.alerts.limit_reached_pro`, `chat.alerts.low_messages`, `chat.alerts.low_messages_plural`) with generic "messages" copy in `en`, `de`, `es` and `fr`. The superseded nested `chat.alerts.limit_reached.*` / `chat.alerts.low_messages.*` blocks and the whole `ai_chat.alerts.*` block are removed, including the previously dead keys. Behavior changes to be aware of: community free users now see the low-messages nudge only at 1 of 3 remaining instead of whenever 3 or fewer remain, and the community limit-reached banner shows the unified upgrade copy instead of the old "Message Limit Reached" title.

`bun run i18n:push -- --tag-new-keys draft` reported import conflicts and was not forced, so the new keys still need a Tolgee push after a pull reconciliation, and `bun run i18n:cleanup` should run after merge to deprecate the removed keys.

`bun scripts/static-checks.ts` on all changed files passes, `bun run test:unit` passes (486 tests, including locale key parity), and the Svelte autofixer reports no issues on the new component. The 3/3, 1/3 and 0/3 banner states were not manually verified in a running dev app.
