### PR TITLE
style(search): match command palette bg to nav hover

### DIFF
--- a/src/lib/components/global-search/command-menu.svelte
+++ b/src/lib/components/global-search/command-menu.svelte
@@ -191,7 +191,7 @@
 <Dialog.Root open={globalSearch.open} onOpenChange={globalSearch.setOpen}>
 	<Dialog.Content
 		showCloseButton={false}
-		class="rounded-xl border-none bg-popover bg-clip-padding p-2 pb-11 shadow-2xl ring-4 ring-foreground/5 dark:ring-foreground/10"
+		class="rounded-xl border-none bg-sidebar-accent bg-clip-padding p-2 pb-11 shadow-2xl ring-4 ring-foreground/5 dark:ring-foreground/10"
 	>
 		<Dialog.Header class="sr-only">
 			<Dialog.Title>{$t('search.command.dialog_title')}</Dialog.Title>


### PR DESCRIPTION
The global search command palette rendered on `bg-popover` (pure white in light mode), so the search surface sat apart from the rest of the app chrome. The sidebar navigation items highlight with `bg-sidebar-accent`, leaving the search dialog and the nav on two different greys.

This switches the command palette `Dialog.Content` background from `bg-popover` to `bg-sidebar-accent`, the same token the sidebar nav uses for its hover and active state. `--accent` and `--sidebar-accent` resolve to the identical value in both light and dark, so the dialog now matches the nav highlight exactly. The selected-item affordance is unaffected because command items highlight with a border plus `bg-input/50`, not the surface token.

`bun scripts/static-checks.ts` passes on the changed file.
