### PR TITLE
fix(deps): pin acorn to 8.15.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,7 @@
   },
   "overrides": {
     "@peculiar/asn1-schema": "^2.7.0",
+    "acorn": "8.15.0",
     "zod": "^4.4.2",
   },
   "packages": {
@@ -3217,8 +3218,6 @@
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "eslint-plugin-svelte/globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
-
-    "espree/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
 	},
 	"overrides": {
 		"zod": "$zod",
-		"@peculiar/asn1-schema": "^2.7.0"
+		"@peculiar/asn1-schema": "^2.7.0",
+		"acorn": "8.15.0"
 	}
 }


### PR DESCRIPTION
See also: #400, #371

The two security update PRs (SvelteKit 2.60.1, Svelte 5.55.7) fail CI on Type Check, Lint, and Workers Builds, but not because of SvelteKit or Svelte. Regenerating the lockfile pulls acorn from 8.15.0 to 8.16.0 (a transitive dependency of svelte via acorn ^8.12.1). acorn 8.16.0 changed tokenizer and keyword recognition that @sveltejs/acorn-typescript depends on, so vite-plugin-svelte's optimizeDeps prebundling can no longer parse the TypeScript script blocks in node_modules .svelte files (svelte-streamdown), and build:emails plus the app build fail with a rolldown "Unexpected token". The Svelte compiler parses those same files fine in 5.55.5 through 5.56.3; only the prebundle path breaks.

This pins acorn to 8.15.0, the version main already resolves, so the dependency graph stays on the working parser. Verified by reproducing the failure on the Svelte 5.55.7 branch (fails with acorn 8.16.0 even after downgrading svelte back to 5.55.5) and confirming the same branch goes green once acorn is pinned to 8.15.0. With the pin in place a future dependency bump will no longer drag acorn forward, which unblocks the two security PRs once they rebase.

Regression guard: covered by the Type Check CI gate, whose build:emails step parses node_modules .svelte components and fails on the regressing acorn (this is how the break surfaced).

cd into a clean checkout, bun install, then bun scripts/static-checks.ts --ci --scope types and --scope lint both pass; build:emails renders all six templates.