### PR TITLE
chore(i18n): Enforce nested key structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,7 @@ These commands use `varlock run` to load env vars from `.env.schema` + `.env.loc
 
 - `bun run i18n:pull` - Download latest translations from Tolgee Cloud. Run this ALWAYS before making any changes to the `src/i18n/*` json translation files.
 - When adding new translation keys, ALWAYS add translations for ALL languages in the `src/i18n/*` json translation files.
+- Key names never contain literal dots; nesting is the only structure. A dotted leaf means a key in Tolgee is both a string leaf and a namespace prefix; resolve the collision in Tolgee instead of committing the dotted fallback (enforced by `scripts/locale-parity.test.ts`).
 - `bun run i18n:push` - Upload local translations. ALWAYS run this after making any changes to the `src/i18n/*` json translation files. Otherwise, your changes wont be pushed to the cloud! Run with `-- --tag-new-keys draft` to tag new keys as e.g. 'draft'
 
   Use tags to organize translation keys:

--- a/scripts/locale-parity.test.ts
+++ b/scripts/locale-parity.test.ts
@@ -15,6 +15,19 @@ function leafKeys(value: unknown, prefix = ''): string[] {
 
 const otherLocales = { de, es, fr };
 
+// Key names never contain literal dots; nesting is the only structure.
+// A dotted key name means a parent/child collision in Tolgee (a key that is
+// both a string leaf and a namespace prefix), which forces the exporter into
+// a flat-dotted fallback and splits one logical key across two shapes.
+function dottedKeyNames(value: unknown, prefix = ''): string[] {
+	if (value === null || typeof value !== 'object') return [];
+	return Object.entries(value as Record<string, unknown>).flatMap(([key, child]) => {
+		const path = prefix ? `${prefix}.${key}` : key;
+		const own = key.includes('.') ? [path] : [];
+		return [...own, ...dottedKeyNames(child, path)];
+	});
+}
+
 describe('locale key parity', () => {
 	const enKeys = leafKeys(en).sort();
 
@@ -25,5 +38,12 @@ describe('locale key parity', () => {
 	it.each(Object.keys(otherLocales))('%s.json has the same leaf keys as en.json', (lang) => {
 		const keys = leafKeys(otherLocales[lang as keyof typeof otherLocales]).sort();
 		expect(keys).toEqual(enKeys);
+	});
+});
+
+describe('locale key structure', () => {
+	it.each(['en', 'de', 'es', 'fr'])('%s.json has no dotted key names', (lang) => {
+		const locale = { en, ...otherLocales }[lang as 'en' | 'de' | 'es' | 'fr'];
+		expect(dottedKeyNames(locale)).toEqual([]);
 	});
 });

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -477,12 +477,13 @@
 			"test_secret_placeholder": "Geheimnis-Wert",
 			"title": "Willkommen zurück"
 		},
-		"signup": "Registrieren",
-		"signup.description": "Geben Sie Ihre Daten ein, um loszulegen",
-		"signup.has_account": "Bereits ein Konto?",
-		"signup.link_signin": "Anmelden",
-		"signup.password_hint": "Mindestens 10 Zeichen mit Groß-, Kleinbuchstaben und Zahl",
-		"signup.title": "Konto erstellen",
+		"signup": {
+			"description": "Geben Sie Ihre Daten ein, um loszulegen",
+			"has_account": "Bereits ein Konto?",
+			"link_signin": "Anmelden",
+			"password_hint": "Mindestens 10 Zeichen mit Groß-, Kleinbuchstaben und Zahl",
+			"title": "Konto erstellen"
+		},
 		"terms": {
 			"agreement": "Mit dem Fortfahren akzeptieren Sie unsere",
 			"and": "und",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -477,12 +477,13 @@
 			"test_secret_placeholder": "secret value",
 			"title": "Welcome back"
 		},
-		"signup": "Sign Up",
-		"signup.description": "Enter your details to get started",
-		"signup.has_account": "Already have an account?",
-		"signup.link_signin": "Sign in",
-		"signup.password_hint": "Minimum 10 characters with uppercase, lowercase, and number",
-		"signup.title": "Create an account",
+		"signup": {
+			"description": "Enter your details to get started",
+			"has_account": "Already have an account?",
+			"link_signin": "Sign in",
+			"password_hint": "Minimum 10 characters with uppercase, lowercase, and number",
+			"title": "Create an account"
+		},
 		"terms": {
 			"agreement": "By clicking continue, you agree to our",
 			"and": "and",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -477,12 +477,13 @@
 			"test_secret_placeholder": "valor secreto",
 			"title": "Bienvenido de nuevo"
 		},
-		"signup": "Registrarse",
-		"signup.description": "Ingresa tus datos para comenzar",
-		"signup.has_account": "¿Ya tienes una cuenta?",
-		"signup.link_signin": "Inicia sesión",
-		"signup.password_hint": "Mínimo 10 caracteres con mayúsculas, minúsculas y número",
-		"signup.title": "Crear una cuenta",
+		"signup": {
+			"description": "Ingresa tus datos para comenzar",
+			"has_account": "¿Ya tienes una cuenta?",
+			"link_signin": "Inicia sesión",
+			"password_hint": "Mínimo 10 caracteres con mayúsculas, minúsculas y número",
+			"title": "Crear una cuenta"
+		},
 		"terms": {
 			"agreement": "Al continuar, aceptas nuestros",
 			"and": "y",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -477,12 +477,13 @@
 			"test_secret_placeholder": "valeur secrète",
 			"title": "Bon retour"
 		},
-		"signup": "S'inscrire",
-		"signup.description": "Entrez vos informations pour commencer",
-		"signup.has_account": "Déjà un compte ?",
-		"signup.link_signin": "Se connecter",
-		"signup.password_hint": "Minimum 10 caractères avec majuscules, minuscules et chiffre",
-		"signup.title": "Créer un compte",
+		"signup": {
+			"description": "Entrez vos informations pour commencer",
+			"has_account": "Déjà un compte ?",
+			"link_signin": "Se connecter",
+			"password_hint": "Minimum 10 caractères avec majuscules, minuscules et chiffre",
+			"title": "Créer un compte"
+		},
 		"terms": {
 			"agreement": "En continuant, vous acceptez nos",
 			"and": "et notre",


### PR DESCRIPTION
See also: #552, #466

The locale files mixed two structures: 859 keys as nested objects and a handful as flat dotted key names (`auth.signup.title` literally stored as a dotted string key). The dotted entries were not a style choice; they were Tolgee's export fallback for two key collisions where a string leaf also served as a namespace prefix: `auth.signup` ("Sign Up", referenced nowhere in code) blocked nesting of the five `auth.signup.*` keys, and the stale pre-#466 keys `chat.alerts.low_messages.{title,description,description_plural}` collided with the live `chat.alerts.low_messages` leaf the quota banner uses. The mix forced consumers like the new `i18n-used-keys` guard in #552 to support two resolution semantics.

The convention is now nested only. The four colliding keys were deleted in Tolgee (verified: a fresh `tolgee pull` exports zero dotted leaves, `auth.signup` as a proper object, and the live `low_messages` leaf intact), `auth.signup.*` is a nested group in all four locale files, and `scripts/locale-parity.test.ts` gains a structure test that rejects any dotted key name at any depth, so the collision class cannot be committed again. AGENTS.md documents the rule next to the existing translation guidance.

`bun run test:unit` passes (540 tests, including the 4 new structure tests) and `bun scripts/static-checks.ts` passes on all changed files.
