### PR TITLE
fix(a11y): Add accessible names to icon controls

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -398,6 +398,7 @@
 		"target": "Ziel",
 		"toggle_sidebar": "Seitenleiste umschalten",
 		"toggle_theme": "Design umschalten",
+		"toggle_threads": "Unterhaltungsliste umschalten",
 		"view": "Ansicht"
 	},
 	"auth": {
@@ -1055,6 +1056,14 @@
 			},
 			"aria_label": "Screenshot-Editor",
 			"capturing": "Wird aufgenommen...",
+			"color": {
+				"black": "Schwarz",
+				"blue": "Blau",
+				"green": "Grün",
+				"purple": "Lila",
+				"red": "Rot",
+				"yellow": "Gelb"
+			},
 			"next": "Bug Markiert",
 			"tool": {
 				"arrow": "Pfeil (A)",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -398,6 +398,7 @@
 		"target": "Target",
 		"toggle_sidebar": "Toggle Sidebar",
 		"toggle_theme": "Toggle theme",
+		"toggle_threads": "Toggle conversation list",
 		"view": "View"
 	},
 	"auth": {
@@ -1055,6 +1056,14 @@
 			},
 			"aria_label": "Screenshot editor",
 			"capturing": "Capturing...",
+			"color": {
+				"black": "Black",
+				"blue": "Blue",
+				"green": "Green",
+				"purple": "Purple",
+				"red": "Red",
+				"yellow": "Yellow"
+			},
 			"next": "Bug Marked",
 			"tool": {
 				"arrow": "Arrow (A)",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -398,6 +398,7 @@
 		"target": "Destino",
 		"toggle_sidebar": "Alternar barra lateral",
 		"toggle_theme": "Cambiar tema",
+		"toggle_threads": "Alternar lista de conversaciones",
 		"view": "Ver"
 	},
 	"auth": {
@@ -1055,6 +1056,14 @@
 			},
 			"aria_label": "Editor de captura de pantalla",
 			"capturing": "Capturando...",
+			"color": {
+				"black": "Negro",
+				"blue": "Azul",
+				"green": "Verde",
+				"purple": "Morado",
+				"red": "Rojo",
+				"yellow": "Amarillo"
+			},
 			"next": "Bug Marcado",
 			"tool": {
 				"arrow": "Flecha (A)",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -398,6 +398,7 @@
 		"target": "Cible",
 		"toggle_sidebar": "Basculer la barre latérale",
 		"toggle_theme": "Changer le thème",
+		"toggle_threads": "Basculer la liste des conversations",
 		"view": "Voir"
 	},
 	"auth": {
@@ -1055,6 +1056,14 @@
 			},
 			"aria_label": "Éditeur de capture d'écran",
 			"capturing": "Capture en cours...",
+			"color": {
+				"black": "Noir",
+				"blue": "Bleu",
+				"green": "Vert",
+				"purple": "Violet",
+				"red": "Rouge",
+				"yellow": "Jaune"
+			},
 			"next": "Bug Marqué",
 			"tool": {
 				"arrow": "Flèche (A)",

--- a/src/lib/chat/ui/InlineEmailPrompt.svelte
+++ b/src/lib/chat/ui/InlineEmailPrompt.svelte
@@ -128,6 +128,7 @@
 						size="icon"
 						onclick={handleUnsubscribe}
 						disabled={isSubmitting}
+						aria-label={$t('chat.email.unsubscribe_tooltip')}
 					>
 						<BellOffIcon class="h-4 w-4" />
 					</Button>

--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -146,6 +146,7 @@
 													class="transition-transform duration-200 active:translate-y-px data-[state=open]:rotate-90"
 												>
 													<ChevronRightIcon />
+													<span class="sr-only"><T keyName="aria.toggle_threads" /></span>
 												</Sidebar.MenuAction>
 											{/snippet}
 										</Collapsible.Trigger>

--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotToolbar.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotToolbar.svelte
@@ -35,6 +35,7 @@
 			class="size-9 "
 			onclick={() => handleToolClick('rect')}
 			title={$t('support.screenshot.tool.rectangle')}
+			aria-label={$t('support.screenshot.tool.rectangle')}
 		>
 			<SquareIcon class="size-4" />
 		</Button>
@@ -46,6 +47,7 @@
 			class="size-9 "
 			onclick={() => handleToolClick('circle')}
 			title={$t('support.screenshot.tool.circle')}
+			aria-label={$t('support.screenshot.tool.circle')}
 		>
 			<CircleIcon class="size-4" />
 		</Button>
@@ -57,6 +59,7 @@
 			class="size-9 "
 			onclick={() => handleToolClick('arrow')}
 			title={$t('support.screenshot.tool.arrow')}
+			aria-label={$t('support.screenshot.tool.arrow')}
 		>
 			<ArrowRightIcon class="size-4" />
 		</Button>
@@ -68,6 +71,7 @@
 			class="size-9 "
 			onclick={() => handleToolClick('pen')}
 			title={$t('support.screenshot.tool.pen')}
+			aria-label={$t('support.screenshot.tool.pen')}
 		>
 			<PencilIcon class="size-4" />
 		</Button>
@@ -86,12 +90,13 @@
 						class="size-6 rounded-full border-2 border-background ring-2 ring-border"
 						style="background-color: {editor.strokeColor};"
 						title={$t('support.screenshot.tool.color')}
+						aria-label={$t('support.screenshot.tool.color')}
 					></Button>
 				{/snippet}
 			</Popover.Trigger>
 			<Popover.Content class="z-[120] w-auto p-2">
 				<div class="grid grid-cols-3 gap-1.5">
-					{#each DEFAULT_COLORS as { name, value } (value)}
+					{#each DEFAULT_COLORS as { nameKey, value } (value)}
 						<Button
 							variant="ghost"
 							size="icon"
@@ -103,8 +108,8 @@
 							)}
 							style="background-color: {value};"
 							onclick={() => (editor.strokeColor = value)}
-							title={name}
-							aria-label={name}
+							title={$t(nameKey)}
+							aria-label={$t(nameKey)}
 						/>
 					{/each}
 				</div>
@@ -122,6 +127,7 @@
 			onclick={() => editor.history.undo()}
 			disabled={!editor.history.canUndo}
 			title={$t('support.screenshot.action.undo')}
+			aria-label={$t('support.screenshot.action.undo')}
 		>
 			<Undo2Icon class="size-4" />
 		</Button>
@@ -134,6 +140,7 @@
 			onclick={() => editor.history.redo()}
 			disabled={!editor.history.canRedo}
 			title={$t('support.screenshot.action.redo')}
+			aria-label={$t('support.screenshot.action.redo')}
 		>
 			<Redo2Icon class="size-4" />
 		</Button>
@@ -150,6 +157,7 @@
 			onclick={editor.handleSave}
 			disabled={editor.isSaving || !editor.hasShapes}
 			title={$t('support.screenshot.next')}
+			aria-label={$t('support.screenshot.next')}
 		>
 			<CheckIcon class="size-4" />
 		</Button>
@@ -170,6 +178,7 @@
 			class="-order-4 size-9 sm:order-none"
 			onclick={editor.handleCancel}
 			title={$t('support.screenshot.action.cancel')}
+			aria-label={$t('support.screenshot.action.cancel')}
 		>
 			<XIcon class="size-4" />
 		</Button>

--- a/src/lib/components/customer-support/screenshot-editor/types.ts
+++ b/src/lib/components/customer-support/screenshot-editor/types.ts
@@ -74,7 +74,8 @@ export type Shape = LineShape | RectShape | CircleShape | ArrowShape;
  * Color preset for quick selection
  */
 export type ColorPreset = {
-	name: string;
+	/** Tolgee key for the localized color name */
+	nameKey: string;
 	value: string;
 };
 
@@ -82,12 +83,12 @@ export type ColorPreset = {
  * Default color palette
  */
 export const DEFAULT_COLORS: ColorPreset[] = [
-	{ name: 'Red', value: 'oklch(63.7% 0.237 25.331)' },
-	{ name: 'Yellow', value: 'oklch(85.2% 0.199 91.936)' },
-	{ name: 'Green', value: 'oklch(72.3% 0.219 149.579)' },
-	{ name: 'Blue', value: 'oklch(58.5% 0.233 277.117)' },
-	{ name: 'Purple', value: 'oklch(51.8% 0.253 323.949)' },
-	{ name: 'Black', value: 'oklch(13% 0.028 261.692)' }
+	{ nameKey: 'support.screenshot.color.red', value: 'oklch(63.7% 0.237 25.331)' },
+	{ nameKey: 'support.screenshot.color.yellow', value: 'oklch(85.2% 0.199 91.936)' },
+	{ nameKey: 'support.screenshot.color.green', value: 'oklch(72.3% 0.219 149.579)' },
+	{ nameKey: 'support.screenshot.color.blue', value: 'oklch(58.5% 0.233 277.117)' },
+	{ nameKey: 'support.screenshot.color.purple', value: 'oklch(51.8% 0.253 323.949)' },
+	{ nameKey: 'support.screenshot.color.black', value: 'oklch(13% 0.028 261.692)' }
 ];
 
 /**

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -131,6 +131,7 @@
 						size="icon"
 						class="h-10 w-10 rounded-full hover:!bg-muted-foreground/10"
 						onclick={onBackClick}
+						aria-label={$t('aria.go_back')}
 					>
 						<ChevronLeft class="size-5" />
 					</Button>


### PR DESCRIPTION
Closes #454

Several icon-only controls expose no accessible name: the nine screenshot toolbar buttons rely on `title` alone (not exposed on touch and inconsistent across screen readers), the color swatches use hardcoded English names from `types.ts`, the AI chat thread chevron `Collapsible.Trigger` in `authenticated-sidebar.svelte` has no name at all, and the skeleton back button in `admin/support/thread-chat.svelte` and the unsubscribe button in `InlineEmailPrompt.svelte` are unnamed for screen reader and touch users.

The toolbar buttons now carry an `aria-label` that reuses each button's existing `title` Tolgee key, so the accessible name always matches the tooltip. `ColorPreset` swaps its hardcoded `name` for a `nameKey` Tolgee key, with six new `support.screenshot.color.*` keys translated in all four locales, and the swatch loop resolves both `title` and `aria-label` through `$t`. The thread chevron gets localized `sr-only` text via a new `aria.toggle_threads` key, following the `data-table-actions.svelte` pattern, the skeleton back button reuses the existing `aria.go_back` key, and the unsubscribe button reuses `chat.email.unsubscribe_tooltip` so its name matches the visible tooltip.

The `nav-projects.svelte` checklist item needs no change because that file was removed in #502. `bun run i18n:push -- --tag-new-keys draft` reported import conflicts and was not forced, so the new keys still need a pull plus conflict resolution before they land in Tolgee Cloud.

`bun scripts/static-checks.ts` on all changed files passes and `bun run test:unit` passes.
