### PR TITLE
fix(btca): correct zxcvbn-ts core searchPath

### DIFF
--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -455,8 +455,8 @@
 			"name": "zxcvbnTs",
 			"url": "https://github.com/zxcvbn-ts/zxcvbn",
 			"branch": "master",
-			"searchPath": "packages/core",
-			"specialNotes": "@zxcvbn-ts/core package (monorepo). Password strength estimation. Powers the password meter. Core scoring lives in packages/core."
+			"searchPath": "packages/libraries/main",
+			"specialNotes": "@zxcvbn-ts/core package (monorepo). Password strength estimation. Powers the password meter. Core scoring lives in packages/libraries/main; language packs are under packages/languages/*."
 		},
 		{
 			"type": "git",


### PR DESCRIPTION
The btca resource for `@zxcvbn-ts/core` (added in #571) set `searchPath` to `packages/core`, but the zxcvbn-ts monorepo keeps the core library under `packages/libraries/main` (language packs live under `packages/languages/*`). The wrong path scoped btca searches to a directory that does not exist, so any zxcvbn lookup returned nothing.

Point `searchPath` at `packages/libraries/main` and note the language-pack location.

Regression guard: not warranted, one-off config path correction rather than a recurring class, and no test covers btca.config.jsonc resource paths.

Verified the corrected path resolves in the cloned sandbox (`packages/libraries/main/package.json` is `@zxcvbn-ts/core`); pre-commit static-checks pass.
