### PR TITLE
fix(auth): break app:auth invalidate loop on prerender

### DIFF
--- a/src/lib/components/app/app-auth-provider.svelte
+++ b/src/lib/components/app/app-auth-provider.svelte
@@ -16,17 +16,31 @@
 
 	const auth = useAuth();
 
+	// Track the auth value we last invalidated for, so the effect fires once per
+	// divergence instead of looping. Plain let (not $state): the effect must read
+	// it without depending on it, and write it without re-triggering itself.
+	let lastInvalidatedAuth: boolean | undefined;
+
 	// Sync server layout data when client auth state diverges.
 	// Prerendered pages bake authState.isAuthenticated: false at build time.
 	// When the client recovers a session from cookies, the server's root layout
 	// data (viewer, autumnState) remains stale. This invalidation triggers a
 	// re-run of the root +layout.server.ts with fresh cookies, so navigating
 	// to /app has the correct viewer data instead of null.
+	//
+	// On a truly prerendered page the re-run returns the frozen build-time data,
+	// so the divergence never clears. Without the per-value guard the effect
+	// would re-fire invalidate on every resulting page.data change — a loop that
+	// repeatedly calls client.setAuth() and re-pauses the Convex WebSocket,
+	// leaving auth-gated queries (e.g. the support widget's thread list) stuck
+	// loading. Invalidate at most once per client-auth transition.
 	$effect(() => {
 		if (!browser || auth.isLoading) return;
 
+		const clientAuth = auth.isAuthenticated;
 		const serverAuth = page.data.authState?.isAuthenticated ?? false;
-		if (auth.isAuthenticated !== serverAuth) {
+		if (clientAuth !== serverAuth && lastInvalidatedAuth !== clientAuth) {
+			lastInvalidatedAuth = clientAuth;
 			invalidate('app:auth');
 		}
 	});


### PR DESCRIPTION
For logged-in users the support widget on the prerendered marketing home intermittently stays blank: no thread list and no "Hi 👋" greeting, regardless of whether the user has chats. Anonymous visitors are unaffected. It loads on some page loads and stays blank on others.

The prerendered root layout bakes `authState.isAuthenticated=false` at build time. After the client recovers a session from cookies, `AppAuthProvider`'s effect saw the client-vs-server auth divergence and called `invalidate('app:auth')` to refresh `viewer`/`autumn` data. On a prerendered page the re-run returns the frozen build-time data, so the divergence never cleared and the effect re-fired on every resulting `page.data` change. Each `invalidate` re-ran the convex-better-auth provider, re-calling `client.setAuth()` and re-pausing the Convex WebSocket, so the support widget's auth-gated `listThreads` query (logged-in users carry no `anonymousUserId` since #547) stayed pending and `threads-overview` rendered its empty loading body. Whether a given load lands the query in an open or a paused window is pure timing, which is why it is intermittent. In dev the page is served dynamically, so the re-run sees the real cookie state and the divergence clears, which is why this only surfaces in production.

Guard the effect to invalidate at most once per client-auth transition, so a frozen server state can no longer drive a re-invalidate loop. The legitimate one-shot refresh on real auth transitions (sign-in and sign-out) is preserved.

Regression guard: not warranted, singular logic error at the only `invalidate('app:auth')` call site (no recurring class to guard).

`bun scripts/static-checks.ts` passes. Reproduces only on a production prerender; the preview deploy lets the logged-in marketing-home support widget be confirmed.