### PR TITLE
fix(e2e): stop reloading the auth wait on cold previews

### DIFF
--- a/e2e/utils/auth.ts
+++ b/e2e/utils/auth.ts
@@ -1,40 +1,27 @@
 import { expect, type Page } from '@playwright/test';
 
 /**
- * Wait for the app to be fully loaded, hydrated, and authenticated.
- * Handles transient app-load failures in CI by retrying page load.
+ * Wait for an authenticated app page to be loaded, hydrated, and interactive.
  *
- * 1. Wait for URL to match the app route
- * 2. Wait for the authenticated UI shell to be visible
- * 3. Wait for Svelte hydration (data-hydrated attribute on <html>)
- * 4. If the shell does not appear, reload and retry (up to maxRetries)
+ * Two signals, in order, on a single generous budget, and deliberately NO
+ * page.reload() on the way:
+ *   1. html[data-hydrated] is set unconditionally in the layout's onMount, so it is
+ *      independent of the Convex WebSocket. The definitive "Svelte hydrated, event
+ *      handlers attached" signal.
+ *   2. #user-menu-trigger is the authenticated shell, SSR-rendered from the JWT
+ *      viewer, so it paints without waiting on the live session.
+ *
+ * Why no reload and a large budget: a cold CF preview boots a fresh worker AND a
+ * freshly provisioned Convex deployment, and signin navigates with a full page
+ * load, so /app starts a cold client + WebSocket. A page.reload() throws that warm
+ * boot away and re-pays the entire cold start from zero. Repeated reloads on a
+ * too-small per-attempt budget is exactly what made the auth setup cascade-fail on
+ * cold previews. One attempt, full budget, lets the boot finish.
  *
  * After this returns, event handlers are attached and elements are interactive.
  */
-export async function waitForAuthenticated(page: Page, timeout = 30000, maxRetries = 3) {
-	const perAttemptTimeout = Math.max(5000, Math.floor(timeout / maxRetries));
-
-	for (let attempt = 1; attempt <= maxRetries; attempt++) {
-		await page.waitForURL(/\/[a-z]{2}\/app/, { timeout });
-		await page.waitForLoadState('domcontentloaded', { timeout });
-
-		try {
-			await expect(page.locator('#user-menu-trigger')).toBeVisible({
-				timeout: perAttemptTimeout
-			});
-			// Wait for Svelte hydration to complete so event handlers are attached.
-			// The app layout sets data-hydrated on <html> in onMount.
-			await page.locator('html[data-hydrated]').waitFor({ timeout: perAttemptTimeout });
-			return;
-		} catch (error) {
-			if (attempt < maxRetries) {
-				console.log(
-					`[waitForAuthenticated] app shell not ready on attempt ${attempt}, retrying...`
-				);
-				await page.reload();
-				continue;
-			}
-			throw error;
-		}
-	}
+export async function waitForAuthenticated(page: Page, timeout = 60000) {
+	await page.waitForURL(/\/[a-z]{2}\/app/, { timeout });
+	await page.locator('html[data-hydrated]').waitFor({ timeout });
+	await expect(page.locator('#user-menu-trigger')).toBeVisible({ timeout: 15000 });
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,8 +33,16 @@ export default defineConfig({
 	forbidOnly: isCI,
 	/* Retry on CI only */
 	retries: isCI ? 2 : 0,
-	/* CI: auto-detect workers based on CPU cores; locally: single worker prevents dev server overload in headed mode */
-	workers: isCI ? undefined : 1,
+	/* Single worker everywhere: the suite shares one preview Convex backend and the
+	 * admin specs mutate shared rows (notification recipients, users), so running
+	 * specs concurrently would cause intra-project data races. Reliability over
+	 * speed: the serial run is slow but deterministic. */
+	workers: 1,
+	/* CI runs against an ephemeral CF preview whose cold start + Convex WebSocket
+	 * boot can make a page take >10s to hydrate. Give each test generous headroom
+	 * so a slow-but-functional preview does not cascade into auth-setup timeouts. */
+	timeout: isCI ? 90_000 : 30_000,
+	expect: { timeout: isCI ? 15_000 : 5_000 },
 	/* Reporter to use - auto-open after tests complete */
 	reporter: [['html', { open: 'always' }]],
 	/* Shared settings for all the projects below */


### PR DESCRIPTION
Closes #592

`waitForAuthenticated` waited for the authenticated shell with a 30s budget split across three attempts (about 10s each), checked `#user-menu-trigger` before `html[data-hydrated]`, and called `page.reload()` on timeout. On a cold Cloudflare preview that boots a fresh worker and a freshly provisioned Convex deployment, signin navigates with a full page load so `/app` starts a cold client and WebSocket. A reload throws that warm boot away and re-pays the entire cold start from zero, so with only about 10s per attempt the auth setup project timed out before the preview hydrated and every dependent spec cascade-failed.

This drops the retry loop and the reload. The helper now runs a single attempt on a generous 60s budget, waits for `html[data-hydrated]` first (set unconditionally in the layout's onMount, so it is independent of the Convex WebSocket) and then `#user-menu-trigger` on a short secondary timeout. The Playwright config pins `workers` to 1 everywhere, since the suite shares one preview backend and admin specs mutate shared rows, and raises the CI per-test timeout to 90s and the expect timeout to 15s so a slow-but-functional preview has headroom instead of cascading into auth-setup timeouts.

Regression guard: not warranted, one-off test-harness timing fix with no other call sites.

`bun run test:unit` passes.