### PR TITLE
Purge Cloudflare edge cache after production deploys

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -220,6 +220,16 @@ CF_PAGES_BRANCH=
 # @public @optional
 PRODUCTION_BRANCH=
 
+# Cloudflare API token with Zone > Cache Purge, used by scripts/cf-prod-deploy.ts
+# to purge the edge cache after a production deploy. Purge is skipped when unset.
+# @sensitive @optional
+CF_PURGE_TOKEN=
+
+# Cloudflare zone id for the production custom domain, used by the post-deploy
+# cache purge. Purge is skipped when unset.
+# @public @optional
+CF_ZONE_ID=
+
 # ====================================
 # CI
 # ====================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -524,11 +524,11 @@ Markdown responses on the same URLs use `Cache-Control: private` to stay out of 
 
 #### Cache purging (production)
 
-When a custom domain is added to CF Workers, add cache purging to the deploy flow (`scripts/cf-deploy.ts`) to prevent stale responses after production deploys:
+`scripts/cf-prod-deploy.ts` is the production deploy command: it runs `wrangler deploy` and then purges the edge cache, so a new deploy is served immediately instead of stale cached HTML. The purge is a no-op unless both `CF_PURGE_TOKEN` and `CF_ZONE_ID` are set, so forks without a custom domain keep plain `wrangler deploy` behaviour.
 
 - CF API: `POST /zones/{zone_id}/purge_cache` with `{ "purge_everything": true }`
 - Docs: https://developers.cloudflare.com/api/resources/cache/methods/purge/
-- Requires: Zone ID + API token with `Cache Purge` permission
+- `CF_PURGE_TOKEN`: API token with `Cache Purge` permission; `CF_ZONE_ID`: the zone id of the custom domain. Set both as CF Workers Builds variables/secrets.
 - Not available for `.workers.dev` subdomains — only works with custom domains
 
 ### Cloudflare Platform Gotchas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -524,11 +524,11 @@ Markdown responses on the same URLs use `Cache-Control: private` to stay out of 
 
 #### Cache purging (production)
 
-`scripts/cf-prod-deploy.ts` is the production deploy command: it runs `wrangler deploy` and then purges the edge cache, so a new deploy is served immediately instead of stale cached HTML. The purge is a no-op unless both `CF_PURGE_TOKEN` and `CF_ZONE_ID` are set, so forks without a custom domain keep plain `wrangler deploy` behaviour.
+`scripts/cf-prod-deploy.ts` is the production deploy command: it runs `wrangler deploy` and then purges the edge cache, so a new deploy is served immediately instead of stale cached HTML. The purge is a no-op unless both `CF_PURGE_TOKEN` and `CF_ZONE_ID` are set, so forks without a custom domain keep plain `wrangler deploy` behavior.
 
 - CF API: `POST /zones/{zone_id}/purge_cache` with `{ "purge_everything": true }`
 - Docs: https://developers.cloudflare.com/api/resources/cache/methods/purge/
-- `CF_PURGE_TOKEN`: API token with `Cache Purge` permission; `CF_ZONE_ID`: the zone id of the custom domain. Set both as CF Workers Builds variables/secrets.
+- `CF_PURGE_TOKEN`: API token with `Cache Purge` permission; `CF_ZONE_ID`: the zone id of the custom domain. Set `CF_ZONE_ID` as a build variable and `CF_PURGE_TOKEN` as a build secret in CF Workers Builds.
 - Not available for `.workers.dev` subdomains — only works with custom domains
 
 ### Cloudflare Platform Gotchas

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Push to your production branch (default: `main`) and the connected platform depl
 **Cloudflare Workers:**
 
 ```bash
-bunx wrangler deploy
+bun scripts/cf-prod-deploy.ts
 ```
 
 **Vercel:**

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Deploy via [Cloudflare Workers](https://developers.cloudflare.com/workers/) with
 | Field                                | Value                                       |
 | ------------------------------------ | ------------------------------------------- |
 | Build command                        | `bunx varlock run -- bun scripts/deploy.ts` |
-| Deploy command                       | `bunx wrangler deploy`                      |
+| Deploy command                       | `bun scripts/cf-prod-deploy.ts`             |
 | Non-production branch deploy command | `bun scripts/cf-deploy.ts`                  |
 
 **4. Add build variables** (plain text, visible in logs)
@@ -250,6 +250,8 @@ For email event tracking (delivery, bounce, open, click):
 
 If your domain's DNS is on Cloudflare: CF dashboard > Workers & Pages > select Worker > Settings > Domains & Routes > Add > Custom Domain. CF creates DNS records and provisions SSL automatically. Set `SITE_URL` on your Convex production deployment to match.
 
+Once a custom domain is live, marketing pages are edge-cached (`s-maxage`), so a production deploy would otherwise serve stale HTML for up to an hour. The production deploy command `scripts/cf-prod-deploy.ts` purges the edge cache after each deploy when you set two values in CF Workers Builds: `CF_ZONE_ID` (build variable, the zone id from the domain's CF Overview page) and `CF_PURGE_TOKEN` (build secret, an API token with the `Zone > Cache Purge` permission). Without them the purge is skipped.
+
 If your domain uses external DNS, use the CF for SaaS method below.
 
 </details>
@@ -327,6 +329,8 @@ Set `PREVIEW_ADMIN_PASSWORD` once as a preview default (`bunx convex env default
 | `CONVEX_PROJECT_ID`         | Numeric project id for quota self-heal (`curl -H "Authorization: Bearer $TOKEN" https://api.convex.dev/v1/teams/{teamId}/list_projects`) |    ○    |      |
 | `WORKERS_NAME`              | CF Workers only: worker name (matches `wrangler.toml`)                                                                                   |    ✓    |  ○   |
 | `WORKERS_SUBDOMAIN`         | CF Workers only: account's `workers.dev` subdomain                                                                                       |    ✓    |  ○   |
+| `CF_ZONE_ID`                | CF Workers only: zone id of the custom domain, for post-deploy edge cache purge (skipped when unset)                                     |         |  ○   |
+| `CF_PURGE_TOKEN`            | CF Workers only: API token with `Cache Purge`, for post-deploy edge cache purge (skipped when unset)                                     |         |  ○   |
 | `NODE_ADAPTER`              | Set to `1` to build with adapter-node for self-hosted production                                                                         |         |  ○   |
 | `CONVEX_INTERNAL_URL`       | Internal Convex URL for Docker-network routing (self-hosted)                                                                             |         |  ○   |
 | `TOLGEE_API_KEY`            | Tolgee CLI key for deploy-time sync (optional, skips when unset)                                                                         |    ○    |  ○   |

--- a/scripts/cf-prod-deploy.ts
+++ b/scripts/cf-prod-deploy.ts
@@ -1,0 +1,50 @@
+/**
+ * CF Workers production deploy command — wraps `wrangler deploy`, then purges the
+ * Cloudflare edge cache.
+ *
+ * Marketing routes that aren't prerendered are edge-cached by the handleCacheControl
+ * hook (`Cache-Control: public, s-maxage=3600, ...`). A plain `wrangler deploy` uploads
+ * the new version but never invalidates that cache, so visitors keep getting the old HTML
+ * until the TTL expires. Purging after a successful deploy makes the new version live
+ * immediately.
+ *
+ * Set as the production deploy command in CF Workers Builds dashboard.
+ * The purge is a no-op unless both CF_PURGE_TOKEN and CF_ZONE_ID are set, so forks
+ * without a custom domain keep plain `wrangler deploy` behaviour.
+ */
+
+import { spawnSync } from 'child_process';
+
+const result = spawnSync('bunx', ['wrangler', 'deploy'], { stdio: 'inherit' });
+if (result.status !== 0) {
+	process.exit(result.status ?? 1);
+}
+
+const token = process.env.CF_PURGE_TOKEN;
+const zoneId = process.env.CF_ZONE_ID;
+
+if (!token || !zoneId) {
+	console.log('Cache purge skipped (CF_PURGE_TOKEN / CF_ZONE_ID not set).');
+	process.exit(0);
+}
+
+const res = await fetch(`https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`, {
+	method: 'POST',
+	headers: {
+		Authorization: `Bearer ${token}`,
+		'Content-Type': 'application/json'
+	},
+	body: JSON.stringify({ purge_everything: true })
+});
+
+const body = (await res.json().catch(() => null)) as { success?: boolean; errors?: unknown } | null;
+
+// The worker is already published at this point. A failed purge only means the edge
+// serves stale HTML until the TTL expires (the pre-existing behaviour), so log loudly
+// but don't fail the build and risk a confusing retry of an already-live deploy.
+if (!res.ok || !body?.success) {
+	console.error(`Cache purge failed (HTTP ${res.status}):`, JSON.stringify(body));
+	process.exit(0);
+}
+
+console.log('Cloudflare edge cache purged.');

--- a/scripts/cf-prod-deploy.ts
+++ b/scripts/cf-prod-deploy.ts
@@ -10,7 +10,11 @@
  *
  * Set as the production deploy command in CF Workers Builds dashboard.
  * The purge is a no-op unless both CF_PURGE_TOKEN and CF_ZONE_ID are set, so forks
- * without a custom domain keep plain `wrangler deploy` behaviour.
+ * without a custom domain keep plain `wrangler deploy` behavior.
+ *
+ * Runs without varlock (like the other deploy commands), so CF_PURGE_TOKEN gets no
+ * log redaction. It must never be written to any log/error string; it is only ever
+ * sent in the Authorization header below.
  */
 
 import { spawnSync } from 'child_process';
@@ -28,23 +32,34 @@ if (!token || !zoneId) {
 	process.exit(0);
 }
 
-const res = await fetch(`https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`, {
-	method: 'POST',
-	headers: {
-		Authorization: `Bearer ${token}`,
-		'Content-Type': 'application/json'
-	},
-	body: JSON.stringify({ purge_everything: true })
-});
+// The worker is already published at this point, so the purge is fail-open: any failure
+// (HTTP error or a network-level throw like DNS/connection refused/timeout) only means the
+// edge serves stale HTML until the TTL expires (the pre-existing behavior). Log loudly but
+// exit 0 so the build doesn't fail and trigger a confusing retry of an already-live deploy.
+// purge_everything is intentional: the zone only caches non-prerendered marketing HTML, so a
+// full purge is the simplest correct invalidation; a tag/prefix purge could miss stale paths.
+try {
+	const res = await fetch(`https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({ purge_everything: true })
+	});
 
-const body = (await res.json().catch(() => null)) as { success?: boolean; errors?: unknown } | null;
+	const body = (await res.json().catch(() => null)) as {
+		success?: boolean;
+		errors?: unknown;
+	} | null;
 
-// The worker is already published at this point. A failed purge only means the edge
-// serves stale HTML until the TTL expires (the pre-existing behaviour), so log loudly
-// but don't fail the build and risk a confusing retry of an already-live deploy.
-if (!res.ok || !body?.success) {
-	console.error(`Cache purge failed (HTTP ${res.status}):`, JSON.stringify(body));
+	if (!res.ok || !body?.success) {
+		console.error(`Cache purge failed (HTTP ${res.status}):`, JSON.stringify(body));
+		process.exit(0);
+	}
+
+	console.log('Cloudflare edge cache purged.');
+} catch (err) {
+	console.error('Cache purge request failed (network error):', err);
 	process.exit(0);
 }
-
-console.log('Cloudflare edge cache purged.');

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -301,6 +301,22 @@ export type CoercedEnvSchema = {
   PRODUCTION_BRANCH?: string;
   
   /**
+   * **CF_PURGE_TOKEN** 🔐 _sensitive_  
+   * Cloudflare API token with Zone > Cache Purge, used by scripts/cf-prod-deploy.ts  
+   * to purge the edge cache after a production deploy. Purge is skipped when unset.  
+   * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
+   */
+  CF_PURGE_TOKEN?: string;
+  
+  /**
+   * **CF_ZONE_ID**  
+   * Cloudflare zone id for the production custom domain, used by the post-deploy  
+   * cache purge. Purge is skipped when unset.  
+   * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
+   */
+  CF_ZONE_ID?: string;
+  
+  /**
    * **CI**  
    * Set to "true" in CI environments (injected by GitHub Actions)  
    * ![icon](data:image/svg+xml;utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2032%2032%22%3E%3Cpath%20fill%3D%22%23808080%22%20d%3D%22M29%2022h-5a2.003%202.003%200%200%201-2-2v-6a2%202%200%200%201%202-2h5v2h-5v6h5ZM18%2012h-4V8h-2v14h6a2.003%202.003%200%200%200%202-2v-6a2%202%200%200%200-2-2m-4%208v-6h4v6Zm-6-8H3v2h5v2H4a2%202%200%200%200-2%202v2a2%202%200%200%200%202%202h6v-8a2%202%200%200%200-2-2m0%208H4v-2h4Z%22%2F%3E%3C%2Fsvg%3E)   
@@ -324,11 +340,11 @@ export type CoercedEnvSchema = {
   
 };
 
-type _CoercedEnvSchema_8eb0ae17 = CoercedEnvSchema;
+type _CoercedEnvSchema_c7dffe3e = CoercedEnvSchema;
 
 declare module 'varlock/env' {
-  export interface TypedEnvSchema extends Readonly<_CoercedEnvSchema_8eb0ae17> {}
-  export interface PublicTypedEnvSchema extends Readonly<Pick<_CoercedEnvSchema_8eb0ae17, 'VARLOCK_ENV' | 'CONVEX_DEPLOYMENT' | 'PUBLIC_CONVEX_URL' | 'PUBLIC_CONVEX_SITE_URL' | 'VITE_TOLGEE_API_URL' | 'VITE_TOLGEE_API_KEY' | 'PUBLIC_POSTHOG_API_KEY' | 'PUBLIC_POSTHOG_HOST' | 'PUBLIC_POSTHOG_PROXY_HOST' | 'PUBLIC_SENTRY_DSN' | 'PUBLIC_SNAPDOM_PROXY_URL' | 'PUBLIC_SITE_URL' | 'CONVEX_PROJECT_ID' | 'NODE_ADAPTER' | 'VERCEL_ENV' | 'VERCEL_URL' | 'VERCEL_GIT_COMMIT_REF' | 'WORKERS_CI' | 'WORKERS_CI_BRANCH' | 'WORKERS_CI_COMMIT_SHA' | 'WORKERS_NAME' | 'WORKERS_SUBDOMAIN' | 'CF_PAGES' | 'CF_PAGES_URL' | 'CF_PAGES_BRANCH' | 'PRODUCTION_BRANCH' | 'CI'>> {}
+  export interface TypedEnvSchema extends Readonly<_CoercedEnvSchema_c7dffe3e> {}
+  export interface PublicTypedEnvSchema extends Readonly<Pick<_CoercedEnvSchema_c7dffe3e, 'VARLOCK_ENV' | 'CONVEX_DEPLOYMENT' | 'PUBLIC_CONVEX_URL' | 'PUBLIC_CONVEX_SITE_URL' | 'VITE_TOLGEE_API_URL' | 'VITE_TOLGEE_API_KEY' | 'PUBLIC_POSTHOG_API_KEY' | 'PUBLIC_POSTHOG_HOST' | 'PUBLIC_POSTHOG_PROXY_HOST' | 'PUBLIC_SENTRY_DSN' | 'PUBLIC_SNAPDOM_PROXY_URL' | 'PUBLIC_SITE_URL' | 'CONVEX_PROJECT_ID' | 'NODE_ADAPTER' | 'VERCEL_ENV' | 'VERCEL_URL' | 'VERCEL_GIT_COMMIT_REF' | 'WORKERS_CI' | 'WORKERS_CI_BRANCH' | 'WORKERS_CI_COMMIT_SHA' | 'WORKERS_NAME' | 'WORKERS_SUBDOMAIN' | 'CF_PAGES' | 'CF_PAGES_URL' | 'CF_PAGES_BRANCH' | 'PRODUCTION_BRANCH' | 'CF_ZONE_ID' | 'CI'>> {}
 }
 
 
@@ -338,17 +354,17 @@ export type EnvSchemaAsStrings = {
       : (CoercedEnvSchema[Property] extends boolean ? ('true' | 'false') : string)
 };
 
-type _EnvSchemaAsStrings_8eb0ae17 = EnvSchemaAsStrings;
+type _EnvSchemaAsStrings_c7dffe3e = EnvSchemaAsStrings;
 declare global {
 
   // add types for global import.meta.env
-  interface ImportMetaEnv extends _EnvSchemaAsStrings_8eb0ae17 {}
+  interface ImportMetaEnv extends _EnvSchemaAsStrings_c7dffe3e {}
   interface ImportMeta {
     readonly env: ImportMetaEnv;
   }
 
   // add types for global process.env
   namespace NodeJS {
-    interface ProcessEnv extends _EnvSchemaAsStrings_8eb0ae17 {}
+    interface ProcessEnv extends _EnvSchemaAsStrings_c7dffe3e {}
   }
 }


### PR DESCRIPTION
Closes #561

Marketing routes that aren't prerendered are edge-cached by the `handleCacheControl` hook (`s-maxage=3600`), but the production deploy command was a plain `wrangler deploy` that never invalidated the cache, so a deploy served stale HTML until the TTL expired. This only surfaces once a custom domain with edge caching is attached.

This adds `scripts/cf-prod-deploy.ts` as the production deploy command. It runs `wrangler deploy` and, on success, purges the zone cache via the Cloudflare API. The purge is gated on `CF_PURGE_TOKEN` and `CF_ZONE_ID`, so forks without a custom domain keep plain `wrangler deploy` behavior. The purge is fail-open: both HTTP errors and network-level throws (DNS, connection refused, timeout) log loudly but exit 0, since the worker is already live and the only consequence is the pre-existing staleness window. Failing the build there would only trigger a confusing retry of an already-published deploy.

Adds `CF_PURGE_TOKEN` and `CF_ZONE_ID` to `.env.schema`, points the AGENTS.md cache-purge note and the README CF setup (including the manual-deploy snippet) at the new wrapper, and documents both vars in the env matrix and the custom-domain section.

Regression guard: not warranted, one-off deploy-command wiring with no recurring code pattern to guard.

`bun scripts/static-checks.ts` passes.
