### PR TITLE
fix(e2e): cache-bust public navigations and harden a11y audit

### DIFF
--- a/e2e/public-a11y.spec.ts
+++ b/e2e/public-a11y.spec.ts
@@ -28,8 +28,39 @@ for (const theme of ['light', 'dark'] as const) {
 				// A unique cb per run forces a fresh origin fetch so axe audits the
 				// current build.
 				await page.goto(`${path}?cb=${Date.now()}`);
-				const results = await makeAxeBuilder().analyze();
-				expect(results.violations).toEqual([]);
+
+				// Settle before axe injects. page.goto resolves on the DOM `load`
+				// event, but the client keeps working after that (SvelteKit
+				// hydration, Convex/auth client bootstrap over the WebSocket).
+				// networkidle waits past the HTTP part of hydration; #main-content
+				// is server-rendered on every audited page (both layout groups), so
+				// the auto-retrying assertion confirms the page actually rendered.
+				await page.waitForLoadState('networkidle');
+				await expect(page.locator('#main-content')).toBeVisible();
+
+				// axe's analyze() runs many page.evaluate() passes; if the page's
+				// execution context is torn down between two of them it throws
+				// "Execution context was destroyed, most likely because of a
+				// navigation". networkidle ignores WebSocket frames, so a late
+				// socket-driven update can still trigger this; retry only that
+				// specific error, re-settling between attempts. A real a11y
+				// violation is returned in results, never thrown, so this cannot
+				// mask one: violations are still asserted empty below.
+				let results: Awaited<ReturnType<ReturnType<typeof makeAxeBuilder>['analyze']>> | undefined;
+				for (let attempt = 0; attempt < 3; attempt++) {
+					try {
+						results = await makeAxeBuilder().analyze();
+						break;
+					} catch (error) {
+						if (attempt < 2 && /Execution context was destroyed/.test(String(error))) {
+							await page.waitForLoadState('networkidle');
+							continue;
+						}
+						throw error;
+					}
+				}
+
+				expect(results!.violations).toEqual([]);
 			});
 		}
 	});

--- a/e2e/public-a11y.spec.ts
+++ b/e2e/public-a11y.spec.ts
@@ -22,7 +22,12 @@ for (const theme of ['light', 'dark'] as const) {
 				await page.addInitScript((t) => {
 					localStorage.setItem('mode-watcher-mode', t);
 				}, theme);
-				await page.goto(path);
+				// Cache-buster: CF Cache API ignores Vary: Accept, so a stale prior-deploy
+				// HTML build (or a markdown body cached for the same URL by
+				// public-agent-surface.spec.ts) can be served to this HTML navigation.
+				// A unique cb per run forces a fresh origin fetch so axe audits the
+				// current build.
+				await page.goto(`${path}?cb=${Date.now()}`);
 				const results = await makeAxeBuilder().analyze();
 				expect(results.violations).toEqual([]);
 			});

--- a/e2e/public-agent-surface.spec.ts
+++ b/e2e/public-agent-surface.spec.ts
@@ -1,30 +1,31 @@
 import { expect, test } from '@playwright/test';
 
+// Cache-buster: CF Cache API ignores Vary: Accept, so HTML and markdown variants
+// of the same URL share one cache key. A unique cb per request keeps each variant
+// on a distinct key (markdown can't poison HTML) and forces a fresh origin fetch
+// on the post-deploy run.
 test.describe('public agent surface', () => {
 	test('page navigation to the localized marketing home returns HTML', async ({ page }) => {
-		const response = await page.goto('/en');
+		const response = await page.goto(`/en?cb=${Date.now()}`);
 
 		expect(response).not.toBeNull();
 		expect(response?.status()).toBe(200);
 		expect(response?.headers()['content-type']).toContain('text/html');
-		await expect(page).toHaveURL(/\/en$/);
+		await expect(page).toHaveURL(/\/en(\?|$)/);
 	});
 
-	test('generic GET requests to marketing pages do not return 406', async ({
-		request,
-		baseURL
-	}) => {
-		const response = await request.get('/en');
+	test('generic GET requests to marketing pages do not return 406', async ({ request }) => {
+		const response = await request.get(`/en?cb=${Date.now()}`);
 
 		expect(response.status()).toBe(200);
 		expect(response.headers()['content-type']).toContain('text/html');
-		expect(response.url()).toBe(`${baseURL}/en`);
+		expect(new URL(response.url()).pathname).toBe('/en');
 		expect(await response.text()).not.toContain('Not Acceptable');
 	});
 
 	test('marketing pages still return markdown when explicitly requested', async ({ request }) => {
 		for (const path of ['/en', '/en/about', '/en/pricing']) {
-			const response = await request.get(path, {
+			const response = await request.get(`${path}?cb=${Date.now()}`, {
 				headers: {
 					Accept: 'text/markdown'
 				}
@@ -37,7 +38,7 @@ test.describe('public agent surface', () => {
 		}
 	});
 
-	test('root discovery files are reachable without redirects', async ({ request, baseURL }) => {
+	test('root discovery files are reachable without redirects', async ({ request }) => {
 		const expectations = [
 			{ path: '/llms.txt', contentType: 'text/plain; charset=utf-8' },
 			{ path: '/robots.txt', contentType: 'text/plain; charset=utf-8' },
@@ -45,10 +46,10 @@ test.describe('public agent surface', () => {
 		];
 
 		for (const { path, contentType } of expectations) {
-			const response = await request.get(path);
+			const response = await request.get(`${path}?cb=${Date.now()}`);
 
 			expect(response.status(), path).toBe(200);
-			expect(response.url(), path).toBe(`${baseURL}${path}`);
+			expect(new URL(response.url()).pathname, path).toBe(path);
 			expect(response.headers()['content-type'], path).toContain(contentType);
 		}
 	});


### PR DESCRIPTION
Closes #576

Cloudflare's Cache API ignores the `Vary` header, so the post-deploy production E2E run can be served a stale edge-cached HTML build for the public marketing URLs, or a markdown body that `public-agent-surface.spec.ts` cached for the same URL with `Accept: text/markdown`. axe then audits stale or wrong DOM and reports violations against elements that are no longer in the current build, while the PR preview run passes on the same code because its edge cache is cold. I confirmed the mechanism against the live production deployment: a plain GET of `/en/pricing` returns `cf-cache-status: HIT` under `s-maxage=3600`, while the same URL with a unique `cb` query returns a fresh origin fetch, and the `cb` param is DOM-neutral (the response body is byte-identical and the canonical URL never echoes the query string).

This appends a unique cache-buster query param to every public navigation in `public-a11y.spec.ts` and `public-agent-surface.spec.ts`, including the markdown loop that was the poisoner, matching the existing workaround in `upgrade-checkout-failure.spec.ts`. The exact-URL assertions in `public-agent-surface.spec.ts` are loosened to compare the pathname, since a query string is now present.

While verifying, I found a second, pre-existing flake in `public-a11y.spec.ts` that is independent of caching: it called `makeAxeBuilder().analyze()` immediately after `page.goto()`, and axe's per-frame `page.evaluate()` passes intermittently raced the page's still-settling client bootstrap, throwing `Execution context was destroyed, most likely because of a navigation` on different pages each run (reproducible on plain `main` with no cache-buster). The spec now waits for `networkidle` and a rendered `#main-content` before auditing, and retries `analyze()` only on that specific error, re-settling between attempts. The retry cannot mask a real violation, which is returned in `results` rather than thrown, so the strict empty-violations assertion is unchanged.

Regression guard: not warranted, both changes are E2E test-hygiene with no app-code change; a static lint for "public navigations must cache-bust" is defeated by variable-driven paths and would false-positive across cacheable marketing versus non-cacheable auth routes.

Verification: `bun scripts/static-checks.ts` on both specs passes; a stress run of `public-a11y.spec.ts` at `--repeat-each=3` (42 executions across both themes) passes 42/42 with zero `Execution context was destroyed`, versus 1 to 6 failures per plain run before the fix.
