### PR TITLE
docs(readme): trim positioning and motivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@
 [![E2E Tests (CF)](https://github.com/stickerdaniel/saas-starter/actions/workflows/e2e-preview-cf.yml/badge.svg)](https://github.com/stickerdaniel/saas-starter/actions/workflows/e2e-preview-cf.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-%233fb950)](https://opensource.org/licenses/MIT)
 
-A free, open-source SaaS template built with SvelteKit, Convex, Better Auth, Tolgee, and Tailwind, made for AI coding agents to work in. Auth, billing, admin, AI chat, email, and i18n are implemented end-to-end, so you and your agents reuse real patterns instead of inventing them. Every recurring class of mistake becomes a rule the codebase enforces on its own, so it gets harder to break the longer it lives. Deploy on Cloudflare Workers or Vercel for $0.
+A free, open-source SaaS template built with SvelteKit, Convex, Better Auth, Tolgee, and Tailwind, made for AI coding agents to work in. Auth, billing, admin, AI chat, email, and i18n are implemented end-to-end, so you and your agents reuse real patterns instead of inventing them. Deploy on Cloudflare Workers or Vercel for $0.
 
 > See a live demo of the user-facing side at **[saas.daniel.sticker.name](https://saas.daniel.sticker.name)**. Admin features like the admin panel, support dashboard, and user management are not accessible there. To explore everything, follow the steps below.
 
 ## Why This Exists
 
-I kept rebuilding the same stack for every project, and pointing my agent at old repos to copy patterns I had already settled on. This template collects those patterns in one place: a streaming AI chat with tool calling and file uploads, a support chat that triages with AI and hands off to a human admin, and auth, billing, admin, and i18n built the same way. Real, working features your agent can read and reuse.
+I kept rebuilding the same stack and pointing my agent at old repos to copy patterns I had settled on, so I collected them here: a streaming AI chat with tool calling and file uploads, a support chat that triages with AI then hands off to a human, plus auth, billing, admin, and i18n. Real features your agent can read and reuse.
 
-Agents have a failure mode: they report a task as done when it isn't, and they reintroduce defects that were already fixed. The codebase handles that itself. Every bug runs through one question: is this a one-off, or a class of mistake an agent (or I) will repeat? When it is a class, the fix makes the mistake impossible to reproduce, through a custom ESLint rule, a banned-pattern scan in the static checks, a unit or E2E test, a Convex validator, a server hook, or a sharper instruction in AGENTS.md. CI enforces it: every fix PR states a `Regression guard:` verdict (`added`, `covered by`, or `not warranted`). This compounds. The more agents work on the project, the harder it becomes for any of them to ship the same defect twice, because the code enforces the rules instead of relying on anyone to remember them.
-
-None of this works without strong opinions. The guards have something to enforce because the stack, the file layout, and the conventions are deliberate. Rich Harris makes the same case in [Frameworks for humans in the age of machines](https://www.youtube.com/watch?v=SmHgtyym6OA&t=2388s): a stack runs more smoothly when it is opinionated about the pieces every app needs, with smart defaults for auth, persistence, i18n, and UI that fit together. This template assembles that combination, and opinionated defaults mean you and your agent never relitigate the basics. Static checks and E2E run on every preview, so each verdict is checked on a real deployment. Open source, free to run.
+Agents report a task as done when it isn't, and reintroduce defects you already fixed. So the codebase enforces its own rules. Every recurring class of bug becomes an ESLint rule, a banned-pattern scan, a test, a Convex validator, or a sharper line in AGENTS.md, and CI checks every fix PR for a `Regression guard:` verdict. The more agents touch it, the harder it gets to ship the same defect twice. This works because the stack is deliberately opinionated, the case [Rich Harris makes](https://www.youtube.com/watch?v=SmHgtyym6OA&t=2388s): smart defaults for auth, persistence, i18n, and UI that fit together. Open source, free to run.
 
 ## Quick Start
 
@@ -355,7 +353,7 @@ Sign in with email/password, Google, GitHub, or passkeys. Powered by [Better Aut
 
 ### Billing
 
-[Autumn](https://docs.useautumn.com/welcome) sits on top of Stripe and lets you define pricing tiers and usage gates without writing webhook handlers. Configure your products in `autumn.config.ts` or generate a starter config at [app.useautumn.com/sandbox/quickstart](https://app.useautumn.com/sandbox/quickstart). Ships with a Free tier (3 messages/month) and a Pro tier ($10/month, unlimited). The community chat enforces quotas, warns users when they are running low, and offers an upgrade flow.
+[Autumn](https://docs.useautumn.com/welcome) sits on top of Stripe and lets you define pricing tiers and usage gates without writing webhook handlers. Configure your products in `autumn.config.ts` or generate a starter config at [app.useautumn.com/sandbox/quickstart](https://app.useautumn.com/sandbox/quickstart). Ships with a Free tier (3 community + 3 AI messages/month) and a Pro tier ($10/month, unlimited community chat and 500 AI messages/month). The community chat enforces quotas, warns users when they are running low, and offers an upgrade flow.
 
 ### Admin Panel
 
@@ -410,7 +408,7 @@ Every component supports light and dark mode via `mode-watcher`. Interactive ele
 
 ### Worktrees
 
-Each worktree gets its own isolated Convex backend, port, and auth secret via [convex-vite-plugin](https://github.com/juliusmarminge/convex-vite-plugin). Run `bun run worktree feature/dark-mode --open-editor` to create one with all local env vars copied over, or use the VS Code task. Work on multiple features in parallel without stepping on each other.
+Each worktree gets its own isolated Convex backend, port, and auth secret via [convex-vite-plugin](https://github.com/juliusmarminge/convex-vite-plugin). Run `bun run worktree feature/dark-mode --open-editor cursor` (or `code`) to create one with all local env vars copied over, or use the VS Code task. Work on multiple features in parallel without stepping on each other.
 
 ### Type-Safe Environment Variables
 


### PR DESCRIPTION
The README opening and Why This Exists ran long. This drops the redundant guard sentence from the tagline and condenses the motivation to two paragraphs, keeping the regression-guard system, the opinionated framing, and the Rich Harris reference.
