### PR TITLE
fix(ssr): Add catch fallbacks to page server loads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,7 +427,9 @@ For each data need in a new route, pick the right pattern:
 
    ```ts
    // +page.server.ts
-   const messages = await client.query(api.messages.list, {});
+   // .catch fallback so a transient backend failure degrades instead of
+   // 500ing the page; the client subscription recovers after hydration
+   const messages = await client.query(api.messages.list, {}).catch(() => []);
    return { messages };
 
    // +page.svelte

--- a/src/routes/[[lang]]/(auth)/signin/+page.server.ts
+++ b/src/routes/[[lang]]/(auth)/signin/+page.server.ts
@@ -4,6 +4,11 @@ import { createServerConvexHttpClient } from '$lib/server/convex-http';
 
 export const load = (async () => {
 	const client = createServerConvexHttpClient({});
-	const oauthProviders = await client.query(api.auth.getAvailableOAuthProviders, {});
+	// Degrade gracefully on transient backend failure; the client useQuery
+	// subscription recovers the real provider availability after hydration.
+	const oauthProviders = await client.query(api.auth.getAvailableOAuthProviders, {}).catch((e) => {
+		console.error('[signin/+page.server.ts] OAuth provider lookup failed:', e);
+		return { google: false, github: false };
+	});
 	return { oauthProviders };
 }) satisfies PageServerLoad;

--- a/src/routes/[[lang]]/(auth)/signup/+page.server.ts
+++ b/src/routes/[[lang]]/(auth)/signup/+page.server.ts
@@ -4,6 +4,11 @@ import { createServerConvexHttpClient } from '$lib/server/convex-http';
 
 export const load = (async () => {
 	const client = createServerConvexHttpClient({});
-	const oauthProviders = await client.query(api.auth.getAvailableOAuthProviders, {});
+	// Degrade gracefully on transient backend failure; the client useQuery
+	// subscription recovers the real provider availability after hydration.
+	const oauthProviders = await client.query(api.auth.getAvailableOAuthProviders, {}).catch((e) => {
+		console.error('[signup/+page.server.ts] OAuth provider lookup failed:', e);
+		return { google: false, github: false };
+	});
 	return { oauthProviders };
 }) satisfies PageServerLoad;

--- a/src/routes/[[lang]]/app/ai-chat/+page.server.ts
+++ b/src/routes/[[lang]]/app/ai-chat/+page.server.ts
@@ -5,6 +5,11 @@ import { createServerConvexHttpClient } from '$lib/server/convex-http';
 export const load = (async (event) => {
 	const client = createServerConvexHttpClient({ token: event.locals.token });
 
-	const viewer = await client.query(api.users.viewer, {});
+	// Degrade gracefully on transient backend failure; the client useQuery
+	// subscription recovers the viewer after hydration.
+	const viewer = await client.query(api.users.viewer, {}).catch((e) => {
+		console.error('[ai-chat/+page.server.ts] Viewer lookup failed:', e);
+		return null;
+	});
 	return { viewer };
 }) satisfies PageServerLoad;

--- a/src/routes/[[lang]]/app/ai-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/+page.svelte
@@ -20,7 +20,7 @@
 	const client = useConvexClient();
 
 	// Auth
-	const viewer = useQuery(api.users.viewer, {}, () => ({ initialData: data.viewer }));
+	const viewer = useQuery(api.users.viewer, {}, () => ({ initialData: data.viewer ?? undefined }));
 
 	// Pro check
 	const autumn = useCustomer();

--- a/src/routes/[[lang]]/app/community-chat/+page.server.ts
+++ b/src/routes/[[lang]]/app/community-chat/+page.server.ts
@@ -5,9 +5,17 @@ import { createServerConvexHttpClient } from '$lib/server/convex-http';
 export const load = (async (event) => {
 	const client = createServerConvexHttpClient({ token: event.locals.token });
 
+	// Degrade gracefully on transient backend failure; the client useQuery
+	// subscriptions recover viewer and messages after hydration.
 	const [viewer, messages] = await Promise.all([
-		client.query(api.users.viewer, {}),
-		client.query(api.messages.list, {})
+		client.query(api.users.viewer, {}).catch((e) => {
+			console.error('[community-chat/+page.server.ts] Viewer lookup failed:', e);
+			return null;
+		}),
+		client.query(api.messages.list, {}).catch((e) => {
+			console.error('[community-chat/+page.server.ts] Messages lookup failed:', e);
+			return [];
+		})
 	]);
 	return {
 		viewer,

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -37,7 +37,9 @@
 	let { data } = $props();
 
 	const client = useConvexClient();
-	const viewerQuery = useQuery(api.users.viewer, {}, () => ({ initialData: data.viewer }));
+	const viewerQuery = useQuery(api.users.viewer, {}, () => ({
+		initialData: data.viewer ?? undefined
+	}));
 	const messagesQuery = useQuery(api.messages.list, {}, () => ({ initialData: data.messages }));
 
 	// Fall back to server-loaded data for SSR (useQuery.data is undefined until hydration)


### PR DESCRIPTION
Closes #458

The root layout wraps its SSR Convex queries in `.catch` fallbacks so a transient backend failure degrades gracefully, but four page server loads skipped that pattern: `signin/+page.server.ts`, `signup/+page.server.ts`, `ai-chat/+page.server.ts`, and `community-chat/+page.server.ts`. A single Convex hiccup during SSR 500ed these pages even though their client-side `useQuery` subscriptions would have recovered the data right after hydration.

Each load now appends a `.catch` that logs the failure with a route-scoped prefix and returns a safe fallback, matching the `+layout.server.ts` shape: `{ google: false, github: false }` for the OAuth provider lookup on signin and signup, `null` for the viewer on ai-chat and community-chat, and `[]` for community-chat messages. Since `api.users.viewer` never returns `null` in its own type, the affected `useQuery` calls in `ai-chat/+page.svelte` and `community-chat/+page.svelte` pass `initialData: data.viewer ?? undefined` to keep strict typing intact; the existing `?? data.viewer` derived fallbacks already tolerate the null. The canonical pattern example in `AGENTS.md` now shows the `.catch` fallback on the server fetch so new routes copy the resilient shape.

`bun scripts/static-checks.ts` on all changed files passes, and the targeted E2E specs `signin-invalid-credentials`, `signin-last-used-badge`, `upgrade-checkout-failure` (community-chat), and `ai-chat` pass locally (9 passed). The degraded path itself is only reachable during a Convex outage, so it is covered by type-checking the fallback shapes rather than a new automated guard.
