### PR TITLE
fix(convex): Repair squash-merge artifacts on main

### DIFF
--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -135,7 +135,10 @@ export default defineSchema({
 		width: v.optional(v.number()),
 		height: v.optional(v.number()),
 		createdAt: v.number()
-	}).index('by_url', ['url']),
+	})
+		.index('by_url', ['url'])
+		// Used by the hourly file vacuum to delete metadata of purged files
+		.index('by_storageId', ['storageId']),
 
 	// Dashboard counters - singleton for materialized user metrics
 	// Updated atomically via auth triggers (onCreate, onUpdate) to avoid

--- a/src/lib/convex/support/threads.ts
+++ b/src/lib/convex/support/threads.ts
@@ -764,46 +764,6 @@ export const syncUserProfile = internalMutation({
 });
 
 /**
- * Sync denormalized user profile fields across all of a user's support threads.
- * Called from the Better Auth onUpdate trigger when name or email changes.
- *
- * Leaves notificationEmail untouched (explicit opt-in that may intentionally
- * differ from the account email) and does not bump updatedAt (a profile edit
- * is not thread activity and must not reorder by_user_and_updated listings).
- */
-export const syncUserProfile = internalMutation({
-	args: {
-		userId: v.string(),
-		userName: v.optional(v.string()),
-		userEmail: v.optional(v.string())
-	},
-	returns: v.null(),
-	handler: async (ctx, args) => {
-		// Bounded: per-user index scan, a single user's support threads are few
-		const supportThreads = await ctx.db
-			.query('supportThreads')
-			.withIndex('by_user', (q) => q.eq('userId', args.userId))
-			.collect();
-
-		for (const supportThread of supportThreads) {
-			await ctx.db.patch(supportThread._id, {
-				userName: args.userName,
-				userEmail: args.userEmail,
-				searchText: buildSupportSearchText({
-					title: supportThread.title,
-					summary: supportThread.summary,
-					lastMessage: supportThread.lastMessage,
-					userName: args.userName,
-					userEmail: args.userEmail
-				})
-			});
-		}
-
-		return null;
-	}
-});
-
-/**
  * Backfill support denormalized fields from existing supportThreads + agent data.
  * Run manually before removing any historical compatibility code.
  */


### PR DESCRIPTION
Two PR pairs from the merge batch were each green in isolation but semantically conflict on main: #532 and #543 both introduced `syncUserProfile` in `src/lib/convex/support/threads.ts`, leaving a duplicate declaration, and #511 removed the `fileMetadata.by_storageId` index while #515's file vacuum queries it. `check:convex` on main fails with TS2451 and TS2345, which blocks every main build and Convex deploy.

This removes the duplicate `syncUserProfile` block and restores `.index('by_storageId', ['storageId'])` on `fileMetadata` with a comment naming its consumer.

`bun run check:convex`, `bun scripts/static-checks.ts` on both files, and `bun run test:unit` (518 tests) pass locally.
