### PR TITLE
chore: consistency, docs, and svelte best-practice fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,7 +388,7 @@ Prop names must match the parent's passed prop name exactly.
 
 ### ESLint & Legacy Plugins
 
-When adding ESLint plugins that export legacy `.eslintrc`-style configs (objects with `overrides`), use `fixupConfigRules()` from `@eslint/compat` to convert. See the Convex plugin block in `eslint.config.js` for the pattern.
+When adding ESLint plugins that export legacy `.eslintrc`-style configs (objects with `overrides`), use `fixupConfigRules()` from `@eslint/compat` to convert.
 
 Adding a top-level dir with `.svelte`/`.ts` files outside the tsconfig `include` (e.g. `archive/`, `scratch/`)? `projectService: true` will refuse to parse it and pre-commit fails with a cryptic "not found by the project service" error. Either add the dir to `tsconfig.json` `include` or to `eslint.config.js` `ignores`.
 
@@ -428,7 +428,7 @@ Decision tree for new routes:
 For each data need in a new route, pick the right pattern:
 
 1. **Auth-dependent data needed in SSR HTML?**
-   → `+page.server.ts` with `createConvexHttpClient({ token: event.locals.token })`
+   → `+page.server.ts` with `createServerConvexHttpClient({ token: event.locals.token })` from `$lib/server/convex-http`
    → Pass result to component as `data` prop
    → Wrap in try-catch for resilience
 
@@ -496,7 +496,7 @@ For each data need in a new route, pick the right pattern:
    → **Shareable / linkable view** (search, sort, active tab) → URL. Read with `page.url.searchParams` in a `$derived` (SvelteKit populates `page.url` on the server, so SSR renders the right view → flash-free); write with `goto(url, { keepFocus: true, noScroll: true })`, omitting defaults from the URL. Default `replaceState: false` pushes a history entry per view switch, matching `admin/support` thread selection (canonical) and the settings tabs fix. `pushState` / `replaceState` from `$app/navigation` are not a substitute — they update `page.state`, not `page.url`, so SSR via `page.url.searchParams` would not see the change. `goto` to the same route does not re-run server loads that do not track the changed param (SvelteKit's dependency tracking handles this); only call out `replaceState: true` when you specifically want to overwrite the current history entry. **Do not use `useSearchParams` (`runed/kit`) for SSR-visible view selection** — it reads the URL client-only (BROWSER-gated init) and renders the default on the server, so the view flashes on first paint. Fine only where the flash is invisible (e.g. a table behind a loading skeleton).
    → **Per-user preference that must be right on first paint but does not belong in the address** (sidebar collapse) → cookie + SSR read. Write client-side (`document.cookie`), read in `hooks.server.ts` into `event.locals` (NOT a layout-load `cookies.get`, see Prerendering constraints), thread as a prop. See #404.
    → **Preference where a hydration flash is fine, or state too large / private to send on every request** (chat drafts, mic settings) → `PersistedState` (localStorage).
-   Three flash-free reads, all because the value is available before first paint: URL via `page.url`, cookie via `event.locals`, or a blocking inline `<head>` script that reads localStorage and sets a single `<html>` class/attribute (e.g. theme via ModeWatcher in `app.html`). `PersistedState` read in component script always flashes.
+   Three flash-free reads, all because the value is available before first paint: URL via `page.url`, cookie via `event.locals`, or a blocking inline `<head>` script that reads localStorage and sets a single `<html>` class/attribute (e.g. theme via the `<ModeWatcher />` component in `+layout.svelte`, which injects a blocking head script). `PersistedState` read in component script always flashes.
 
 #### Deferred loading pattern
 
@@ -693,7 +693,7 @@ For general animation craft (easing, duration, when to animate, performance, acc
 
 - Simple animations should be implemented with plain CSS whenever possible.
 - Before implementing any custom animation, check if sv-animate has a prebuilt component that can be used. Use btca with `svAnimate` resource.
-- For custom animations, use Svelte's built-in animations, or motion-svelte (Framer Motion for Svelte). Use btca with `motionSvelte` resource.
+- For custom animations, use Svelte's built-in animations, or motion-sv (Framer Motion for Svelte). Use btca with `motionSvelte` resource.
 - For Tailwind, use `motion-safe:` / `motion-reduce:` prefixes (e.g., `motion-safe:animate-fade-in`, `motion-reduce:animate-none`).
 - For page transitions and state changes, use the View Transitions API with SvelteKit's `onNavigate`:
 
@@ -760,7 +760,7 @@ Use `svelte-infinite` with convex-svelte pagination for huge lists to automatica
 
 Before creating our own utilities, research the runed library to see if the utility you need already exists. Use btca with `runed` resource.
 
-- For URL/query state, prefer Runed `useSearchParams` over manual `$page.url` + `goto` wiring.
+- For client-only or flash-invisible URL/query state, prefer Runed `useSearchParams` over manual `page.url` + `goto` wiring. For SSR-visible view selection, use `page.url.searchParams` + `goto` instead (see the data-fetching decision tree above: `useSearchParams` reads the URL client-only, so the view flashes on first paint).
 - Exception: in high-frequency selection UIs where query-param writes would cause unwanted Convex refetches (for example `src/routes/[[lang]]/admin/support/+page.svelte` thread selection), manual URL handling is acceptable.
   Here is a list of the utilities available:
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ No external services required. To activate optional features (email, OAuth, bill
 I'd recommend the local embedded backend for day-to-day work. Each git worktree gets its own isolated Convex instance, you can develop multiple features in parallel without conflicts.
 
 ```bash
-bunx convex init                              # creates a Convex project
+bunx convex dev --configure                   # creates/links a Convex project
 ```
 
-`convex init` prints a `CONVEX_DEPLOYMENT` value — add it to `.env.local`. `bun run dev` still uses the local embedded backend; the variable is only needed for `dev:cloud` and the Convex CLI.
+`convex dev` prints a `CONVEX_DEPLOYMENT` value, add it to `.env.local`. `bun run dev` still uses the local embedded backend; the variable is only needed for `dev:cloud` and the Convex CLI.
 
 ```bash
 bun run dev:cloud                             # frontend + cloud Convex backend
@@ -81,7 +81,7 @@ Once the app runs, rebrand it:
 bun run setup
 ```
 
-The setup script replaces the project name, GitHub links, and prompts for brand, company, operator, address, and contact email — all written to `src/lib/config/legal.ts`. After running it:
+The setup script replaces the project name, GitHub links, and prompts for brand, company, operator, address, and contact email, all written to `src/lib/config/legal.ts`. After running it:
 
 1. Replace `static/logo.svg` with your logo, then run `bun run build:emails`
 2. Refresh email snapshots: `bun run test:unit -- email-snapshots.test.ts -u`
@@ -164,7 +164,7 @@ Push a branch and Vercel creates a preview deployment with its own Convex previe
 
 </details>
 
-Convex cleans up preview deployments after 5 days (14 days on Professional). If you hit `DeploymentQuotaReached` anyway (team quota is 40, counted across all projects), the deploy script can self-heal by pruning the oldest eligible preview — opt in by setting `CONVEX_MANAGEMENT_TOKEN` and `CONVEX_PROJECT_ID` (see the [env matrix](#environment-variables)).
+Convex cleans up preview deployments after 5 days (14 days on Professional). If you hit `DeploymentQuotaReached` anyway (team quota is 40, counted across all projects), the deploy script can self-heal by pruning the oldest eligible preview, opt in by setting `CONVEX_MANAGEMENT_TOKEN` and `CONVEX_PROJECT_ID` (see the [env matrix](#environment-variables)).
 
 ## Production Deployment
 
@@ -409,7 +409,7 @@ Every component supports light and dark mode via `mode-watcher`. Interactive ele
 
 ### Worktrees
 
-Each worktree gets its own isolated Convex backend, port, and auth secret via [convex-vite-plugin](https://github.com/juliusmarminge/convex-vite-plugin). Run `bun run worktree feature/dark-mode --open-editor cursor` (or `code`) to create one with all local env vars copied over, or use the VS Code task. Work on multiple features in parallel without stepping on each other.
+Each worktree gets its own isolated Convex backend, port, and auth secret via [convex-vite-plugin](https://github.com/juliusmarminge/agent-tools/tree/main/packages/convex-vite-plugin). Run `bun run worktree feature/dark-mode --open-editor cursor` (or `code`) to create one with all local env vars copied over, or use the VS Code task. Work on multiple features in parallel without stepping on each other.
 
 ### Type-Safe Environment Variables
 

--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -395,6 +395,13 @@
 		},
 		{
 			"type": "git",
+			"name": "convexAutumnSvelte",
+			"url": "https://github.com/stickerdaniel/convex-autumn-svelte",
+			"branch": "main",
+			"specialNotes": "@stickerdaniel/convex-autumn-svelte. SvelteKit/Convex binding for Autumn billing. Reactive useCustomer() (customer.products/features), autumn.refetch() after billing-affecting mutations, and the /sveltekit + /sveltekit/server entrypoints. Autumn state flows through page.data.autumnState set in the root +layout.server.ts."
+		},
+		{
+			"type": "git",
 			"name": "adapterNode",
 			"url": "https://github.com/sveltejs/kit",
 			"branch": "main",

--- a/docs/forms/README.md
+++ b/docs/forms/README.md
@@ -1,0 +1,7 @@
+# Form Builder Scaffolding
+
+The JSON files in this directory (`change-email`, `change-password`, `forgot-password`, `login`, `reset-password`, `signup`) are historical UI-layout scaffolding produced by the Svelte Form Builder. They describe field layout only and are kept for reference. They are not live remote-form configs and nothing at runtime reads them.
+
+All six cover Better Auth session-sensitive flows. The form decision tree in `AGENTS.md` routes those flows to the client-side `authClient` pattern and lists them as "Not recommended" for SvelteKit remote forms, so they stay on `authClient`.
+
+The only production remote form is the admin add-email dialog: `addEmailForm` in `src/routes/[[lang]]/admin/settings/data.remote.ts`, built with SvelteKit `form()` plus Valibot validation and surfaced by `add-email-dialog.svelte`. It has no builder JSON in this directory.

--- a/docs/setup/i18n/i18n-setup.md
+++ b/docs/setup/i18n/i18n-setup.md
@@ -4,7 +4,7 @@ This project uses **Tolgee** for cloud-hosted translation management with SEO-fr
 
 ## Tolgee Cloud is Optional
 
-This template includes **many translation keys that exceed Tolgee Cloud's free tier** (500 keys on the free plan, this project has ~1,100). You have three options:
+This template includes **many translation keys that exceed Tolgee Cloud's free tier** (500 keys on the free plan, this project has ~740). You have three options:
 
 ### Option 1: Skip Tolgee Entirely (Easiest)
 

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -661,7 +661,7 @@
 	"meta": {
 		"about": {
 			"description": "Lernen Sie das talentierte Team hinter unserem Produkt kennen",
-			"title": "Über uns - Lernen Sie unser Team kennen"
+			"title": "Über uns"
 		},
 		"admin": {
 			"dashboard": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -661,7 +661,7 @@
 	"meta": {
 		"about": {
 			"description": "Meet the talented team behind our product",
-			"title": "About Us - Meet Our Team"
+			"title": "About Us"
 		},
 		"admin": {
 			"dashboard": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -661,7 +661,7 @@
 	"meta": {
 		"about": {
 			"description": "Conoce al talentoso equipo detrás de nuestro producto",
-			"title": "Acerca de nosotros - Conoce a nuestro equipo"
+			"title": "Acerca de nosotros"
 		},
 		"admin": {
 			"dashboard": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -661,7 +661,7 @@
 	"meta": {
 		"about": {
 			"description": "Rencontrez l'équipe talentueuse derrière notre produit",
-			"title": "À propos de nous - Rencontrez notre équipe"
+			"title": "À propos"
 		},
 		"admin": {
 			"dashboard": {

--- a/src/lib/chat/ui/ChatMessages.svelte
+++ b/src/lib/chat/ui/ChatMessages.svelte
@@ -65,7 +65,7 @@
 		// Re-run when the color mode changes so the gradient matches the new theme background
 		void mode.current;
 		// Defer style read until the browser has applied the new theme class
-		requestAnimationFrame(() => {
+		const rafId = requestAnimationFrame(() => {
 			// Walk up to find the first ancestor with a non-transparent background
 			let el: HTMLElement | null = wrapperEl!;
 			while (el) {
@@ -77,6 +77,7 @@
 				el = el.parentElement;
 			}
 		});
+		return () => cancelAnimationFrame(rafId);
 	});
 
 	// Handoff message text to detect - use the same translation as backend

--- a/src/lib/components/ai-elements/conversation/ConversationContent.svelte
+++ b/src/lib/components/ai-elements/conversation/ConversationContent.svelte
@@ -20,13 +20,12 @@
 	}: ConversationContentProps = $props();
 
 	const context = stickToBottomContext.get();
-	let element: HTMLDivElement; // assigned by Svelte bind:this
 
 	watch(
-		() => element,
+		() => ref,
 		() => {
-			if (element) {
-				context.setElement(element);
+			if (ref) {
+				context.setElement(ref);
 				// Initial scroll to bottom
 				context.scrollToBottom('smooth');
 			}
@@ -34,11 +33,6 @@
 	);
 </script>
 
-<div
-	bind:this={element}
-	bind:this={ref}
-	class={cn('flex-1 overflow-y-auto p-4', className)}
-	{...restProps}
->
+<div bind:this={ref} class={cn('flex-1 overflow-y-auto p-4', className)} {...restProps}>
 	{@render children?.()}
 </div>

--- a/src/lib/components/authenticated/sidebar-thread-list.svelte
+++ b/src/lib/components/authenticated/sidebar-thread-list.svelte
@@ -3,6 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { DEFAULT_LANGUAGE } from '$lib/i18n/languages';
 	import autoAnimate from '@formkit/auto-animate';
 	import { getTranslate } from '@tolgee/svelte';
 	import type { NavSubItem } from './types';
@@ -22,7 +23,7 @@
 	// revealed on row hover. Reactive on the route language so switching locales
 	// reformats live.
 	const dateFormatter = $derived(
-		new Intl.DateTimeFormat(page.params.lang ?? 'en', {
+		new Intl.DateTimeFormat(page.data.lang ?? DEFAULT_LANGUAGE, {
 			day: '2-digit',
 			month: '2-digit',
 			hour: '2-digit',

--- a/src/lib/components/customer-support/customer-support.svelte
+++ b/src/lib/components/customer-support/customer-support.svelte
@@ -19,6 +19,7 @@
 	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import { Button } from '$lib/components/ui/button';
 	import { getLegalEmailAddress } from '$lib/config/legal';
+	import { buildMailto } from '$lib/utils/mailto';
 
 	const { t } = getTranslate();
 
@@ -221,7 +222,7 @@
 		}
 		// Plain location assignment, not an <a href>, so SvelteKit's client router
 		// doesn't intercept the mailto and silently no-op the click.
-		window.location.href = `mailto:${getLegalEmailAddress()}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+		window.location.href = buildMailto({ email: getLegalEmailAddress(), subject, body });
 		captureErrorOpen = false;
 	}
 </script>

--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotCanvas.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotCanvas.svelte
@@ -10,8 +10,8 @@
 	const height = typeof window !== 'undefined' ? window.innerHeight : 1080;
 
 	// Konva Stage/Layer ref binding (assigned by Svelte bind:this at runtime)
-	let stageComponent: any;
-	let layerComponent: any;
+	let stageComponent = $state<any>(null);
+	let layerComponent = $state<any>(null);
 
 	// Bind refs to context when mounted
 	$effect(() => {

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -19,6 +19,7 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';
 	import { page } from '$app/state';
+	import { DEFAULT_LANGUAGE } from '$lib/i18n/languages';
 
 	const { t } = getTranslate();
 
@@ -217,7 +218,7 @@
 		if (days === 1) return $t('support.time.yesterday');
 		if (days < 7) return $t('support.time.days_ago', { days });
 
-		return new Date(timestamp).toLocaleDateString(page.data.lang ?? 'en');
+		return new Date(timestamp).toLocaleDateString(page.data.lang ?? DEFAULT_LANGUAGE);
 	}
 </script>
 

--- a/src/lib/convex/admin/notificationPreferences/mutations.ts
+++ b/src/lib/convex/admin/notificationPreferences/mutations.ts
@@ -6,6 +6,7 @@
  */
 
 import { v, ConvexError } from 'convex/values';
+import * as val from 'valibot';
 import { adminMutation } from '../../functions';
 import { internalMutation } from '../../_generated/server';
 import { components } from '../../_generated/api';
@@ -68,9 +69,8 @@ export const addCustomEmail = adminMutation({
 	handler: async (ctx, args) => {
 		const email = args.email.toLowerCase().trim();
 
-		// Validate email format (basic check)
-		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-		if (!emailRegex.test(email)) {
+		// Validate email format
+		if (!val.safeParse(val.pipe(val.string(), val.email()), email).success) {
 			throw new ConvexError('Invalid email address');
 		}
 

--- a/src/lib/convex/admin/support/mutations.ts
+++ b/src/lib/convex/admin/support/mutations.ts
@@ -3,6 +3,8 @@ import { internal, components } from '../../_generated/api';
 import { saveMessage, getFile } from '@convex-dev/agent';
 import { adminMutation } from '../../functions';
 import { shouldSendNotification, syncSupportLastMessage } from '../../support/threads';
+import { MAX_MESSAGE_LENGTH } from '../../constants';
+import { t } from '../../i18n/translations';
 import type { AssistantContent, TextPart, FilePart } from 'ai';
 
 /**
@@ -139,6 +141,7 @@ export const updateThreadPriority = adminMutation({
  * @param args.fileIds - Optional array of file IDs to attach to the message
  * @returns void
  * @throws {Error} When message content is empty (no text and no files)
+ * @throws {Error} When message exceeds the maximum allowed length
  * @throws {Error} When support thread is not found
  */
 export const sendAdminReply = adminMutation({
@@ -152,6 +155,12 @@ export const sendAdminReply = adminMutation({
 		// Validate content
 		if (!args.prompt.trim() && (!args.fileIds || args.fileIds.length === 0)) {
 			throw new ConvexError('Message content cannot be empty');
+		}
+
+		if (args.prompt.length > MAX_MESSAGE_LENGTH) {
+			throw new ConvexError(
+				t(undefined, 'backend.support.message_too_long', { max: MAX_MESSAGE_LENGTH })
+			);
 		}
 
 		// Get support thread for auto-assign and read status

--- a/src/lib/utils/mailto.ts
+++ b/src/lib/utils/mailto.ts
@@ -1,10 +1,20 @@
 /**
- * Builds an RFC 6068 `mailto:` href for a pre-filled bug report.
+ * Builds an RFC 6068 `mailto:` href, normalizing body line breaks to CRLF
+ * before percent-encoding. Apple Mail and other RFC-6068-strict clients
+ * silently refuse to open a mailto whose body uses bare LF (`%0A`); they
+ * require `%0D%0A`.
+ */
+export function buildMailto(options: { email: string; subject: string; body: string }): string {
+	const body = options.body.replace(/\r?\n/g, '\r\n');
+	return `mailto:${options.email}?subject=${encodeURIComponent(options.subject)}&body=${encodeURIComponent(body)}`;
+}
+
+/**
+ * Builds a `mailto:` href for a pre-filled bug report.
  *
  * Substitutes `{status}` in the subject and `{url}` / `{status}` in the
- * body, then normalizes body line breaks to CRLF before percent-encoding.
- * Apple Mail and other RFC-6068-strict clients silently refuse to open a
- * mailto whose body uses bare LF (`%0A`); they require `%0D%0A`.
+ * body, then delegates to {@link buildMailto} for CRLF normalization and
+ * percent-encoding.
  */
 export function buildBugReportMailto(options: {
 	email: string;
@@ -15,9 +25,6 @@ export function buildBugReportMailto(options: {
 }): string {
 	const status = String(options.status);
 	const subject = options.subjectTemplate.replace('{status}', status);
-	const body = options.bodyTemplate
-		.replace('{url}', options.url)
-		.replace('{status}', status)
-		.replace(/\r?\n/g, '\r\n');
-	return `mailto:${options.email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+	const body = options.bodyTemplate.replace('{url}', options.url).replace('{status}', status);
+	return buildMailto({ email: options.email, subject, body });
 }

--- a/src/routes/[[lang]]/(auth)/forgot-password/schema.ts
+++ b/src/routes/[[lang]]/(auth)/forgot-password/schema.ts
@@ -1,8 +1,9 @@
 import * as v from 'valibot';
+import { emailSchema } from '$lib/schemas/auth';
 
 // Forgot Password Schema
 export const forgotPasswordSchema = v.object({
-	email: v.pipe(v.string(), v.email('validation.email.invalid'))
+	email: emailSchema
 });
 
 // Types

--- a/src/routes/[[lang]]/(auth)/signin/schema.ts
+++ b/src/routes/[[lang]]/(auth)/signin/schema.ts
@@ -1,4 +1,5 @@
 import * as v from 'valibot';
+import { emailSchema } from '$lib/schemas/auth';
 import {
 	PASSWORD_MIN_LENGTH,
 	passwordValidation,
@@ -10,14 +11,14 @@ export { PASSWORD_MIN_LENGTH };
 
 // Sign In Schema
 export const signInSchema = v.object({
-	email: v.pipe(v.string(), v.email('validation.email.invalid')),
+	email: emailSchema,
 	_password: passwordRequired
 });
 
 // Sign Up Schema
 export const signUpSchema = v.object({
 	name: v.pipe(v.string(), v.nonEmpty('validation.name.required')),
-	email: v.pipe(v.string(), v.email('validation.email.invalid')),
+	email: emailSchema,
 	_password: passwordValidation
 });
 

--- a/src/routes/[[lang]]/admin/settings/add-email-dialog.svelte
+++ b/src/routes/[[lang]]/admin/settings/add-email-dialog.svelte
@@ -8,7 +8,7 @@
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { toast } from 'svelte-sonner';
 	import { addEmailForm } from './data.remote';
-	import { emailSchema } from './email-schema';
+	import { addEmailSchema } from './email-schema';
 	import { translateRemoteFormIssues } from '$lib/utils/validation-i18n';
 
 	const { t } = getTranslate();
@@ -43,7 +43,7 @@
 			</Dialog.Description>
 		</Dialog.Header>
 		<form
-			{...addEmailForm.preflight(emailSchema).enhance(async ({ submit, form: formEl }) => {
+			{...addEmailForm.preflight(addEmailSchema).enhance(async ({ submit, form: formEl }) => {
 				try {
 					await submit();
 					// Check if server returned validation errors (e.g., duplicate email)

--- a/src/routes/[[lang]]/admin/settings/data.remote.ts
+++ b/src/routes/[[lang]]/admin/settings/data.remote.ts
@@ -2,7 +2,7 @@ import { form, getRequestEvent } from '$app/server';
 import { invalid } from '@sveltejs/kit';
 import { api } from '$lib/convex/_generated/api';
 import { createServerConvexHttpClient } from '$lib/server/convex-http';
-import { emailSchema } from './email-schema';
+import { addEmailSchema } from './email-schema';
 
 /**
  * Remote form for adding a custom email recipient
@@ -10,7 +10,7 @@ import { emailSchema } from './email-schema';
  * Uses SvelteKit remote functions with Valibot validation.
  * Calls Convex mutation server-side with proper authentication.
  */
-export const addEmailForm = form(emailSchema, async ({ email }, issue) => {
+export const addEmailForm = form(addEmailSchema, async ({ email }, issue) => {
 	const event = getRequestEvent();
 	const client = createServerConvexHttpClient({ token: event.locals.token });
 

--- a/src/routes/[[lang]]/admin/settings/email-schema.ts
+++ b/src/routes/[[lang]]/admin/settings/email-schema.ts
@@ -5,7 +5,7 @@ import * as v from 'valibot';
  * Used for both server-side validation in data.remote.ts and
  * client-side preflight validation in add-email-dialog.svelte
  */
-export const emailSchema = v.object({
+export const addEmailSchema = v.object({
 	email: v.pipe(
 		v.string(),
 		v.nonEmpty('validation.email.required'),

--- a/src/routes/[[lang]]/admin/users/columns.ts
+++ b/src/routes/[[lang]]/admin/users/columns.ts
@@ -5,6 +5,7 @@ import DataTableCheckbox from '$lib/components/data-table-checkbox.svelte';
 import DataTableColumnHeader from '$lib/components/admin/data-table-column-header.svelte';
 import DataTableActions from './data-table-actions.svelte';
 import type { AdminUserData } from '$lib/convex/admin/types';
+import { DEFAULT_LANGUAGE } from '$lib/i18n/languages';
 import StatusBadge from './status-badge.svelte';
 import RoleBadge from './role-badge.svelte';
 import ProviderBadge from './provider-badge.svelte';
@@ -164,7 +165,9 @@ export function createColumns(lang: string): Array<ColumnDef<AdminUserData>> {
 			cell: ({ row }) => {
 				const dateSnippet = createRawSnippet<[{ createdAt?: number }]>((getData) => {
 					const { createdAt } = getData();
-					const formatted = createdAt ? new Date(createdAt).toLocaleDateString(lang || 'en') : '-';
+					const formatted = createdAt
+						? new Date(createdAt).toLocaleDateString(lang || DEFAULT_LANGUAGE)
+						: '-';
 					return {
 						render: () => `<div>${formatted}</div>`
 					};

--- a/src/routes/[[lang]]/app/settings/security-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/security-settings.svelte
@@ -10,6 +10,7 @@
 	import { toast } from 'svelte-sonner';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { page } from '$app/state';
+	import { DEFAULT_LANGUAGE } from '$lib/i18n/languages';
 	import KeyIcon from '@lucide/svelte/icons/key-round';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
@@ -114,7 +115,7 @@
 	}
 
 	function formatDate(date: Date): string {
-		return new Date(date).toLocaleDateString(page.data.lang ?? 'en', {
+		return new Date(date).toLocaleDateString(page.data.lang ?? DEFAULT_LANGUAGE, {
 			year: 'numeric',
 			month: 'short',
 			day: 'numeric'


### PR DESCRIPTION
A consistency scan surfaced a batch of low-risk drift: one real correctness bug, several convention inconsistencies, and stale documentation that pointed at code which had since changed. None ship broken behavior on their own, but together they erode the template's consistency and mislead anyone following the docs literally.

The one change with real user impact: the screenshot-error `mailto:` body is now CRLF-normalized through a shared `buildMailto` helper, so Apple Mail and other RFC-6068-strict clients stop silently refusing to open it.

The rest tighten consistency without changing behavior. `ChatMessages` now cancels its `requestAnimationFrame` on cleanup, and the conversation and screenshot-canvas components watch reactive `$state` `bind:this` targets so their effects can't miss the mount assignment. `sendAdminReply` gains the server-side length guard the other three chat-send mutations already have. Email validation is unified on the shared `emailSchema` and valibot, and the colliding admin `emailSchema` export is renamed to `addEmailSchema`. Language and date fallbacks read `page.data.lang` and `DEFAULT_LANGUAGE` instead of a hardcoded `'en'`. The about page title drops its subtitle so `SEOHead` doesn't append a second clause.

The documentation pass corrects the data-fetching client name, the ModeWatcher location, the animation package name, the deprecated page store reference, a broken plugin link, the convex setup command, and the translation-key count in `AGENTS.md` and `README.md`, registers the convex-autumn-svelte btca resource, and adds a `docs/forms/README.md` explaining that the form-builder JSONs are reference scaffolding, not live remote-form configs.

Regression guard: not warranted, single-site corrections.

static-checks, check:convex, and `bun run test:unit` (610 tests) pass.