### PR TITLE
fix(admin): localize users Created column date

### DIFF
--- a/src/routes/[[lang]]/admin/users/+page.svelte
+++ b/src/routes/[[lang]]/admin/users/+page.svelte
@@ -30,12 +30,14 @@
 	import ConvexCursorTableShell from '$lib/components/tables/convex-cursor-table-shell.svelte';
 	import { createConvexCursorTable } from '$lib/tables/convex/create-convex-cursor-table.svelte';
 	import type { CursorListResult } from '$lib/tables/convex/contract';
-	import { columns } from './columns.js';
+	import { createColumns } from './columns.js';
 	import DataTableFilters from './data-table-filters.svelte';
 	import type { ActionEvent } from './data-table-actions.svelte';
 	import { browser } from '$app/environment';
 
-	let { data: _data }: { data: PageData } = $props();
+	let { data }: { data: PageData } = $props();
+
+	const columns = $derived(createColumns(data.lang ?? 'en'));
 
 	const client = useConvexClient();
 
@@ -242,7 +244,9 @@
 		get data() {
 			return usersTable.rows;
 		},
-		columns,
+		get columns() {
+			return columns;
+		},
 		state: {
 			get pagination() {
 				return { pageIndex, pageSize };

--- a/src/routes/[[lang]]/admin/users/columns.ts
+++ b/src/routes/[[lang]]/admin/users/columns.ts
@@ -20,169 +20,171 @@ function getStatusSortValue(user: AdminUserData): number {
 	return 0;
 }
 
-export const columns: Array<ColumnDef<AdminUserData>> = [
-	{
-		id: 'select',
-		size: 40,
-		minSize: 40,
-		maxSize: 40,
-		header: ({ table }) =>
-			renderComponent(DataTableCheckbox, {
-				checked: table.getIsAllPageRowsSelected(),
-				indeterminate: table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
-				onCheckedChange: (value: boolean) => table.toggleAllPageRowsSelected(!!value),
-				'aria-label-key': 'admin.users.select_all'
-			}),
-		cell: ({ row }) =>
-			renderComponent(DataTableCheckbox, {
-				checked: row.getIsSelected(),
-				onCheckedChange: (value: boolean) => row.toggleSelected(!!value),
-				'aria-label-key': 'admin.users.select_row'
-			}),
-		enableSorting: false,
-		enableHiding: false
-	},
-	{
-		accessorKey: 'name',
-		accessorFn: (row) => row.name ?? '',
-		size: 180,
-		minSize: 180,
-		header: ({ column }) =>
-			renderComponent(DataTableColumnHeader, {
-				column,
-				titleKey: 'admin.users.name',
-				testId: 'admin-users-sort-name'
-			}),
-		cell: ({ row }) =>
-			renderComponent(UserAvatar, {
-				name: row.original.name,
-				image: row.original.image
-			})
-	},
-	{
-		accessorKey: 'email',
-		size: 250,
-		minSize: 200,
-		header: ({ column }) =>
-			renderComponent(DataTableColumnHeader, {
-				column,
-				titleKey: 'admin.users.email',
-				testId: 'admin-users-sort-email'
-			}),
-		cell: ({ row }) => {
-			const emailSnippet = createRawSnippet<[{ email: string }]>((getData) => {
-				const { email } = getData();
-				return {
-					render: () => `<div data-testid="admin-users-email-cell">${email}</div>`
-				};
-			});
-			return renderSnippet(emailSnippet, { email: row.original.email });
+export function createColumns(lang: string): Array<ColumnDef<AdminUserData>> {
+	return [
+		{
+			id: 'select',
+			size: 40,
+			minSize: 40,
+			maxSize: 40,
+			header: ({ table }) =>
+				renderComponent(DataTableCheckbox, {
+					checked: table.getIsAllPageRowsSelected(),
+					indeterminate: table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
+					onCheckedChange: (value: boolean) => table.toggleAllPageRowsSelected(!!value),
+					'aria-label-key': 'admin.users.select_all'
+				}),
+			cell: ({ row }) =>
+				renderComponent(DataTableCheckbox, {
+					checked: row.getIsSelected(),
+					onCheckedChange: (value: boolean) => row.toggleSelected(!!value),
+					'aria-label-key': 'admin.users.select_row'
+				}),
+			enableSorting: false,
+			enableHiding: false
 		},
-		filterFn: (row, _columnId, filterValue) => {
-			const email = row.original.email.toLowerCase();
-			const name = (row.original.name ?? '').toLowerCase();
-			const search = (filterValue as string).toLowerCase();
-			return email.includes(search) || name.includes(search);
+		{
+			accessorKey: 'name',
+			accessorFn: (row) => row.name ?? '',
+			size: 180,
+			minSize: 180,
+			header: ({ column }) =>
+				renderComponent(DataTableColumnHeader, {
+					column,
+					titleKey: 'admin.users.name',
+					testId: 'admin-users-sort-name'
+				}),
+			cell: ({ row }) =>
+				renderComponent(UserAvatar, {
+					name: row.original.name,
+					image: row.original.image
+				})
+		},
+		{
+			accessorKey: 'email',
+			size: 250,
+			minSize: 200,
+			header: ({ column }) =>
+				renderComponent(DataTableColumnHeader, {
+					column,
+					titleKey: 'admin.users.email',
+					testId: 'admin-users-sort-email'
+				}),
+			cell: ({ row }) => {
+				const emailSnippet = createRawSnippet<[{ email: string }]>((getData) => {
+					const { email } = getData();
+					return {
+						render: () => `<div data-testid="admin-users-email-cell">${email}</div>`
+					};
+				});
+				return renderSnippet(emailSnippet, { email: row.original.email });
+			},
+			filterFn: (row, _columnId, filterValue) => {
+				const email = row.original.email.toLowerCase();
+				const name = (row.original.name ?? '').toLowerCase();
+				const search = (filterValue as string).toLowerCase();
+				return email.includes(search) || name.includes(search);
+			}
+		},
+		{
+			accessorKey: 'role',
+			size: 80,
+			minSize: 80,
+			header: ({ column }) =>
+				renderComponent(DataTableColumnHeader, {
+					column,
+					titleKey: 'admin.users.role',
+					testId: 'admin-users-sort-role'
+				}),
+			cell: ({ row }) =>
+				renderComponent(RoleBadge, {
+					role: row.original.role,
+					testId: 'admin-users-role-badge'
+				}),
+			filterFn: (row, _columnId, filterValue: string) => {
+				if (!filterValue || filterValue === 'all') return true;
+				return row.original.role === filterValue;
+			},
+			enableSorting: true
+		},
+		{
+			id: 'status',
+			accessorFn: (row) => getStatusSortValue(row),
+			size: 100,
+			minSize: 100,
+			header: ({ column }) =>
+				renderComponent(DataTableColumnHeader, {
+					column,
+					titleKey: 'admin.users.status'
+				}),
+			cell: ({ row }) =>
+				renderComponent(StatusBadge, {
+					banned: row.original.banned,
+					emailVerified: row.original.emailVerified,
+					testId: 'admin-users-status-badge'
+				}),
+			filterFn: (row, _columnId, filterValue: string) => {
+				if (!filterValue || filterValue === 'all') return true;
+				const user = row.original;
+				if (filterValue === 'banned') return user.banned;
+				if (filterValue === 'verified') return !user.banned && user.emailVerified === true;
+				if (filterValue === 'unverified') return !user.banned && !user.emailVerified;
+				return true;
+			},
+			enableSorting: false
+		},
+		{
+			accessorKey: 'providers',
+			accessorFn: (row) => row.providers.join(','),
+			size: 100,
+			minSize: 80,
+			header: ({ column }) =>
+				renderComponent(DataTableColumnHeader, {
+					column,
+					titleKey: 'admin.users.provider',
+					testId: 'admin-users-sort-provider'
+				}),
+			cell: ({ row }) =>
+				renderComponent(ProviderBadge, {
+					providers: row.original.providers,
+					testId: 'admin-users-provider-badge'
+				}),
+			enableSorting: true
+		},
+		{
+			accessorKey: 'createdAt',
+			size: 110,
+			minSize: 110,
+			header: ({ column }) =>
+				renderComponent(DataTableColumnHeader, {
+					column,
+					titleKey: 'admin.users.created',
+					testId: 'admin-users-sort-created'
+				}),
+			cell: ({ row }) => {
+				const dateSnippet = createRawSnippet<[{ createdAt?: number }]>((getData) => {
+					const { createdAt } = getData();
+					const formatted = createdAt ? new Date(createdAt).toLocaleDateString(lang || 'en') : '-';
+					return {
+						render: () => `<div>${formatted}</div>`
+					};
+				});
+				return renderSnippet(dateSnippet, { createdAt: row.original.createdAt });
+			}
+		},
+		{
+			id: 'actions',
+			size: 50,
+			minSize: 50,
+			maxSize: 50,
+			enableHiding: false,
+			enableSorting: false,
+			header: () =>
+				renderComponent(DataTableColumnHeader, {
+					titleKey: 'aria.actions',
+					class: 'sr-only'
+				}),
+			cell: ({ row }) => renderComponent(DataTableActions, { user: row.original })
 		}
-	},
-	{
-		accessorKey: 'role',
-		size: 80,
-		minSize: 80,
-		header: ({ column }) =>
-			renderComponent(DataTableColumnHeader, {
-				column,
-				titleKey: 'admin.users.role',
-				testId: 'admin-users-sort-role'
-			}),
-		cell: ({ row }) =>
-			renderComponent(RoleBadge, {
-				role: row.original.role,
-				testId: 'admin-users-role-badge'
-			}),
-		filterFn: (row, _columnId, filterValue: string) => {
-			if (!filterValue || filterValue === 'all') return true;
-			return row.original.role === filterValue;
-		},
-		enableSorting: true
-	},
-	{
-		id: 'status',
-		accessorFn: (row) => getStatusSortValue(row),
-		size: 100,
-		minSize: 100,
-		header: ({ column }) =>
-			renderComponent(DataTableColumnHeader, {
-				column,
-				titleKey: 'admin.users.status'
-			}),
-		cell: ({ row }) =>
-			renderComponent(StatusBadge, {
-				banned: row.original.banned,
-				emailVerified: row.original.emailVerified,
-				testId: 'admin-users-status-badge'
-			}),
-		filterFn: (row, _columnId, filterValue: string) => {
-			if (!filterValue || filterValue === 'all') return true;
-			const user = row.original;
-			if (filterValue === 'banned') return user.banned;
-			if (filterValue === 'verified') return !user.banned && user.emailVerified === true;
-			if (filterValue === 'unverified') return !user.banned && !user.emailVerified;
-			return true;
-		},
-		enableSorting: false
-	},
-	{
-		accessorKey: 'providers',
-		accessorFn: (row) => row.providers.join(','),
-		size: 100,
-		minSize: 80,
-		header: ({ column }) =>
-			renderComponent(DataTableColumnHeader, {
-				column,
-				titleKey: 'admin.users.provider',
-				testId: 'admin-users-sort-provider'
-			}),
-		cell: ({ row }) =>
-			renderComponent(ProviderBadge, {
-				providers: row.original.providers,
-				testId: 'admin-users-provider-badge'
-			}),
-		enableSorting: true
-	},
-	{
-		accessorKey: 'createdAt',
-		size: 110,
-		minSize: 110,
-		header: ({ column }) =>
-			renderComponent(DataTableColumnHeader, {
-				column,
-				titleKey: 'admin.users.created',
-				testId: 'admin-users-sort-created'
-			}),
-		cell: ({ row }) => {
-			const dateSnippet = createRawSnippet<[{ createdAt?: number }]>((getData) => {
-				const { createdAt } = getData();
-				const formatted = createdAt ? new Date(createdAt).toLocaleDateString() : '-';
-				return {
-					render: () => `<div>${formatted}</div>`
-				};
-			});
-			return renderSnippet(dateSnippet, { createdAt: row.original.createdAt });
-		}
-	},
-	{
-		id: 'actions',
-		size: 50,
-		minSize: 50,
-		maxSize: 50,
-		enableHiding: false,
-		enableSorting: false,
-		header: () =>
-			renderComponent(DataTableColumnHeader, {
-				titleKey: 'aria.actions',
-				class: 'sr-only'
-			}),
-		cell: ({ row }) => renderComponent(DataTableActions, { user: row.original })
-	}
-];
+	];
+}


### PR DESCRIPTION
Closes #572

The admin users table "Created" column formatted dates with `new Date(createdAt).toLocaleDateString()` and no locale argument, so it fell back to the browser locale instead of the active UI language. On a non-English UI the created date could render in the wrong language.

`columns` was a static `const` consumed in `+page.svelte` both for the table and for the `columns.length` colspans, so threading the language needed a small factory refactor rather than a one-liner. This turns `columns` into a `createColumns(lang)` factory, derives `const columns = $derived(createColumns(data.lang ?? 'en'))` in the page, and passes it into `createSvelteTable` through a `get columns()` getter so the dates re-render on language switch, matching the existing `get data()` reactive-options pattern. The three `columns.length` colspan usages stay unchanged. This follows the same `data.lang ?? 'en'` approach already used by `community-chat/+page.svelte`.

Regression guard: not warranted, this was the last UI-facing toLocale* call missing a locale (the other localized routes already pass the active language) and a banned-pattern guard would be false-positive-prone against correct variable-locale and server-side en-US calls.

`bun scripts/static-checks.ts` on both changed files passes.
