### PR TITLE
fix(ci): Fail E2E status when preview build fails

### DIFF
--- a/.github/workflows/e2e-preview-cf.yml
+++ b/.github/workflows/e2e-preview-cf.yml
@@ -50,8 +50,9 @@ jobs:
           ref: ${{ github.event.check_run.head_sha }}
 
       - name: Extract preview URL
+        env:
+          SUMMARY: ${{ github.event.check_run.output.summary }}
         run: |
-          SUMMARY="${{ github.event.check_run.output.summary }}"
           PREVIEW_URL=$(echo "$SUMMARY" | grep 'Preview Alias URL:' | sed 's/.*Preview Alias URL: //' | tr -d '[:space:]')
           if [ -z "$PREVIEW_URL" ]; then
             echo "::error::No Preview Alias URL found in check_run output"

--- a/.github/workflows/e2e-preview-cf.yml
+++ b/.github/workflows/e2e-preview-cf.yml
@@ -26,6 +26,40 @@ jobs:
             -f context="E2E Tests" \
             -f description="Skipped (production build, no preview)"
 
+  # Resolve the required E2E status when the CF preview build does not succeed.
+  # Without this, the pending status set by static-checks.yml would stay
+  # pending forever and block merging on this SHA.
+  e2e-build-failed:
+    name: E2E Build Failed Status
+    runs-on: ubicloud-standard-2
+    permissions:
+      statuses: write
+    # conclusion is always terminal here because the trigger is check_run: [completed]
+    if: |
+      github.event.check_run.app.slug == 'cloudflare-workers-and-pages' &&
+      github.event.check_run.conclusion != 'success' &&
+      github.event.check_run.pull_requests[0]
+    steps:
+      - name: Report build failure to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.check_run.head_sha }}
+          CONCLUSION: ${{ github.event.check_run.conclusion }}
+          TARGET_URL: ${{ github.event.check_run.html_url }}
+        run: |
+          for i in 1 2 3; do
+            gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
+              -f state=failure \
+              -f context="E2E Tests" \
+              -f description="CF preview build ${CONCLUSION}, E2E skipped" \
+              -f target_url="$TARGET_URL" \
+              && exit 0
+            echo "Attempt $i failed, retrying in 5s..."
+            sleep 5
+          done
+          echo "::warning::Failed to report status after 3 attempts"
+          exit 1
+
   e2e-tests:
     name: E2E Tests
     runs-on: ubicloud-standard-2

--- a/.github/workflows/e2e-preview-vercel.yml
+++ b/.github/workflows/e2e-preview-vercel.yml
@@ -7,6 +7,9 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubicloud-standard-2
+    permissions:
+      statuses: write
+      contents: read
     # Only run on successful Vercel preview deployments
     if: |
       github.event.deployment_status.state == 'success' &&
@@ -82,3 +85,56 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report/
+
+      - name: Report status to PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.deployment.sha }}
+        run: |
+          for i in 1 2 3; do
+            gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
+              -f state=${{ job.status == 'success' && 'success' || 'failure' }} \
+              -f context="E2E Tests" \
+              -f description="E2E Tests (Vercel Preview)" \
+              -f target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              && exit 0
+            echo "Attempt $i failed, retrying in 5s..."
+            sleep 5
+          done
+          echo "::warning::Failed to report status after 3 attempts"
+          exit 1
+
+  # Resolve the required E2E status when the Vercel preview deployment fails.
+  # Without this, the pending status set by static-checks.yml would stay
+  # pending forever and block merging on this SHA.
+  e2e-deploy-failed:
+    name: E2E Deploy Failed Status
+    runs-on: ubicloud-standard-2
+    permissions:
+      statuses: write
+    # deployment_status also fires for pending/in_progress/queued, so gate on
+    # explicit terminal failure states only
+    if: |
+      github.event.deployment_status.environment == 'Preview' &&
+      (github.event.deployment_status.state == 'failure' || github.event.deployment_status.state == 'error')
+    steps:
+      - name: Report deploy failure to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.deployment.sha }}
+          DEPLOY_STATE: ${{ github.event.deployment_status.state }}
+          TARGET_URL: ${{ github.event.deployment_status.target_url || format('https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id) }}
+        run: |
+          for i in 1 2 3; do
+            gh api "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
+              -f state=failure \
+              -f context="E2E Tests" \
+              -f description="Vercel preview deploy ${DEPLOY_STATE}, E2E skipped" \
+              -f target_url="$TARGET_URL" \
+              && exit 0
+            echo "Attempt $i failed, retrying in 5s..."
+            sleep 5
+          done
+          echo "::warning::Failed to report status after 3 attempts"
+          exit 1


### PR DESCRIPTION
Closes #482

`static-checks.yml` sets the required `E2E Tests` commit status to pending on every same-repo PR, but every job that resolves it was gated on a successful preview build. When the CF check run concluded with `failure`, `cancelled`, or `timed_out`, or the Vercel preview deployment failed, nothing overwrote the pending status and the PR could not merge on that SHA. The Vercel workflow additionally had no status-posting step at all, so even a green Vercel E2E run left the status stuck.

`e2e-preview-cf.yml` gains an `e2e-build-failed` job that fires on any non-success CF check-run conclusion for a PR commit and posts `state=failure` for the `E2E Tests` context, with `target_url` pointing at the CF check run. The conclusion is always terminal because the trigger is `check_run: [completed]`. Event data reaches the shell only through `env`, matching the injection-safe pattern this branch stacks on, and the status write reuses the existing 3-attempt retry loop. `e2e-preview-vercel.yml` gains `statuses: write` permission, a `Report status to PR` step with `if: always()` that posts success or failure on `github.event.deployment.sha` after E2E runs, and an `e2e-deploy-failed` job that posts `state=failure` when a `Preview` deployment ends in `failure` or `error`. That job gates on those explicit terminal states only, since `deployment_status` also fires for `pending` and `in_progress`.

`bun scripts/static-checks.ts` on both workflow files passes, and `actionlint` reports no new findings beyond the pre-existing custom runner label warnings. The live failure path needs a deliberately broken preview build to observe and is not exercised by this PR.
