### PR TITLE
fix(support): Sync denormalized profile fields

### DIFF
--- a/src/lib/convex/admin/founderWelcome/mutations.ts
+++ b/src/lib/convex/admin/founderWelcome/mutations.ts
@@ -74,7 +74,7 @@ export const updateConfig = adminMutation({
 		// Upsert per-user profile (name, title, replyTo)
 		const existingProfile = await ctx.db
 			.query('adminProfiles')
-			.withIndex('by_userId', (q) => q.eq('userId', adminUserId))
+			.withIndex('by_user', (q) => q.eq('userId', adminUserId))
 			.unique();
 
 		if (existingProfile) {

--- a/src/lib/convex/admin/founderWelcome/queries.ts
+++ b/src/lib/convex/admin/founderWelcome/queries.ts
@@ -63,7 +63,7 @@ async function readFounderWelcomeConfig(ctx: QueryCtx): Promise<FounderWelcomeCo
 	// Read per-user profile for contact person
 	const profile = await ctx.db
 		.query('adminProfiles')
-		.withIndex('by_userId', (q) => q.eq('userId', contactUserId))
+		.withIndex('by_user', (q) => q.eq('userId', contactUserId))
 		.unique();
 
 	// Read global email config
@@ -110,7 +110,7 @@ export const getFounderWelcomeConfig = adminQuery({
 		// Read viewer's own profile for form pre-fill
 		const viewerProfile = await ctx.db
 			.query('adminProfiles')
-			.withIndex('by_userId', (q) => q.eq('userId', ctx.user._id))
+			.withIndex('by_user', (q) => q.eq('userId', ctx.user._id))
 			.unique();
 
 		const viewerUser = await ctx.runQuery(components.betterAuth.adapter.findOne, {

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -210,9 +210,11 @@ export const authComponent = createClient<DataModel, typeof authSchema>(componen
 			 * Called when a user is updated
 			 * - Sends signup notification when email becomes verified
 			 * - Detects admin role changes and syncs notification preferences
+			 * - Re-syncs denormalized support thread identity on name/email change
 			 *
 			 * Notification scheduling is intentionally unwrapped (see onCreate).
-			 * Preference sync IS wrapped to prevent blocking user updates.
+			 * Preference and support thread syncs ARE wrapped to prevent blocking
+			 * user updates.
 			 */
 			onUpdate: async (ctx, newUser, oldUser) => {
 				const becameVerified = oldUser.emailVerified !== true && newUser.emailVerified === true;
@@ -282,6 +284,20 @@ export const authComponent = createClient<DataModel, typeof authSchema>(componen
 					}
 				} catch (error) {
 					console.error('Failed to sync admin preferences on user update:', error);
+				}
+
+				// Support threads denormalize userName/userEmail into searchText;
+				// re-sync them so the admin support list reflects the new identity.
+				if (oldUser.name !== newUser.name || oldUser.email !== newUser.email) {
+					try {
+						await ctx.runMutation(internal.support.threads.syncUserProfile, {
+							userId: newUser._id,
+							userName: newUser.name ?? undefined,
+							userEmail: newUser.email
+						});
+					} catch (error) {
+						console.error('Failed to sync support thread profile on user update:', error);
+					}
 				}
 			}
 		}

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -129,7 +129,7 @@ export default defineSchema({
 		founderWelcomeName: v.optional(v.string()),
 		founderWelcomeTitle: v.optional(v.string()),
 		founderWelcomeReplyTo: v.optional(v.string())
-	}).index('by_userId', ['userId']),
+	}).index('by_user', ['userId']),
 
 	// File metadata - stores image dimensions for proper dialog sizing
 	// (agent component strips unknown fields from file parts, so we store dimensions separately)

--- a/src/lib/convex/support/__tests__/maintenance.test.ts
+++ b/src/lib/convex/support/__tests__/maintenance.test.ts
@@ -22,6 +22,11 @@ vi.mock('../../_generated/api', () => ({
 			messages: {
 				listMessagesByThreadId: 'components.agent.messages.listMessagesByThreadId'
 			}
+		},
+		betterAuth: {
+			adapter: {
+				findOne: 'components.betterAuth.adapter.findOne'
+			}
 		}
 	},
 	internal: {}
@@ -30,7 +35,7 @@ vi.mock('../../_generated/api', () => ({
 import { authComponent } from '../../auth';
 import { supportAgent } from '../agent';
 import { migrateAnonymousTickets } from '../migration';
-import { backfillThreadMetadata } from '../threads';
+import { backfillThreadMetadata, syncUserProfile } from '../threads';
 
 const getAuthUserMock = authComponent.getAuthUser as unknown as ReturnType<typeof vi.fn>;
 const updateThreadMetadataMock = supportAgent.updateThreadMetadata as unknown as ReturnType<
@@ -50,37 +55,41 @@ const migrateAnonymousTicketsHandler = migrateAnonymousTickets as unknown as Mut
 	{ anonymousUserId: string },
 	{ migratedCount: number }
 >;
+const syncUserProfileHandler = syncUserProfile as unknown as MutationHandler<
+	{ userId: string; userName?: string; userEmail?: string },
+	null
+>;
 
 describe('support maintenance helpers', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it('backfills support denormalized fields from existing agent data', async () => {
+	it('backfills support denormalized fields from the live user profile', async () => {
 		const collect = vi.fn().mockResolvedValue([
 			{
 				_id: 'support_doc_1',
 				threadId: 'thread_1',
-				userName: 'Ada',
-				userEmail: 'ada@example.com'
+				userId: 'user_1',
+				userName: 'Ada Old',
+				userEmail: 'old@example.com'
+			},
+			{
+				_id: 'support_doc_anon',
+				threadId: 'thread_anon',
+				userId: 'anon_123'
 			}
 		]);
 		const patch = vi.fn().mockResolvedValue(undefined);
-		const ctx = {
-			db: {
-				query: vi.fn(() => ({
-					collect
-				})),
-				patch
-			},
-			runQuery: vi
-				.fn()
-				.mockResolvedValueOnce({
-					_id: 'thread_1',
-					title: 'Billing',
-					summary: 'Upgrade issue'
-				})
-				.mockResolvedValueOnce({
+		const runQuery = vi.fn(async (ref: string, args: { threadId?: string }) => {
+			if (ref === 'components.agent.threads.getThread') {
+				return { _id: args.threadId, title: 'Billing', summary: 'Upgrade issue' };
+			}
+			if (ref === 'components.betterAuth.adapter.findOne') {
+				return { name: 'Ada', email: 'ada@example.com' };
+			}
+			if (ref === 'components.agent.messages.listMessagesByThreadId') {
+				return {
 					page: [
 						{
 							text: 'Latest support reply',
@@ -89,20 +98,104 @@ describe('support maintenance helpers', () => {
 							message: { role: 'assistant' }
 						}
 					]
-				})
+				};
+			}
+			throw new Error(`Unexpected runQuery ref: ${ref}`);
+		});
+		const ctx = {
+			db: {
+				query: vi.fn(() => ({
+					collect
+				})),
+				patch
+			},
+			runQuery
 		};
 
 		const result = await backfillThreadMetadataHandler._handler(ctx, {});
 
-		expect(result).toEqual({ updated: 1, total: 1 });
-		expect(patch).toHaveBeenCalledWith('support_doc_1', {
+		expect(result).toEqual({ updated: 2, total: 2 });
+
+		// Authenticated thread: stale denormalized values are replaced by the live profile
+		expect(patch).toHaveBeenNthCalledWith(1, 'support_doc_1', {
 			title: 'Billing',
 			summary: 'Upgrade issue',
+			userName: 'Ada',
+			userEmail: 'ada@example.com',
 			lastMessage: 'Latest support reply',
 			lastMessageAt: 1234,
 			lastMessageRole: 'assistant',
 			lastAgentName: 'Kai',
 			searchText: 'billing | upgrade issue | latest support reply | ada | ada@example.com'
+		});
+
+		// Anonymous thread: no profile fetch, no identity in searchText
+		expect(patch).toHaveBeenNthCalledWith(2, 'support_doc_anon', {
+			title: 'Billing',
+			summary: 'Upgrade issue',
+			userName: undefined,
+			userEmail: undefined,
+			lastMessage: 'Latest support reply',
+			lastMessageAt: 1234,
+			lastMessageRole: 'assistant',
+			lastAgentName: 'Kai',
+			searchText: 'billing | upgrade issue | latest support reply'
+		});
+
+		const profileLookups = runQuery.mock.calls.filter(
+			([ref]) => ref === 'components.betterAuth.adapter.findOne'
+		);
+		expect(profileLookups).toHaveLength(1);
+		expect(profileLookups[0][1]).toEqual({
+			model: 'user',
+			where: [{ field: '_id', operator: 'eq', value: 'user_1' }]
+		});
+	});
+
+	it('syncs denormalized profile fields across all threads of a user', async () => {
+		const collect = vi.fn().mockResolvedValue([
+			{
+				_id: 'support_doc_1',
+				title: 'Billing',
+				summary: 'Upgrade issue',
+				lastMessage: 'Latest support reply',
+				userName: 'Ada Old',
+				userEmail: 'old@example.com',
+				notificationEmail: 'custom@example.com',
+				updatedAt: 1000
+			},
+			{
+				_id: 'support_doc_2',
+				userName: 'Ada Old',
+				userEmail: 'old@example.com'
+			}
+		]);
+		const withIndex = vi.fn(() => ({ collect }));
+		const patch = vi.fn().mockResolvedValue(undefined);
+		const ctx = {
+			db: {
+				query: vi.fn(() => ({ withIndex })),
+				patch
+			}
+		};
+
+		const result = await syncUserProfileHandler._handler(ctx, {
+			userId: 'user_1',
+			userName: 'Ada New',
+			userEmail: 'new@example.com'
+		});
+
+		expect(result).toBeNull();
+		// Exact patch objects: notificationEmail and updatedAt are intentionally untouched
+		expect(patch).toHaveBeenNthCalledWith(1, 'support_doc_1', {
+			userName: 'Ada New',
+			userEmail: 'new@example.com',
+			searchText: 'billing | upgrade issue | latest support reply | ada new | new@example.com'
+		});
+		expect(patch).toHaveBeenNthCalledWith(2, 'support_doc_2', {
+			userName: 'Ada New',
+			userEmail: 'new@example.com',
+			searchText: 'ada new | new@example.com'
 		});
 	});
 
@@ -117,6 +210,9 @@ describe('support maintenance helpers', () => {
 			{
 				_id: 'support_doc_1',
 				threadId: 'thread_support_1',
+				title: 'Billing',
+				summary: 'Upgrade issue',
+				lastMessage: 'Anon message',
 				notificationEmail: undefined
 			},
 			{
@@ -167,6 +263,7 @@ describe('support maintenance helpers', () => {
 			userId: 'user_1',
 			userName: 'Ada',
 			userEmail: 'ada@example.com',
+			searchText: 'billing | upgrade issue | anon message | ada | ada@example.com',
 			notificationEmail: 'ada@example.com',
 			updatedAt: expect.any(Number)
 		});
@@ -174,6 +271,7 @@ describe('support maintenance helpers', () => {
 			userId: 'user_1',
 			userName: 'Ada',
 			userEmail: 'ada@example.com',
+			searchText: 'ada | ada@example.com',
 			notificationEmail: 'custom@example.com',
 			updatedAt: expect.any(Number)
 		});

--- a/src/lib/convex/support/migration.ts
+++ b/src/lib/convex/support/migration.ts
@@ -3,6 +3,7 @@ import { v, ConvexError } from 'convex/values';
 import { authComponent } from '../auth';
 import { isAnonymousUser } from '../utils/anonymousUser';
 import { supportAgent } from './agent';
+import { buildSupportSearchText } from './denormalization';
 
 /**
  * Migrate anonymous support tickets to an authenticated user account.
@@ -71,11 +72,19 @@ export const migrateAnonymousTickets = mutation({
 				patch: { userId: authUserId }
 			});
 
-			// Update supportThreads.userId and enrich with user data
+			// Update supportThreads.userId and enrich with user data.
+			// Rebuild searchText so the migrated thread is searchable by the new identity.
 			await ctx.db.patch(supportThread._id, {
 				userId: authUserId,
 				userName: authUserName,
 				userEmail: authUserEmail,
+				searchText: buildSupportSearchText({
+					title: supportThread.title,
+					summary: supportThread.summary,
+					lastMessage: supportThread.lastMessage,
+					userName: authUserName,
+					userEmail: authUserEmail
+				}),
 				// Keep existing notification email if set, otherwise use account email
 				notificationEmail: supportThread.notificationEmail || authUserEmail,
 				updatedAt: Date.now()

--- a/src/lib/convex/support/supportThreadFields.ts
+++ b/src/lib/convex/support/supportThreadFields.ts
@@ -8,7 +8,7 @@ import { v } from 'convex/values';
  */
 export const supportThreadFields = {
 	threadId: v.string(), // Reference to agent:threads
-	userId: v.optional(v.string()), // Denormalized for quick lookups
+	userId: v.string(), // Denormalized for quick lookups; every write path sets it (auth or anon_* owner)
 	isWarm: v.optional(v.boolean()), // true = pre-warmed empty support thread awaiting first message
 	status: v.union(v.literal('open'), v.literal('done')),
 	isHandedOff: v.optional(v.boolean()), // true = human-only mode, undefined/false = AI responds

--- a/src/lib/convex/support/threads.ts
+++ b/src/lib/convex/support/threads.ts
@@ -255,7 +255,7 @@ export const listThreads = query({
 			v.object({
 				_id: v.string(),
 				_creationTime: v.number(),
-				userId: v.optional(v.string()),
+				userId: v.string(),
 				title: v.optional(v.string()),
 				summary: v.optional(v.string()),
 				status: v.union(v.literal('active'), v.literal('archived')),
@@ -340,7 +340,7 @@ export const listThreads = query({
 				return {
 					_id: supportThread.threadId,
 					_creationTime: supportThread.createdAt,
-					userId: supportThread.userId ?? thread.userId,
+					userId: supportThread.userId,
 					title: supportThread.title,
 					summary: supportThread.summary,
 					status: thread.status,

--- a/src/lib/convex/support/threads.ts
+++ b/src/lib/convex/support/threads.ts
@@ -25,6 +25,7 @@ import {
 } from './denormalization';
 import { supportRateLimiter } from './rateLimit';
 import { createRateLimitError } from './types';
+import { isAnonymousUser } from '../utils/anonymousUser';
 
 /**
  * Rate-limit a support thread-creation path. Anonymous callers share a
@@ -712,6 +713,46 @@ export const updateLastMessage = internalMutation({
 });
 
 /**
+ * Sync denormalized user profile fields across all of a user's support threads.
+ * Called from the Better Auth onUpdate trigger when name or email changes.
+ *
+ * Leaves notificationEmail untouched (explicit opt-in that may intentionally
+ * differ from the account email) and does not bump updatedAt (a profile edit
+ * is not thread activity and must not reorder by_user_and_updated listings).
+ */
+export const syncUserProfile = internalMutation({
+	args: {
+		userId: v.string(),
+		userName: v.optional(v.string()),
+		userEmail: v.optional(v.string())
+	},
+	returns: v.null(),
+	handler: async (ctx, args) => {
+		// Bounded: per-user index scan, a single user's support threads are few
+		const supportThreads = await ctx.db
+			.query('supportThreads')
+			.withIndex('by_user', (q) => q.eq('userId', args.userId))
+			.collect();
+
+		for (const supportThread of supportThreads) {
+			await ctx.db.patch(supportThread._id, {
+				userName: args.userName,
+				userEmail: args.userEmail,
+				searchText: buildSupportSearchText({
+					title: supportThread.title,
+					summary: supportThread.summary,
+					lastMessage: supportThread.lastMessage,
+					userName: args.userName,
+					userEmail: args.userEmail
+				})
+			});
+		}
+
+		return null;
+	}
+});
+
+/**
  * Backfill support denormalized fields from existing supportThreads + agent data.
  * Run manually before removing any historical compatibility code.
  */
@@ -735,14 +776,24 @@ export const backfillThreadMetadata = internalMutation({
 
 			if (!agentThread) continue;
 
+			// Re-fetch the live profile so a manual backfill repairs drifted
+			// userName/userEmail instead of re-propagating the stale values.
+			const { userName, userEmail } = await getSupportOwnerProfile(
+				ctx,
+				supportThread.userId,
+				isAnonymousUser(supportThread.userId)
+			);
+
 			const patch = {
 				title: agentThread.title,
 				summary: agentThread.summary,
+				userName,
+				userEmail,
 				...buildSupportMessageDenormalization({
 					title: agentThread.title,
 					summary: agentThread.summary,
-					userName: supportThread.userName,
-					userEmail: supportThread.userEmail,
+					userName,
+					userEmail,
 					latestMessage: await getLatestCompletedThreadMessage(ctx, supportThread.threadId)
 				})
 			};


### PR DESCRIPTION
Closes #459

`supportThreads` denormalizes `userName` and `userEmail` and folds them into `searchText`, which backs the admin `search_all` index. There was no sync path: the Better Auth `onUpdate` trigger never re-patched threads when a user renamed or changed email, and the other `searchText` writers kept propagating the stale values, so the admin support list and search showed the old identity forever.

This adds a `syncUserProfile` internal mutation in `src/lib/convex/support/threads.ts` that patches all of a user's threads via the `by_user` index and rebuilds `searchText` with `buildSupportSearchText`. The `onUpdate` trigger in `src/lib/convex/auth.ts` calls it when `name` or `email` changed, wrapped in try/catch like the adjacent admin-preference sync so a sync failure never blocks a profile update. The mutation intentionally leaves `notificationEmail` alone (explicit opt-in that may differ from the account email) and does not bump `updatedAt` (a profile edit is not thread activity and must not reorder the `by_user_and_updated` thread list).

Two same-family gaps are fixed along the way. `backfillThreadMetadata` now re-fetches the live profile via `getSupportOwnerProfile` instead of re-supplying the stale denormalized values, so a manual backfill can actually repair drift. The anonymous-ticket migration in `src/lib/convex/support/migration.ts` now rebuilds `searchText` when it sets `userName` and `userEmail`, so migrated threads are searchable by the new identity. Unit tests in `maintenance.test.ts` cover the new sync mutation, the backfill live-refetch (including the anonymous skip), and the migration `searchText` rebuild.

`bun scripts/static-checks.ts` on the changed files, `bun run check:convex`, and `bun run test:unit` (487 tests) all pass.
