### PR TITLE
ci(guards): Add actionlint and batch-merge guards

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  # Ubicloud managed runners used by all workflows in this repo
+  labels:
+    - ubicloud-standard-2

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,30 @@
+name: Actionlint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Lint Workflows
+    runs-on: ubicloud-standard-2
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
+        with:
+          # Log-only reporter: needs no write permissions and works on both
+          # pull_request and push events. fail_level makes findings fail the job
+          # instead of only annotating.
+          reporter: github-annotations
+          filter_mode: nofilter
+          fail_level: error

--- a/.github/workflows/e2e-preview-cf.yml
+++ b/.github/workflows/e2e-preview-cf.yml
@@ -113,14 +113,18 @@ jobs:
             HEADERS="-H CF-Access-Client-Id:$CF_ACCESS_CLIENT_ID -H CF-Access-Client-Secret:$CF_ACCESS_CLIENT_SECRET"
           fi
 
+          # Intentional word splitting for optional -H args
+          # shellcheck disable=SC2086
           CONFIG=$(curl -sf $HEADERS "${PREVIEW_URL}/.well-known/e2e-config.json")
 
           echo "Config fetched successfully"
           echo "$CONFIG" | jq .
 
-          echo "PUBLIC_CONVEX_URL=$(echo "$CONFIG" | jq -r '.convexUrl')" >> "$GITHUB_ENV"
-          echo "PUBLIC_CONVEX_SITE_URL=$(echo "$CONFIG" | jq -r '.convexSiteUrl')" >> "$GITHUB_ENV"
-          echo "PUBLIC_SITE_URL=${PREVIEW_URL}" >> "$GITHUB_ENV"
+          {
+            echo "PUBLIC_CONVEX_URL=$(echo "$CONFIG" | jq -r '.convexUrl')"
+            echo "PUBLIC_CONVEX_SITE_URL=$(echo "$CONFIG" | jq -r '.convexSiteUrl')"
+            echo "PUBLIC_SITE_URL=${PREVIEW_URL}"
+          } >> "$GITHUB_ENV"
 
       - name: Wait for Convex backend readiness
         run: |

--- a/.github/workflows/e2e-preview-vercel.yml
+++ b/.github/workflows/e2e-preview-vercel.yml
@@ -57,14 +57,18 @@ jobs:
 
           # Retry up to 5 times (deployment might take a moment to be fully ready)
           for i in {1..5}; do
+            # Intentional word splitting for optional -H arg
+            # shellcheck disable=SC2086
             if CONFIG=$(curl -sf $BYPASS_HEADER "$CONFIG_URL"); then
               echo "Config fetched successfully"
               echo "$CONFIG" | jq .
 
               # Extract values and set as env vars
-              echo "PUBLIC_CONVEX_URL=$(echo $CONFIG | jq -r '.convexUrl')" >> $GITHUB_ENV
-              echo "PUBLIC_CONVEX_SITE_URL=$(echo $CONFIG | jq -r '.convexSiteUrl')" >> $GITHUB_ENV
-              echo "PUBLIC_SITE_URL=${PREVIEW_URL}" >> $GITHUB_ENV
+              {
+                echo "PUBLIC_CONVEX_URL=$(echo "$CONFIG" | jq -r '.convexUrl')"
+                echo "PUBLIC_CONVEX_SITE_URL=$(echo "$CONFIG" | jq -r '.convexSiteUrl')"
+                echo "PUBLIC_SITE_URL=${PREVIEW_URL}"
+              } >> "$GITHUB_ENV"
               exit 0
             fi
             echo "Attempt $i failed, retrying in 10s..."

--- a/.github/workflows/require-regression-guard.yml
+++ b/.github/workflows/require-regression-guard.yml
@@ -1,0 +1,35 @@
+# Enforces the Regression Guard Decision Tree contract from AGENTS.md:
+# every fix PR must state its regression-guard verdict in the body
+# (added <name> / covered by <name> / none feasible, <reason>).
+name: Require Regression Guard
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  check:
+    name: Regression Guard Verdict
+    runs-on: ubicloud-standard-2
+    # Only fix PRs by humans; bots (Renovate "fix(deps)") are exempt
+    if: |
+      !endsWith(github.actor, '[bot]') &&
+      startsWith(github.event.pull_request.title, 'fix')
+    steps:
+      - name: Check PR body for verdict line
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if printf '%s\n' "$PR_BODY" | grep -qiE '^Regression guard: (added|covered by|none feasible)'; then
+            echo "Regression guard verdict found."
+          else
+            echo "::error::Fix PRs must state their regression-guard verdict in the body."
+            echo "Add one line directly above the verification line:"
+            echo "  Regression guard: added <name>"
+            echo "  Regression guard: covered by <name>"
+            echo "  Regression guard: none feasible, <one-line reason>"
+            echo "See AGENTS.md, section Regression Guard Decision Tree."
+            exit 1
+          fi

--- a/.github/workflows/require-regression-guard.yml
+++ b/.github/workflows/require-regression-guard.yml
@@ -22,14 +22,14 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if printf '%s\n' "$PR_BODY" | grep -qiE '^Regression guard: (added|covered by|none feasible)'; then
+          if printf '%s\n' "$PR_BODY" | grep -qiE '^Regression guard: (added|covered by|not warranted)'; then
             echo "Regression guard verdict found."
           else
             echo "::error::Fix PRs must state their regression-guard verdict in the body."
             echo "Add one line directly above the verification line:"
             echo "  Regression guard: added <name>"
             echo "  Regression guard: covered by <name>"
-            echo "  Regression guard: none feasible, <one-line reason>"
+            echo "  Regression guard: not warranted, <one-line reason>"
             echo "See AGENTS.md, section Regression Guard Decision Tree."
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ references/
 
 # local convex dev deployment
 .convex
+
+# Orchestration marker files written by worktree provisioning; must never be committed
+.worktree-ready

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ Local dev notes (`bun run dev`):
 
 - `bun run check:convex` - Convex TypeScript project check. **Required after any change** to `src/lib/convex/**` or shared code imported by Convex.
 - `bun run generate` - Regenerate `_generated/` from a Convex deployment. Rarely needed manually — the convex-vite-plugin keeps it in sync while `bun run dev` is running. Auto-detects: cloud/self-hosted (if configured) > local embedded backend > offline. **Caution**: from a worktree without `bun run dev`, this falls through to cloud and can produce surprising diffs.
+- Local dev/test backends regenerate `src/lib/convex/_generated/**` and `src/lib/convex/betterAuth/_generated/**` as a side effect. Revert that churn (`git checkout -- <paths>`) before committing unless the regeneration is the intended change.
 
 - `bun convex env set KEY value` - Set Convex environment variables (cloud)
 - `bun convex env set KEY value --prod` - Set production environment variables (cloud)
@@ -623,6 +624,14 @@ Examples: `optionOrAlt` (keyboard shortcut convention sibling of `cmdOrCtrl`), `
 
 → **JSDoc `@public` tag** on the export with a one-line reason, never a bare tag. Knip stops reporting it as unused and emits a tag hint once the export gains a real consumer, so the tag can be removed again.
 For intentionally kept **files**, use a `knip.config.ts` `ignore` entry with a why-comment instead, and remove entries that go stale when files are deleted. Anything regenerable from upstream (shadcn demos, cnblocks, prompt-kit examples) has no keep-value as dead code — delete it and re-fetch on demand.
+
+#### "Two PRs are green in isolation but conflict semantically on main"
+
+Examples: one PR removed a schema index another PR's new code queried; two PRs each introduced the same function (every PR green, main broken; hotfix #550).
+
+→ **Required up-to-date branches** (`required_status_checks.strict` on main, enabled 2026-06-12). With strict off, branch protection ran required checks per branch only, so batch-merging sibling PRs could break main even though every PR was green. Strict on means a PR behind main cannot merge until updated and re-validated, which deterministically prevents this class. GitHub merge queue is unavailable for user-owned repos (rulesets API rejects the `merge_queue` rule type).
+Consequence: after every merge, remaining open PRs need a branch update (Update-branch button, `gt sync`, or Renovate auto-rebase) plus a fresh CI cycle; batch merges are sequential by design.
+Defense in depth: after merging, still verify pulled main with `bun run check:convex` and `bun run test:unit`.
 
 #### Guard execution timeline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,13 +537,13 @@ When a custom domain is added to CF Workers, add cache purging to the deploy flo
 
 ### Regression Guard Decision Tree
 
-**Mandatory for every bug fix and issue resolution.** Walking this tree is part of the fix itself, never a separate task someone has to request: before marking work done, classify the bug, pick the guard type below, and record the outcome as a single `Regression guard:` line in the PR body, directly above the verification line. Exactly one of three verdicts:
+**The decision is mandatory for every bug fix; the guard is not.** Before marking work done, decide whether the bug is an instance of a recurring class and record the outcome as a single `Regression guard:` line in the PR body, directly above the verification line. Exactly one of three verdicts:
 
-- `Regression guard: added <name>` (the test/rule/banned pattern this PR adds; most fixes land here)
+- `Regression guard: added <name>` (the test/rule/banned pattern this PR adds)
 - `Regression guard: covered by <name>` (an existing guard already fails on this bug class; name it, do not duplicate it)
-- `Regression guard: none feasible, <one-line reason>` (the class is not deterministically detectable; say why, e.g. cross-file semantic drift or product judgment)
+- `Regression guard: not warranted, <one-line reason>` (one-off; the expected verdict for singular logic errors)
 
-A fix PR without this line is incomplete. CI enforces the line on `fix`-titled PRs (`.github/workflows/require-regression-guard.yml`). The bar for "none feasible" is high: prefer a narrow guard with an escape hatch (eslint-disable with reason) over no guard.
+Add a guard ONLY when the bug is a recurring class: the same pattern already exists at other sites (the issue found multiple occurrences), it is part of a convention agents keep writing (copy-paste surface, template forks inherit it), or it fails silently past review (i18n, SSR, a11y). A singular logic error fixed at its only call site gets `not warranted`; a guard there freezes implementation details and adds CI cost for a class of one. Guards must be cheap and precise: prefer ONE structural invariant over many instance tests, extend existing guard files (banned patterns list, sibling sync tests) over new CI surface, and treat false positives as a cost that can exceed the bug. CI enforces the verdict line on `fix`-titled PRs (`.github/workflows/require-regression-guard.yml`).
 
 #### "Two separate data sources must agree"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,7 +537,13 @@ When a custom domain is added to CF Workers, add cache purging to the deploy flo
 
 ### Regression Guard Decision Tree
 
-When implementing a feature or fixing a bug, choose the right automated guard to prevent future regressions. Go through this decision tree **before marking work as done**.
+**Mandatory for every bug fix and issue resolution.** Walking this tree is part of the fix itself, never a separate task someone has to request: before marking work done, classify the bug, pick the guard type below, and record the outcome as a single `Regression guard:` line in the PR body, directly above the verification line. Exactly one of three verdicts:
+
+- `Regression guard: added <name>` (the test/rule/banned pattern this PR adds; most fixes land here)
+- `Regression guard: covered by <name>` (an existing guard already fails on this bug class; name it, do not duplicate it)
+- `Regression guard: none feasible, <one-line reason>` (the class is not deterministically detectable; say why, e.g. cross-file semantic drift or product judgment)
+
+A fix PR without this line is incomplete. CI enforces the line on `fix`-titled PRs (`.github/workflows/require-regression-guard.yml`). The bar for "none feasible" is high: prefer a narrow guard with an escape hatch (eslint-disable with reason) over no guard.
 
 #### "Two separate data sources must agree"
 

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -47,7 +47,14 @@ const CONFIG = {
 		 * first paint. Lazy-load via $lib/monitoring/sentry instead; `import type`
 		 * stays allowed (erased at build time).
 		 */
-		staticSentryImport: /(?:import|export)\s+(?!type[\s{])[^'"]*from\s*['"]@sentry\/sveltekit['"]/
+		staticSentryImport: /(?:import|export)\s+(?!type[\s{])[^'"]*from\s*['"]@sentry\/sveltekit['"]/,
+		/**
+		 * Shell-string spawning. Removed in #473/#514; build argument arrays and use
+		 * spawn-style helpers instead (see runCommandCapture in scripts/deploy/utils.ts).
+		 * Scope: this scanner only covers .svelte/.ts files under src/ (full runs glob
+		 * that set; --staged/file-args runs filter the given files down to it).
+		 */
+		execSync: /\bexecSync\s*\(/
 	}
 };
 
@@ -238,7 +245,7 @@ async function main(): Promise<void> {
 		}
 		console.log('\n');
 
-		// Banned patterns (deprecated tokens, bare animate-spin, static Sentry imports)
+		// Banned patterns (deprecated tokens, bare animate-spin, static Sentry imports, execSync)
 		printHeader(step++, 'Banned patterns');
 		{
 			const filesToScan = scopedMode
@@ -266,6 +273,11 @@ async function main(): Promise<void> {
 					if (CONFIG.bannedPatterns.staticSentryImport.test(line)) {
 						violations.push(
 							`${file}:${i + 1}: static @sentry/sveltekit import (lazy-load via $lib/monitoring/sentry; import type is allowed): ${line.trim()}`
+						);
+					}
+					if (CONFIG.bannedPatterns.execSync.test(line)) {
+						violations.push(
+							`${file}:${i + 1}: execSync (use spawn-style argument arrays, see runCommandCapture in scripts/deploy/utils.ts): ${line.trim()}`
 						);
 					}
 				}


### PR DESCRIPTION
See also: #481, #483, #473

The recent 40-PR merge wave exposed process gaps that no automated guard covered: a shell-injection class in CI workflows (#481), workflow permission gaps (#483), shell-string spawning in scripts (#473), and a batch-merge incident where two individually green PRs broke main semantically (the same function landed from two PRs, and one PR removed a schema index while another added code querying it; hotfixed in #550).

This adds `.github/workflows/actionlint.yml`, which lints all workflows on `pull_request` and on push to main (path-filtered to `.github/workflows/**`). It uses `reviewdog/action-actionlint` pinned to the verified v1.72.0 commit SHA with `fail_level: error`, so findings fail the job instead of only annotating, and the `github-annotations` reporter keeps the job on read-only permissions. A new `.github/actionlint.yaml` declares the `ubicloud-standard-2` runner label. Making the check green from day one meant fixing what it surfaced in the two e2e preview workflows: the `SC2129` grouped-redirect findings (which the action maps to error severity), quoting around `$CONFIG` and `$GITHUB_ENV`, and an explicit `shellcheck disable=SC2086` with a reason on the intentionally word-split curl header variables.

`scripts/static-checks.ts` gains a banned pattern for `execSync(` so the shell-string spawn class removed in #473/#514 cannot reappear in `src/`; the repo currently has zero hits, and spawn-style argument arrays (`runCommandCapture` in `scripts/deploy/utils.ts`) remain the sanctioned path. `.gitignore` adds `.worktree-ready` so worktree provisioning markers never get committed. AGENTS.md gets a new Regression Guard Decision Tree entry for the batch-merge incident class that #550 hotfixed, reflecting that `required_status_checks.strict` is now enabled on main, plus a Convex Backend note about reverting local `_generated` churn before committing.

The Regression Guard Decision Tree itself is now a hard contract instead of advice, with the obligation on the decision rather than the guard: every fix PR records one of three verdicts (`Regression guard: added <name>`, `covered by <name>`, or `not warranted, <reason>`) directly above its verification line, and the new `require-regression-guard.yml` workflow fails fix-titled PRs from humans that omit the line (bots like Renovate are exempt; the PR body is passed via `env:` so the check is not an injection sink). Guards are scoped to recurring bug classes (multiple occurrences, convention copy-paste surface, silent failures); singular logic errors take the `not warranted` verdict instead of accumulating one-off instance tests in CI.

`bun scripts/static-checks.ts` passes on all changed files, `actionlint` reports zero findings across `.github/workflows`, the new banned pattern fires on a test fixture, and both new YAML files parse with pyyaml.

