### PR TITLE
test(i18n): guard against orphan keys and prune dead ones

### DIFF
--- a/scripts/i18n-orphan-keys.test.ts
+++ b/scripts/i18n-orphan-keys.test.ts
@@ -1,0 +1,253 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import en from '../src/i18n/en.json';
+
+// Defined-but-unused guard for translation keys: every leaf key in en.json must
+// be reachable from code. An orphan (a key nobody references) is dead weight
+// that every locale has to keep in sync (locale-parity.test.ts forces de/es/fr
+// to mirror en.json), and it lets a stale namespace masquerade as live copy.
+//
+// This is the mirror image of i18n-used-keys.test.ts: that test asserts every
+// referenced key EXISTS in en.json (catches typos / renamed keys); this test
+// asserts every key in en.json IS referenced (catches abandoned keys).
+//
+// The hard part is that translation keys are referenced both statically and
+// DYNAMICALLY. i18n-used-keys.test.ts can safely skip dynamic refs (skipping a
+// real ref only risks a false "missing" report, which never happens because the
+// key exists). An orphan detector cannot: skipping a dynamic ref would falsely
+// flag a live key as dead. So this detector resolves all five dynamic forms the
+// codebase actually uses (see USED DERIVATION below) before declaring an orphan.
+
+const SCAN_ROOT = path.resolve('src');
+const EXCLUDED_DIRS = new Set([path.join(SCAN_ROOT, 'i18n')]);
+const CONVEX_ROOT = path.join(SCAN_ROOT, 'lib', 'convex');
+
+// ---------------------------------------------------------------------------
+// Literal extraction — same regexes as i18n-used-keys.test.ts.
+// ---------------------------------------------------------------------------
+
+// <T keyName="..."> static attribute, plus keyName={'...'} / keyName={"..."}.
+const KEYNAME_ATTR = /keyName=(?:"([^"\n]*)"|\{\s*'([^'\n]*)'\s*\}|\{\s*"([^"\n]*)"\s*\})/g;
+
+// Tolgee translate store: $t('key') / $t("key").
+const TOLGEE_T = /\$t\(\s*(?:'([^'\n]*)'|"([^"\n]*)")/g;
+
+// Convex backend helper t(locale, 'key', params?) — the key is the 2nd arg.
+// Only meaningful under src/lib/convex/ where the helper lives.
+const CONVEX_T =
+	/(?<![\w$.])t\(\s*(?:['"][a-z]{2}['"]|[\w.$]+(?:\([^()]*\))?)\s*,\s*(?:'([^'\n]*)'|"([^"\n]*)")/g;
+
+// ---------------------------------------------------------------------------
+// Dynamic-reference resolvers — the part i18n-used-keys.test.ts deliberately
+// omits. Each resolves one of the dynamic forms this codebase actually uses.
+// ---------------------------------------------------------------------------
+
+// (b/d) Any dotted string literal anywhere: 'a.b.c' / "a.b" / `a.b`.
+// This single rule covers every *Key config-property convention because those
+// values are plain dotted literals: translationKey:/roleKey:/nameKey:/titleKey:
+// (sidebar, nav, team, screenshot-color, search-route, table-column configs),
+// the 'aria-label-key' kebab attr, the ERROR_CODE_MAP / DEFAULT_AUTH_ERROR_KEY
+// values in auth-messages.ts, ternary branch literals (keyName={c ? 'a' : 'b'}),
+// and Record lookup maps ($t(map[field])). A literal only counts when it
+// resolves to a real leaf, so non-i18n dotted strings (import paths, oklch()
+// values, css selectors) are ignored.
+const DOTTED_LITERAL = /['"`]([a-zA-Z_$][\w$]*(?:\.[a-zA-Z_$][\w$]*)+)['"`]/g;
+
+// (c) Svelte attribute interpolation prefix: keyName="prefix.{x}".
+// pricing-three.svelte iterates feature index keys via
+// <T keyName="pricing.features.free.{key}" />. Capture the literal prefix and
+// mark every leaf under it as used.
+const INTERP_ATTR_PREFIX = /keyName="([a-zA-Z_$][\w$.]*?)\.\{/g;
+
+// (c) Template-literal prefix: $t(`prefix.${x}`) / t(locale, `prefix.${x}`).
+const TEMPLATE_PREFIX = /`([a-zA-Z_$][\w$.]*?)\.\$\{/g;
+
+// (d) Object-property access chains: error_page.* is reached only through member
+// access (translations.error_page.not_found_title) in ErrorDisplay.svelte, never
+// as a quoted dotted string. Match identifier chains and accept any contiguous
+// sub-window that resolves to a real multi-segment leaf. en.json leaf paths are
+// specific enough that ordinary JS member access (page.status, etc.) does not
+// collide — verified: this resolver matches exactly the 9 error_page.* leaves
+// and nothing else.
+const MEMBER_CHAIN = /\b([a-z_$][\w$]*(?:\.[a-z_$][\w$]*)+)\b/gi;
+const ANY_QUOTED_DOTTED = /['"`]([\w.]+)['"`]/g;
+
+// ---------------------------------------------------------------------------
+// (e) Allowlist — keys reachable ONLY via fully-dynamic runtime refs that no
+// static scan can see. Keep this minimal and documented; never add a key here
+// just to silence the test.
+//
+// auth.messages.* error keys: getAuthErrorKey() (src/lib/utils/auth-messages.ts)
+// translates Better Auth error CODES into auth.messages.* keys at runtime, then
+// the value is rendered via <T keyName={formError}> / toast.error($t(formError)).
+// The ERROR_CODE_MAP literals are caught by DOTTED_LITERAL above, but these five
+// correspond to Better Auth failure conditions (signup gating, password-breach
+// checks, rate limiting, cancelled flows) that the backend can surface without a
+// matching map entry in source. They are runtime-reachable, not dead copy, so
+// they are allowlisted rather than reported as prune candidates.
+const ALLOWLIST: Record<string, string> = {
+	'auth.messages.auth_cancelled':
+		'Better Auth runtime error key (auth flow cancelled); surfaced via getAuthErrorKey/formError, no static ref',
+	'auth.messages.password_compromised':
+		'Better Auth runtime error key (have-i-been-pwned breach check); surfaced via getAuthErrorKey/formError, no static ref',
+	'auth.messages.rate_limited':
+		'Better Auth runtime error key (auth rate limit hit); surfaced via getAuthErrorKey/formError, no static ref',
+	'auth.messages.signup_disabled':
+		'Better Auth runtime error key (signup disabled); surfaced via getAuthErrorKey/formError, no static ref',
+	'auth.messages.too_many_attempts':
+		'Better Auth runtime error key (too many attempts); surfaced via getAuthErrorKey/formError, no static ref'
+};
+
+// ---------------------------------------------------------------------------
+// File walk — sorted fs traversal, deterministic, skips generated dirs.
+// ---------------------------------------------------------------------------
+
+function isScannable(file: string): boolean {
+	if (file.endsWith('.test.ts') || file.endsWith('.spec.ts')) return false;
+	return file.endsWith('.svelte') || file.endsWith('.ts');
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+	const entries = fs
+		.readdirSync(dir, { withFileTypes: true })
+		.sort((a, b) => a.name.localeCompare(b.name));
+	for (const entry of entries) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === '_generated' || EXCLUDED_DIRS.has(full)) continue;
+			walk(full, out);
+		} else if (entry.isFile() && isScannable(full)) {
+			out.push(full);
+		}
+	}
+	return out;
+}
+
+// Every dot-path that resolves to a string leaf in en.json.
+function flattenLeafKeys(value: unknown, prefix: string, out: Set<string>): Set<string> {
+	if (typeof value === 'string') {
+		out.add(prefix);
+	} else if (value !== null && typeof value === 'object') {
+		for (const [key, child] of Object.entries(value)) {
+			flattenLeafKeys(child, prefix ? `${prefix}.${key}` : key, out);
+		}
+	}
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// USED DERIVATION
+// Combine, for every scanned src file:
+//   (a) literal refs        — KEYNAME_ATTR + TOLGEE_T (+ CONVEX_T under convex)
+//   (b) dotted literals      — config-property *Key values, ternary branches,
+//                              lookup-map literals, auth error-code map values
+//   (c) interpolation/template prefixes — mark all leaves under the prefix used
+//   (d) member-access chains — error_page.* via translations.error_page.<leaf>
+// then union the allowlist (e). Only keys that resolve to a real en.json leaf
+// are ever added, so noise (import paths, css, etc.) cannot inflate the set.
+// ---------------------------------------------------------------------------
+function deriveUsedKeys(leaves: Set<string>): { used: Set<string>; literalCount: number } {
+	const used = new Set<string>();
+	const prefixes = new Set<string>();
+	let literalCount = 0;
+
+	const markIfLeaf = (key: string | undefined) => {
+		if (!key || key.includes('{') || key.includes('}')) return;
+		if (leaves.has(key)) used.add(key);
+	};
+
+	for (const file of walk(SCAN_ROOT)) {
+		const content = fs.readFileSync(file, 'utf-8');
+
+		// (a) literal references
+		const literalPatterns: RegExp[] = [KEYNAME_ATTR, TOLGEE_T];
+		if (file.startsWith(CONVEX_ROOT + path.sep)) literalPatterns.push(CONVEX_T);
+		for (const pattern of literalPatterns) {
+			for (const match of content.matchAll(pattern)) {
+				const key = match.slice(1).find((g) => g !== undefined);
+				if (key === undefined || key === '') continue;
+				literalCount++;
+				markIfLeaf(key);
+			}
+		}
+
+		// (b/d-via-literal) any dotted string literal that resolves to a leaf
+		for (const match of content.matchAll(DOTTED_LITERAL)) markIfLeaf(match[1]);
+
+		// (c) interpolation + template prefixes
+		for (const match of content.matchAll(INTERP_ATTR_PREFIX)) prefixes.add(match[1]);
+		for (const match of content.matchAll(TEMPLATE_PREFIX)) prefixes.add(match[1]);
+
+		// (d) member-access chains (object-property access, not quoted strings)
+		const quotedDotted = new Set<string>();
+		for (const match of content.matchAll(ANY_QUOTED_DOTTED)) {
+			if (match[1].includes('.')) quotedDotted.add(match[1]);
+		}
+		for (const match of content.matchAll(MEMBER_CHAIN)) {
+			const chain = match[1];
+			if (quotedDotted.has(chain)) continue; // already handled as a literal
+			const parts = chain.split('.');
+			for (let i = 0; i < parts.length; i++) {
+				for (let j = i + 2; j <= parts.length; j++) {
+					const sub = parts.slice(i, j).join('.');
+					if (leaves.has(sub)) used.add(sub);
+				}
+			}
+		}
+	}
+
+	// (c) expand prefixes: every leaf at-or-under a captured prefix is used.
+	for (const leaf of leaves) {
+		for (const prefix of prefixes) {
+			if (leaf === prefix || leaf.startsWith(prefix + '.')) {
+				used.add(leaf);
+				break;
+			}
+		}
+	}
+
+	// (e) allowlist — runtime-only reachable keys.
+	for (const key of Object.keys(ALLOWLIST)) {
+		if (leaves.has(key)) used.add(key);
+	}
+
+	return { used, literalCount };
+}
+
+describe('i18n orphan keys', () => {
+	const leaves = flattenLeafKeys(en, '', new Set<string>());
+	const { used, literalCount } = deriveUsedKeys(leaves);
+
+	it('en.json has leaf keys', () => {
+		expect(leaves.size).toBeGreaterThan(0);
+	});
+
+	it('finds literal key references in src', () => {
+		// Sanity floor: if the walk or the regexes break, fail here loudly rather
+		// than letting the orphan assertion pass vacuously by flagging everything.
+		expect(literalCount).toBeGreaterThan(100);
+	});
+
+	it('every allowlisted key still exists in en.json', () => {
+		// A stale allowlist entry (key deleted from en.json) should fail so the
+		// allowlist never silently rots.
+		const stale = Object.keys(ALLOWLIST).filter((key) => !leaves.has(key));
+		expect(
+			stale,
+			`Allowlisted keys missing from en.json (remove them):\n${stale.join('\n')}`
+		).toEqual([]);
+	});
+
+	it('has no orphan keys (defined in en.json but never referenced)', () => {
+		const orphans = [...leaves].filter((key) => !used.has(key)).sort();
+		const report = orphans.join('\n');
+		expect(
+			orphans.length,
+			`Translation keys defined in en.json but never referenced in src ` +
+				`(literal, dotted-literal, interpolation/template prefix, member-access, ` +
+				`or allowlist). Either remove them from all locale files, reference them, ` +
+				`or add a documented ALLOWLIST entry if reachable only at runtime:\n${report}`
+		).toBe(0);
+	});
+});

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -14,8 +14,7 @@
 			"database_backend": "Datenbank & Backend",
 			"email_service": "E-Mail-Zustelldienst",
 			"external_services": "Externe Dienste",
-			"hosting_deployment": "Hosting & Deployment",
-			"title": "Admin Dashboard"
+			"hosting_deployment": "Hosting & Deployment"
 		},
 		"dialog": {
 			"ban_description": "Möchten Sie {email} wirklich sperren? Der Zugriff auf die App wird blockiert.",
@@ -23,7 +22,6 @@
 			"ban_title": "Benutzer sperren",
 			"impersonation_active_description": "Bitte laden Sie die Seite neu, um als der andere Benutzer angemeldet zu werden.",
 			"impersonation_active_title": "Identitätswechsel aktiv",
-			"reload_page": "Seite neu laden",
 			"revoke_description": "Möchten Sie wirklich alle Sitzungen für {email} widerrufen? Die Person wird überall abgemeldet.",
 			"revoke_title": "Sitzungen widerrufen",
 			"set_role_description": "Möchten Sie die Rolle von {email} wirklich auf {role} ändern?",
@@ -37,16 +35,13 @@
 			"admin_users": "Plattformverwaltung",
 			"admins": "Admins",
 			"admins_desc": "Benutzer mit Admin-Rechten",
-			"banned_users": "Gesperrte Benutzer",
-			"banned_users_desc": "Zugriff eingeschränkt",
 			"currently_active": "Tägliche Aktivität",
 			"last_7_days": "Letzte 7 Tage",
 			"recent_signups": "Neuanmeldungen",
 			"recent_signups_desc": "Neue Benutzer",
 			"registered_users": "Plattform-Nutzerbasis",
 			"total_users": "Benutzer gesamt",
-			"total_users_desc": "Alle registrierten Konten",
-			"users_banned": "Konten zur Überprüfung"
+			"total_users_desc": "Alle registrierten Konten"
 		},
 		"navigation": {
 			"app": "App",
@@ -63,18 +58,12 @@
 			"column_new_tickets": "Neue Tickets",
 			"column_type": "Typ",
 			"column_user_replies": "Benutzerantworten",
-			"default_support_email": "Standard-Support-E-Mail",
-			"default_support_email_help": "Leer lassen, um Benachrichtigungen an alle Admin-Benutzer zu senden.",
-			"default_support_email_placeholder": "support@example.com",
 			"delete_email": "Entfernen",
-			"delete_email_confirm": "{email} aus den Benachrichtigungsempfängern entfernen?",
 			"delete_email_description": "{email} aus den Benachrichtigungsempfängern entfernen?",
 			"delete_email_title": "E-Mail entfernen",
-			"description": "Admin-Panel-Einstellungen und Benachrichtigungen konfigurieren.",
 			"email_add_failed": "E-Mail konnte nicht hinzugefügt werden",
 			"email_added": "E-Mail hinzugefügt",
 			"email_exists": "Diese E-Mail existiert bereits",
-			"email_removed": "E-Mail entfernt",
 			"field_new_signups": "Benachrichtigungen für neue Anmeldungen",
 			"field_new_tickets": "Benachrichtigungen für neue Tickets",
 			"field_user_replies": "Benachrichtigungen für Benutzerantworten",
@@ -85,63 +74,34 @@
 				"custom_only": "Nur Benutzerdefiniert"
 			},
 			"founder_welcome": {
-				"became_contact": "Sie sind jetzt der Ansprechpartner für Willkommens-E-Mails",
 				"cancel": "Abbrechen",
-				"click_to_edit": "Klicken zum Bearbeiten",
 				"config_body_label": "E-Mail-Text",
 				"config_name_label": "Ihr Name",
-				"config_reply_to_description": "Wohin Antworten gehen. Standardmäßig Ihre Konto-E-Mail, wenn leer.",
 				"config_reply_to_label": "Antwort-E-Mail",
 				"config_reply_to_placeholder": "z.B. hallo@ihrfirma.de",
 				"config_subject_label": "E-Mail-Betreff",
 				"config_title_label": "Ihr Titel",
-				"config_variables_hint": "Verfügbare Variablen: '{{userFirstName}}', '{{userLastName}}', '{{founderName}}', '{{founderTitle}}'",
-				"contact_person": "Ansprechpartner",
-				"contact_person_info": "{name} ({email})",
 				"description": "Automatisch eine persönliche Willkommens-E-Mail von einem Teammitglied an neue Nutzer nach der Registrierung senden. Wird als reiner Text für Authentizität gesendet.",
 				"edit_button": "Bearbeiten",
-				"email_legend": "E-Mail-Inhalt",
 				"error": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.",
-				"not_configured": "Kein Ansprechpartner konfiguriert. Richten Sie ein Teammitglied ein, das Willkommens-E-Mails an neue Nutzer sendet.",
-				"preview_subject": "Betreff",
-				"preview_title": "Vorschau",
 				"save": "Änderungen speichern",
 				"saved": "Willkommens-E-Mail-Konfiguration gespeichert",
-				"sender_legend": "Absender-Info",
 				"setup_button": "Ansprechpartner werden",
-				"setup_confirm": "Einrichten",
-				"setup_title_label": "Ihr Titel",
 				"setup_title_placeholder": "z.B. Gründer von SaaS Starter",
 				"step_down": "Zurücktreten",
 				"step_down_confirm": "Als Ansprechpartner zurücktreten? Willkommens-E-Mails werden nicht mehr gesendet.",
 				"stepped_down": "Sie sind nicht mehr der Ansprechpartner",
-				"take_over": "Übernehmen",
-				"take_over_confirm": "Als Ansprechpartner übernehmen? Die bestehende E-Mail-Vorlage bleibt erhalten.",
 				"title": "Gründer-Willkommens-E-Mail",
-				"took_over": "Sie haben als Ansprechpartner übernommen",
 				"variables_label": "Variablen:"
 			},
-			"invalid_email": "Ungültige E-Mail-Adresse",
 			"no_recipients": "Keine Benachrichtigungsempfänger konfiguriert",
-			"notification_recipients": "Benachrichtigungsempfänger",
-			"notification_recipients_desc": "Konfigurieren Sie, wer Admin-Benachrichtigungen erhält. Admin-Benutzer werden automatisch einbezogen.",
 			"preference_disabled": "{field} deaktiviert",
 			"preference_disabling": "{field} wird deaktiviert...",
 			"preference_enabled": "{field} aktiviert",
 			"preference_enabling": "{field} wird aktiviert...",
 			"preference_update_failed": "Einstellung konnte nicht aktualisiert werden",
-			"recipient_count": "{count, plural, other {# Empfänger}}",
 			"recipients_search_placeholder": "Benachrichtigungsempfänger durchsuchen...",
-			"save": "Einstellungen speichern",
-			"saved": "Einstellungen gespeichert",
-			"saving": "Speichern...",
 			"selected": "{selected} von {total} ausgewählt",
-			"support_notifications": "Support-Benachrichtigungen",
-			"support_notifications_desc": "E-Mail-Benachrichtigungen für neue und nicht zugewiesene wiedereröffnete Support-Tickets konfigurieren.",
-			"tabs": {
-				"notifications": "Benachrichtigungen",
-				"recipients": "Empfänger"
-			},
 			"title": "Admin-Einstellungen",
 			"type_admin": "Admin",
 			"type_custom": "Benutzerdefiniert"
@@ -154,7 +114,6 @@
 			"users": "Benutzer"
 		},
 		"support": {
-			"all_statuses": "Alle Status",
 			"anonymous": "Anonym",
 			"assignee": {
 				"not_assigned": "Nicht zugewiesen",
@@ -172,9 +131,7 @@
 				"page_url": "Seiten-URL",
 				"priority": "Priorität",
 				"status": "Status",
-				"title": "Details",
-				"user_notes": "Benutzernotizen",
-				"user_notes_description": "Notizen werden auf Benutzerebene gespeichert und erscheinen in allen Support-Threads des Benutzers"
+				"user_notes": "Benutzernotizen"
 			},
 			"email": {
 				"label": "Benachrichtigungs-E-Mail"
@@ -190,7 +147,6 @@
 			},
 			"filter_showing_completed": "Zeigt abgeschlossene Threads, klicken um offene anzuzeigen",
 			"filter_showing_open": "Zeigt offene Threads, klicken um abgeschlossene anzuzeigen",
-			"no_chats": "Keine Chats gefunden",
 			"no_done_chats": "Keine abgeschlossenen Chats",
 			"no_email": "Keine E-Mail",
 			"no_open_chats": "Keine offenen Chats",
@@ -212,9 +168,7 @@
 			"select_chat_for_details": "Wählen Sie einen Chat, um Details anzuzeigen",
 			"status": {
 				"done": "Erledigt",
-				"in_progress": "In Bearbeitung",
-				"open": "Offen",
-				"resolved": "Gelöst"
+				"open": "Offen"
 			},
 			"thread": {
 				"badge": {
@@ -225,12 +179,10 @@
 				"no_messages": "Keine Nachrichten",
 				"retry": "Erneut versuchen"
 			},
-			"threads_title": "Support-Threads",
-			"title": "Support-Chats"
+			"threads_title": "Support-Threads"
 		},
 		"title": "Admin-Bereich",
 		"users": {
-			"actions_column": "Aktionen",
 			"ban_reason": {
 				"default": "Verstoß gegen die Nutzungsbedingungen"
 			},
@@ -274,7 +226,6 @@
 				"ban_failed": "Benutzer konnte nicht gesperrt werden: {message}",
 				"banned": "Benutzer wurde gesperrt",
 				"impersonate_failed": "Identitätswechsel fehlgeschlagen: {message}",
-				"impersonation_started": "Identitätswechsel gestartet",
 				"note_added": "Notiz hinzugefügt",
 				"note_failed": "Notiz konnte nicht hinzugefügt werden: {message}",
 				"priority_failed": "Priorität konnte nicht aktualisiert werden: {message}",
@@ -288,60 +239,36 @@
 				"unban_failed": "Sperre konnte nicht aufgehoben werden: {message}",
 				"unbanned": "Benutzersperre wurde aufgehoben"
 			},
-			"total": "Benutzer",
-			"unnamed": "Unbenannt",
 			"unverified": "Nicht verifiziert",
 			"verified": "Verifiziert"
 		}
 	},
 	"ai_chat": {
-		"delete_thread": "Unterhaltung löschen",
-		"delete_thread_confirm": "Sind Sie sicher, dass Sie diese Unterhaltung löschen möchten?",
-		"description": "Chatten Sie mit unserem KI-Assistenten",
-		"empty": {
-			"description": "Stellen Sie eine Frage und erhalten Sie sofort KI-gestützte Antworten.",
-			"title": "Unterhaltung starten"
-		},
 		"input": {
 			"placeholder": "Nachricht eingeben..."
 		},
-		"new_chat": "Neuer Chat",
-		"select_chat": "Wählen Sie eine Unterhaltung oder starten Sie einen neuen Chat",
 		"suggestion": {
 			"explain": "Erkläre etwas",
 			"help": "Hilfe erhalten",
-			"understand": "Hilf mir zu verstehen",
 			"weather": "Wie ist das Wetter in Tokio?"
 		},
 		"thread": {
-			"loading": "Wird geladen...",
 			"no_messages": "Neue Unterhaltung"
-		},
-		"title": "KI-Chat"
+		}
 	},
 	"app": {
-		"dashboard": {
-			"subtitle": "Dies ist Ihre Zentrale. Echtzeit-Metriken und Aktivitäten werden hier angezeigt, während Sie Ihre App aufbauen.",
-			"title": "Willkommen in Ihrem Dashboard"
-		},
 		"sidebar": {
 			"admin_panel": "Admin-Bereich",
 			"ai_chat": "KI-Chat",
 			"community_chat": "Community-Chat",
-			"dashboard": "Dashboard",
-			"docs": "Dokumentation",
-			"home": "Start",
-			"show_less": "Weniger anzeigen",
 			"show_more": "Mehr anzeigen"
 		},
 		"user_menu": {
-			"account": "Konto",
 			"billing": "Abrechnung",
 			"impersonating_banner": "Sie agieren als dieser Benutzer",
 			"impersonation_stop_failed": "Identitätswechsel konnte nicht beendet werden",
 			"impersonation_stopped": "Identitätswechsel beendet",
 			"logout": "Abmelden",
-			"notifications": "Benachrichtigungen",
 			"pro_badge": "Pro",
 			"settings": "Einstellungen",
 			"stop_impersonating": "Identitätswechsel beenden",
@@ -357,42 +284,26 @@
 		"copied": "Kopiert",
 		"copy": "Kopieren",
 		"copy_failed": "Kopieren fehlgeschlagen",
-		"drag_to_reorder": "Zum Neuanordnen ziehen",
 		"feedback_close": "Feedback schließen",
 		"feedback_open": "Feedback öffnen",
 		"github_repository": "GitHub-Repository",
 		"go_back": "Zurück",
 		"hide_password": "Passwort ausblenden",
-		"home": "Startseite",
 		"interactive_pointer_tracking_area": "Interaktiver Bereich zur Zeigerverfolgung",
-		"limit": "Limit",
 		"loading": "Wird geladen",
-		"login_with_apple": "Mit Apple anmelden",
-		"login_with_google": "Mit Google anmelden",
-		"login_with_meta": "Mit Meta anmelden",
 		"logout": "Abmelden",
 		"menu_close": "Menü schließen",
 		"menu_open": "Menü öffnen",
 		"mobile_sidebar_description": "Zeigt die mobile Seitenleiste an.",
 		"more": "Mehr",
 		"notification_toggle_for_email": "{field} für {email}",
-		"pagination_first": "Erste Seite",
-		"pagination_last": "Letzte Seite",
-		"pagination_next": "Nächste Seite",
-		"pagination_previous": "Vorherige Seite",
 		"remove_attachment": "Anhang entfernen",
-		"reviewer": "Prüfer",
 		"scroll_to_bottom": "Nach unten scrollen",
-		"select_all": "Alle auswählen",
-		"select_row": "Zeile auswählen",
-		"select_value": "Wert auswählen",
 		"show_password": "Passwort anzeigen",
 		"sidebar": "Seitenleiste",
-		"target": "Ziel",
 		"toggle_sidebar": "Seitenleiste umschalten",
 		"toggle_theme": "Design umschalten",
-		"toggle_threads": "Unterhaltungsliste umschalten",
-		"view": "Ansicht"
+		"toggle_threads": "Unterhaltungsliste umschalten"
 	},
 	"auth": {
 		"back_to_home": "Zurück zur Startseite",
@@ -403,8 +314,6 @@
 			"description": "Wir senden Ihnen einen Link zum Zurücksetzen",
 			"title": "Passwort vergessen"
 		},
-		"login": "Anmelden",
-		"logout": "Abmelden",
 		"messages": {
 			"auth_cancelled": "Authentifizierung abgebrochen",
 			"credential_account_not_found": "Kein Passwortkonto gefunden. Versuchen Sie die Anmeldung mit Ihrem sozialen Anbieter.",
@@ -448,7 +357,6 @@
 			"description": "Geben Sie Ihr neues Passwort ein",
 			"new_password_label": "Neues Passwort",
 			"sign_in_link": "Anmelden",
-			"success": "Ihr Passwort wurde zurückgesetzt.",
 			"title": "Passwort zurücksetzen"
 		},
 		"signin": {
@@ -456,10 +364,8 @@
 			"button_signin_loading": "Wird angemeldet...",
 			"button_signup": "Registrieren",
 			"button_signup_loading": "Konto wird erstellt...",
-			"cancel": "Abbrechen",
 			"description": "Melden Sie sich bei Ihrem Konto an oder erstellen Sie ein neues",
 			"email_label": "E-Mail",
-			"email_placeholder": "du@beispiel.de",
 			"forgot_password": "Passwort vergessen?",
 			"link_signup": "Registrieren",
 			"name_label": "Name",
@@ -470,19 +376,13 @@
 			"or_continue_with": "Oder fortfahren mit",
 			"passkey_button": "Mit Passkey anmelden",
 			"password_label": "Passwort",
-			"password_placeholder": "••••••••",
 			"tab_signin": "Anmelden",
-			"tab_signup": "Registrieren",
-			"test_secret_button": "Mit Geheimnis anmelden",
-			"test_secret_label": "Nur Test: Mit Geheimnis anmelden",
-			"test_secret_placeholder": "Geheimnis-Wert",
 			"title": "Willkommen zurück"
 		},
 		"signup": {
 			"description": "Geben Sie Ihre Daten ein, um loszulegen",
 			"has_account": "Bereits ein Konto?",
 			"link_signin": "Anmelden",
-			"password_hint": "Mindestens 10 Zeichen mit Groß-, Kleinbuchstaben und Zahl",
 			"title": "Konto erstellen"
 		},
 		"terms": {
@@ -493,12 +393,7 @@
 		},
 		"verification": {
 			"button_back": "Zurück zur Anmeldung",
-			"button_cancel": "Abbrechen",
-			"button_verify": "E-Mail verifizieren",
-			"button_verify_loading": "Wird verifiziert...",
 			"check_email": "Bitte überprüfen Sie Ihre E-Mail und klicken Sie auf den Verifizierungslink, um Ihre Registrierung abzuschließen.",
-			"code_label": "Verifizierungscode",
-			"code_placeholder": "12345678",
 			"description": "Wir haben Ihnen einen Verifizierungslink gesendet",
 			"sent_to": "Wir haben eine Verifizierungs-E-Mail an",
 			"title": "E-Mail-Verifizierung",
@@ -526,12 +421,6 @@
 			"rate_limit": {
 				"global": "Ich habe gerade eine hohe Auslastung. Bitte versuchen Sie es in einem Moment erneut.",
 				"user": "Zu viele Nachrichten. Bitte warten Sie, bevor Sie eine weitere senden."
-			},
-			"summary": {
-				"default": "Neues Support-Gespräch"
-			},
-			"title": {
-				"default": "Kundensupport"
 			}
 		}
 	},
@@ -562,22 +451,16 @@
 			"preview_loading": "Vorschau wird geladen…",
 			"preview_truncated": "Vorschau auf {size} gekürzt"
 		},
-		"avatar": {
-			"team_member": "Teammitglied"
-		},
 		"buttons": {
 			"processing": "Wird verarbeitet...",
 			"upgrade": "Auf Pro upgraden"
 		},
-		"description": "Öffnen Sie diese App in mehreren Browser-Fenstern, um die Echtzeit-Datenbank in Aktion zu sehen",
 		"email": {
 			"placeholder": "Email",
 			"save_failed": "E-Mail konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
-			"saved_success": "E-Mail gespeichert! Wir benachrichtigen Sie, wenn wir antworten.",
 			"subscribe_button": "Abonnieren",
 			"unsubscribe_failed": "Abmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.",
-			"unsubscribe_tooltip": "Abbestellen",
-			"unsubscribed": "E-Mail-Benachrichtigungen abbestellt."
+			"unsubscribe_tooltip": "Abbestellen"
 		},
 		"error": {
 			"file_max_size": "Maximale Größe ist {maxSize}",
@@ -589,25 +472,14 @@
 			"upload_failed": "Hochladen von \"{filename}\" fehlgeschlagen",
 			"upload_failed_description": "Hochladen fehlgeschlagen"
 		},
-		"greeting": "Wie können wir helfen?",
-		"greeting_hi": "Hallo",
-		"header": {
-			"messages_left": "({remaining}/{total} Nachricht übrig)",
-			"messages_left_plural": "({remaining}/{total} Nachrichten übrig)",
-			"pro_unlimited": "(Pro - Unbegrenzt)",
-			"subtitle": "Echtzeit-Chat",
-			"title": "Chat"
-		},
 		"input": {
 			"placeholder": "Nachricht eingeben...",
 			"placeholder_disabled": "Nachrichtenlimit erreicht",
-			"send_tooltip": "Nachricht senden",
-			"upgrade_tooltip": "Auf Pro upgraden für unbegrenzte Nachrichten"
+			"send_tooltip": "Nachricht senden"
 		},
 		"messages": {
 			"rate_limited": "Sie senden zu schnell Nachrichten. Versuchen Sie es in {seconds}s erneut.",
-			"send_failed": "Nachricht konnte nicht gesendet werden",
-			"sent_success": "Nachricht gesendet!"
+			"send_failed": "Nachricht konnte nicht gesendet werden"
 		},
 		"reasoning": {
 			"connecting": "Verbinde...",
@@ -616,15 +488,6 @@
 			"thought_for_seconds": "Nachgedacht für {duration} Sekunde",
 			"thought_for_seconds_plural": "Nachgedacht für {duration} Sekunden"
 		},
-		"suggestion": {
-			"help_label": "Hilfe erhalten",
-			"help_text": "Können Sie mir helfen mit...",
-			"issue_label": "Problem melden",
-			"issue_text": "Ich habe ein Problem gefunden mit...",
-			"question_label": "Frage stellen",
-			"question_text": "Ich habe eine Frage zu..."
-		},
-		"title": "Community Chat",
 		"tooltip": {
 			"attach_files": "Dateien anhängen",
 			"mark_bug": "Fehler markieren"
@@ -638,7 +501,6 @@
 		"delete": "Löschen",
 		"error": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.",
 		"load_error": "Daten konnten nicht geladen werden. Bitte versuchen Sie es später erneut.",
-		"save": "Speichern",
 		"you": "Sie"
 	},
 	"email": {
@@ -730,9 +592,7 @@
 		"cta": "Jetzt starten",
 		"cta_demo": "Demo anfordern",
 		"description": "Erwecke dein SaaS zum Leben in Minuten, nicht in Monaten. Open-Source Template mit einem Tech-Stack, der dich schnell shippen lässt.",
-		"section_label": "Start",
-		"tagline": "Mit Produktfokus\nschneller zum Ziel",
-		"title": "SaaS-Starter-Vorlage"
+		"tagline": "Mit Produktfokus\nschneller zum Ziel"
 	},
 	"integrations": {
 		"cards": {
@@ -856,12 +716,6 @@
 				"title": "Registrieren"
 			}
 		},
-		"emails": {
-			"preview": {
-				"description": "Vorschau von E-Mail-Templates und gerendertem Inhalt.",
-				"title": "E-Mail-Vorschau"
-			}
-		},
 		"home": {
 			"description": "SaaS-Starter für SvelteKit mit Auth, Billing, E-Mail und Analytics.",
 			"title": "Schneller entwickeln und veröffentlichen"
@@ -890,23 +744,18 @@
 	"nav": {
 		"about": "Über uns",
 		"dashboard": "Dashboard",
-		"features": "Funktionen",
 		"get_started": "Jetzt starten",
 		"home": "Start",
 		"login": "Anmelden",
 		"pricing": "Pläne",
-		"signup": "Registrieren",
-		"solution": "Lösung"
+		"signup": "Registrieren"
 	},
 	"pricing": {
 		"buttons": {
-			"loading": "Lädt...",
-			"manage_subscription": "Abonnement verwalten"
+			"loading": "Lädt..."
 		},
-		"current_plan": "Aktueller Plan",
 		"current_plan_badge": "(Aktueller Plan)",
 		"description": "Diese SaaS-Starter-Vorlage ist vollständig kostenlos und Open Source. Testen Sie den Zahlungsablauf mit der Testkartennummer 4242 4242 4242 4242 und einem beliebigen zukünftigen Ablaufdatum.",
-		"description_autumn": "Testen Sie das integrierte Zahlungssystem powered by Autumn - eine Open-Source-Abrechnungsplattform, die Abonnements, Nutzungslimits und Stripe-Webhooks automatisch verwaltet.",
 		"features": {
 			"enterprise": {
 				"0": "Individuelle Nachrichtenlimits",
@@ -928,7 +777,6 @@
 			}
 		},
 		"popular_badge": "Beliebt",
-		"section_label": "Preise",
 		"tiers": {
 			"enterprise": {
 				"button": "Vertrieb kontaktieren",
@@ -938,7 +786,6 @@
 			},
 			"free": {
 				"button": "Für immer kostenlos",
-				"button_manage": "Abonnement verwalten",
 				"description": "Perfekt für den Einstieg",
 				"name": "Kostenlos",
 				"price": "0€ / Monat"
@@ -959,8 +806,7 @@
 			"dialog_description": "Suche nach einer Seite, zu der du navigieren möchtest.",
 			"dialog_title": "Seiten suchen",
 			"footer": {
-				"go_to_page": "Zur Seite wechseln",
-				"open_new_tab": "Klick, um in neuem Tab zu öffnen"
+				"go_to_page": "Zur Seite wechseln"
 			},
 			"groups": {
 				"admin": "Admin",
@@ -1031,7 +877,6 @@
 			"description": "Aktualisieren Sie Ihr Passwort, um Ihr Konto sicher zu halten.",
 			"error_title": "Fehler",
 			"new_password_label": "Neues Passwort",
-			"password_helper": "Muss mindestens 8 Zeichen lang sein.",
 			"placeholder": {
 				"confirm": "Neues Passwort bestätigen",
 				"current": "Aktuelles Passwort eingeben",
@@ -1059,8 +904,6 @@
 				"placeholder": "Passkey-Name",
 				"unnamed": "Unbenannter Passkey"
 			},
-			"passkey_delete_failed": "Passkey konnte nicht gelöscht werden",
-			"passkey_deleted": "Passkey entfernt",
 			"passkey_info_description": "Passkeys sind eine sichere, passwortlose Anmeldemethode. Sie verwenden Biometrie oder Geräte-PIN und werden sicher auf Ihren Geräten gespeichert.",
 			"passkey_info_title": "Was sind Passkeys?",
 			"passkey_name_label": "Passkey-Name",
@@ -1197,7 +1040,6 @@
 			"ux_engineer": "UX Engineer",
 			"visual_designer": "Visual Designer"
 		},
-		"section_label": "Team",
 		"title": "Unser Traumteam"
 	},
 	"validation": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -14,8 +14,7 @@
 			"database_backend": "Database & backend",
 			"email_service": "Email delivery service",
 			"external_services": "External Services",
-			"hosting_deployment": "Hosting & deployment",
-			"title": "Admin Dashboard"
+			"hosting_deployment": "Hosting & deployment"
 		},
 		"dialog": {
 			"ban_description": "Are you sure you want to ban {email}? They will be unable to access the app.",
@@ -23,7 +22,6 @@
 			"ban_title": "Ban User",
 			"impersonation_active_description": "Please reload the page to be logged in as the impersonated user.",
 			"impersonation_active_title": "Impersonation Active",
-			"reload_page": "Reload Page",
 			"revoke_description": "Are you sure you want to revoke all sessions for {email}? They will be logged out everywhere.",
 			"revoke_title": "Revoke Sessions",
 			"set_role_description": "Are you sure you want to change the role of {email} to {role}?",
@@ -37,16 +35,13 @@
 			"admin_users": "Managing the platform",
 			"admins": "Admins",
 			"admins_desc": "Users with admin privileges",
-			"banned_users": "Banned Users",
-			"banned_users_desc": "Access restricted",
 			"currently_active": "Daily activity",
 			"last_7_days": "Last 7 days",
 			"recent_signups": "Recent Signups",
 			"recent_signups_desc": "New user growth",
 			"registered_users": "Platform user base",
 			"total_users": "Total Users",
-			"total_users_desc": "All registered accounts",
-			"users_banned": "Accounts need review"
+			"total_users_desc": "All registered accounts"
 		},
 		"navigation": {
 			"app": "App",
@@ -63,18 +58,12 @@
 			"column_new_tickets": "New Tickets",
 			"column_type": "Type",
 			"column_user_replies": "User Replies",
-			"default_support_email": "Default Support Email",
-			"default_support_email_help": "Leave empty to send notifications to all admin users.",
-			"default_support_email_placeholder": "support@example.com",
 			"delete_email": "Remove",
-			"delete_email_confirm": "Remove {email} from notification recipients?",
 			"delete_email_description": "Remove {email} from notification recipients?",
 			"delete_email_title": "Remove Email",
-			"description": "Configure admin panel settings and notifications.",
 			"email_add_failed": "Failed to add email",
 			"email_added": "Email added",
 			"email_exists": "This email already exists",
-			"email_removed": "Email removed",
 			"field_new_signups": "New signup notifications",
 			"field_new_tickets": "New ticket notifications",
 			"field_user_replies": "User reply notifications",
@@ -85,63 +74,34 @@
 				"custom_only": "Custom Only"
 			},
 			"founder_welcome": {
-				"became_contact": "You are now the contact person for welcome emails",
 				"cancel": "Cancel",
-				"click_to_edit": "Click to edit",
 				"config_body_label": "Email Body",
 				"config_name_label": "Your Name",
-				"config_reply_to_description": "Where replies go. Defaults to your account email if left empty.",
 				"config_reply_to_label": "Reply-To Email",
 				"config_reply_to_placeholder": "e.g. hello@yourcompany.com",
 				"config_subject_label": "Email Subject",
 				"config_title_label": "Your Title",
-				"config_variables_hint": "Available variables: '{{userFirstName}}', '{{userLastName}}', '{{founderName}}', '{{founderTitle}}'",
-				"contact_person": "Contact Person",
-				"contact_person_info": "{name} ({email})",
 				"description": "Automatically send a personal welcome email from a team member to new users after signup. Sent as plain text for authenticity.",
 				"edit_button": "Edit",
-				"email_legend": "Email Content",
 				"error": "Something went wrong. Please try again.",
-				"not_configured": "No contact person is configured. Set up a team member to send welcome emails to new users.",
-				"preview_subject": "Subject",
-				"preview_title": "Preview",
 				"save": "Save Changes",
 				"saved": "Welcome email config saved",
-				"sender_legend": "Sender Info",
 				"setup_button": "Become Contact Person",
-				"setup_confirm": "Set Up",
-				"setup_title_label": "Your Title",
 				"setup_title_placeholder": "e.g. Founder of SaaS Starter",
 				"step_down": "Step Down",
 				"step_down_confirm": "Step down as contact person? Welcome emails will stop being sent.",
 				"stepped_down": "You are no longer the contact person",
-				"take_over": "Take Over",
-				"take_over_confirm": "Take over as contact person? The existing email template will be preserved.",
 				"title": "Founder Welcome Email",
-				"took_over": "You have taken over as contact person",
 				"variables_label": "Variables:"
 			},
-			"invalid_email": "Invalid email address",
 			"no_recipients": "No notification recipients configured",
-			"notification_recipients": "Notification Recipients",
-			"notification_recipients_desc": "Configure who receives admin notifications. Admin users are automatically included.",
 			"preference_disabled": "{field} disabled",
 			"preference_disabling": "Disabling {field}...",
 			"preference_enabled": "{field} enabled",
 			"preference_enabling": "Enabling {field}...",
 			"preference_update_failed": "Failed to update preference",
-			"recipient_count": "{count, plural, one {# recipient} other {# recipients}}",
 			"recipients_search_placeholder": "Search notification recipients...",
-			"save": "Save Settings",
-			"saved": "Settings saved",
-			"saving": "Saving...",
 			"selected": "{selected} of {total} selected",
-			"support_notifications": "Support Notifications",
-			"support_notifications_desc": "Configure email notifications for new and unassigned reopened support tickets.",
-			"tabs": {
-				"notifications": "Notifications",
-				"recipients": "Recipients"
-			},
 			"title": "Admin Settings",
 			"type_admin": "Admin",
 			"type_custom": "Custom"
@@ -154,7 +114,6 @@
 			"users": "Users"
 		},
 		"support": {
-			"all_statuses": "All statuses",
 			"anonymous": "Anonymous",
 			"assignee": {
 				"not_assigned": "Not assigned",
@@ -172,9 +131,7 @@
 				"page_url": "Page URL",
 				"priority": "Priority",
 				"status": "Status",
-				"title": "Details",
-				"user_notes": "User Notes",
-				"user_notes_description": "Notes are saved at the user level and appear across all their support threads"
+				"user_notes": "User Notes"
 			},
 			"email": {
 				"label": "Notification Email"
@@ -190,7 +147,6 @@
 			},
 			"filter_showing_completed": "Showing completed threads, click to show open",
 			"filter_showing_open": "Showing open threads, click to show completed",
-			"no_chats": "No chats found",
 			"no_done_chats": "No completed chats",
 			"no_email": "No email",
 			"no_open_chats": "No open chats",
@@ -212,9 +168,7 @@
 			"select_chat_for_details": "Select a chat to view details",
 			"status": {
 				"done": "Done",
-				"in_progress": "In Progress",
-				"open": "Open",
-				"resolved": "Resolved"
+				"open": "Open"
 			},
 			"thread": {
 				"badge": {
@@ -225,12 +179,10 @@
 				"no_messages": "No messages",
 				"retry": "Retry"
 			},
-			"threads_title": "Support Threads",
-			"title": "Support Chats"
+			"threads_title": "Support Threads"
 		},
 		"title": "Admin Panel",
 		"users": {
-			"actions_column": "Actions",
 			"ban_reason": {
 				"default": "Violated terms of service"
 			},
@@ -274,7 +226,6 @@
 				"ban_failed": "Failed to ban user: {message}",
 				"banned": "User has been banned",
 				"impersonate_failed": "Failed to impersonate user: {message}",
-				"impersonation_started": "Now impersonating user",
 				"note_added": "Note added",
 				"note_failed": "Failed to add note: {message}",
 				"priority_failed": "Failed to update priority: {message}",
@@ -288,60 +239,36 @@
 				"unban_failed": "Failed to unban user: {message}",
 				"unbanned": "User has been unbanned"
 			},
-			"total": "users",
-			"unnamed": "Unnamed",
 			"unverified": "Unverified",
 			"verified": "Verified"
 		}
 	},
 	"ai_chat": {
-		"delete_thread": "Delete conversation",
-		"delete_thread_confirm": "Are you sure you want to delete this conversation?",
-		"description": "Chat with our AI assistant",
-		"empty": {
-			"description": "Ask anything and get instant AI-powered answers.",
-			"title": "Start a conversation"
-		},
 		"input": {
 			"placeholder": "Type a message..."
 		},
-		"new_chat": "New Chat",
-		"select_chat": "Select a conversation or start a new chat",
 		"suggestion": {
 			"explain": "Explain something",
 			"help": "Get help",
-			"understand": "Help me understand",
 			"weather": "What's the weather like in Tokyo?"
 		},
 		"thread": {
-			"loading": "Loading...",
 			"no_messages": "New conversation"
-		},
-		"title": "AI Chat"
+		}
 	},
 	"app": {
-		"dashboard": {
-			"subtitle": "This is your home base. Real-time metrics and activity will appear here as you build out your app.",
-			"title": "Welcome to your dashboard"
-		},
 		"sidebar": {
 			"admin_panel": "Admin Panel",
 			"ai_chat": "AI Chat",
 			"community_chat": "Community Chat",
-			"dashboard": "Dashboard",
-			"docs": "Docs",
-			"home": "Home",
-			"show_less": "Show less",
 			"show_more": "Show more"
 		},
 		"user_menu": {
-			"account": "Account",
 			"billing": "Billing",
 			"impersonating_banner": "You are impersonating this user",
 			"impersonation_stop_failed": "Failed to stop impersonation",
 			"impersonation_stopped": "Stopped impersonating",
 			"logout": "Log out",
-			"notifications": "Notifications",
 			"pro_badge": "Pro",
 			"settings": "Settings",
 			"stop_impersonating": "Stop Impersonating",
@@ -357,42 +284,26 @@
 		"copied": "Copied",
 		"copy": "Copy",
 		"copy_failed": "Failed to copy",
-		"drag_to_reorder": "Drag to reorder",
 		"feedback_close": "Close feedback",
 		"feedback_open": "Open feedback",
 		"github_repository": "GitHub repository",
 		"go_back": "Go back",
 		"hide_password": "Hide password",
-		"home": "home",
 		"interactive_pointer_tracking_area": "Interactive pointer tracking area",
-		"limit": "Limit",
 		"loading": "Loading",
-		"login_with_apple": "Login with Apple",
-		"login_with_google": "Login with Google",
-		"login_with_meta": "Login with Meta",
 		"logout": "Log out",
 		"menu_close": "Close Menu",
 		"menu_open": "Open Menu",
 		"mobile_sidebar_description": "Displays the mobile sidebar.",
 		"more": "More",
 		"notification_toggle_for_email": "{field} for {email}",
-		"pagination_first": "First page",
-		"pagination_last": "Last page",
-		"pagination_next": "Next page",
-		"pagination_previous": "Previous page",
 		"remove_attachment": "Remove attachment",
-		"reviewer": "Reviewer",
 		"scroll_to_bottom": "Scroll to bottom",
-		"select_all": "Select all",
-		"select_row": "Select row",
-		"select_value": "Select a value",
 		"show_password": "Show password",
 		"sidebar": "Sidebar",
-		"target": "Target",
 		"toggle_sidebar": "Toggle Sidebar",
 		"toggle_theme": "Toggle theme",
-		"toggle_threads": "Toggle conversation list",
-		"view": "View"
+		"toggle_threads": "Toggle conversation list"
 	},
 	"auth": {
 		"back_to_home": "Back to home",
@@ -403,8 +314,6 @@
 			"description": "We will email you a reset link",
 			"title": "Forgot password"
 		},
-		"login": "Login",
-		"logout": "Logout",
 		"messages": {
 			"auth_cancelled": "Authentication was cancelled",
 			"credential_account_not_found": "No password account found. Try signing in with your social provider.",
@@ -448,7 +357,6 @@
 			"description": "Enter your new password",
 			"new_password_label": "New password",
 			"sign_in_link": "Sign in",
-			"success": "Your password has been reset.",
 			"title": "Reset password"
 		},
 		"signin": {
@@ -456,10 +364,8 @@
 			"button_signin_loading": "Signing in...",
 			"button_signup": "Sign Up",
 			"button_signup_loading": "Creating account...",
-			"cancel": "Cancel",
 			"description": "Sign in to your account or create a new one",
 			"email_label": "Email",
-			"email_placeholder": "you@example.com",
 			"forgot_password": "Forgot password?",
 			"link_signup": "Sign up",
 			"name_label": "Name",
@@ -470,19 +376,13 @@
 			"or_continue_with": "Or continue with",
 			"passkey_button": "Sign in with Passkey",
 			"password_label": "Password",
-			"password_placeholder": "••••••••",
 			"tab_signin": "Sign In",
-			"tab_signup": "Sign Up",
-			"test_secret_button": "Sign in with secret",
-			"test_secret_label": "Test only: Sign in with a secret",
-			"test_secret_placeholder": "secret value",
 			"title": "Welcome back"
 		},
 		"signup": {
 			"description": "Enter your details to get started",
 			"has_account": "Already have an account?",
 			"link_signin": "Sign in",
-			"password_hint": "Minimum 10 characters with uppercase, lowercase, and number",
 			"title": "Create an account"
 		},
 		"terms": {
@@ -493,12 +393,7 @@
 		},
 		"verification": {
 			"button_back": "Back to login",
-			"button_cancel": "Cancel",
-			"button_verify": "Verify Email",
-			"button_verify_loading": "Verifying...",
 			"check_email": "Please check your email and click the verification link to complete your registration.",
-			"code_label": "Verification Code",
-			"code_placeholder": "12345678",
 			"description": "We've sent you a verification link",
 			"sent_to": "We've sent a verification email to",
 			"title": "Email Verification",
@@ -526,12 +421,6 @@
 			"rate_limit": {
 				"global": "I'm currently experiencing high demand. Please try sending your message again in a moment.",
 				"user": "Too many messages. Please wait before sending another."
-			},
-			"summary": {
-				"default": "New support conversation"
-			},
-			"title": {
-				"default": "Customer Support"
 			}
 		}
 	},
@@ -562,22 +451,16 @@
 			"preview_loading": "Loading preview…",
 			"preview_truncated": "Preview truncated to {size}"
 		},
-		"avatar": {
-			"team_member": "Team member"
-		},
 		"buttons": {
 			"processing": "Processing...",
 			"upgrade": "Upgrade to Pro"
 		},
-		"description": "Open this app in multiple browser windows to see the real-time database in action",
 		"email": {
 			"placeholder": "Email",
 			"save_failed": "Failed to save email. Please try again.",
-			"saved_success": "Email saved! We'll notify you when we respond.",
 			"subscribe_button": "Subscribe",
 			"unsubscribe_failed": "Failed to unsubscribe. Please try again.",
-			"unsubscribe_tooltip": "Unsubscribe",
-			"unsubscribed": "Unsubscribed from email notifications."
+			"unsubscribe_tooltip": "Unsubscribe"
 		},
 		"error": {
 			"file_max_size": "Maximum size is {maxSize}",
@@ -589,25 +472,14 @@
 			"upload_failed": "Failed to upload \"{filename}\"",
 			"upload_failed_description": "Upload failed"
 		},
-		"greeting": "How can we help?",
-		"greeting_hi": "Hi",
-		"header": {
-			"messages_left": "({remaining}/{total} message left)",
-			"messages_left_plural": "({remaining}/{total} messages left)",
-			"pro_unlimited": "(Pro - Unlimited)",
-			"subtitle": "Real-time chat",
-			"title": "Chat"
-		},
 		"input": {
 			"placeholder": "Type a message...",
 			"placeholder_disabled": "Message limit reached",
-			"send_tooltip": "Send message",
-			"upgrade_tooltip": "Upgrade to Pro for unlimited messages"
+			"send_tooltip": "Send message"
 		},
 		"messages": {
 			"rate_limited": "You're sending messages too fast. Try again in {seconds}s.",
-			"send_failed": "Failed to send message",
-			"sent_success": "Message sent!"
+			"send_failed": "Failed to send message"
 		},
 		"reasoning": {
 			"connecting": "Connecting...",
@@ -616,15 +488,6 @@
 			"thought_for_seconds": "Thought for {duration} second",
 			"thought_for_seconds_plural": "Thought for {duration} seconds"
 		},
-		"suggestion": {
-			"help_label": "Get help",
-			"help_text": "Can you help me with...",
-			"issue_label": "Report an issue",
-			"issue_text": "I found an issue with...",
-			"question_label": "Ask a question",
-			"question_text": "I have a question about..."
-		},
-		"title": "Community Chat",
 		"tooltip": {
 			"attach_files": "Attach files",
 			"mark_bug": "Mark the bug"
@@ -638,7 +501,6 @@
 		"delete": "Delete",
 		"error": "Something went wrong. Please try again.",
 		"load_error": "Failed to load data. Please try again later.",
-		"save": "Save",
 		"you": "You"
 	},
 	"email": {
@@ -730,9 +592,7 @@
 		"cta": "Start Building",
 		"cta_demo": "Request a demo",
 		"description": "SaaS starter with SvelteKit, auth, billing, and analytics.",
-		"section_label": "Home",
-		"tagline": "Focus on your product.\nShip faster.",
-		"title": "SaaS Starter Template"
+		"tagline": "Focus on your product.\nShip faster."
 	},
 	"integrations": {
 		"cards": {
@@ -856,12 +716,6 @@
 				"title": "Sign Up"
 			}
 		},
-		"emails": {
-			"preview": {
-				"description": "Preview email templates and rendered output.",
-				"title": "Email Preview"
-			}
-		},
 		"home": {
 			"description": "SaaS starter for SvelteKit with auth, billing, email, and analytics.",
 			"title": "Build & Ship Your Product Faster"
@@ -890,23 +744,18 @@
 	"nav": {
 		"about": "About",
 		"dashboard": "Dashboard",
-		"features": "Features",
 		"get_started": "Get Started",
 		"home": "Home",
 		"login": "Login",
 		"pricing": "Pricing",
-		"signup": "Sign up",
-		"solution": "Solution"
+		"signup": "Sign up"
 	},
 	"pricing": {
 		"buttons": {
-			"loading": "Loading...",
-			"manage_subscription": "Manage Subscription"
+			"loading": "Loading..."
 		},
-		"current_plan": "Current Plan",
 		"current_plan_badge": "(Current Plan)",
 		"description": "This SaaS starter template is completely free and open source. Try the payment flow using the test card number 4242 4242 4242 4242 with any future expiry date.",
-		"description_autumn": "Test the integrated payment system powered by Autumn - an open-source billing platform that handles subscriptions, usage limits, and Stripe webhooks automatically.",
 		"features": {
 			"enterprise": {
 				"0": "Custom message limits",
@@ -928,7 +777,6 @@
 			}
 		},
 		"popular_badge": "Popular",
-		"section_label": "Pricing",
 		"tiers": {
 			"enterprise": {
 				"button": "Contact Sales",
@@ -938,7 +786,6 @@
 			},
 			"free": {
 				"button": "Free Forever",
-				"button_manage": "Manage Subscription",
 				"description": "Perfect for getting started",
 				"name": "Free",
 				"price": "$0 / month"
@@ -959,8 +806,7 @@
 			"dialog_description": "Search for a page to navigate to.",
 			"dialog_title": "Search pages",
 			"footer": {
-				"go_to_page": "Go to page",
-				"open_new_tab": "Click to open in new tab"
+				"go_to_page": "Go to page"
 			},
 			"groups": {
 				"admin": "Admin",
@@ -1031,7 +877,6 @@
 			"description": "Update your password to keep your account secure.",
 			"error_title": "Error",
 			"new_password_label": "New Password",
-			"password_helper": "Must be at least 10 characters long.",
 			"placeholder": {
 				"confirm": "Confirm new password",
 				"current": "Enter current password",
@@ -1059,8 +904,6 @@
 				"placeholder": "Passkey name",
 				"unnamed": "Unnamed Passkey"
 			},
-			"passkey_delete_failed": "Failed to delete passkey",
-			"passkey_deleted": "Passkey removed",
 			"passkey_info_description": "Passkeys are a secure, passwordless way to sign in. They use biometrics or device PIN and are stored securely on your devices.",
 			"passkey_info_title": "What are Passkeys?",
 			"passkey_name_label": "Passkey name",
@@ -1197,7 +1040,6 @@
 			"ux_engineer": "UX Engineer",
 			"visual_designer": "Visual Designer"
 		},
-		"section_label": "Team",
 		"title": "Our dream team"
 	},
 	"validation": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -14,8 +14,7 @@
 			"database_backend": "Base de datos y backend",
 			"email_service": "Servicio de entrega de correo",
 			"external_services": "Servicios Externos",
-			"hosting_deployment": "Hosting y despliegue",
-			"title": "Panel de Administración"
+			"hosting_deployment": "Hosting y despliegue"
 		},
 		"dialog": {
 			"ban_description": "¿Estás seguro de que quieres bloquear a {email}? No podrá acceder a la app.",
@@ -23,7 +22,6 @@
 			"ban_title": "Bloquear Usuario",
 			"impersonation_active_description": "Por favor, recarga la página para iniciar sesión como el usuario suplantado.",
 			"impersonation_active_title": "Suplantación activa",
-			"reload_page": "Recargar página",
 			"revoke_description": "¿Estás seguro de que quieres revocar todas las sesiones de {email}? Se cerrará sesión en todos los dispositivos.",
 			"revoke_title": "Revocar Sesiones",
 			"set_role_description": "¿Estás seguro de que quieres cambiar el rol de {email} a {role}?",
@@ -37,16 +35,13 @@
 			"admin_users": "Gestionando la plataforma",
 			"admins": "Admins",
 			"admins_desc": "Usuarios con privilegios de admin",
-			"banned_users": "Usuarios Bloqueados",
-			"banned_users_desc": "Acceso restringido",
 			"currently_active": "Actividad diaria",
 			"last_7_days": "Últimos 7 días",
 			"recent_signups": "Registros Recientes",
 			"recent_signups_desc": "Crecimiento de usuarios",
 			"registered_users": "Base de usuarios",
 			"total_users": "Usuarios Totales",
-			"total_users_desc": "Todas las cuentas registradas",
-			"users_banned": "Cuentas pendientes de revisión"
+			"total_users_desc": "Todas las cuentas registradas"
 		},
 		"navigation": {
 			"app": "App",
@@ -63,18 +58,12 @@
 			"column_new_tickets": "Nuevos Tickets",
 			"column_type": "Tipo",
 			"column_user_replies": "Respuestas de Usuario",
-			"default_support_email": "Email de Soporte Predeterminado",
-			"default_support_email_help": "Dejar vacío para enviar notificaciones a todos los administradores.",
-			"default_support_email_placeholder": "soporte@example.com",
 			"delete_email": "Eliminar",
-			"delete_email_confirm": "¿Eliminar {email} de los destinatarios de notificaciones?",
 			"delete_email_description": "¿Eliminar {email} de los destinatarios de notificaciones?",
 			"delete_email_title": "Eliminar Email",
-			"description": "Configura los ajustes del panel de administración y las notificaciones.",
 			"email_add_failed": "No se pudo agregar el email",
 			"email_added": "Email agregado",
 			"email_exists": "Este email ya existe",
-			"email_removed": "Email eliminado",
 			"field_new_signups": "Notificaciones de nuevos registros",
 			"field_new_tickets": "Notificaciones de nuevos tickets",
 			"field_user_replies": "Notificaciones de respuestas de usuario",
@@ -85,63 +74,34 @@
 				"custom_only": "Solo Personalizados"
 			},
 			"founder_welcome": {
-				"became_contact": "Ahora eres la persona de contacto para emails de bienvenida",
 				"cancel": "Cancelar",
-				"click_to_edit": "Haz clic para editar",
 				"config_body_label": "Cuerpo del email",
 				"config_name_label": "Tu nombre",
-				"config_reply_to_description": "A dónde van las respuestas. Usa tu email de cuenta si se deja vacío.",
 				"config_reply_to_label": "Email de respuesta",
 				"config_reply_to_placeholder": "ej. hola@tuempresa.com",
 				"config_subject_label": "Asunto del email",
 				"config_title_label": "Su título",
-				"config_variables_hint": "Variables disponibles: '{{userFirstName}}', '{{userLastName}}', '{{founderName}}', '{{founderTitle}}'",
-				"contact_person": "Persona de contacto",
-				"contact_person_info": "{name} ({email})",
 				"description": "Envía automáticamente un email personal de bienvenida de un miembro del equipo a nuevos usuarios después del registro. Se envía como texto plano para mayor autenticidad.",
 				"edit_button": "Editar",
-				"email_legend": "Contenido del email",
 				"error": "Algo salió mal. Por favor, inténtalo de nuevo.",
-				"not_configured": "No hay persona de contacto configurada. Configure un miembro del equipo para enviar emails de bienvenida a nuevos usuarios.",
-				"preview_subject": "Asunto",
-				"preview_title": "Vista previa",
 				"save": "Guardar cambios",
 				"saved": "Configuración de email de bienvenida guardada",
-				"sender_legend": "Información del remitente",
 				"setup_button": "Ser persona de contacto",
-				"setup_confirm": "Configurar",
-				"setup_title_label": "Su título",
 				"setup_title_placeholder": "ej. Fundador de SaaS Starter",
 				"step_down": "Dejar el rol",
 				"step_down_confirm": "¿Dejar de ser persona de contacto? Los emails de bienvenida dejarán de enviarse.",
 				"stepped_down": "Ya no eres la persona de contacto",
-				"take_over": "Asumir rol",
-				"take_over_confirm": "¿Asumir como persona de contacto? La plantilla de email existente se conservará.",
 				"title": "Email de bienvenida del fundador",
-				"took_over": "Has asumido como persona de contacto",
 				"variables_label": "Variables:"
 			},
-			"invalid_email": "Dirección de email inválida",
 			"no_recipients": "No hay destinatarios de notificaciones configurados",
-			"notification_recipients": "Destinatarios de Notificaciones",
-			"notification_recipients_desc": "Configura quién recibe notificaciones de administrador. Los usuarios administradores se incluyen automáticamente.",
 			"preference_disabled": "{field} desactivadas",
 			"preference_disabling": "Desactivando {field}...",
 			"preference_enabled": "{field} activadas",
 			"preference_enabling": "Activando {field}...",
 			"preference_update_failed": "Error al actualizar preferencia",
-			"recipient_count": "{count, plural, one {# destinatario} other {# destinatarios}}",
 			"recipients_search_placeholder": "Buscar destinatarios de notificaciones...",
-			"save": "Guardar Configuración",
-			"saved": "Configuración guardada",
-			"saving": "Guardando...",
 			"selected": "{selected} de {total} seleccionados",
-			"support_notifications": "Notificaciones de Soporte",
-			"support_notifications_desc": "Configura las notificaciones por email para tickets de soporte nuevos y reabiertos no asignados.",
-			"tabs": {
-				"notifications": "Notificaciones",
-				"recipients": "Destinatarios"
-			},
 			"title": "Configuración de Admin",
 			"type_admin": "Admin",
 			"type_custom": "Personalizado"
@@ -154,7 +114,6 @@
 			"users": "Usuarios"
 		},
 		"support": {
-			"all_statuses": "Todos los estados",
 			"anonymous": "Anónimo",
 			"assignee": {
 				"not_assigned": "No asignado",
@@ -172,9 +131,7 @@
 				"page_url": "URL de la página",
 				"priority": "Prioridad",
 				"status": "Estado",
-				"title": "Detalles",
-				"user_notes": "Notas del Usuario",
-				"user_notes_description": "Las notas se guardan a nivel de usuario y aparecen en todos sus hilos de soporte"
+				"user_notes": "Notas del Usuario"
 			},
 			"email": {
 				"label": "Email de notificación"
@@ -190,7 +147,6 @@
 			},
 			"filter_showing_completed": "Mostrando hilos completados, haga clic para ver los abiertos",
 			"filter_showing_open": "Mostrando hilos abiertos, haga clic para ver los completados",
-			"no_chats": "No se encontraron chats",
 			"no_done_chats": "No hay chats completados",
 			"no_email": "Sin correo electrónico",
 			"no_open_chats": "No hay chats abiertos",
@@ -212,9 +168,7 @@
 			"select_chat_for_details": "Seleccione un chat para ver detalles",
 			"status": {
 				"done": "Hecho",
-				"in_progress": "En progreso",
-				"open": "Abierto",
-				"resolved": "Resuelto"
+				"open": "Abierto"
 			},
 			"thread": {
 				"badge": {
@@ -225,12 +179,10 @@
 				"no_messages": "Sin mensajes",
 				"retry": "Reintentar"
 			},
-			"threads_title": "Hilos de Soporte",
-			"title": "Chats de Soporte"
+			"threads_title": "Hilos de Soporte"
 		},
 		"title": "Panel de Admin",
 		"users": {
-			"actions_column": "Acciones",
 			"ban_reason": {
 				"default": "Violación de los términos de servicio"
 			},
@@ -274,7 +226,6 @@
 				"ban_failed": "Error al bloquear usuario: {message}",
 				"banned": "Usuario bloqueado",
 				"impersonate_failed": "Error al suplantar usuario: {message}",
-				"impersonation_started": "Suplantación de usuario iniciada",
 				"note_added": "Nota agregada",
 				"note_failed": "Error al agregar nota: {message}",
 				"priority_failed": "Error al actualizar prioridad: {message}",
@@ -288,60 +239,36 @@
 				"unban_failed": "Error al desbloquear usuario: {message}",
 				"unbanned": "Usuario desbloqueado"
 			},
-			"total": "usuarios",
-			"unnamed": "Sin nombre",
 			"unverified": "No verificado",
 			"verified": "Verificado"
 		}
 	},
 	"ai_chat": {
-		"delete_thread": "Eliminar conversación",
-		"delete_thread_confirm": "¿Estás seguro de que quieres eliminar esta conversación?",
-		"description": "Chatea con nuestro asistente de IA",
-		"empty": {
-			"description": "Pregunta lo que quieras y obtén respuestas instantáneas con IA.",
-			"title": "Inicia una conversación"
-		},
 		"input": {
 			"placeholder": "Escribe un mensaje..."
 		},
-		"new_chat": "Nuevo chat",
-		"select_chat": "Selecciona una conversación o inicia un nuevo chat",
 		"suggestion": {
 			"explain": "Explica algo",
 			"help": "Obtener ayuda",
-			"understand": "Ayúdame a entender",
 			"weather": "¿Qué tiempo hace en Tokio?"
 		},
 		"thread": {
-			"loading": "Cargando...",
 			"no_messages": "Nueva conversación"
-		},
-		"title": "Chat IA"
+		}
 	},
 	"app": {
-		"dashboard": {
-			"subtitle": "Este es tu centro de control. Las métricas en tiempo real y la actividad aparecerán aquí a medida que desarrolles tu aplicación.",
-			"title": "Bienvenido a tu panel"
-		},
 		"sidebar": {
 			"admin_panel": "Panel de Admin",
 			"ai_chat": "Chat IA",
 			"community_chat": "Chat comunitario",
-			"dashboard": "Panel",
-			"docs": "Documentación",
-			"home": "Inicio",
-			"show_less": "Mostrar menos",
 			"show_more": "Mostrar más"
 		},
 		"user_menu": {
-			"account": "Cuenta",
 			"billing": "Facturación",
 			"impersonating_banner": "Estás suplantando a este usuario",
 			"impersonation_stop_failed": "Error al dejar de suplantar",
 			"impersonation_stopped": "Suplantación detenida",
 			"logout": "Cerrar sesión",
-			"notifications": "Notificaciones",
 			"pro_badge": "Pro",
 			"settings": "Configuración",
 			"stop_impersonating": "Dejar de suplantar",
@@ -357,42 +284,26 @@
 		"copied": "Copiado",
 		"copy": "Copiar",
 		"copy_failed": "Error al copiar",
-		"drag_to_reorder": "Arrastrar para reordenar",
 		"feedback_close": "Cerrar comentarios",
 		"feedback_open": "Abrir comentarios",
 		"github_repository": "Repositorio de GitHub",
 		"go_back": "Volver",
 		"hide_password": "Ocultar contraseña",
-		"home": "inicio",
 		"interactive_pointer_tracking_area": "Área interactiva de seguimiento del puntero",
-		"limit": "Límite",
 		"loading": "Cargando",
-		"login_with_apple": "Iniciar sesión con Apple",
-		"login_with_google": "Iniciar sesión con Google",
-		"login_with_meta": "Iniciar sesión con Meta",
 		"logout": "Cerrar sesión",
 		"menu_close": "Cerrar menú",
 		"menu_open": "Abrir menú",
 		"mobile_sidebar_description": "Muestra la barra lateral móvil.",
 		"more": "Más",
 		"notification_toggle_for_email": "{field} para {email}",
-		"pagination_first": "Primera página",
-		"pagination_last": "Última página",
-		"pagination_next": "Página siguiente",
-		"pagination_previous": "Página anterior",
 		"remove_attachment": "Eliminar adjunto",
-		"reviewer": "Revisor",
 		"scroll_to_bottom": "Desplazarse al final",
-		"select_all": "Seleccionar todo",
-		"select_row": "Seleccionar fila",
-		"select_value": "Seleccionar un valor",
 		"show_password": "Mostrar contraseña",
 		"sidebar": "Barra lateral",
-		"target": "Destino",
 		"toggle_sidebar": "Alternar barra lateral",
 		"toggle_theme": "Cambiar tema",
-		"toggle_threads": "Alternar lista de conversaciones",
-		"view": "Ver"
+		"toggle_threads": "Alternar lista de conversaciones"
 	},
 	"auth": {
 		"back_to_home": "Volver al inicio",
@@ -403,8 +314,6 @@
 			"description": "Te enviaremos un enlace para restablecer",
 			"title": "¿Olvidaste tu contraseña?"
 		},
-		"login": "Iniciar sesión",
-		"logout": "Cerrar sesión",
 		"messages": {
 			"auth_cancelled": "La autenticación fue cancelada",
 			"credential_account_not_found": "No se encontró cuenta con contraseña. Intenta iniciar sesión con tu proveedor social.",
@@ -448,7 +357,6 @@
 			"description": "Ingresa tu nueva contraseña",
 			"new_password_label": "Nueva contraseña",
 			"sign_in_link": "Iniciar sesión",
-			"success": "Tu contraseña ha sido restablecida.",
 			"title": "Restablecer contraseña"
 		},
 		"signin": {
@@ -456,10 +364,8 @@
 			"button_signin_loading": "Iniciando sesión...",
 			"button_signup": "Registrarse",
 			"button_signup_loading": "Creando cuenta...",
-			"cancel": "Cancelar",
 			"description": "Inicia sesión en tu cuenta o crea una nueva",
 			"email_label": "Correo electrónico",
-			"email_placeholder": "tu@ejemplo.com",
 			"forgot_password": "¿Olvidaste tu contraseña?",
 			"link_signup": "Regístrate",
 			"name_label": "Nombre",
@@ -470,19 +376,13 @@
 			"or_continue_with": "O continuar con",
 			"passkey_button": "Iniciar sesión con Passkey",
 			"password_label": "Contraseña",
-			"password_placeholder": "••••••••",
 			"tab_signin": "Iniciar sesión",
-			"tab_signup": "Registrarse",
-			"test_secret_button": "Iniciar sesión con secreto",
-			"test_secret_label": "Solo prueba: Iniciar sesión con secreto",
-			"test_secret_placeholder": "valor secreto",
 			"title": "Bienvenido de nuevo"
 		},
 		"signup": {
 			"description": "Ingresa tus datos para comenzar",
 			"has_account": "¿Ya tienes una cuenta?",
 			"link_signin": "Inicia sesión",
-			"password_hint": "Mínimo 10 caracteres con mayúsculas, minúsculas y número",
 			"title": "Crear una cuenta"
 		},
 		"terms": {
@@ -493,12 +393,7 @@
 		},
 		"verification": {
 			"button_back": "Volver al inicio de sesión",
-			"button_cancel": "Cancelar",
-			"button_verify": "Verificar correo",
-			"button_verify_loading": "Verificando...",
 			"check_email": "Por favor revisa tu correo electrónico y haz clic en el enlace de verificación para completar tu registro.",
-			"code_label": "Código de verificación",
-			"code_placeholder": "12345678",
 			"description": "Te hemos enviado un enlace de verificación",
 			"sent_to": "Hemos enviado un correo de verificación a",
 			"title": "Verificación de correo electrónico",
@@ -526,12 +421,6 @@
 			"rate_limit": {
 				"global": "Estoy experimentando alta demanda. Por favor intenta enviar tu mensaje de nuevo en un momento.",
 				"user": "Demasiados mensajes. Por favor espera antes de enviar otro."
-			},
-			"summary": {
-				"default": "Nueva conversación de soporte"
-			},
-			"title": {
-				"default": "Soporte al Cliente"
 			}
 		}
 	},
@@ -562,22 +451,16 @@
 			"preview_loading": "Cargando vista previa…",
 			"preview_truncated": "Vista previa truncada a {size}"
 		},
-		"avatar": {
-			"team_member": "Miembro del equipo"
-		},
 		"buttons": {
 			"processing": "Procesando...",
 			"upgrade": "Actualizar a Pro"
 		},
-		"description": "Abre esta aplicación en múltiples ventanas del navegador para ver la base de datos en tiempo real en acción",
 		"email": {
 			"placeholder": "Email",
 			"save_failed": "Error al guardar email. Por favor intenta de nuevo.",
-			"saved_success": "¡Email guardado! Te notificaremos cuando respondamos.",
 			"subscribe_button": "Suscribirse",
 			"unsubscribe_failed": "Error al cancelar suscripción. Por favor intenta de nuevo.",
-			"unsubscribe_tooltip": "Cancelar suscripción",
-			"unsubscribed": "Suscripción a notificaciones por email cancelada."
+			"unsubscribe_tooltip": "Cancelar suscripción"
 		},
 		"error": {
 			"file_max_size": "Tamaño máximo es {maxSize}",
@@ -589,25 +472,14 @@
 			"upload_failed": "No se pudo subir \"{filename}\"",
 			"upload_failed_description": "Error al subir"
 		},
-		"greeting": "¿Cómo podemos ayudarte?",
-		"greeting_hi": "Hola",
-		"header": {
-			"messages_left": "({remaining}/{total} mensaje restante)",
-			"messages_left_plural": "({remaining}/{total} mensajes restantes)",
-			"pro_unlimited": "(Pro - Ilimitado)",
-			"subtitle": "Chat en tiempo real",
-			"title": "Chat"
-		},
 		"input": {
 			"placeholder": "Escribe un mensaje...",
 			"placeholder_disabled": "Límite de mensajes alcanzado",
-			"send_tooltip": "Enviar mensaje",
-			"upgrade_tooltip": "Actualiza a Pro para mensajes ilimitados"
+			"send_tooltip": "Enviar mensaje"
 		},
 		"messages": {
 			"rate_limited": "Estás enviando mensajes demasiado rápido. Vuelve a intentarlo en {seconds}s.",
-			"send_failed": "Error al enviar mensaje",
-			"sent_success": "¡Mensaje enviado!"
+			"send_failed": "Error al enviar mensaje"
 		},
 		"reasoning": {
 			"connecting": "Conectando...",
@@ -616,15 +488,6 @@
 			"thought_for_seconds": "Pensó durante {duration} segundo",
 			"thought_for_seconds_plural": "Pensó durante {duration} segundos"
 		},
-		"suggestion": {
-			"help_label": "Obtener ayuda",
-			"help_text": "¿Puedes ayudarme con...",
-			"issue_label": "Reportar un problema",
-			"issue_text": "Encontré un problema con...",
-			"question_label": "Hacer una pregunta",
-			"question_text": "Tengo una pregunta sobre..."
-		},
-		"title": "Chat Comunitario",
 		"tooltip": {
 			"attach_files": "Adjuntar archivos",
 			"mark_bug": "Marcar el error"
@@ -638,7 +501,6 @@
 		"delete": "Eliminar",
 		"error": "Algo salió mal. Por favor, inténtalo de nuevo.",
 		"load_error": "No se pudieron cargar los datos. Por favor, inténtalo de nuevo más tarde.",
-		"save": "Guardar",
 		"you": "Tú"
 	},
 	"email": {
@@ -730,9 +592,7 @@
 		"cta": "Comenzar ahora",
 		"cta_demo": "Solicitar una demo",
 		"description": "Dale vida a tu SaaS en minutos, no en meses. Plantilla open-source cargada con la tecnología que te hace lanzar rápido.",
-		"section_label": "Inicio",
-		"tagline": "Foco en tu producto.\nLanzamiento más rápido.",
-		"title": "Plantilla SaaS Starter"
+		"tagline": "Foco en tu producto.\nLanzamiento más rápido."
 	},
 	"integrations": {
 		"cards": {
@@ -856,12 +716,6 @@
 				"title": "Registrarse"
 			}
 		},
-		"emails": {
-			"preview": {
-				"description": "Vista previa de plantillas de correo y su renderizado.",
-				"title": "Vista previa de correos"
-			}
-		},
 		"home": {
 			"description": "Starter SaaS para SvelteKit con auth, pagos, email y analítica.",
 			"title": "Construye y lanza tu producto más rápido"
@@ -890,23 +744,18 @@
 	"nav": {
 		"about": "Acerca de",
 		"dashboard": "Panel",
-		"features": "Características",
 		"get_started": "Comenzar",
 		"home": "Inicio",
 		"login": "Iniciar sesión",
 		"pricing": "Precios",
-		"signup": "Registrarse",
-		"solution": "Solución"
+		"signup": "Registrarse"
 	},
 	"pricing": {
 		"buttons": {
-			"loading": "Cargando...",
-			"manage_subscription": "Gestionar Suscripción"
+			"loading": "Cargando..."
 		},
-		"current_plan": "Plan Actual",
 		"current_plan_badge": "(Plan Actual)",
 		"description": "Esta plantilla SaaS starter es completamente gratuita y de código abierto. Prueba el flujo de pago usando el número de tarjeta de prueba 4242 4242 4242 4242 con cualquier fecha de vencimiento futura.",
-		"description_autumn": "Prueba el sistema de pago integrado powered by Autumn - una plataforma de facturación de código abierto que gestiona suscripciones, límites de uso y webhooks de Stripe automáticamente.",
 		"features": {
 			"enterprise": {
 				"0": "Límites de mensajes personalizados",
@@ -928,7 +777,6 @@
 			}
 		},
 		"popular_badge": "Popular",
-		"section_label": "Precios",
 		"tiers": {
 			"enterprise": {
 				"button": "Contactar Ventas",
@@ -938,7 +786,6 @@
 			},
 			"free": {
 				"button": "Gratis para siempre",
-				"button_manage": "Gestionar Suscripción",
 				"description": "Perfecto para comenzar",
 				"name": "Gratis",
 				"price": "$0 / mes"
@@ -959,8 +806,7 @@
 			"dialog_description": "Busca una página para navegar.",
 			"dialog_title": "Buscar páginas",
 			"footer": {
-				"go_to_page": "Ir a la página",
-				"open_new_tab": "Clic para abrir en nueva pestaña"
+				"go_to_page": "Ir a la página"
 			},
 			"groups": {
 				"admin": "Admin",
@@ -1031,7 +877,6 @@
 			"description": "Actualiza tu contraseña para mantener tu cuenta segura.",
 			"error_title": "Error",
 			"new_password_label": "Nueva contraseña",
-			"password_helper": "Debe tener al menos 8 caracteres.",
 			"placeholder": {
 				"confirm": "Confirmar nueva contraseña",
 				"current": "Ingresa contraseña actual",
@@ -1059,8 +904,6 @@
 				"placeholder": "Nombre del passkey",
 				"unnamed": "Passkey sin nombre"
 			},
-			"passkey_delete_failed": "No se pudo eliminar la passkey",
-			"passkey_deleted": "Passkey eliminada",
 			"passkey_info_description": "Los passkeys son una forma segura de iniciar sesión sin contraseña. Utilizan biometría o PIN del dispositivo y se almacenan de forma segura en tus dispositivos.",
 			"passkey_info_title": "¿Qué son los Passkeys?",
 			"passkey_name_label": "Nombre del passkey",
@@ -1197,7 +1040,6 @@
 			"ux_engineer": "Ingeniero UX",
 			"visual_designer": "Diseñador Visual"
 		},
-		"section_label": "Equipo",
 		"title": "Nuestro equipo soñado"
 	},
 	"validation": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -14,8 +14,7 @@
 			"database_backend": "Base de données & backend",
 			"email_service": "Service d'envoi d'e-mails",
 			"external_services": "Services Externes",
-			"hosting_deployment": "Hébergement & déploiement",
-			"title": "Tableau de bord Admin"
+			"hosting_deployment": "Hébergement & déploiement"
 		},
 		"dialog": {
 			"ban_description": "Êtes-vous sûr de vouloir bannir {email} ? L'accès à l'app sera bloqué.",
@@ -23,7 +22,6 @@
 			"ban_title": "Bannir l'Utilisateur",
 			"impersonation_active_description": "Veuillez recharger la page pour vous connecter en tant qu'utilisateur usurpé.",
 			"impersonation_active_title": "Usurpation active",
-			"reload_page": "Recharger la page",
 			"revoke_description": "Êtes-vous sûr de vouloir révoquer toutes les sessions de {email} ? La déconnexion sera effectuée partout.",
 			"revoke_title": "Révoquer les Sessions",
 			"set_role_description": "Êtes-vous sûr de vouloir changer le rôle de {email} en {role} ?",
@@ -37,16 +35,13 @@
 			"admin_users": "Gestion de la plateforme",
 			"admins": "Admins",
 			"admins_desc": "Utilisateurs avec privilèges admin",
-			"banned_users": "Utilisateurs Bannis",
-			"banned_users_desc": "Accès restreint",
 			"currently_active": "Activité quotidienne",
 			"last_7_days": "7 derniers jours",
 			"recent_signups": "Inscriptions Récentes",
 			"recent_signups_desc": "Croissance des utilisateurs",
 			"registered_users": "Base d'utilisateurs",
 			"total_users": "Utilisateurs Totaux",
-			"total_users_desc": "Tous les comptes enregistrés",
-			"users_banned": "Comptes à vérifier"
+			"total_users_desc": "Tous les comptes enregistrés"
 		},
 		"navigation": {
 			"app": "App",
@@ -63,18 +58,12 @@
 			"column_new_tickets": "Nouveaux Tickets",
 			"column_type": "Type",
 			"column_user_replies": "Réponses Utilisateur",
-			"default_support_email": "Email de Support par Défaut",
-			"default_support_email_help": "Laisser vide pour envoyer les notifications à tous les administrateurs.",
-			"default_support_email_placeholder": "support@example.com",
 			"delete_email": "Supprimer",
-			"delete_email_confirm": "Supprimer {email} des destinataires de notifications ?",
 			"delete_email_description": "Supprimer {email} des destinataires de notifications ?",
 			"delete_email_title": "Supprimer l'Email",
-			"description": "Configurez les paramètres du panneau d'administration et les notifications.",
 			"email_add_failed": "Impossible d'ajouter l'email",
 			"email_added": "Email ajouté",
 			"email_exists": "Cet email existe déjà",
-			"email_removed": "Email supprimé",
 			"field_new_signups": "Notifications de nouvelles inscriptions",
 			"field_new_tickets": "Notifications de nouveaux tickets",
 			"field_user_replies": "Notifications de réponses utilisateur",
@@ -85,63 +74,34 @@
 				"custom_only": "Personnalisés Uniquement"
 			},
 			"founder_welcome": {
-				"became_contact": "Vous êtes maintenant la personne de contact pour les emails de bienvenue",
 				"cancel": "Annuler",
-				"click_to_edit": "Cliquez pour modifier",
 				"config_body_label": "Corps de l'email",
 				"config_name_label": "Votre nom",
-				"config_reply_to_description": "Où vont les réponses. Utilise votre email de compte si laissé vide.",
 				"config_reply_to_label": "Email de réponse",
 				"config_reply_to_placeholder": "ex. bonjour@votreentreprise.com",
 				"config_subject_label": "Objet de l'email",
 				"config_title_label": "Votre titre",
-				"config_variables_hint": "Variables disponibles : '{{userFirstName}}', '{{userLastName}}', '{{founderName}}', '{{founderTitle}}'",
-				"contact_person": "Personne de contact",
-				"contact_person_info": "{name} ({email})",
 				"description": "Envoie automatiquement un email personnel de bienvenue d'un membre de l'équipe aux nouveaux utilisateurs après l'inscription. Envoyé en texte brut pour plus d'authenticité.",
 				"edit_button": "Modifier",
-				"email_legend": "Contenu de l'email",
 				"error": "Une erreur est survenue. Veuillez réessayer.",
-				"not_configured": "Aucune personne de contact configurée. Configurez un membre de l'équipe pour envoyer des emails de bienvenue aux nouveaux utilisateurs.",
-				"preview_subject": "Objet",
-				"preview_title": "Aperçu",
 				"save": "Enregistrer les modifications",
 				"saved": "Configuration de l'email de bienvenue enregistrée",
-				"sender_legend": "Informations de l'expéditeur",
 				"setup_button": "Devenir personne de contact",
-				"setup_confirm": "Configurer",
-				"setup_title_label": "Votre titre",
 				"setup_title_placeholder": "ex. Fondateur de SaaS Starter",
 				"step_down": "Se retirer",
 				"step_down_confirm": "Se retirer en tant que personne de contact ? Les emails de bienvenue ne seront plus envoyés.",
 				"stepped_down": "Vous n'êtes plus la personne de contact",
-				"take_over": "Reprendre le rôle",
-				"take_over_confirm": "Reprendre en tant que personne de contact ? Le modèle d'email existant sera conservé.",
 				"title": "Email de bienvenue du fondateur",
-				"took_over": "Vous avez repris le rôle de personne de contact",
 				"variables_label": "Variables :"
 			},
-			"invalid_email": "Adresse email invalide",
 			"no_recipients": "Aucun destinataire de notifications configuré",
-			"notification_recipients": "Destinataires des Notifications",
-			"notification_recipients_desc": "Configurez qui reçoit les notifications admin. Les utilisateurs admin sont automatiquement inclus.",
 			"preference_disabled": "{field} désactivées",
 			"preference_disabling": "Désactivation de {field}...",
 			"preference_enabled": "{field} activées",
 			"preference_enabling": "Activation de {field}...",
 			"preference_update_failed": "Échec de la mise à jour de la préférence",
-			"recipient_count": "{count, plural, one {# destinataire} other {# destinataires}}",
 			"recipients_search_placeholder": "Rechercher des destinataires de notification...",
-			"save": "Enregistrer les Paramètres",
-			"saved": "Paramètres enregistrés",
-			"saving": "Enregistrement...",
 			"selected": "{selected} sur {total} sélectionnés",
-			"support_notifications": "Notifications de Support",
-			"support_notifications_desc": "Configurez les notifications par email pour les tickets de support nouveaux et rouverts non assignés.",
-			"tabs": {
-				"notifications": "Notifications",
-				"recipients": "Destinataires"
-			},
 			"title": "Paramètres Admin",
 			"type_admin": "Admin",
 			"type_custom": "Personnalisé"
@@ -154,7 +114,6 @@
 			"users": "Utilisateurs"
 		},
 		"support": {
-			"all_statuses": "Tous les statuts",
 			"anonymous": "Anonyme",
 			"assignee": {
 				"not_assigned": "Non assigné",
@@ -172,9 +131,7 @@
 				"page_url": "URL de la page",
 				"priority": "Priorité",
 				"status": "Statut",
-				"title": "Détails",
-				"user_notes": "Notes Utilisateur",
-				"user_notes_description": "Les notes sont enregistrées au niveau de l utilisateur et apparaissent dans tous leurs fils de support"
+				"user_notes": "Notes Utilisateur"
 			},
 			"email": {
 				"label": "Email de notification"
@@ -190,7 +147,6 @@
 			},
 			"filter_showing_completed": "Affiche les fils terminés, cliquer pour afficher les ouverts",
 			"filter_showing_open": "Affiche les fils ouverts, cliquer pour afficher les terminés",
-			"no_chats": "Aucun chat trouvé",
 			"no_done_chats": "Aucun chat terminé",
 			"no_email": "Pas d'e-mail",
 			"no_open_chats": "Aucun chat ouvert",
@@ -212,9 +168,7 @@
 			"select_chat_for_details": "Sélectionnez un chat pour voir les détails",
 			"status": {
 				"done": "Terminé",
-				"in_progress": "En cours",
-				"open": "Ouvert",
-				"resolved": "Résolu"
+				"open": "Ouvert"
 			},
 			"thread": {
 				"badge": {
@@ -225,12 +179,10 @@
 				"no_messages": "Aucun message",
 				"retry": "Réessayer"
 			},
-			"threads_title": "Fils de Support",
-			"title": "Chats de Support"
+			"threads_title": "Fils de Support"
 		},
 		"title": "Panneau Admin",
 		"users": {
-			"actions_column": "Actions",
 			"ban_reason": {
 				"default": "Violation des conditions d'utilisation"
 			},
@@ -274,7 +226,6 @@
 				"ban_failed": "Échec du bannissement : {message}",
 				"banned": "Utilisateur banni",
 				"impersonate_failed": "Échec de l'usurpation : {message}",
-				"impersonation_started": "Usurpation d'identité démarrée",
 				"note_added": "Note ajoutée",
 				"note_failed": "Échec de l'ajout de la note : {message}",
 				"priority_failed": "Échec de la mise à jour de la priorité : {message}",
@@ -288,60 +239,36 @@
 				"unban_failed": "Échec du débannissement : {message}",
 				"unbanned": "Utilisateur débanni"
 			},
-			"total": "utilisateurs",
-			"unnamed": "Sans nom",
 			"unverified": "Non vérifié",
 			"verified": "Vérifié"
 		}
 	},
 	"ai_chat": {
-		"delete_thread": "Supprimer la conversation",
-		"delete_thread_confirm": "Êtes-vous sûr de vouloir supprimer cette conversation ?",
-		"description": "Discutez avec notre assistant IA",
-		"empty": {
-			"description": "Posez n'importe quelle question et obtenez des réponses instantanées par IA.",
-			"title": "Démarrer une conversation"
-		},
 		"input": {
 			"placeholder": "Tapez un message..."
 		},
-		"new_chat": "Nouveau chat",
-		"select_chat": "Sélectionnez une conversation ou démarrez un nouveau chat",
 		"suggestion": {
 			"explain": "Explique quelque chose",
 			"help": "Obtenir de l'aide",
-			"understand": "Aide-moi à comprendre",
 			"weather": "Quel temps fait-il à Tokyo ?"
 		},
 		"thread": {
-			"loading": "Chargement...",
 			"no_messages": "Nouvelle conversation"
-		},
-		"title": "Chat IA"
+		}
 	},
 	"app": {
-		"dashboard": {
-			"subtitle": "Voici votre base. Les métriques en temps réel et l'activité apparaîtront ici au fur et à mesure que vous développez votre application.",
-			"title": "Bienvenue sur votre tableau de bord"
-		},
 		"sidebar": {
 			"admin_panel": "Panneau Admin",
 			"ai_chat": "Chat IA",
 			"community_chat": "Chat communautaire",
-			"dashboard": "Tableau de bord",
-			"docs": "Documentation",
-			"home": "Accueil",
-			"show_less": "Afficher moins",
 			"show_more": "Afficher plus"
 		},
 		"user_menu": {
-			"account": "Compte",
 			"billing": "Facturation",
 			"impersonating_banner": "Vous usurpez l'identité de cet utilisateur",
 			"impersonation_stop_failed": "Échec de l'arrêt de l'usurpation",
 			"impersonation_stopped": "Usurpation arrêtée",
 			"logout": "Se déconnecter",
-			"notifications": "Notifications",
 			"pro_badge": "Pro",
 			"settings": "Paramètres",
 			"stop_impersonating": "Arrêter l'usurpation",
@@ -357,42 +284,26 @@
 		"copied": "Copié",
 		"copy": "Copier",
 		"copy_failed": "Échec de la copie",
-		"drag_to_reorder": "Glisser pour réorganiser",
 		"feedback_close": "Fermer les commentaires",
 		"feedback_open": "Ouvrir les commentaires",
 		"github_repository": "Dépôt GitHub",
 		"go_back": "Retour",
 		"hide_password": "Masquer le mot de passe",
-		"home": "accueil",
 		"interactive_pointer_tracking_area": "Zone interactive de suivi du pointeur",
-		"limit": "Limite",
 		"loading": "Chargement",
-		"login_with_apple": "Se connecter avec Apple",
-		"login_with_google": "Se connecter avec Google",
-		"login_with_meta": "Se connecter avec Meta",
 		"logout": "Se déconnecter",
 		"menu_close": "Fermer le menu",
 		"menu_open": "Ouvrir le menu",
 		"mobile_sidebar_description": "Affiche la barre latérale mobile.",
 		"more": "Plus",
 		"notification_toggle_for_email": "{field} pour {email}",
-		"pagination_first": "Première page",
-		"pagination_last": "Dernière page",
-		"pagination_next": "Page suivante",
-		"pagination_previous": "Page précédente",
 		"remove_attachment": "Supprimer la pièce jointe",
-		"reviewer": "Réviseur",
 		"scroll_to_bottom": "Faire défiler vers le bas",
-		"select_all": "Tout sélectionner",
-		"select_row": "Sélectionner la ligne",
-		"select_value": "Sélectionner une valeur",
 		"show_password": "Afficher le mot de passe",
 		"sidebar": "Barre latérale",
-		"target": "Cible",
 		"toggle_sidebar": "Basculer la barre latérale",
 		"toggle_theme": "Changer le thème",
-		"toggle_threads": "Basculer la liste des conversations",
-		"view": "Voir"
+		"toggle_threads": "Basculer la liste des conversations"
 	},
 	"auth": {
 		"back_to_home": "Retour à l'accueil",
@@ -403,8 +314,6 @@
 			"description": "Nous vous enverrons un lien de réinitialisation",
 			"title": "Mot de passe oublié"
 		},
-		"login": "Connexion",
-		"logout": "Déconnexion",
 		"messages": {
 			"auth_cancelled": "L'authentification a été annulée",
 			"credential_account_not_found": "Aucun compte avec mot de passe trouvé. Essayez de vous connecter avec votre fournisseur social.",
@@ -448,7 +357,6 @@
 			"description": "Entrez votre nouveau mot de passe",
 			"new_password_label": "Nouveau mot de passe",
 			"sign_in_link": "Se connecter",
-			"success": "Votre mot de passe a été réinitialisé.",
 			"title": "Réinitialiser le mot de passe"
 		},
 		"signin": {
@@ -456,10 +364,8 @@
 			"button_signin_loading": "Connexion en cours...",
 			"button_signup": "S'inscrire",
 			"button_signup_loading": "Création du compte...",
-			"cancel": "Annuler",
 			"description": "Connectez-vous à votre compte ou créez-en un nouveau",
 			"email_label": "E-mail",
-			"email_placeholder": "vous@exemple.fr",
 			"forgot_password": "Mot de passe oublié ?",
 			"link_signup": "S'inscrire",
 			"name_label": "Nom",
@@ -470,19 +376,13 @@
 			"or_continue_with": "Ou continuer avec",
 			"passkey_button": "Se connecter avec Passkey",
 			"password_label": "Mot de passe",
-			"password_placeholder": "••••••••",
 			"tab_signin": "Connexion",
-			"tab_signup": "S'inscrire",
-			"test_secret_button": "Se connecter avec un secret",
-			"test_secret_label": "Test uniquement : Se connecter avec un secret",
-			"test_secret_placeholder": "valeur secrète",
 			"title": "Bon retour"
 		},
 		"signup": {
 			"description": "Entrez vos informations pour commencer",
 			"has_account": "Déjà un compte ?",
 			"link_signin": "Se connecter",
-			"password_hint": "Minimum 10 caractères avec majuscules, minuscules et chiffre",
 			"title": "Créer un compte"
 		},
 		"terms": {
@@ -493,12 +393,7 @@
 		},
 		"verification": {
 			"button_back": "Retour à la connexion",
-			"button_cancel": "Annuler",
-			"button_verify": "Vérifier l'e-mail",
-			"button_verify_loading": "Vérification en cours...",
 			"check_email": "Veuillez vérifier votre e-mail et cliquer sur le lien de vérification pour finaliser votre inscription.",
-			"code_label": "Code de vérification",
-			"code_placeholder": "12345678",
 			"description": "Nous vous avons envoyé un lien de vérification",
 			"sent_to": "Nous avons envoyé un e-mail de vérification à",
 			"title": "Vérification de l'e-mail",
@@ -526,12 +421,6 @@
 			"rate_limit": {
 				"global": "Je suis actuellement très sollicité. Veuillez réessayer d'envoyer votre message dans un instant.",
 				"user": "Trop de messages. Veuillez patienter avant d'en envoyer un autre."
-			},
-			"summary": {
-				"default": "Nouvelle conversation de support"
-			},
-			"title": {
-				"default": "Support Client"
 			}
 		}
 	},
@@ -562,22 +451,16 @@
 			"preview_loading": "Chargement de l'aperçu…",
 			"preview_truncated": "Aperçu tronqué à {size}"
 		},
-		"avatar": {
-			"team_member": "Membre de l'équipe"
-		},
 		"buttons": {
 			"processing": "Traitement...",
 			"upgrade": "Passer à Pro"
 		},
-		"description": "Ouvrez cette application dans plusieurs fenêtres de navigateur pour voir la base de données en temps réel en action",
 		"email": {
 			"placeholder": "Email",
 			"save_failed": "Échec de l'enregistrement de l'email. Veuillez réessayer.",
-			"saved_success": "Email enregistré ! Nous vous notifierons lorsque nous répondrons.",
 			"subscribe_button": "S'abonner",
 			"unsubscribe_failed": "Échec du désabonnement. Veuillez réessayer.",
-			"unsubscribe_tooltip": "Se désabonner",
-			"unsubscribed": "Désabonné des notifications par email."
+			"unsubscribe_tooltip": "Se désabonner"
 		},
 		"error": {
 			"file_max_size": "Taille maximale : {maxSize}",
@@ -589,25 +472,14 @@
 			"upload_failed": "Échec du téléversement de « {filename} »",
 			"upload_failed_description": "Échec du téléversement"
 		},
-		"greeting": "Comment pouvons-nous vous aider ?",
-		"greeting_hi": "Bonjour",
-		"header": {
-			"messages_left": "({remaining}/{total} message restant)",
-			"messages_left_plural": "({remaining}/{total} messages restants)",
-			"pro_unlimited": "(Pro - Illimité)",
-			"subtitle": "Chat en temps réel",
-			"title": "Chat"
-		},
 		"input": {
 			"placeholder": "Tapez un message...",
 			"placeholder_disabled": "Limite de messages atteinte",
-			"send_tooltip": "Envoyer le message",
-			"upgrade_tooltip": "Passez à Pro pour des messages illimités"
+			"send_tooltip": "Envoyer le message"
 		},
 		"messages": {
 			"rate_limited": "Vous envoyez des messages trop vite. Réessayez dans {seconds}s.",
-			"send_failed": "Échec de l'envoi du message",
-			"sent_success": "Message envoyé !"
+			"send_failed": "Échec de l'envoi du message"
 		},
 		"reasoning": {
 			"connecting": "Connexion...",
@@ -616,15 +488,6 @@
 			"thought_for_seconds": "A réfléchi pendant {duration} seconde",
 			"thought_for_seconds_plural": "A réfléchi pendant {duration} secondes"
 		},
-		"suggestion": {
-			"help_label": "Obtenir de l'aide",
-			"help_text": "Pouvez-vous m'aider avec...",
-			"issue_label": "Signaler un problème",
-			"issue_text": "J'ai trouvé un problème avec...",
-			"question_label": "Poser une question",
-			"question_text": "J'ai une question sur..."
-		},
-		"title": "Chat Communautaire",
 		"tooltip": {
 			"attach_files": "Joindre des fichiers",
 			"mark_bug": "Marquer le bug"
@@ -638,7 +501,6 @@
 		"delete": "Supprimer",
 		"error": "Une erreur est survenue. Veuillez réessayer.",
 		"load_error": "Échec du chargement des données. Veuillez réessayer plus tard.",
-		"save": "Enregistrer",
 		"you": "Vous"
 	},
 	"email": {
@@ -730,9 +592,7 @@
 		"cta": "Commencer maintenant",
 		"cta_demo": "Demander une démo",
 		"description": "Donne vie à ton SaaS en quelques minutes, pas en mois. Template open-source bourré de tech qui te fait shipper direct.",
-		"section_label": "Accueil",
-		"tagline": "Focus sur ton produit.\nLancement plus rapide.",
-		"title": "Modèle SaaS Starter"
+		"tagline": "Focus sur ton produit.\nLancement plus rapide."
 	},
 	"integrations": {
 		"cards": {
@@ -856,12 +716,6 @@
 				"title": "Inscription"
 			}
 		},
-		"emails": {
-			"preview": {
-				"description": "Prévisualisez les modèles d'e-mails et leur rendu.",
-				"title": "Aperçu des e-mails"
-			}
-		},
 		"home": {
 			"description": "Starter SaaS pour SvelteKit avec auth, paiements, email et analytics.",
 			"title": "Construisez et lancez votre produit plus rapidement"
@@ -890,23 +744,18 @@
 	"nav": {
 		"about": "À propos",
 		"dashboard": "Tableau de bord",
-		"features": "Fonctionnalités",
 		"get_started": "Commencer",
 		"home": "Accueil",
 		"login": "Connexion",
 		"pricing": "Tarifs",
-		"signup": "S'inscrire",
-		"solution": "Solution"
+		"signup": "S'inscrire"
 	},
 	"pricing": {
 		"buttons": {
-			"loading": "Chargement...",
-			"manage_subscription": "Gérer l'Abonnement"
+			"loading": "Chargement..."
 		},
-		"current_plan": "Plan Actuel",
 		"current_plan_badge": "(Plan Actuel)",
 		"description": "Ce modèle SaaS starter est complètement gratuit et open source. Testez le flux de paiement en utilisant le numéro de carte de test 4242 4242 4242 4242 avec n'importe quelle date d'expiration future.",
-		"description_autumn": "Testez le système de paiement intégré powered by Autumn - une plateforme de facturation open source qui gère automatiquement les abonnements, les limites d'utilisation et les webhooks Stripe.",
 		"features": {
 			"enterprise": {
 				"0": "Limites de messages personnalisées",
@@ -928,7 +777,6 @@
 			}
 		},
 		"popular_badge": "Populaire",
-		"section_label": "Tarifs",
 		"tiers": {
 			"enterprise": {
 				"button": "Contacter les Ventes",
@@ -938,7 +786,6 @@
 			},
 			"free": {
 				"button": "Gratuit à vie",
-				"button_manage": "Gérer l'Abonnement",
 				"description": "Parfait pour commencer",
 				"name": "Gratuit",
 				"price": "0€ / mois"
@@ -959,8 +806,7 @@
 			"dialog_description": "Recherchez une page vers laquelle naviguer.",
 			"dialog_title": "Rechercher des pages",
 			"footer": {
-				"go_to_page": "Aller à la page",
-				"open_new_tab": "Cliquer pour ouvrir dans un nouvel onglet"
+				"go_to_page": "Aller à la page"
 			},
 			"groups": {
 				"admin": "Admin",
@@ -1031,7 +877,6 @@
 			"description": "Mettez à jour votre mot de passe pour sécuriser votre compte.",
 			"error_title": "Erreur",
 			"new_password_label": "Nouveau mot de passe",
-			"password_helper": "Doit contenir au moins 8 caractères.",
 			"placeholder": {
 				"confirm": "Confirmez le nouveau mot de passe",
 				"current": "Entrez le mot de passe actuel",
@@ -1059,8 +904,6 @@
 				"placeholder": "Nom du passkey",
 				"unnamed": "Passkey sans nom"
 			},
-			"passkey_delete_failed": "Impossible de supprimer la passkey",
-			"passkey_deleted": "Passkey supprimée",
 			"passkey_info_description": "Les passkeys sont un moyen sécurisé de se connecter sans mot de passe. Ils utilisent la biométrie ou le code PIN de l'appareil et sont stockés en toute sécurité sur vos appareils.",
 			"passkey_info_title": "Que sont les Passkeys ?",
 			"passkey_name_label": "Nom du passkey",
@@ -1197,7 +1040,6 @@
 			"ux_engineer": "Ingénieur UX",
 			"visual_designer": "Designer Visuel"
 		},
-		"section_label": "Équipe",
 		"title": "Notre équipe de rêve"
 	},
 	"validation": {


### PR DESCRIPTION
en.json carried 138 leaf keys (16% of 869) that no code references. The existing `scripts/i18n-used-keys.test.ts` only checks the forward direction, that every referenced key exists, so dead keys accumulated silently and every locale file had to keep mirroring them under locale parity.

This adds `scripts/i18n-orphan-keys.test.ts`, the reverse guard: every leaf key in en.json must be reachable from code. The hard part is that keys are referenced dynamically as well as literally, so a naive detector would flag live keys as dead. It resolves the dynamic forms the codebase actually uses: dotted string literals (which covers the `translationKey`/`roleKey`/`titleKey` config-property conventions, ternary branches, and lookup maps), `keyName="prefix.{x}"` interpolation and template-literal prefixes, and member-access chains like `translations.error_page.<leaf>`. Five Better Auth runtime error keys surfaced only through `getAuthErrorKey()`/`formError` are covered by a small documented allowlist. A literal-count floor makes the scan fail loudly if it breaks rather than passing vacuously by flagging everything.

With the guard in place, the 138 keys it surfaced are pruned across all four locales. They are mostly superseded namespaces (`aria.pagination_*` replaced by `table.pagination.*`, `aria.select_*` by `admin.users.select_*`) and residue from removed UI (generic `admin.settings.save/saved/saving`, dead `founder_welcome` variants, `nav.features`/`nav.solution`). Each removed key was independently confirmed to have no literal, config-value, or interpolation reference anywhere in the tree.

Regression guard: added (`scripts/i18n-orphan-keys.test.ts`), verified to go red against an injected fake orphan and to fail loudly if the scan breaks.

Verification: `bun run test:unit` (580 tests) and the three i18n guards (orphan, used-keys, parity) pass. Tolgee `i18n:cleanup` should run after merge to deprecate the removed keys in the cloud.