### PR TITLE
refactor(sentry): Lazy-load SDK behind DSN gate

### DIFF
--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -40,7 +40,14 @@ const CONFIG = {
 		deprecated:
 			/ring-offset-background|ring-offset-foreground|text-destructive-foreground|flex-shrink-0|bg-gradient-to-/,
 		/** animate-spin without motion-safe: prefix (WCAG 2.3.3) */
-		bareAnimateSpin: /(?<!motion-safe:)animate-spin/
+		bareAnimateSpin: /(?<!motion-safe:)animate-spin/,
+		/**
+		 * Static value imports/re-exports of the Sentry SDK under src/. They defeat
+		 * dead-code elimination when PUBLIC_SENTRY_DSN is unset and ship the SDK to
+		 * first paint. Lazy-load via $lib/monitoring/sentry instead; `import type`
+		 * stays allowed (erased at build time).
+		 */
+		staticSentryImport: /(?:import|export)\s+(?!type[\s{])[^'"]*from\s*['"]@sentry\/sveltekit['"]/
 	}
 };
 
@@ -231,7 +238,7 @@ async function main(): Promise<void> {
 		}
 		console.log('\n');
 
-		// Banned patterns (deprecated tokens, bare animate-spin)
+		// Banned patterns (deprecated tokens, bare animate-spin, static Sentry imports)
 		printHeader(step++, 'Banned patterns');
 		{
 			const filesToScan = scopedMode
@@ -254,6 +261,11 @@ async function main(): Promise<void> {
 					if (CONFIG.bannedPatterns.bareAnimateSpin.test(line)) {
 						violations.push(
 							`${file}:${i + 1}: bare animate-spin (use motion-safe:animate-spin): ${line.trim()}`
+						);
+					}
+					if (CONFIG.bannedPatterns.staticSentryImport.test(line)) {
+						violations.push(
+							`${file}:${i + 1}: static @sentry/sveltekit import (lazy-load via $lib/monitoring/sentry; import type is allowed): ${line.trim()}`
 						);
 					}
 				}

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,24 +1,7 @@
 import { dev, browser } from '$app/environment';
-import { PUBLIC_SENTRY_DSN } from '$env/static/public';
 import { getPosthog } from '$lib/analytics/posthog';
-import { devNotice } from '$lib/dev/notice';
-import * as Sentry from '@sentry/sveltekit';
+import { loadSentry } from '$lib/monitoring/sentry';
 import type { HandleClientError } from '@sveltejs/kit';
-
-if (browser) {
-	if (PUBLIC_SENTRY_DSN) {
-		Sentry.init({
-			dsn: PUBLIC_SENTRY_DSN,
-			tracesSampleRate: 0.1
-		});
-	} else {
-		devNotice({
-			feature: 'Error monitoring (Sentry)',
-			missing: ['PUBLIC_SENTRY_DSN'],
-			scope: 'vite-public'
-		});
-	}
-}
 
 const customHandleError: HandleClientError = ({ error, status }) => {
 	if (status === 404) return;
@@ -30,6 +13,19 @@ const customHandleError: HandleClientError = ({ error, status }) => {
 	getPosthog()?.captureException(error);
 };
 
-export const handleError = PUBLIC_SENTRY_DSN
-	? Sentry.handleErrorWithSentry(customHandleError)
-	: customHandleError;
+// Sentry loads lazily (see $lib/monitoring/sentry) so the SDK stays out of
+// the first-paint bundle and is dropped entirely when PUBLIC_SENTRY_DSN is
+// unset. Errors thrown before the SDK resolves fall back to the PostHog
+// path below, the same race tolerance getPosthog() already has.
+let sentryHandleError: HandleClientError | null = null;
+
+if (browser) {
+	void loadSentry().then((sentry) => {
+		if (sentry) {
+			sentryHandleError = sentry.handleErrorWithSentry(customHandleError);
+		}
+	});
+}
+
+export const handleError: HandleClientError = (input) =>
+	(sentryHandleError ?? customHandleError)(input);

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,8 +1,7 @@
 import { sequence } from '@sveltejs/kit/hooks';
-import { redirect, type Handle, type Cookies } from '@sveltejs/kit';
+import { redirect, type Handle, type HandleServerError, type Cookies } from '@sveltejs/kit';
 import { dev } from '$app/environment';
 import { PUBLIC_SENTRY_DSN } from '$env/static/public';
-import * as Sentry from '@sentry/sveltekit';
 import { isSupportedLanguage, DEFAULT_LANGUAGE } from '$lib/i18n/languages';
 import {
 	getMarketingMarkdownDocument,
@@ -10,15 +9,11 @@ import {
 } from '$lib/marketing/public-routes';
 import { createMarketingMarkdownResponse, isMarkdownRequest } from '$lib/markdown/marketing';
 import { devNotice } from '$lib/dev/notice';
+import { loadSentry } from '$lib/monitoring/sentry';
 import { safeRedirectPath } from '$lib/utils/url';
 import { SIDEBAR_COOKIE_NAME } from '$lib/components/ui/sidebar/constants.js';
 
-if (PUBLIC_SENTRY_DSN) {
-	Sentry.init({
-		dsn: PUBLIC_SENTRY_DSN,
-		tracesSampleRate: 0.1
-	});
-} else {
+if (!PUBLIC_SENTRY_DSN) {
 	devNotice({
 		feature: 'Error monitoring (Sentry)',
 		missing: ['PUBLIC_SENTRY_DSN'],
@@ -241,6 +236,29 @@ const handleCacheControl: Handle = async function handleCacheControl({ event, re
 };
 
 /**
+ * Forward requests through Sentry's request handler, loading the SDK lazily
+ * (see $lib/monitoring/sentry) so it stays out of the server bundle and cold
+ * start when PUBLIC_SENTRY_DSN is unset. The DSN is statically replaced at
+ * build time, so the unset case reduces this hook to a plain pass-through.
+ * The sentryHandle() instance is memoized per server process.
+ */
+let sentryRequestHandle: Handle | null = null;
+
+const handleSentry: Handle = async function handleSentry({ event, resolve }) {
+	if (!PUBLIC_SENTRY_DSN) {
+		return resolve(event);
+	}
+	if (!sentryRequestHandle) {
+		const sentry = await loadSentry();
+		if (!sentry) {
+			return resolve(event);
+		}
+		sentryRequestHandle = sentry.sentryHandle();
+	}
+	return sentryRequestHandle({ event, resolve });
+};
+
+/**
  * Add security headers to all responses
  */
 const handleSecurityHeaders: Handle = async function handleSecurityHeaders({ event, resolve }) {
@@ -255,7 +273,7 @@ const handleSecurityHeaders: Handle = async function handleSecurityHeaders({ eve
 };
 
 export const handle = sequence(
-	...(PUBLIC_SENTRY_DSN ? [Sentry.sentryHandle()] : []),
+	handleSentry,
 	handleDevOnlyRoutes,
 	handleAuth,
 	handleSidebarState,
@@ -266,4 +284,17 @@ export const handle = sequence(
 	handleSecurityHeaders
 );
 
-export const handleError = PUBLIC_SENTRY_DSN ? Sentry.handleErrorWithSentry() : undefined;
+// Memoized Sentry error handler, created on first error so the SDK import
+// stays lazy. When the DSN is unset the export is undefined, same as before.
+let sentryHandleError: HandleServerError | null = null;
+
+export const handleError: HandleServerError | undefined = PUBLIC_SENTRY_DSN
+	? async (input) => {
+			if (!sentryHandleError) {
+				const sentry = await loadSentry();
+				if (!sentry) return;
+				sentryHandleError = sentry.handleErrorWithSentry<HandleServerError>();
+			}
+			return sentryHandleError(input);
+		}
+	: undefined;

--- a/src/lib/components/customer-support/customer-support.svelte
+++ b/src/lib/components/customer-support/customer-support.svelte
@@ -12,7 +12,7 @@
 	import { supportUserId } from './support-user-id.svelte';
 	import { useSupportUrlState } from './use-support-url-state.svelte';
 	import { getTranslate } from '@tolgee/svelte';
-	import * as Sentry from '@sentry/sveltekit';
+	import { loadSentry } from '$lib/monitoring/sentry';
 	import { PUBLIC_SENTRY_DSN } from '$env/static/public';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import { Button } from '$lib/components/ui/button';
@@ -177,8 +177,15 @@
 
 	function handleScreenshotCaptureError(error: unknown) {
 		isScreenshotMode = false;
-		captureEventId = browser && PUBLIC_SENTRY_DSN ? Sentry.captureException(error) : undefined;
+		// Open the dialog immediately; the Sentry event id streams in once the
+		// lazily loaded SDK (see $lib/monitoring/sentry) resolves.
+		captureEventId = undefined;
 		captureErrorOpen = true;
+		if (browser && PUBLIC_SENTRY_DSN) {
+			void loadSentry().then((sentry) => {
+				captureEventId = sentry?.captureException(error);
+			});
+		}
 	}
 
 	function retryScreenshotCapture() {

--- a/src/lib/monitoring/sentry.ts
+++ b/src/lib/monitoring/sentry.ts
@@ -1,0 +1,54 @@
+import { PUBLIC_SENTRY_DSN } from '$env/static/public';
+import type * as Sentry from '@sentry/sveltekit';
+import { devNotice } from '$lib/dev/notice';
+
+type SentryModule = typeof Sentry;
+
+let initPromise: Promise<SentryModule | null> | null = null;
+let client: SentryModule | null = null;
+
+/**
+ * Lazily load and initialize the Sentry SDK.
+ *
+ * Mirrors the PostHog loader in `$lib/analytics/posthog.ts`: the SDK is only
+ * referenced via `import type` plus a dynamic import behind the
+ * `PUBLIC_SENTRY_DSN` gate, so when the DSN is unset the static build-time
+ * replacement of the env var lets the whole SDK be dead-code-eliminated from
+ * both the client and server bundles.
+ *
+ * Memoized per process (browser session or server instance): `init` runs
+ * once, and later calls resolve to the same module namespace.
+ */
+export async function loadSentry(): Promise<SentryModule | null> {
+	if (!PUBLIC_SENTRY_DSN) {
+		devNotice({
+			feature: 'Error monitoring (Sentry)',
+			missing: ['PUBLIC_SENTRY_DSN'],
+			scope: 'vite-public'
+		});
+		return null;
+	}
+
+	if (client) return client;
+	if (initPromise) return initPromise;
+
+	initPromise = (async () => {
+		try {
+			const sentry = await import('@sentry/sveltekit');
+			sentry.init({
+				dsn: PUBLIC_SENTRY_DSN,
+				tracesSampleRate: 0.1
+			});
+			client = sentry;
+			return sentry;
+		} catch (error: unknown) {
+			if (import.meta.env.DEV) {
+				console.warn('Sentry initialization failed:', error);
+			}
+			initPromise = null;
+			return null;
+		}
+	})();
+
+	return initPromise;
+}


### PR DESCRIPTION
Closes #485

`src/hooks.client.ts`, `src/hooks.server.ts`, and `src/lib/components/customer-support/customer-support.svelte` all did a top-level `import * as Sentry from '@sentry/sveltekit'` and only gated usage with runtime ternaries on `PUBLIC_SENTRY_DSN`. Because the namespace value is referenced at runtime, the SDK cannot be tree-shaken, so a no-DSN build ships the full Sentry browser runtime in the universal client entry that loads on every page, including the prerendered marketing landing, and the same unstrippable import weighs on the server bundle and cold start.

The fix follows the existing PostHog loader pattern. A new `src/lib/monitoring/sentry.ts` exposes a memoized `loadSentry()` that references the SDK only via `import type` plus a dynamic `import('@sentry/sveltekit')` gated on `PUBLIC_SENTRY_DSN`, calls `init` once per process, and emits the existing `devNotice` when the DSN is unset. `hooks.client.ts` now exports a stable `handleError` delegate that upgrades to `handleErrorWithSentry(customHandleError)` once the SDK resolves and falls back to the PostHog path before that, the same race tolerance `getPosthog()` already has. `hooks.server.ts` replaces the spread `sentryHandle()` with a `handleSentry` hook that passes straight through when the DSN is unset and otherwise memoizes a lazily created `sentryHandle()` instance, and `handleError` wraps `handleErrorWithSentry()` the same way while staying `undefined` without a DSN. The customer-support widget opens its capture-error dialog synchronously and fills in the Sentry event id when the lazily loaded SDK resolves. A new banned pattern in `scripts/static-checks.ts` rejects static value imports of `@sentry/sveltekit` under `src/` (`import type` stays allowed) so the regression cannot creep back in.

On a no-DSN production build the server output contains no SDK code at all, and `loadSentry()` compiles down to the `devNotice` plus `return null` in both the client and server graphs, so the client entries (`start`, `app`) carry only the small delegate. Rolldown still emits the SDK chunk as an orphaned asset, but no module in the client graph references it, so it is never fetched. With a dummy DSN set, the build succeeds with the `sentrySvelteKit` plugin active and a small loader chunk lazily imports and initializes the SDK.

`bun scripts/static-checks.ts` on the changed files, `bun run test:unit`, `bun run test:e2e`, and both no-DSN and DSN-set `bun run build` runs pass locally.
