### PR TITLE
chore(audit): consistency, docs, and svelte best-practice fixes

### DIFF
--- a/.env.convex.example
+++ b/.env.convex.example
@@ -95,6 +95,16 @@ AUTH_GITHUB_SECRET=
 AUTH_E2E_TEST_SECRET=your-secure-random-test-secret
 
 # ====================================
+# Preview Dev (auto-seeded on preview deployments)
+# ====================================
+
+# Preview Admin Password (OPTIONAL)
+# Password for the auto-seeded preview admin (admin@preview.dev)
+# Inherited by preview deployments from the Convex project preview default
+# Command: bunx convex env default set --type preview PREVIEW_ADMIN_PASSWORD your-secure-password-here
+PREVIEW_ADMIN_PASSWORD=your-secure-password-here
+
+# ====================================
 # Autumn Billing System (REQUIRED for billing features)
 # ====================================
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,7 +369,7 @@ Derived: let doubled = $derived(count \* 2);
 Props: <script lang="ts">let { name = 'World' } = $props(); </script> `<p>Hello, {name}!</p>`
 Binding: `<script lang="ts">let { value = $bindable() } = $props(); </script> <input bind:value={value} />`
 Snippets: `<div>{@render header()}</div> with <Child>{#snippet header()}<h1>Header</h1>{/snippet}</Child>`
-Class Store: class Counter { count = $state(0); increment() { this.count += 1; } } export const counter = new Counter();
+Class Store: class Counter { count = $state(0); increment() { this.count += 1; } } export const counter = new Counter(); but this module-singleton pattern is banned in `.svelte.ts` rune modules (`local/no-module-state-singleton`, SSR cross-request leak #500); share per-request state via a runed `Context` instead.
 Notes:
 Type $derived explicitly (e.g., let items: Item[] = $derived(...)) for arrays in TypeScript.
 Default to new syntax for Svelte 5 benefits.
@@ -627,7 +627,7 @@ Examples: URL parsing, stream processing, optimistic updates.
 
 #### "This security header / policy must be present"
 
-Examples: CSP, HSTS, X-Frame-Options on all responses including static assets.
+Examples: HSTS, X-Frame-Options on all responses including static assets (no CSP is currently set).
 
 → **`_headers` file** (project root) for static assets + **server hook** for SSR responses.
 Both are needed — static assets bypass hooks.

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Set `PREVIEW_ADMIN_PASSWORD` once as a preview default (`bunx convex env default
 | `TOLGEE_API_KEY`            | Tolgee CLI key for deploy-time sync (optional, skips when unset)                                                                         |    ○    |  ○   |
 | `PUBLIC_POSTHOG_API_KEY`    | PostHog analytics API key                                                                                                                |         |  ○   |
 | `PUBLIC_POSTHOG_HOST`       | PostHog analytics host                                                                                                                   |         |  ○   |
+| `PUBLIC_POSTHOG_PROXY_HOST` | CF Worker proxy host for ad-blocker bypass (falls back to `PUBLIC_POSTHOG_HOST` when unset)                                              |         |  ○   |
 | `PRODUCTION_BRANCH`         | Cloudflare only: production branch name (default: `main`)                                                                                |    ○    |  ○   |
 
 `PUBLIC_CONVEX_URL` and `PUBLIC_CONVEX_SITE_URL` are intentionally not in this table. The build (`scripts/deploy.ts`) derives both from `CONVEX_DEPLOY_KEY` and overwrites any value you set on the hosting platform, so setting them there has no effect. To point production at a different Convex deployment, change the deploy key, not the URL.
@@ -365,7 +366,7 @@ An AI agent built on [Convex Agent](https://www.convex.dev/components/agent) and
 
 ### Email System
 
-Transactional email delivered through [Resend](https://www.convex.dev/components/resend) with automatic retries, idempotency, and delivery tracking. Templates are written as Svelte components using a shadcn-style email component library (same `tv()` variants, same design tokens) and compiled to inline HTML at build time. Your logo is converted to an email-safe PNG automatically. During development, preview every template in the browser at `/emails` and optionally send a real test email when a Resend key is configured.
+Transactional email delivered through [Resend](https://www.convex.dev/components/resend) with automatic retries, idempotency, and delivery tracking. Templates are written as Svelte components using a shadcn-style email component library (same `tv()` variants, same design tokens) and compiled to inline HTML at build time. Your logo is converted to an email-safe PNG automatically. `bun run build:emails` renders every template into `src/lib/convex/emails/_generated/`, and a snapshot test (`src/lib/emails/__tests__/email-snapshots.test.ts`) flags any unintended markup change.
 
 ### Internationalization
 
@@ -379,7 +380,7 @@ Transactional email delivered through [Resend](https://www.convex.dev/components
 
 ### AI Readiness
 
-Marketing pages return structured markdown when an AI agent sends `Accept: text/markdown`, complete with YAML frontmatter and `Vary: Accept` headers for correct CDN caching. A `/llms.txt` endpoint lists available pages and explains how to request them. Sitemap and robots.txt are generated dynamically across all 4 languages.
+Marketing pages return structured markdown when an AI agent sends `Accept: text/markdown`, complete with YAML frontmatter. The markdown variant still sets `Vary: Accept`, but since CF Edge and most shared caches ignore `Vary`, it is served `Cache-Control: private` so a shared cache cannot key one variant under the URL and poison the HTML response with markdown (or vice versa). A `/llms.txt` endpoint lists available pages and explains how to request them. Sitemap and robots.txt are generated dynamically across all 4 languages.
 
 ### SEO
 
@@ -436,7 +437,7 @@ Renovate groups non-major updates into a single PR and creates separate PRs for 
 
 ### Email Development
 
-Email templates are Svelte components compiled to inline HTML on `postinstall` and during builds. Preview every template in the browser at `/emails` with mock data, and optionally send a real test email when a Resend key is configured.
+Email templates are Svelte components compiled to inline HTML on `postinstall` and during builds. `bun run build:emails` renders each template with mock data into `src/lib/convex/emails/_generated/`, and the snapshot test `src/lib/emails/__tests__/email-snapshots.test.ts` catches any unexpected markup change.
 
 </details>
 

--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -435,6 +435,42 @@
 			"url": "https://github.com/jamsinclair/jSquash",
 			"branch": "main",
 			"specialNotes": "WASM image codecs (WebP/AVIF/JPEG/PNG/JXL/OXIPNG/QOI). Used for client-side encode in workers. Each codec is a separate package under packages/ — @jsquash/webp at packages/webp."
+		},
+		{
+			"type": "git",
+			"name": "svelteStreamdown",
+			"url": "https://github.com/beynar/svelte-streamdown",
+			"branch": "master",
+			"specialNotes": "svelte-streamdown package. Streaming-aware Markdown renderer for Svelte. Used for chat attachment text previews and legal markdown."
+		},
+		{
+			"type": "git",
+			"name": "openrouterAiSdkProvider",
+			"url": "https://github.com/OpenRouterTeam/ai-sdk-provider",
+			"branch": "main",
+			"specialNotes": "@openrouter/ai-sdk-provider package. OpenRouter provider for the Vercel AI SDK. Model ids, provider options, reasoning/tool support. Used by the Convex AI chat agent."
+		},
+		{
+			"type": "git",
+			"name": "zxcvbnTs",
+			"url": "https://github.com/zxcvbn-ts/zxcvbn",
+			"branch": "master",
+			"searchPath": "packages/core",
+			"specialNotes": "@zxcvbn-ts/core package (monorepo). Password strength estimation. Powers the password meter. Core scoring lives in packages/core."
+		},
+		{
+			"type": "git",
+			"name": "riveWasm",
+			"url": "https://github.com/rive-app/rive-wasm",
+			"branch": "master",
+			"specialNotes": "@rive-app/canvas package (monorepo). Rive runtime for canvas. Used by RiveBackground.svelte for animated backgrounds."
+		},
+		{
+			"type": "git",
+			"name": "posthogJs",
+			"url": "https://github.com/PostHog/posthog-js",
+			"branch": "main",
+			"specialNotes": "posthog-js package. PostHog browser SDK. init options, person_profiles, proxy/api_host config. Used by the lazy analytics bootstrap."
 		}
 	]
 }

--- a/docs/setup/customer-support/screenshot-proxy-setup.md
+++ b/docs/setup/customer-support/screenshot-proxy-setup.md
@@ -109,7 +109,7 @@ This guide walks you through setting up a Cloudflare Worker to proxy external im
 
 **5-Minute Setup:**
 
-1. Copy worker code from `docs/screenshot-proxy-worker.js`
+1. Copy worker code from `./screenshot-proxy-worker.js`
 2. Create Cloudflare Worker at https://workers.cloudflare.com
 3. Update `ALLOWED_DOMAINS` and `ALLOWED_ORIGINS` in worker code
 4. Deploy worker
@@ -133,7 +133,7 @@ This guide walks you through setting up a Cloudflare Worker to proxy external im
 
 ### 3. Configure Worker Code
 
-1. Open `docs/screenshot-proxy-worker.js` in your project
+1. Open `./screenshot-proxy-worker.js` in your project
 2. Update the configuration section:
 
 ```javascript
@@ -485,7 +485,7 @@ Before deploying to production:
 - **Cloudflare Workers Docs:** https://developers.cloudflare.com/workers/
 - **SnapDOM Documentation:** https://github.com/zumerlab/snapdom
 - **CORS Explained:** https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
-- **Project PostHog Proxy:** `docs/analytics/posthog-proxy-setup.md` (similar pattern)
+- **Project PostHog Proxy:** `docs/setup/analytics/posthog-proxy-setup.md` (similar pattern)
 
 ## Support
 

--- a/docs/setup/i18n/i18n-setup.md
+++ b/docs/setup/i18n/i18n-setup.md
@@ -307,12 +307,37 @@ import ja from '../i18n/ja.json';
 const translations: TolgeeStaticData = { en, de, es, fr, ja };
 ```
 
-4. Add translations for the new language (in Tolgee Cloud, or by editing `src/i18n/ja.json` directly)
+4. Add the code to the `LANGUAGES` array in `svelte.config.js` (drives prerendering of `[[lang]]` routes):
+
+```javascript
+const LANGUAGES = ['en', 'de', 'es', 'fr', 'ja'];
+```
+
+5. Add the code to `SUPPORTED_LOCALES` in `src/lib/convex/i18n/translations.ts`:
+
+```typescript
+export const SUPPORTED_LOCALES = ['en', 'de', 'es', 'fr', 'ja'] as const;
+```
+
+6. Add both the bare prefix and the wildcard to `run_worker_first` in `wrangler.toml` (so markdown content negotiation covers `/ja` and every page under it):
+
+```toml
+run_worker_first = ["/en", "/en/*", "/de", "/de/*", "/es", "/es/*", "/fr", "/fr/*", "/ja", "/ja/*"]
+```
+
+7. Add translations for the new language (in Tolgee Cloud, or by editing `src/i18n/ja.json` directly)
+
+`scripts/prerender-sync.test.ts` checks `svelte.config.js`, `SUPPORTED_LOCALES`, the `+layout.svelte` `translations` map, and `wrangler.toml` against `SUPPORTED_LANGUAGES`, so `bun run test:unit` fails if any one is missing the code.
 
 ### To Remove a Language
 
 1. Remove from `SUPPORTED_LANGUAGES` in `src/lib/i18n/languages.ts`
 2. Remove from `availableLanguages` and the `translations` map in the root `src/routes/+layout.svelte`
+3. Remove from the `LANGUAGES` array in `svelte.config.js`
+4. Remove from `SUPPORTED_LOCALES` in `src/lib/convex/i18n/translations.ts`
+5. Remove both the bare prefix and the wildcard (`/<code>` and `/<code>/*`) from `run_worker_first` in `wrangler.toml`
+
+Keep all five sources in sync, otherwise `scripts/prerender-sync.test.ts` fails `bun run test:unit`.
 
 ## SEO Features
 

--- a/src/blocks/hero/hero-five.svelte
+++ b/src/blocks/hero/hero-five.svelte
@@ -1,6 +1,9 @@
 <script>
-	import { T } from '@tolgee/svelte';
+	import { T, getTranslate } from '@tolgee/svelte';
 	import { localizedHref } from '$lib/utils/i18n';
+
+	const { t } = getTranslate();
+
 	import { Marquee } from '$lib/components/spell/marquee';
 	import ProgressiveBlur from '../magic/ProgressiveBlur.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
@@ -83,50 +86,56 @@
 							<img
 								class="h-5 dark:invert"
 								src={nvidiaLogo}
-								alt="Nvidia Logo"
+								alt={$t('hero.logo_alt', { name: 'Nvidia' })}
 								width="106"
 								height="20"
 							/>
 							<img
 								class="h-4 dark:invert"
 								src={columnLogo}
-								alt="Column Logo"
+								alt={$t('hero.logo_alt', { name: 'Column' })}
 								width="73"
 								height="16"
 							/>
 							<img
 								class="h-4 dark:invert"
 								src={githubLogo}
-								alt="GitHub Logo"
+								alt={$t('hero.logo_alt', { name: 'GitHub' })}
 								width="60"
 								height="16"
 							/>
-							<img class="h-5 dark:invert" src={nikeLogo} alt="Nike Logo" width="56" height="20" />
+							<img
+								class="h-5 dark:invert"
+								src={nikeLogo}
+								alt={$t('hero.logo_alt', { name: 'Nike' })}
+								width="56"
+								height="20"
+							/>
 							<img
 								class="h-5 dark:invert"
 								src={lemonsqueezyLogo}
-								alt="Lemon Squeezy Logo"
+								alt={$t('hero.logo_alt', { name: 'Lemon Squeezy' })}
 								width="153"
 								height="20"
 							/>
 							<img
 								class="h-4 dark:invert"
 								src={laravelLogo}
-								alt="Laravel Logo"
+								alt={$t('hero.logo_alt', { name: 'Laravel' })}
 								width="65"
 								height="16"
 							/>
 							<img
 								class="h-7 dark:invert"
 								src={lillyLogo}
-								alt="Lilly Logo"
+								alt={$t('hero.logo_alt', { name: 'Lilly' })}
 								width="53"
 								height="28"
 							/>
 							<img
 								class="h-6 dark:invert"
 								src={openaiLogo}
-								alt="OpenAI Logo"
+								alt={$t('hero.logo_alt', { name: 'OpenAI' })}
 								width="84"
 								height="24"
 							/>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -18,6 +18,7 @@
 		},
 		"dialog": {
 			"ban_description": "Möchten Sie {email} wirklich sperren? Der Zugriff auf die App wird blockiert.",
+			"ban_reason_label": "Sperrgrund",
 			"ban_reason_placeholder": "Sperrgrund (optional)",
 			"ban_title": "Benutzer sperren",
 			"impersonation_active_description": "Bitte laden Sie die Seite neu, um als der andere Benutzer angemeldet zu werden.",
@@ -488,6 +489,13 @@
 			"thought_for_seconds": "Nachgedacht für {duration} Sekunde",
 			"thought_for_seconds_plural": "Nachgedacht für {duration} Sekunden"
 		},
+		"tool": {
+			"call_id": "Aufruf-ID: {toolCallId}",
+			"error": "Fehler",
+			"input": "Eingabe",
+			"output": "Ausgabe",
+			"processing": "Tool-Aufruf wird verarbeitet..."
+		},
 		"tooltip": {
 			"attach_files": "Dateien anhängen",
 			"mark_bug": "Fehler markieren"
@@ -592,6 +600,7 @@
 		"cta": "Jetzt starten",
 		"cta_demo": "Demo anfordern",
 		"description": "Erwecke dein SaaS zum Leben in Minuten, nicht in Monaten. Open-Source Template mit einem Tech-Stack, der dich schnell shippen lässt.",
+		"logo_alt": "{name}-Logo",
 		"tagline": "Mit Produktfokus\nschneller zum Ziel"
 	},
 	"integrations": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -18,6 +18,7 @@
 		},
 		"dialog": {
 			"ban_description": "Are you sure you want to ban {email}? They will be unable to access the app.",
+			"ban_reason_label": "Ban reason",
 			"ban_reason_placeholder": "Ban reason (optional)",
 			"ban_title": "Ban User",
 			"impersonation_active_description": "Please reload the page to be logged in as the impersonated user.",
@@ -488,6 +489,13 @@
 			"thought_for_seconds": "Thought for {duration} second",
 			"thought_for_seconds_plural": "Thought for {duration} seconds"
 		},
+		"tool": {
+			"call_id": "Call ID: {toolCallId}",
+			"error": "Error",
+			"input": "Input",
+			"output": "Output",
+			"processing": "Processing tool call..."
+		},
 		"tooltip": {
 			"attach_files": "Attach files",
 			"mark_bug": "Mark the bug"
@@ -592,6 +600,7 @@
 		"cta": "Start Building",
 		"cta_demo": "Request a demo",
 		"description": "SaaS starter with SvelteKit, auth, billing, and analytics.",
+		"logo_alt": "{name} Logo",
 		"tagline": "Focus on your product.\nShip faster."
 	},
 	"integrations": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -18,6 +18,7 @@
 		},
 		"dialog": {
 			"ban_description": "¿Estás seguro de que quieres bloquear a {email}? No podrá acceder a la app.",
+			"ban_reason_label": "Motivo del bloqueo",
 			"ban_reason_placeholder": "Motivo del bloqueo (opcional)",
 			"ban_title": "Bloquear Usuario",
 			"impersonation_active_description": "Por favor, recarga la página para iniciar sesión como el usuario suplantado.",
@@ -488,6 +489,13 @@
 			"thought_for_seconds": "Pensó durante {duration} segundo",
 			"thought_for_seconds_plural": "Pensó durante {duration} segundos"
 		},
+		"tool": {
+			"call_id": "ID de llamada: {toolCallId}",
+			"error": "Error",
+			"input": "Entrada",
+			"output": "Salida",
+			"processing": "Procesando llamada a la herramienta..."
+		},
 		"tooltip": {
 			"attach_files": "Adjuntar archivos",
 			"mark_bug": "Marcar el error"
@@ -592,6 +600,7 @@
 		"cta": "Comenzar ahora",
 		"cta_demo": "Solicitar una demo",
 		"description": "Dale vida a tu SaaS en minutos, no en meses. Plantilla open-source cargada con la tecnología que te hace lanzar rápido.",
+		"logo_alt": "Logo de {name}",
 		"tagline": "Foco en tu producto.\nLanzamiento más rápido."
 	},
 	"integrations": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -18,6 +18,7 @@
 		},
 		"dialog": {
 			"ban_description": "Êtes-vous sûr de vouloir bannir {email} ? L'accès à l'app sera bloqué.",
+			"ban_reason_label": "Motif du bannissement",
 			"ban_reason_placeholder": "Motif du bannissement (optionnel)",
 			"ban_title": "Bannir l'Utilisateur",
 			"impersonation_active_description": "Veuillez recharger la page pour vous connecter en tant qu'utilisateur usurpé.",
@@ -488,6 +489,13 @@
 			"thought_for_seconds": "A réfléchi pendant {duration} seconde",
 			"thought_for_seconds_plural": "A réfléchi pendant {duration} secondes"
 		},
+		"tool": {
+			"call_id": "ID d'appel : {toolCallId}",
+			"error": "Erreur",
+			"input": "Entrée",
+			"output": "Sortie",
+			"processing": "Traitement de l'appel d'outil..."
+		},
 		"tooltip": {
 			"attach_files": "Joindre des fichiers",
 			"mark_bug": "Marquer le bug"
@@ -592,6 +600,7 @@
 		"cta": "Commencer maintenant",
 		"cta_demo": "Demander une démo",
 		"description": "Donne vie à ton SaaS en quelques minutes, pas en mois. Template open-source bourré de tech qui te fait shipper direct.",
+		"logo_alt": "Logo {name}",
 		"tagline": "Focus sur ton produit.\nLancement plus rapide."
 	},
 	"integrations": {

--- a/src/lib/chat/examples/SimpleChat.svelte
+++ b/src/lib/chat/examples/SimpleChat.svelte
@@ -34,6 +34,7 @@
 		greeting?: string;
 	} = $props();
 
+	// Intentionally English-only: this is a copy-and-customize example, not shipped UI.
 	const suggestions = [
 		{ text: 'I have a question about...', label: 'Ask a question' },
 		{ text: 'I found an issue with...', label: 'Report an issue' },

--- a/src/lib/chat/ui/AttachmentTextPreview.svelte
+++ b/src/lib/chat/ui/AttachmentTextPreview.svelte
@@ -105,7 +105,11 @@
 {:else if status === 'error'}
 	{#if url}
 		<!-- Fall back to the raw browser view when text could not be loaded. -->
-		<iframe src={url} title={filename ?? ''} class="h-[70vh] w-full rounded-md"></iframe>
+		<iframe
+			src={url}
+			title={filename ?? $t('chat.attachment.file_fallback')}
+			class="h-[70vh] w-full rounded-md"
+		></iframe>
 	{:else}
 		<div
 			class="flex h-[70vh] w-full items-center justify-center text-sm text-muted-foreground"

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -53,7 +53,7 @@
 	});
 
 	// Derive agent name from context with fallback
-	let agentName = $derived(threadContext.currentAgentName || 'Kai');
+	const agentName = $derived(threadContext.currentAgentName || 'Kai');
 
 	// Derive chat panel open state
 	const isChatOpen = $derived(threadContext.currentView !== 'overview');

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -18,6 +18,7 @@
 	import { motion } from 'motion-sv';
 	import { SvelteSet } from 'svelte/reactivity';
 	import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';
+	import { page } from '$app/state';
 
 	const { t } = getTranslate();
 
@@ -192,6 +193,10 @@
 
 	/**
 	 * Format a timestamp as relative time (e.g., "a few seconds ago", "3 minutes ago")
+	 *
+	 * The customer-facing widget intentionally uses bespoke Tolgee phrasing for
+	 * relative time, distinct from the admin path (thread-list/thread-details),
+	 * which renders date-fns formatDistanceToNow. Keep this hand-rolled wording.
 	 */
 	function formatRelativeTime(timestamp?: number): string {
 		if (!timestamp) return '';
@@ -212,7 +217,7 @@
 		if (days === 1) return $t('support.time.yesterday');
 		if (days < 7) return $t('support.time.days_ago', { days });
 
-		return new Date(timestamp).toLocaleDateString();
+		return new Date(timestamp).toLocaleDateString(page.data.lang ?? 'en');
 	}
 </script>
 

--- a/src/lib/components/prompt-kit/tool/ToolDetails.svelte
+++ b/src/lib/components/prompt-kit/tool/ToolDetails.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import { getTranslate } from '@tolgee/svelte';
 	import type { ToolPart } from './types.js';
 	import type { HTMLAttributes } from 'svelte/elements';
+
+	const { t } = getTranslate();
 
 	let {
 		toolPart,
@@ -28,7 +31,7 @@
 <div class={cn('space-y-3 bg-background p-3', className)} {...restProps}>
 	{#if input && Object.keys(input).length > 0}
 		<div>
-			<h4 class="mb-2 text-sm font-medium text-muted-foreground">Input</h4>
+			<h4 class="mb-2 text-sm font-medium text-muted-foreground">{$t('chat.tool.input')}</h4>
 			<div class="rounded border bg-background p-2 font-mono text-sm">
 				{#each Object.entries(input) as [key, value] (key)}
 					<div class="mb-1">
@@ -42,7 +45,7 @@
 
 	{#if output}
 		<div>
-			<h4 class="mb-2 text-sm font-medium text-muted-foreground">Output</h4>
+			<h4 class="mb-2 text-sm font-medium text-muted-foreground">{$t('chat.tool.output')}</h4>
 			<div class="max-h-60 overflow-auto rounded border bg-background p-2 font-mono text-sm">
 				<pre class="whitespace-pre-wrap">{formatValue(output)}</pre>
 			</div>
@@ -51,7 +54,7 @@
 
 	{#if state === 'output-error' && errorText}
 		<div>
-			<h4 class="mb-2 text-sm font-medium text-destructive">Error</h4>
+			<h4 class="mb-2 text-sm font-medium text-destructive">{$t('chat.tool.error')}</h4>
 			<div class="rounded border border-destructive/20 bg-destructive/10 p-2 text-sm">
 				{errorText}
 			</div>
@@ -59,12 +62,12 @@
 	{/if}
 
 	{#if state === 'input-streaming'}
-		<div class="text-sm text-muted-foreground">Processing tool call...</div>
+		<div class="text-sm text-muted-foreground">{$t('chat.tool.processing')}</div>
 	{/if}
 
 	{#if toolCallId}
 		<div class="border-t pt-2 text-xs text-muted-foreground">
-			<span class="font-mono">Call ID: {toolCallId}</span>
+			<span class="font-mono">{$t('chat.tool.call_id', { toolCallId })}</span>
 		</div>
 	{/if}
 </div>

--- a/src/lib/convex/admin/queries.ts
+++ b/src/lib/convex/admin/queries.ts
@@ -572,13 +572,12 @@ export const getDashboardMetrics = adminQuery({
 		const counters = await getCounters(ctx);
 
 		// Time-windowed metrics — bounded by recency, so full-scan is acceptable
-		const sessions = await fetchAllSessions(ctx);
+		const [sessions, users] = await Promise.all([fetchAllSessions(ctx), fetchAllUsers(ctx)]);
 		const now = Date.now();
 		const oneDayAgo = now - 24 * 60 * 60 * 1000;
 		const activeIn24h = sessions.filter((s) => s.updatedAt && s.updatedAt > oneDayAgo);
 		const uniqueActiveUsers = new Set(activeIn24h.map((s) => s.userId));
 
-		const users = await fetchAllUsers(ctx);
 		const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000;
 		const recentSignups = users.filter((u) => u.createdAt && u.createdAt > sevenDaysAgo).length;
 

--- a/src/lib/convex/files/metadata.ts
+++ b/src/lib/convex/files/metadata.ts
@@ -22,16 +22,18 @@ export async function getFileMetadataByUrls(
 ): Promise<Record<string, { width?: number; height?: number }>> {
 	const results: Record<string, { width?: number; height?: number }> = {};
 
-	for (const url of urls) {
-		const meta = await ctx.db
-			.query('fileMetadata')
-			.withIndex('by_url', (q) => q.eq('url', url))
-			.first();
+	await Promise.all(
+		urls.map(async (url) => {
+			const meta = await ctx.db
+				.query('fileMetadata')
+				.withIndex('by_url', (q) => q.eq('url', url))
+				.first();
 
-		if (meta && (meta.width || meta.height)) {
-			results[url] = { width: meta.width, height: meta.height };
-		}
-	}
+			if (meta && (meta.width || meta.height)) {
+				results[url] = { width: meta.width, height: meta.height };
+			}
+		})
+	);
 
 	return results;
 }

--- a/src/lib/convex/support/threads.ts
+++ b/src/lib/convex/support/threads.ts
@@ -300,19 +300,21 @@ export const listThreads = query({
 		}
 
 		const adminMap = new Map<string, { name?: string; image: string | null }>();
-		for (const adminId of adminIds) {
-			try {
-				const admin = await ctx.runQuery(components.betterAuth.adapter.findOne, {
-					model: 'user',
-					where: [{ field: '_id', operator: 'eq', value: adminId }]
-				});
-				if (admin) {
-					adminMap.set(adminId, { name: admin.name, image: admin.image ?? null });
+		await Promise.all(
+			[...adminIds].map(async (adminId) => {
+				try {
+					const admin = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+						model: 'user',
+						where: [{ field: '_id', operator: 'eq', value: adminId }]
+					});
+					if (admin) {
+						adminMap.set(adminId, { name: admin.name, image: admin.image ?? null });
+					}
+				} catch (error) {
+					console.log(`[listThreads] Failed to fetch admin ${adminId}:`, error);
 				}
-			} catch (error) {
-				console.log(`[listThreads] Failed to fetch admin ${adminId}:`, error);
-			}
-		}
+			})
+		);
 
 		// For each thread, get the last message and combine with support data
 		const threadsWithLastMessage = await Promise.all(

--- a/src/lib/schemas/auth.ts
+++ b/src/lib/schemas/auth.ts
@@ -8,9 +8,5 @@ export const redirectParamsSchema = v.object({
 	redirectTo: v.optional(v.fallback(v.string(), ''), '')
 });
 
-// Legacy alias — remove once all consumers are migrated
-export const authParamsSchema = redirectParamsSchema;
-
 // Types
 export type RedirectParams = v.InferOutput<typeof redirectParamsSchema>;
-export type AuthParams = RedirectParams;

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -1,6 +1,17 @@
 import { getLanguage } from '$lib/i18n/languages';
 import { page } from '$app/state';
 import { useLanguage as useLanguageContext } from '$lib/i18n/context';
+import { type Locale, de, es, fr } from 'date-fns/locale';
+
+const dateFnsLocaleMap: Record<string, Locale> = { de, es, fr };
+
+/**
+ * Map a UI language code to a date-fns locale.
+ * Returns undefined for 'en' and unknown codes (date-fns defaults to en-US).
+ */
+export function getDateFnsLocale(lang: string): Locale | undefined {
+	return dateFnsLocaleMap[lang] ?? undefined;
+}
 
 /**
  * Get the current language from context

--- a/src/routes/[[lang]]/(auth)/email-verified/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/email-verified/+page.svelte
@@ -2,7 +2,7 @@
 	import SEOHead from '$lib/components/SEOHead.svelte';
 	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 	import { useSearchParams } from 'runed/kit';
-	import { authParamsSchema } from '$lib/schemas/auth.js';
+	import { redirectParamsSchema } from '$lib/schemas/auth.js';
 	import { localizedHref } from '$lib/utils/i18n';
 	import { safeRedirectPath } from '$lib/utils/url';
 	import * as Card from '$lib/components/ui/card/index.js';
@@ -11,7 +11,7 @@
 
 	const auth = useAuth();
 	const { t } = getTranslate();
-	const params = useSearchParams(authParamsSchema, {
+	const params = useSearchParams(redirectParamsSchema, {
 		debounce: 300,
 		pushHistory: false
 	});

--- a/src/routes/[[lang]]/admin/support/thread-details.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-details.svelte
@@ -16,13 +16,12 @@
 	import { T, getTranslate } from '@tolgee/svelte';
 
 	import { formatDistanceToNow } from 'date-fns';
-	import { type Locale, de, es, fr } from 'date-fns/locale';
 	import { page } from '$app/state';
+	import { getDateFnsLocale } from '$lib/utils/i18n';
 
 	const { t } = getTranslate();
 
-	const dateFnsLocaleMap: Record<string, Locale> = { de, es, fr };
-	const dateFnsLocale = $derived(dateFnsLocaleMap[page.data.lang] ?? undefined);
+	const dateFnsLocale = $derived(getDateFnsLocale(page.data.lang));
 
 	let {
 		threadId

--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -10,15 +10,14 @@
 	import ArchiveIcon from '@lucide/svelte/icons/archive';
 	import Loader2Icon from '@lucide/svelte/icons/loader-2';
 	import { formatDistanceToNow } from 'date-fns';
-	import { type Locale, de, es, fr } from 'date-fns/locale';
 	import { watch } from 'runed';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { InfiniteLoader, LoaderState } from 'svelte-infinite';
 	import { page } from '$app/state';
+	import { getDateFnsLocale } from '$lib/utils/i18n';
 
-	const dateFnsLocaleMap: Record<string, Locale> = { de, es, fr };
-	const dateFnsLocale = $derived(dateFnsLocaleMap[page.data.lang] ?? undefined);
+	const dateFnsLocale = $derived(getDateFnsLocale(page.data.lang));
 
 	const { t } = getTranslate();
 

--- a/src/routes/[[lang]]/admin/users/+page.svelte
+++ b/src/routes/[[lang]]/admin/users/+page.svelte
@@ -662,7 +662,11 @@
 					<div class="mt-4">
 						<Field.Group>
 							<Field.Field>
+								<Field.Label class="sr-only" for="admin-users-ban-reason">
+									<T keyName="admin.dialog.ban_reason_label" />
+								</Field.Label>
 								<Input
+									id="admin-users-ban-reason"
 									placeholder={$t('admin.dialog.ban_reason_placeholder')}
 									data-testid="admin-users-ban-reason-input"
 									bind:value={banReason}

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -112,11 +112,11 @@
 		});
 	});
 
-	const suggestions = [
+	const suggestions = $derived([
 		{ text: $t('ai_chat.suggestion.weather'), label: $t('ai_chat.suggestion.weather') },
 		{ text: $t('ai_chat.suggestion.explain'), label: $t('ai_chat.suggestion.explain') },
 		{ text: $t('ai_chat.suggestion.help'), label: $t('ai_chat.suggestion.help') }
-	];
+	]);
 </script>
 
 <div bind:this={chatContainer} class="flex h-full flex-col">

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -89,7 +89,7 @@
 	$effect(() => {
 		if (!wrapperEl) return;
 		void mode.current;
-		requestAnimationFrame(() => {
+		const rafId = requestAnimationFrame(() => {
 			let el: HTMLElement | null = wrapperEl!;
 			while (el) {
 				const bg = getComputedStyle(el).backgroundColor;
@@ -100,6 +100,7 @@
 				el = el.parentElement;
 			}
 		});
+		return () => cancelAnimationFrame(rafId);
 	});
 
 	function isOwnMessage(userId: string): boolean {

--- a/src/routes/[[lang]]/app/settings/account-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/account-settings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import * as v from 'valibot';
 	import { authClient } from '$lib/auth-client.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
@@ -11,8 +12,13 @@
 	import { api } from '$lib/convex/_generated/api.js';
 	import { ConvexError } from 'convex/values';
 	import { PROFILE_IMAGE_MAX_SIZE, PROFILE_IMAGE_MAX_SIZE_LABEL } from '$lib/convex/constants.js';
+	import { translateValidationErrors } from '$lib/utils/validation-i18n.js';
 
 	const { t } = getTranslate();
+
+	const nameSchema = v.object({
+		name: v.pipe(v.string(), v.trim(), v.nonEmpty('validation.name.required'))
+	});
 
 	interface Props {
 		user: {
@@ -31,6 +37,9 @@
 	let image = $derived(user?.image ?? '');
 	let isUploading = $state(false);
 	let isSaving = $state(false);
+
+	// Field errors
+	let errors = $state<Record<string, string[]>>({});
 
 	async function handleFileSelect(e: Event) {
 		const target = e.target as HTMLInputElement;
@@ -107,13 +116,31 @@
 		toast.success($t('settings.account.avatar.removed'));
 	}
 
+	function validate(): boolean {
+		const result = v.safeParse(nameSchema, { name });
+		if (!result.success) {
+			const fieldErrors: Record<string, string[]> = {};
+			for (const issue of result.issues) {
+				const path = (issue.path?.[0]?.key as string) || 'name';
+				// Keep the first issue per field so inline errors stay focused and predictable.
+				if (!fieldErrors[path]) fieldErrors[path] = [issue.message];
+			}
+			errors = fieldErrors;
+			return false;
+		}
+		errors = {};
+		return true;
+	}
+
 	async function handleUpdateProfile(e: Event) {
 		e.preventDefault();
+		if (!validate()) return;
+
 		isSaving = true;
 
 		try {
 			await authClient.updateUser({
-				name,
+				name: name.trim(),
 				image: image || null
 			});
 
@@ -135,7 +162,7 @@
 		<Card.Description><T keyName="settings.account.description" /></Card.Description>
 	</Card.Header>
 	<Card.Content>
-		<form onsubmit={handleUpdateProfile} class="space-y-4">
+		<form onsubmit={handleUpdateProfile} novalidate class="space-y-4">
 			<Field.Group>
 				<Field.Field>
 					<Field.Label for="name"><T keyName="settings.account.name_label" /></Field.Label>
@@ -144,8 +171,8 @@
 						type="text"
 						bind:value={name}
 						placeholder={$t('settings.account.name.placeholder')}
-						required
 					/>
+					<Field.Error errors={translateValidationErrors(errors.name, $t)} />
 					<Field.Description>
 						<T keyName="settings.account.name_helper" />
 					</Field.Description>

--- a/src/routes/[[lang]]/app/settings/email-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/email-settings.svelte
@@ -108,7 +108,7 @@
 		<Card.Description><T keyName="settings.email.description" /></Card.Description>
 	</Card.Header>
 	<Card.Content>
-		<form onsubmit={handleSubmit} class="space-y-4">
+		<form onsubmit={handleSubmit} novalidate class="space-y-4">
 			{#if formError}
 				<Alert.Root variant="destructive">
 					<InfoIcon class="h-4 w-4" />

--- a/src/routes/[[lang]]/app/settings/password-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/password-settings.svelte
@@ -112,7 +112,7 @@
 		<Card.Description><T keyName="settings.password.description" /></Card.Description>
 	</Card.Header>
 	<Card.Content>
-		<form onsubmit={handleSubmit} class="space-y-4">
+		<form onsubmit={handleSubmit} novalidate class="space-y-4">
 			{#if formError}
 				<Alert.Root variant="destructive">
 					<InfoIcon class="h-4 w-4" />

--- a/src/routes/[[lang]]/app/settings/security-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/security-settings.svelte
@@ -9,6 +9,7 @@
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { toast } from 'svelte-sonner';
 	import { T, getTranslate } from '@tolgee/svelte';
+	import { page } from '$app/state';
 	import KeyIcon from '@lucide/svelte/icons/key-round';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
@@ -113,7 +114,7 @@
 	}
 
 	function formatDate(date: Date): string {
-		return new Date(date).toLocaleDateString(undefined, {
+		return new Date(date).toLocaleDateString(page.data.lang ?? 'en', {
 			year: 'numeric',
 			month: 'short',
 			day: 'numeric'


### PR DESCRIPTION
A multi-dimension scan of the codebase surfaced 26 verified findings: documentation that pointed at routes, headers, and setup steps that no longer match the code, plus small consistency gaps in i18n, form validation, locale formatting, and Convex query parallelism. None were correctness or security bugs, but they accumulate as fork confusion and minor UX and accessibility rough edges.

This branch applies all 26 as seven topical commits. The documentation pass corrects the removed /emails preview route, the Vary/CDN caching wording, the CSP example, the stale proxy-worker paths, and the add-a-language steps, and registers the missing env vars and btca resources. The code pass localizes hardcoded labels (AI chat tool panel, marketing logo alt text, the admin ban-reason label) and gives the attachment-preview fallback an accessible name; parallelizes independent Convex reads in the admin dashboard and support threads; shares a single date-fns locale helper; makes the AI chat suggestions re-localize on a language switch and adds the missing effect cleanup; aligns the settings forms with the auth forms (novalidate plus Valibot name validation); and drops the legacy authParamsSchema alias.

Regression guard: not warranted, these are one-off consistency and doc-drift cleanups rather than a recurring bug class, and the existing locale-parity, prerender-sync, and orphan-key tests already guard the i18n surface.

In the branch, bun run check:convex, static-checks across all changed files, bun run test:unit (580 tests), and a full bun run build all pass.
