### PR TITLE
style(search): tint the search trigger, not the dialog

### DIFF
--- a/src/lib/components/global-search/command-menu.svelte
+++ b/src/lib/components/global-search/command-menu.svelte
@@ -191,7 +191,7 @@
 <Dialog.Root open={globalSearch.open} onOpenChange={globalSearch.setOpen}>
 	<Dialog.Content
 		showCloseButton={false}
-		class="rounded-xl border-none bg-sidebar-accent bg-clip-padding p-2 pb-11 shadow-2xl ring-4 ring-foreground/5 dark:ring-foreground/10"
+		class="rounded-xl border-none bg-popover bg-clip-padding p-2 pb-11 shadow-2xl ring-4 ring-foreground/5 dark:ring-foreground/10"
 	>
 		<Dialog.Header class="sr-only">
 			<Dialog.Title>{$t('search.command.dialog_title')}</Dialog.Title>

--- a/src/lib/components/global-search/command-trigger.svelte
+++ b/src/lib/components/global-search/command-trigger.svelte
@@ -20,7 +20,7 @@
 <Button
 	variant="secondary"
 	class={cn(
-		'relative h-8 w-full justify-start bg-card pl-3 font-medium text-foreground shadow-none md:w-48 lg:w-56 xl:w-64',
+		'relative h-8 w-full justify-start bg-sidebar-accent-hover pl-3 font-medium text-foreground shadow-none md:w-48 lg:w-56 xl:w-64',
 		className
 	)}
 	onclick={() => globalSearch.openMenu()}


### PR DESCRIPTION
The grey nav-hover background landed on the command palette overlay in #587, but it belongs on the search trigger bar instead. The dialog floats over a dimmed backdrop, so the subtle tint was barely visible there; the actual goal was for the resting search bar to carry that colour.

This reverts the command palette `Dialog.Content` back to `bg-popover` and changes the search trigger's resting background from `bg-card` to `bg-sidebar-accent-hover`. That token is the opaque equivalent of the sidebar nav item hover (`bg-sidebar-accent/65`), so the search bar at rest now renders the exact colour a nav item shows on hover.

`bun scripts/static-checks.ts` passes. Rendered colours were measured in the browser (light and dark) to confirm the search trigger matches the nav hover.
