### PR TITLE
fix(dev): Ignore static SITE_URL in .env.convex.local

### DIFF
--- a/.env.convex.example
+++ b/.env.convex.example
@@ -77,8 +77,8 @@ AUTH_GITHUB_SECRET=
 # Auto-derived from VERCEL_URL for preview deployments
 # Note: For email images, use EMAIL_ASSET_URL (always production)
 # Local dev: auto-derived from the running Vite port (per-project, see
-# scripts/dev-ports.ts). Leave SITE_URL unset locally so a copied value can't pin
-# the trusted origin to a wrong port and break the admin sign-in.
+# scripts/dev-ports.ts). A value set here is ignored with a warning, because a
+# static URL would pin the trusted origin to a wrong origin and break sign-in.
 # For cloud/prod, set via: bunx convex env set SITE_URL https://yourapp.com
 # SITE_URL=https://yourapp.com
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Local dev notes (`bun run dev`):
 - Local seeded admin credentials: `admin@local.dev` / `LocalDevAdmin123!`
 - Convex backend env vars are loaded from `.env.convex.local` (optional services like email, OAuth, billing, AI).
 - `RESEND_API_KEY` and `AUTH_EMAIL` in `.env.convex.local` are only needed for real signup, verification, and password reset email flows.
-- `SITE_URL` is auto-derived locally from the running Vite port (per-project, see `scripts/dev-ports.ts`); leave it unset in `.env.convex.local` for local dev and only set it for cloud/prod. A hardcoded or production URL here breaks the admin sign-in via Better Auth.
+- `SITE_URL` is auto-derived locally from the running Vite port (per-project, see `scripts/dev-ports.ts`) and only needs to be set for cloud/prod. A `SITE_URL` in `.env.convex.local` is ignored with a loud warning (`vite.config.ts` strips it), because a static value would pin Better Auth's trusted origin to the wrong origin and break the admin sign-in.
 - Dev and test Vite ports are deterministic per project/worktree (separate ranges in `scripts/dev-ports.ts`, so dev can't creep into the test port). Override with `DEV_VITE_PORT` / `TEST_VITE_PORT`, or set `PORTLESS_SITE_URL` to front the local stack with vercel-labs/portless.
 - Local Convex state is isolated per branch/worktree under `.convex/`.
 - `RESET_LOCAL_BACKEND=true bun run dev` clears the existing local Convex state before startup and restores the default seeded admin credentials.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -215,8 +215,15 @@ export default defineConfig(async ({ mode }) => {
 			loadedEnv.BETTER_AUTH_SECRET?.trim() ||
 			getPersistentBetterAuthSecret(cwd, resetLocalBackend, stateIdSuffix);
 
-		// Load Convex backend env vars from .env.convex.local
-		const convexLocalEnv = parseEnvFile(path.join(cwd, '.env.convex.local'));
+		// Load Convex backend env vars from .env.convex.local.
+		// SITE_URL is stripped: locally it must always track the running dev server
+		// (or PORTLESS_SITE_URL), and a static value copied into the file would pin
+		// Better Auth's trusted origin to the wrong origin and silently break
+		// sign-in. The envVars callback below derives it and warns when a stripped
+		// value differed.
+		const { SITE_URL: ignoredLocalSiteUrl, ...convexLocalEnv } = parseEnvFile(
+			path.join(cwd, '.env.convex.local')
+		);
 		// Register Convex backend env values with varlock's redaction map so that
 		// convex-vite-plugin's env-var logging is automatically redacted.
 		// varlockLoadedEnv already contains .env.schema values; we merge in
@@ -283,6 +290,13 @@ export default defineConfig(async ({ mode }) => {
 					const siteUrl = portlessOwnsPort()
 						? process.env.PORTLESS_SITE_URL!
 						: (resolvedUrls?.local[0] ?? `http://localhost:${vitePort}`);
+					if (ignoredLocalSiteUrl && ignoredLocalSiteUrl !== siteUrl) {
+						console.warn(
+							`[convex] Ignoring SITE_URL=${ignoredLocalSiteUrl} from .env.convex.local; ` +
+								`using ${siteUrl} (derived from the running dev server) so local sign-in keeps working. ` +
+								`Remove SITE_URL from .env.convex.local to silence this warning.`
+						);
+					}
 					return {
 						// Auto-generated defaults for local dev
 						BETTER_AUTH_SECRET: betterAuthSecret,


### PR DESCRIPTION
A `SITE_URL` copied into `.env.convex.local` (from the cloud setup steps, the example file, or because the schema marks it `@required`) overrode the URL that local dev derives from the running Vite port. That pinned Better Auth's trusted origin to the wrong origin and silently broke local admin sign-in, with nothing pointing at the env file as the cause. Until now only doc warnings in AGENTS.md and the example file guarded against this.

`vite.config.ts` now strips `SITE_URL` from the local override file and always uses the derived URL (or `PORTLESS_SITE_URL`, unchanged). When a stripped value differs from the derived one, it logs a warning naming both values and the fix. Cloud and preview deployments are unaffected: `scripts/deploy.ts` sets `SITE_URL` per deployment on Cloudflare and Vercel and never reads `.env.convex.local`, which is gitignored and absent in CI. The stale doc warnings in AGENTS.md and `.env.convex.example` now describe the new behavior.

`bun scripts/static-checks.ts vite.config.ts AGENTS.md .env.convex.example` passes. Verified locally: with `SITE_URL=https://production.example.com` in `.env.convex.local`, `bun run dev` logs the ignore warning and sets `SITE_URL=http://localhost:20191/` on the local backend.