### PR TITLE
feat(env): adopt Convex typed env declarations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,7 @@
         "bits-ui": "2.18.0",
         "bun-tasks": "0.1.2",
         "clsx": "2.1.1",
-        "convex": "1.37.0",
+        "convex": "1.40.0",
         "convex-vite-plugin": "0.4.0",
         "eslint": "10.4.1",
         "eslint-config-prettier": "10.1.8",
@@ -1669,7 +1669,7 @@
 
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
-    "convex": ["convex@1.37.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-xGSx5edIsXCEex3OU2U2N0oyB/cOa9qGwKiImF9yOWqjqZgOkx39idtpdlwNBTBSt4S30oAvs4yeXY5xxPIX3A=="],
+    "convex": ["convex@1.40.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.20.1" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-jChWEB45q+9Ibryc7hg0l6hB1xA4zwE2y6ZhkhGP6oJkqYeiURkMagA2ZQZYMy1/T8PZ9ztoVJJtbL/+Ob851Q=="],
 
     "convex-helpers": ["convex-helpers@0.1.108", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.25.4", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-5dHYX4Dy/qnBuvP5CI9ZKEwYtSlyQKK2MiIdGTVV8WUON5mWr/St8IeBxsJTBNh/vuBrlX0XPAZ1arbk4KQUdg=="],
 
@@ -3189,7 +3189,7 @@
 
     "convex/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
-    "convex/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "convex/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
 

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"bits-ui": "2.18.0",
 		"bun-tasks": "0.1.2",
 		"clsx": "2.1.1",
-		"convex": "1.37.0",
+		"convex": "1.40.0",
 		"convex-vite-plugin": "0.4.0",
 		"eslint": "10.4.1",
 		"eslint-config-prettier": "10.1.8",

--- a/scripts/env-schema-parity.test.ts
+++ b/scripts/env-schema-parity.test.ts
@@ -1,0 +1,106 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The Convex `env` block in `src/lib/convex/convex.config.ts` and the varlock
+ * `.env-convex.schema` are two declarations of the same variable set. The env
+ * block drives Convex's push-time validation and the generated typed `env`
+ * object; the schema drives varlock typegen, log redaction, leak scanning, and
+ * the `@type=url`/`@type=boolean` coercion. They must agree on which vars exist
+ * and which are required, or one source silently drifts from the other.
+ *
+ * Validator types intentionally differ (the schema's url/boolean vars are plain
+ * strings in the env block, because Convex env values are always strings), so
+ * this guard only checks the name set and the required/optional split.
+ */
+
+type VarMap = Map<string, { required: boolean }>;
+
+/** Required var names + optionality from the varlock schema (decorator blocks). */
+function parseSchema(): VarMap {
+	const content = fs.readFileSync(
+		path.resolve(import.meta.dirname, '..', '.env-convex.schema'),
+		'utf-8'
+	);
+	const lines = content.split('\n');
+
+	const headerEnd = lines.findIndex((line) => line.trim() === '# ---');
+	expect(headerEnd, '.env-convex.schema: missing `# ---` header separator').toBeGreaterThan(-1);
+
+	const vars: VarMap = new Map();
+	let blockIsOptional = false;
+
+	for (let i = headerEnd + 1; i < lines.length; i++) {
+		const line = lines[i].trim();
+		if (!line) {
+			blockIsOptional = false;
+			continue;
+		}
+		if (line.startsWith('#')) {
+			if (line.includes('@optional')) blockIsOptional = true;
+			continue;
+		}
+		const match = line.match(/^([A-Z_][A-Z0-9_]*)=/);
+		if (match) {
+			vars.set(match[1], { required: !blockIsOptional });
+			blockIsOptional = false;
+		}
+	}
+	return vars;
+}
+
+/** Var names + optionality from the `defineApp({ env: { ... } })` block. */
+function parseEnvBlock(): VarMap {
+	const content = fs.readFileSync(
+		path.resolve(import.meta.dirname, '..', 'src/lib/convex/convex.config.ts'),
+		'utf-8'
+	);
+	const blockMatch = content.match(/env:\s*\{([\s\S]*?)\n\t\}/);
+	expect(blockMatch, 'env block not found in convex.config.ts').not.toBeNull();
+
+	const vars: VarMap = new Map();
+	for (const raw of blockMatch![1].split('\n')) {
+		const line = raw.trim();
+		if (!line || line.startsWith('//')) continue;
+		const match = line.match(/^([A-Z_][A-Z0-9_]*):\s*(.+)$/);
+		if (!match) continue;
+		vars.set(match[1], { required: !match[2].startsWith('v.optional(') });
+	}
+	return vars;
+}
+
+describe('Convex env declaration parity', () => {
+	const schema = parseSchema();
+	const envBlock = parseEnvBlock();
+
+	it('schema is non-empty and was parsed', () => {
+		expect(schema.size).toBeGreaterThan(0);
+		expect(envBlock.size).toBeGreaterThan(0);
+	});
+
+	it('every schema var is declared in the env block', () => {
+		const missing = [...schema.keys()].filter((name) => !envBlock.has(name));
+		expect(
+			missing,
+			`vars in .env-convex.schema but missing from the env block: ${missing}`
+		).toEqual([]);
+	});
+
+	it('every env-block var exists in the schema', () => {
+		const extra = [...envBlock.keys()].filter((name) => !schema.has(name));
+		expect(extra, `vars in the env block but missing from .env-convex.schema: ${extra}`).toEqual(
+			[]
+		);
+	});
+
+	it('required/optional status agrees for every var', () => {
+		const mismatches = [...schema.entries()]
+			.filter(([name, { required }]) => envBlock.get(name)?.required !== required)
+			.map(([name, { required }]) => `${name}: schema ${required ? 'required' : 'optional'}`);
+		expect(
+			mismatches,
+			`required/optional mismatch between schema and env block: ${mismatches}`
+		).toEqual([]);
+	});
+});

--- a/src/lib/convex/_generated/server.d.ts
+++ b/src/lib/convex/_generated/server.d.ts
@@ -22,6 +22,30 @@ import {
 import type { DataModel } from "./dataModel.js";
 
 /**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly AUTH_E2E_TEST_SECRET: string | undefined;
+  readonly AUTH_EMAIL: string;
+  readonly AUTH_GITHUB_ID: string | undefined;
+  readonly AUTH_GITHUB_SECRET: string | undefined;
+  readonly AUTH_GOOGLE_ID: string | undefined;
+  readonly AUTH_GOOGLE_SECRET: string | undefined;
+  readonly AUTUMN_SECRET_KEY: string;
+  readonly BETTER_AUTH_SECRET: string;
+  readonly EMAIL_ASSET_URL: string;
+  readonly LOCAL_CONVEX_DEV: string | undefined;
+  readonly LOCAL_SEEDED_ADMIN_EMAIL: string | undefined;
+  readonly LOCAL_SEEDED_ADMIN_NAME: string | undefined;
+  readonly LOCAL_SEEDED_ADMIN_PASSWORD: string | undefined;
+  readonly OPENROUTER_API_KEY: string;
+  readonly PREVIEW_ADMIN_PASSWORD: string | undefined;
+  readonly RESEND_API_KEY: string;
+  readonly RESEND_WEBHOOK_SECRET: string | undefined;
+  readonly SITE_URL: string;
+};
+
+/**
  * Define a query in this Convex app's public API.
  *
  * This function will be allowed to read your Convex database and will be accessible from the client.
@@ -94,6 +118,11 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
 
 /**
  * A set of services for use within Convex query functions.

--- a/src/lib/convex/_generated/server.js
+++ b/src/lib/convex/_generated/server.js
@@ -91,3 +91,8 @@ export const internalAction = internalActionGeneric;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/src/lib/convex/convex.config.ts
+++ b/src/lib/convex/convex.config.ts
@@ -1,4 +1,5 @@
 import { defineApp } from 'convex/server';
+import { v } from 'convex/values';
 import betterAuth from './betterAuth/convex.config';
 import resend from '@convex-dev/resend/convex.config';
 import autumn from '@useautumn/convex/convex.config';
@@ -6,7 +7,45 @@ import agent from '@convex-dev/agent/convex.config';
 import rateLimiter from '@convex-dev/rate-limiter/convex.config';
 import convexFilesControl from '@gilhrpenner/convex-files-control/convex.config';
 
-const app = defineApp();
+/**
+ * Declared Convex backend environment variables.
+ *
+ * Convex validates these at push time (missing required vars or values that
+ * fail their validator reject the deploy) and emits a typed `env` object into
+ * `_generated/server`. This mirrors `.env-convex.schema`, which stays the
+ * canonical superset: varlock still owns log redaction, leak scanning, the
+ * `@type=url`/`@type=boolean` coercion, and the SvelteKit runtime side.
+ *
+ * Env values are always strings, so only string-like validators are allowed
+ * (`v.string()`, string `v.literal()`/`v.union()`, and `v.optional()`).
+ * `scripts/env-schema-parity.test.ts` keeps this block in sync with the schema.
+ */
+const app = defineApp({
+	env: {
+		// Required, string-like (deploy-time presence + value guard)
+		BETTER_AUTH_SECRET: v.string(),
+		SITE_URL: v.string(), // @type=url stays enforced by varlock
+		RESEND_API_KEY: v.string(),
+		AUTH_EMAIL: v.string(),
+		EMAIL_ASSET_URL: v.string(), // @type=url stays enforced by varlock
+		AUTUMN_SECRET_KEY: v.string(),
+		OPENROUTER_API_KEY: v.string(),
+		// Optional
+		RESEND_WEBHOOK_SECRET: v.optional(v.string()),
+		AUTH_GOOGLE_ID: v.optional(v.string()),
+		AUTH_GOOGLE_SECRET: v.optional(v.string()),
+		AUTH_GITHUB_ID: v.optional(v.string()),
+		AUTH_GITHUB_SECRET: v.optional(v.string()),
+		AUTH_E2E_TEST_SECRET: v.optional(v.string()),
+		PREVIEW_ADMIN_PASSWORD: v.optional(v.string()),
+		// @type=boolean cannot be expressed here; varlock keeps the boolean type,
+		// runtime code compares the raw 'true' string.
+		LOCAL_CONVEX_DEV: v.optional(v.string()),
+		LOCAL_SEEDED_ADMIN_EMAIL: v.optional(v.string()),
+		LOCAL_SEEDED_ADMIN_PASSWORD: v.optional(v.string()),
+		LOCAL_SEEDED_ADMIN_NAME: v.optional(v.string())
+	}
+});
 app.use(betterAuth);
 app.use(resend);
 app.use(autumn);

--- a/src/lib/convex/env.ts
+++ b/src/lib/convex/env.ts
@@ -1,27 +1,34 @@
 /**
  * Typed Convex Environment Variable Access
  *
- * Type source of truth: .env-convex.schema (varlock)
- * Generated types: ./convex-env.d.ts (via `varlock typegen --path .env-convex.schema`)
- * Build-time validation: scripts/validate-convex-env.ts
+ * Declared in: ./convex.config.ts (`defineApp` `env` block). Convex validates
+ * presence and validators at push time and emits the typed `env` object below.
+ * `env` is a plain alias of `process.env` (see `_generated/server`), so the
+ * required/optional split comes for free: required vars type as `string`,
+ * optional vars as `string | undefined`.
+ *
+ * varlock (.env-convex.schema) stays canonical for log redaction, leak
+ * scanning, `@type=url`/`@type=boolean` coercion, and the SvelteKit runtime
+ * side; `scripts/env-schema-parity.test.ts` keeps the two declarations in sync.
  */
 
-import type { CoercedEnvSchema } from './convex-env';
+import { env } from './_generated/server';
 
-// Extract keys whose type is `string` (required) vs `string | undefined` (optional)
+// Required keys type as `string`; optional keys as `string | undefined`.
 type RequiredKeys = {
-	[K in keyof CoercedEnvSchema]-?: undefined extends CoercedEnvSchema[K] ? never : K;
-}[keyof CoercedEnvSchema];
+	[K in keyof typeof env]-?: undefined extends (typeof env)[K] ? never : K;
+}[keyof typeof env];
 
 /**
  * Placeholders for vars accessed at module-analysis time.
  *
- * Convex bundles and statically analyzes modules before env vars are available.
- * `createApi()` in adapter.ts calls `createAuthOptions()` at load time to
- * extract the Better Auth schema, and `new Autumn()` in autumn.ts runs at
- * top level, so these vars must return something during analysis.
- * Placeholders are never used at runtime -- build-time validation
- * (validate-convex-env.ts) ensures the real values are set before deploy.
+ * Convex bundles and statically analyzes modules before env vars are available,
+ * and `env` is just `process.env`, so a top-level read returns `undefined`
+ * during that pass. `createApi()` in adapter.ts calls `createAuthOptions()` at
+ * load time to extract the Better Auth schema, and `new Autumn()` in autumn.ts
+ * runs at top level, so these vars must return something during analysis.
+ * Placeholders are never used at runtime -- the declared `env` block makes
+ * Convex reject a deploy that is missing the real values.
  */
 const ANALYSIS_PLACEHOLDERS: Partial<Record<string, string>> = {
 	BETTER_AUTH_SECRET: 'placeholder-secret-for-analysis',
@@ -47,7 +54,7 @@ export type RequireEnvOptions = {
  * surfaces a useful breadcrumb in Convex logs when an end-user flow trips it.
  */
 export function requireEnv<K extends RequiredKeys>(name: K, opts?: RequireEnvOptions): string {
-	const value = process.env[name as string];
+	const value = env[name];
 	if (value) return value;
 
 	const placeholder = ANALYSIS_PLACEHOLDERS[name as string];
@@ -69,14 +76,14 @@ export function requireEnv<K extends RequiredKeys>(name: K, opts?: RequireEnvOpt
 
 /** Google OAuth - disabled if not configured */
 export const googleOAuth = {
-	enabled: !!(process.env.AUTH_GOOGLE_ID && process.env.AUTH_GOOGLE_SECRET),
-	clientId: process.env.AUTH_GOOGLE_ID,
-	clientSecret: process.env.AUTH_GOOGLE_SECRET
+	enabled: !!(env.AUTH_GOOGLE_ID && env.AUTH_GOOGLE_SECRET),
+	clientId: env.AUTH_GOOGLE_ID,
+	clientSecret: env.AUTH_GOOGLE_SECRET
 };
 
 /** GitHub OAuth - disabled if not configured */
 export const githubOAuth = {
-	enabled: !!(process.env.AUTH_GITHUB_ID && process.env.AUTH_GITHUB_SECRET),
-	clientId: process.env.AUTH_GITHUB_ID,
-	clientSecret: process.env.AUTH_GITHUB_SECRET
+	enabled: !!(env.AUTH_GITHUB_ID && env.AUTH_GITHUB_SECRET),
+	clientId: env.AUTH_GITHUB_ID,
+	clientSecret: env.AUTH_GITHUB_SECRET
 };


### PR DESCRIPTION
Closes #577

Convex 1.39 added typesafe environment variables: you declare them in `convex.config.ts`, the backend validates their presence and validators at push time, and a typed `env` object is generated into `_generated/server`. This repo predates that and instead carried a hand-rolled access layer where `env.ts` derived a `RequiredKeys` mapped type from the varlock-generated `convex-env.d.ts`, so the required/optional split lived in a second place and nothing guarded the deployment itself.

This bumps `convex` 1.37.0 to 1.40.0 (staying below 1.41 to avoid the `@convex-dev/resend` peer hold) and declares the full env var set in the `defineApp` `env` block. Env values are always strings, so only string-like validators are used. `env.ts` now sources its required/optional split from the generated `env` and reads through it, dropping the dependency on the varlock type. The module-load placeholder fallback stays, because `env` is a plain alias of `process.env`, so a top-level read is still `undefined` during Convex's static-analysis pass, which the Better Auth adapter and the Autumn client rely on.

varlock (`.env-convex.schema`) stays canonical for log redaction, leak scanning, the `@type=url`/`@type=boolean` coercion, and the SvelteKit runtime side, none of which the Convex feature covers. The var set now lives in two declarations, so a parity test asserts the schema and the `env` block agree on names and optionality.

One behavior change to watch: the `env` block makes every declared required var mandatory at push for every deployment, so a preview or production deploy that is missing one will now fail loudly at deploy time instead of at runtime. That is the point of the feature, but it means any required var must be set as a preview/prod default.

Regression guard: added `scripts/env-schema-parity.test.ts`, which asserts `.env-convex.schema` and the `convex.config.ts` env block declare the same vars with matching required/optional status.
`bun run check:convex`, `bun scripts/static-checks.ts`, and `bun run test:unit` (584 tests) pass.