### PR TITLE
chore(deploy): Drop build-env preview password override

### DIFF
--- a/.env-convex.schema
+++ b/.env-convex.schema
@@ -85,7 +85,8 @@ AUTH_E2E_TEST_SECRET=
 # ====================================
 
 # Password for the auto-seeded preview admin (admin@preview.dev)
-# Only set on preview Convex deployments by deploy.ts
+# Inherited by preview deployments from the Convex project preview default
+# env var: bunx convex env default set --type preview PREVIEW_ADMIN_PASSWORD
 # @optional @sensitive
 PREVIEW_ADMIN_PASSWORD=
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,6 @@ Set `PREVIEW_ADMIN_PASSWORD` once as a preview default (`bunx convex env default
 | `NODE_ADAPTER`              | Set to `1` to build with adapter-node for self-hosted production                                                                         |         |  ○   |
 | `CONVEX_INTERNAL_URL`       | Internal Convex URL for Docker-network routing (self-hosted)                                                                             |         |  ○   |
 | `TOLGEE_API_KEY`            | Tolgee CLI key for deploy-time sync (optional, skips when unset)                                                                         |    ○    |  ○   |
-| `PREVIEW_ADMIN_PASSWORD`    | Preview admin password override (canonical place is the Convex preview default env var, see above)                                       |    ○    |      |
 | `PUBLIC_POSTHOG_API_KEY`    | PostHog analytics API key                                                                                                                |         |  ○   |
 | `PUBLIC_POSTHOG_HOST`       | PostHog analytics host                                                                                                                   |         |  ○   |
 | `PRODUCTION_BRANCH`         | Cloudflare only: production branch name (default: `main`)                                                                                |    ○    |  ○   |

--- a/scripts/deploy/steps.ts
+++ b/scripts/deploy/steps.ts
@@ -341,31 +341,8 @@ export async function setupPreviewEnv(
 
 	// Seed preview admin. The mutation reads PREVIEW_ADMIN_PASSWORD from the
 	// Convex deployment env, which new preview deployments inherit from the
-	// project's preview default env vars. A build-env PREVIEW_ADMIN_PASSWORD
-	// acts as an optional override.
-	const previewAdminPassword = process.env.PREVIEW_ADMIN_PASSWORD;
-	if (previewAdminPassword) {
-		const setPwResult = await runCommandWithRetry(
-			'bunx',
-			[
-				'convex',
-				'env',
-				'set',
-				'--deployment-name',
-				deployment.name,
-				'PREVIEW_ADMIN_PASSWORD',
-				previewAdminPassword
-			],
-			{ maxRetries: 3, delayMs: 3000, description: 'convex env set PREVIEW_ADMIN_PASSWORD' }
-		);
-
-		if (!setPwResult.success) {
-			console.warn(
-				`${colors.yellow}Warning: Failed to set PREVIEW_ADMIN_PASSWORD from build env${colors.reset}`
-			);
-		}
-	}
-
+	// project's preview default env vars (bunx convex env default set --type preview).
+	// Intentionally no build-env override: Convex runtime values live in Convex only.
 	console.log('');
 	console.log('Seeding preview admin user...');
 	const seedResult = runCommandCapture('bunx', [
@@ -384,7 +361,7 @@ export async function setupPreviewEnv(
 		if (seedResult.stdout) console.log(`  Result: ${seedResult.stdout}`);
 	} else {
 		console.warn(
-			`${colors.yellow}Warning: Preview admin seeding failed (non-blocking). Set PREVIEW_ADMIN_PASSWORD as a Convex preview default env var (bunx convex env default set --type preview) or in the build env.${colors.reset}`
+			`${colors.yellow}Warning: Preview admin seeding failed (non-blocking). Set PREVIEW_ADMIN_PASSWORD as a Convex preview default env var (bunx convex env default set --type preview).${colors.reset}`
 		);
 		if (seedResult.stdout) console.log(`  stdout: ${seedResult.stdout}`);
 		if (seedResult.stderr) console.log(`  stderr: ${seedResult.stderr}`);


### PR DESCRIPTION
The preview admin password had two competing sources: the Convex project default env var for preview deployments (documented as the canonical place) and a `PREVIEW_ADMIN_PASSWORD` in the hosting platform build env, which `scripts/deploy/steps.ts` wrote into every preview deployment via `convex env set`, silently overriding the default. A stale value in the CF Workers Builds env did exactly that, so logging in with the documented default password failed and nothing pointed at the cause.

Remove the override path from the deploy script and the corresponding row from the README's hosting platform env table. The Convex preview default (`bunx convex env default set --type preview PREVIEW_ADMIN_PASSWORD`) is now the single source, and the hosting build env only carries build concerns like deploy keys. The seeding failure warning no longer suggests the build env as an alternative.

`bun scripts/static-checks.ts scripts/deploy/steps.ts README.md` passes. The stale `PREVIEW_ADMIN_PASSWORD` build var in CF Workers Builds gets removed alongside this change so future previews seed with the project default.