### PR TITLE
chore(eslint): Add retro regression guard rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,9 @@ import noHardcodedSrOnlyRule from './eslint/rules/no-hardcoded-sr-only.js';
 import noDebounceInRuneRule from './eslint/rules/no-debounce-in-rune.js';
 import noHardcodedModifierKeysRule from './eslint/rules/no-hardcoded-modifier-keys.js';
 import requireReturnsValidatorRule from './eslint/rules/require-returns-validator.js';
+import noBareTestSkipRule from './eslint/rules/no-bare-test-skip.js';
+import noModuleStateSingletonRule from './eslint/rules/no-module-state-singleton.js';
+import requireMotionGuardTransitionRule from './eslint/rules/require-motion-guard-transition.js';
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
 const localPlugin = {
@@ -25,7 +28,10 @@ const localPlugin = {
 		'no-hardcoded-sr-only': noHardcodedSrOnlyRule,
 		'no-debounce-in-rune': noDebounceInRuneRule,
 		'no-hardcoded-modifier-keys': noHardcodedModifierKeysRule,
-		'require-returns-validator': requireReturnsValidatorRule
+		'require-returns-validator': requireReturnsValidatorRule,
+		'no-bare-test-skip': noBareTestSkipRule,
+		'no-module-state-singleton': noModuleStateSingletonRule,
+		'require-motion-guard-transition': requireMotionGuardTransitionRule
 	}
 };
 
@@ -214,6 +220,39 @@ export default defineConfig(
 		},
 		rules: {
 			'local/require-returns-validator': 'error'
+		}
+	},
+	{
+		// Bare runtime test.skip() dodges timing races instead of fixing them
+		// (#508). See eslint/rules/no-bare-test-skip.js.
+		files: ['e2e/**/*.spec.ts'],
+		plugins: {
+			local: localPlugin
+		},
+		rules: {
+			'local/no-bare-test-skip': 'error'
+		}
+	},
+	{
+		// Module-scope class instances in .svelte.ts are shared across SSR
+		// requests (#500). See eslint/rules/no-module-state-singleton.js.
+		files: ['**/*.svelte.ts'],
+		plugins: {
+			local: localPlugin
+		},
+		rules: {
+			'local/no-module-state-singleton': 'error'
+		}
+	},
+	{
+		// fly/slide transitions must be gated on prefers-reduced-motion (#475).
+		// See eslint/rules/require-motion-guard-transition.js.
+		files: ['**/*.svelte'],
+		plugins: {
+			local: localPlugin
+		},
+		rules: {
+			'local/require-motion-guard-transition': 'error'
 		}
 	},
 	// Convex best-practice rules — v2 ships ESLint 9 flat config natively

--- a/eslint/rules/no-bare-test-skip.js
+++ b/eslint/rules/no-bare-test-skip.js
@@ -1,0 +1,47 @@
+/**
+ * ESLint rule: no-bare-test-skip
+ *
+ * Flags bare runtime `test.skip()` calls (zero arguments) in Playwright
+ * e2e specs.
+ *
+ * Why: a bare `test.skip()` inside a test body is the timing-race dodge:
+ * the test snapshots some state once and gives up instead of waiting (#508,
+ * #491). Legitimate environment gating passes a condition and a reason:
+ * `test.skip(condition, 'reason')` (see e2e/signin-last-used-badge.spec.ts
+ * gating on hasGoogleOAuth).
+ *
+ * ❌ if ((await rows.count()) === 0) test.skip();
+ * ✅ test.skip(!hasGoogleOAuth, 'Google OAuth is disabled in this environment');
+ * ✅ await expect(locator).toBeVisible();
+ */
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow bare test.skip() (zero arguments) in e2e specs'
+		},
+		schema: [],
+		messages: {
+			bareTestSkip:
+				"Bare test.skip() dodges a timing race. Make the test deterministic with auto-waiting assertions (expect(locator).toBeVisible(), expect.poll) or gate on the environment with test.skip(condition, 'reason')."
+		}
+	},
+	create(context) {
+		return {
+			CallExpression(node) {
+				const callee = node.callee;
+				if (
+					callee?.type === 'MemberExpression' &&
+					!callee.computed &&
+					callee.object?.type === 'Identifier' &&
+					callee.object.name === 'test' &&
+					callee.property?.type === 'Identifier' &&
+					callee.property.name === 'skip' &&
+					node.arguments.length === 0
+				) {
+					context.report({ node, messageId: 'bareTestSkip' });
+				}
+			}
+		};
+	}
+};

--- a/eslint/rules/no-bare-test-skip.test.ts
+++ b/eslint/rules/no-bare-test-skip.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { parser } from 'typescript-eslint';
+import rule from './no-bare-test-skip.js';
+
+function lint(code: string): Array<{ messageId: string }> {
+	const reports: Array<{ messageId: string }> = [];
+	const ast = parser.parseForESLint(code, {});
+
+	const context = {
+		report: (opts: { messageId: string }) => reports.push(opts),
+		getFilename: () => 'e2e/example.spec.ts',
+		filename: 'e2e/example.spec.ts'
+	};
+
+	const listeners = rule.create(context) as Record<string, (n: unknown) => void>;
+
+	function walk(node: Record<string, unknown>) {
+		if (!node || typeof node !== 'object') return;
+		const type = node.type as string;
+		if (type && typeof listeners[type] === 'function') listeners[type](node);
+		for (const key of Object.keys(node)) {
+			if (key === 'parent') continue;
+			const val = node[key];
+			if (Array.isArray(val)) val.forEach((v) => walk(v as Record<string, unknown>));
+			else if (val && typeof val === 'object' && (val as Record<string, unknown>).type)
+				walk(val as Record<string, unknown>);
+		}
+	}
+
+	walk(ast.ast as unknown as Record<string, unknown>);
+	return reports;
+}
+
+describe('no-bare-test-skip', () => {
+	it('flags bare test.skip() with zero arguments', () => {
+		const reports = lint(`
+			test('list shows rows', async ({ page }) => {
+				if ((await page.locator('tr').count()) === 0) test.skip();
+			});
+		`);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('bareTestSkip');
+	});
+
+	it('allows environment gating with condition and reason', () => {
+		const reports = lint(`
+			test.skip(!hasGoogleOAuth, 'Google OAuth is disabled in this environment');
+		`);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows test.skip with a single condition argument', () => {
+		const reports = lint(`test.skip(process.env.CI === undefined);`);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows declarative skips like test.skip(title, fn)', () => {
+		const reports = lint(`test.skip('flaky upstream', async () => {});`);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('ignores skip calls on other objects', () => {
+		expect(lint(`suite.skip();`)).toHaveLength(0);
+		expect(lint(`this.skip();`)).toHaveLength(0);
+	});
+
+	it('ignores other test methods', () => {
+		expect(lint(`test.fixme();`)).toHaveLength(0);
+		expect(lint(`test.describe('group', () => {});`)).toHaveLength(0);
+	});
+
+	it('ignores computed member access', () => {
+		expect(lint(`test['skip']();`)).toHaveLength(0);
+	});
+});

--- a/eslint/rules/no-module-state-singleton.js
+++ b/eslint/rules/no-module-state-singleton.js
@@ -1,0 +1,52 @@
+/**
+ * ESLint rule: no-module-state-singleton
+ *
+ * Flags top-level `export const x = new SomeClass(...)` in `.svelte.ts`
+ * modules, except when the constructed class is runed's `Context`.
+ *
+ * Why: a module-scope class instance is created once per server process and
+ * shared by every SSR request. Any `$state` it holds leaks between users
+ * (#500). The sanctioned pattern is a module-scope `Context` definition whose
+ * instance is created and `set()` inside a layout/component, so each request
+ * tree gets its own state.
+ *
+ * ❌ export const manager = new ChatManager();
+ * ✅ export const chatContext = new Context<ChatManager>('chat');   // set in a layout
+ * ✅ // eslint-disable-next-line local/no-module-state-singleton -- browser-only writes, nothing rendered into SSR HTML
+ *    export const haptic = new UseHaptic();
+ */
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Disallow module-scope class instances in .svelte.ts files (cross-request SSR state leak)'
+		},
+		schema: [],
+		messages: {
+			moduleStateSingleton:
+				'Module-scope class instance is shared across SSR requests; any $state it holds leaks between users. Create the instance in a layout/component and share it via runed Context (export const fooContext = new Context<T>(...); fooContext.set(...) in the component).'
+		}
+	},
+	create(context) {
+		return {
+			// ExportNamedDeclaration only occurs at module top level, so this
+			// matches exactly the top-level exported singletons without needing
+			// parent traversal.
+			ExportNamedDeclaration(node) {
+				const declaration = node.declaration;
+				if (!declaration || declaration.type !== 'VariableDeclaration') return;
+
+				for (const declarator of declaration.declarations) {
+					const init = declarator.init;
+					if (!init || init.type !== 'NewExpression') continue;
+
+					// runed's Context is the sanctioned per-request sharing pattern.
+					if (init.callee?.type === 'Identifier' && init.callee.name === 'Context') continue;
+
+					context.report({ node: declarator, messageId: 'moduleStateSingleton' });
+				}
+			}
+		};
+	}
+};

--- a/eslint/rules/no-module-state-singleton.test.ts
+++ b/eslint/rules/no-module-state-singleton.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { parser } from 'typescript-eslint';
+import rule from './no-module-state-singleton.js';
+
+function lint(code: string): Array<{ messageId: string }> {
+	const reports: Array<{ messageId: string }> = [];
+	const ast = parser.parseForESLint(code, {});
+
+	const context = {
+		report: (opts: { messageId: string }) => reports.push(opts),
+		getFilename: () => 'test.svelte.ts',
+		filename: 'test.svelte.ts'
+	};
+
+	const listeners = rule.create(context) as Record<string, (n: unknown) => void>;
+
+	function walk(node: Record<string, unknown>) {
+		if (!node || typeof node !== 'object') return;
+		const type = node.type as string;
+		if (type && typeof listeners[type] === 'function') listeners[type](node);
+		for (const key of Object.keys(node)) {
+			if (key === 'parent') continue;
+			const val = node[key];
+			if (Array.isArray(val)) val.forEach((v) => walk(v as Record<string, unknown>));
+			else if (val && typeof val === 'object' && (val as Record<string, unknown>).type)
+				walk(val as Record<string, unknown>);
+		}
+	}
+
+	walk(ast.ast as unknown as Record<string, unknown>);
+	return reports;
+}
+
+describe('no-module-state-singleton', () => {
+	it('flags a top-level exported class instance', () => {
+		const reports = lint(`export const manager = new ChatManager();`);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('moduleStateSingleton');
+	});
+
+	it('flags an exported PersistedState instance', () => {
+		const reports = lint(`
+			export const supportUserId = new PersistedState<string | null>('supportUserId', null);
+		`);
+		expect(reports).toHaveLength(1);
+	});
+
+	it('allows runed Context definitions', () => {
+		const reports = lint(`
+			export const chatContext = new Context<ChatManager>('chat');
+		`);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('flags every offending declarator in a multi-declarator export', () => {
+		const reports = lint(`export const a = new A(), ctx = new Context('x'), b = new B();`);
+		expect(reports).toHaveLength(2);
+	});
+
+	it('allows non-exported module-scope instances', () => {
+		const reports = lint(`const internal = new Helper();`);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows exported factory-function results', () => {
+		const reports = lint(`export const table = createConvexCursorTable(options);`);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows exported classes, functions and plain values', () => {
+		expect(lint(`export class ChatManager {}`)).toHaveLength(0);
+		expect(lint(`export function makeManager() { return new ChatManager(); }`)).toHaveLength(0);
+		expect(lint(`export const LIMIT = 100;`)).toHaveLength(0);
+	});
+
+	it('flags export let and export var the same as export const', () => {
+		expect(lint(`export let manager = new ChatManager();`)).toHaveLength(1);
+		expect(lint(`export var manager = new ChatManager();`)).toHaveLength(1);
+	});
+});

--- a/eslint/rules/require-motion-guard-transition.js
+++ b/eslint/rules/require-motion-guard-transition.js
@@ -1,0 +1,84 @@
+/**
+ * ESLint rule: require-motion-guard-transition
+ *
+ * Requires movement transitions (`fly`, `slide` via `transition:`/`in:`/`out:`)
+ * to be gated on prefers-reduced-motion. A site is flagged when it cannot
+ * possibly respect the preference: no params object at all, or a params object
+ * whose property values are all plain literals. Any conditional, identifier,
+ * member expression or call in a param value counts as guarded (the guard may
+ * live upstream, not our call to make). `fade` is exempt: opacity-only is
+ * WCAG-acceptable.
+ *
+ * Why: fly/slide move content, which prefers-reduced-motion users opted out
+ * of (#475). The repo's two sanctioned styles both gate through `svelte/motion`:
+ * `duration: skipTransition ? 0 : 200` (sliding-header.svelte) and
+ * `y: prefersReducedMotion.current ? 0 : 10` (ConversationScrollButton.svelte).
+ *
+ * ❌ <div in:fly></div>
+ * ❌ <div in:fly={{ y: 10, duration: 200 }}></div>
+ * ✅ <div in:fly={{ y: prefersReducedMotion.current ? 0 : 10, duration: 200 }}></div>
+ * ✅ <div transition:slide={{ duration: prefersReducedMotion.current ? 0 : 200 }}></div>
+ * ✅ <div in:fade={{ duration: 150 }}></div>
+ */
+
+const MOVEMENT_TRANSITIONS = new Set(['fly', 'slide']);
+
+/** Plain literal param value: 10, 'linear', or a negative number like -20. */
+function isPlainLiteral(value) {
+	if (!value) return false;
+	if (value.type === 'Literal') return true;
+	if (
+		value.type === 'UnaryExpression' &&
+		value.operator === '-' &&
+		value.argument?.type === 'Literal'
+	) {
+		return true;
+	}
+	return false;
+}
+
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Require fly/slide transition params to be gated on prefers-reduced-motion'
+		},
+		schema: [],
+		messages: {
+			unguardedMovementTransition:
+				"Movement transitions (fly, slide) must honor prefers-reduced-motion. Gate the offset or duration on prefersReducedMotion from 'svelte/motion', e.g. duration: prefersReducedMotion.current ? 0 : 200."
+		}
+	},
+	create(context) {
+		return {
+			SvelteDirective(node) {
+				// Covers transition:, in: and out: directives.
+				if (node.kind !== 'Transition') return;
+
+				const transitionName = node.key?.name?.name;
+				if (!MOVEMENT_TRANSITIONS.has(transitionName)) return;
+
+				const params = node.expression;
+
+				// in:fly with no params: default offsets, nothing can zero them.
+				if (!params) {
+					context.report({ node, messageId: 'unguardedMovementTransition' });
+					return;
+				}
+
+				// in:fly={params} / in:fly={makeParams()}: the guard may live upstream.
+				if (params.type !== 'ObjectExpression') return;
+
+				for (const property of params.properties) {
+					// A spread may carry a guarded value; skip to avoid false positives.
+					if (property.type === 'SpreadElement') return;
+					// Conditional/identifier/member/call values count as guarded.
+					if (!isPlainLiteral(property.value)) return;
+				}
+
+				// Empty object or all-literal params: motion is unconditional.
+				context.report({ node, messageId: 'unguardedMovementTransition' });
+			}
+		};
+	}
+};

--- a/eslint/rules/require-motion-guard-transition.test.ts
+++ b/eslint/rules/require-motion-guard-transition.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import parser from 'svelte-eslint-parser';
+import rule from './require-motion-guard-transition.js';
+
+function lint(template: string): Array<{ messageId: string }> {
+	const reports: Array<{ messageId: string }> = [];
+	const ast = parser.parseForESLint(template, {});
+
+	const context = {
+		report: (opts: { messageId: string }) => reports.push(opts),
+		getFilename: () => 'test.svelte',
+		filename: 'test.svelte'
+	};
+
+	const listeners = rule.create(context);
+
+	function walk(node: Record<string, unknown>) {
+		if (!node || typeof node !== 'object') return;
+		const type = node.type as string;
+		if (type && typeof listeners[type] === 'function') {
+			(listeners[type] as (n: unknown) => void)(node);
+		}
+		for (const key of Object.keys(node)) {
+			if (key === 'parent') continue;
+			const val = node[key];
+			if (Array.isArray(val)) val.forEach((v) => walk(v as Record<string, unknown>));
+			else if (val && typeof val === 'object' && (val as Record<string, unknown>).type)
+				walk(val as Record<string, unknown>);
+		}
+	}
+
+	walk(ast.ast as unknown as Record<string, unknown>);
+	return reports;
+}
+
+describe('require-motion-guard-transition', () => {
+	it('flags fly without params', () => {
+		const reports = lint('<div in:fly></div>');
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('unguardedMovementTransition');
+	});
+
+	it('flags fly with all-literal params', () => {
+		const reports = lint('<div transition:fly={{ y: 10, duration: 200 }}></div>');
+		expect(reports).toHaveLength(1);
+	});
+
+	it('flags slide with all-literal params', () => {
+		const reports = lint('<div out:slide={{ duration: 150 }}></div>');
+		expect(reports).toHaveLength(1);
+	});
+
+	it('flags negative number literals as plain literals', () => {
+		const reports = lint('<div in:fly={{ x: -20, duration: 200 }}></div>');
+		expect(reports).toHaveLength(1);
+	});
+
+	it('flags an empty params object', () => {
+		const reports = lint('<div in:fly={{}}></div>');
+		expect(reports).toHaveLength(1);
+	});
+
+	it('allows a prefersReducedMotion-gated duration (field-error style)', () => {
+		const reports = lint(
+			'<div transition:slide={{ duration: prefersReducedMotion.current ? 0 : 200 }}></div>'
+		);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows gated offsets and durations (sliding-header style)', () => {
+		const reports = lint(
+			'<div in:fly={{ x: noMotion ? 0 : 20, duration: skipTransition ? 0 : 200, easing: backOut }}></div>'
+		);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows a gated offset next to a literal duration (ConversationScrollButton style)', () => {
+		const reports = lint(
+			'<div in:fly={{ duration: 300, y: prefersReducedMotion.current ? 0 : 10, easing: backOut }}></div>'
+		);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows fade with literal params (opacity-only is WCAG-acceptable)', () => {
+		expect(lint('<div in:fade={{ duration: 150 }}></div>')).toHaveLength(0);
+		expect(lint('<div transition:fade></div>')).toHaveLength(0);
+	});
+
+	it('allows spread params (guard may come from the spread)', () => {
+		const reports = lint('<div in:fly={{ ...flyParams }}></div>');
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows identifier params (guard may live upstream)', () => {
+		const reports = lint('<div in:fly={flyParams}></div>');
+		expect(reports).toHaveLength(0);
+	});
+
+	it('checks in:, out: and transition: directives alike', () => {
+		const reports = lint(
+			'<div in:fly={{ y: 10 }} out:fly={{ y: 10 }} transition:slide={{ duration: 100 }}></div>'
+		);
+		expect(reports).toHaveLength(3);
+	});
+});

--- a/src/lib/components/customer-support/support-user-id.svelte.ts
+++ b/src/lib/components/customer-support/support-user-id.svelte.ts
@@ -23,6 +23,7 @@ const serializer = {
 // Initial value is `undefined` (not `null`) so PersistedState does not eagerly write to storage
 // on import. The constructor writes the initial value when the key is absent, and #serialize
 // is a no-op for `undefined`.
+// eslint-disable-next-line local/no-module-state-singleton -- PersistedState is browser-written only (localStorage), no per-request SSR state
 export const supportUserId = new PersistedState<string | null | undefined>(
 	'supportUserId',
 	undefined,

--- a/src/lib/hooks/last-auth-method.svelte.ts
+++ b/src/lib/hooks/last-auth-method.svelte.ts
@@ -6,11 +6,13 @@ export type PendingOAuthProvider = 'google' | 'github';
 const LAST_AUTH_METHOD_STORAGE_KEY = 'auth:last-auth-method';
 const PENDING_OAUTH_PROVIDER_STORAGE_KEY = 'auth:pending-oauth-provider';
 
+// eslint-disable-next-line local/no-module-state-singleton -- PersistedState is browser-written only (localStorage), no per-request SSR state
 export const lastSuccessfulAuthMethod = new PersistedState<LastAuthMethod | null>(
 	LAST_AUTH_METHOD_STORAGE_KEY,
 	null
 );
 
+// eslint-disable-next-line local/no-module-state-singleton -- PersistedState is browser-written only (sessionStorage), no per-request SSR state
 export const pendingOAuthProvider = new PersistedState<PendingOAuthProvider | null>(
 	PENDING_OAUTH_PROVIDER_STORAGE_KEY,
 	null,

--- a/src/lib/hooks/use-haptic.svelte.ts
+++ b/src/lib/hooks/use-haptic.svelte.ts
@@ -103,4 +103,5 @@ export class UseHaptic {
 // per-request data, and no field is rendered into SSR HTML, so nothing can
 // leak across requests. Kept as a singleton (instead of context) for
 // ergonomic imports across its many call sites.
+// eslint-disable-next-line local/no-module-state-singleton -- SSR-safe: browser-guarded writes, see rationale above
 export const haptic = new UseHaptic();


### PR DESCRIPTION
See also: #508, #500, #475

Three anti-patterns were fixed across the recent fix PRs, and all three issues explicitly deferred a lint rule as follow-up. Nothing currently prevents reintroduction: a copy-pasted bare `test.skip()` reintroduces the timing-race dodge, a new module-scope class instance in a `.svelte.ts` file reintroduces the cross-request SSR state leak, and a new `fly`/`slide` transition with literal params silently ignores `prefers-reduced-motion` again.

This adds three custom ESLint rules following the existing `eslint/rules/` pattern, each with a co-located vitest suite. `local/no-bare-test-skip` (scoped to `e2e/**/*.spec.ts`) flags `test.skip()` with zero arguments and points to auto-waiting assertions or `test.skip(condition, 'reason')` gating, the style already used in `e2e/signin-last-used-badge.spec.ts`. `local/no-module-state-singleton` (scoped to `**/*.svelte.ts`) flags top-level `export const x = new SomeClass(...)` while exempting runed `Context`, the sanctioned per-request sharing pattern. `local/require-motion-guard-transition` (scoped to `**/*.svelte`) flags `fly` and `slide` directives (`transition:`, `in:`, `out:`) that have no params or only plain literal params; any conditional, identifier, member or call value counts as guarded, so both sanctioned styles (`duration: skipTransition ? 0 : 200` in `sliding-header.svelte` and `y: prefersReducedMotion.current ? 0 : 10` in `ConversationScrollButton.svelte`) pass unchanged, and `fade` stays exempt as opacity-only.

The two intentional singletons named in #500 got an `eslint-disable-next-line` with a short reason next to their existing rationale comments: `haptic` in `use-haptic.svelte.ts` (browser-guarded writes, SSR-safe) and `supportUserId` in `support-user-id.svelte.ts` (`PersistedState`, browser-written only). The repo sweep surfaced a third module with the same pattern, `last-auth-method.svelte.ts`, whose two `PersistedState` exports got the same disable. The motion rule checks guards syntactically; data-flow analysis that would verify an identifier param object actually zeroes motion was out of scope.

Full `eslint .` run passes with zero findings, `bun scripts/static-checks.ts` on all changed files passes, and `bun run test:unit` passes (563 tests, including the 27 new rule tests).
