### PR TITLE
fix(ssr): guard server Convex client construction in SSR loads

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ import noBareTestSkipRule from './eslint/rules/no-bare-test-skip.js';
 import noModuleStateSingletonRule from './eslint/rules/no-module-state-singleton.js';
 import requireMotionGuardTransitionRule from './eslint/rules/require-motion-guard-transition.js';
 import requireFieldErrorAssociationRule from './eslint/rules/require-field-error-association.js';
+import requireGuardedServerConvexClientRule from './eslint/rules/require-guarded-server-convex-client.js';
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
 const localPlugin = {
@@ -33,7 +34,8 @@ const localPlugin = {
 		'no-bare-test-skip': noBareTestSkipRule,
 		'no-module-state-singleton': noModuleStateSingletonRule,
 		'require-motion-guard-transition': requireMotionGuardTransitionRule,
-		'require-field-error-association': requireFieldErrorAssociationRule
+		'require-field-error-association': requireFieldErrorAssociationRule,
+		'require-guarded-server-convex-client': requireGuardedServerConvexClientRule
 	}
 };
 
@@ -256,6 +258,19 @@ export default defineConfig(
 		},
 		rules: {
 			'local/require-motion-guard-transition': 'error'
+		}
+	},
+	{
+		// The server Convex client throws synchronously on an unresolved Convex
+		// URL (cold preview before env propagates); a per-query .catch does not
+		// cover the construction line, so it must sit inside a try (#594).
+		// See eslint/rules/require-guarded-server-convex-client.js.
+		files: ['src/routes/**/+page.server.ts', 'src/routes/**/+layout.server.ts'],
+		plugins: {
+			local: localPlugin
+		},
+		rules: {
+			'local/require-guarded-server-convex-client': 'error'
 		}
 	},
 	// Convex best-practice rules — v2 ships ESLint 9 flat config natively

--- a/eslint/rules/require-guarded-server-convex-client.js
+++ b/eslint/rules/require-guarded-server-convex-client.js
@@ -1,0 +1,78 @@
+/**
+ * ESLint rule: require-guarded-server-convex-client
+ *
+ * Flags `createServerConvexHttpClient(...)` constructed outside a try block in
+ * a SvelteKit server load (`+page.server.ts` / `+layout.server.ts`).
+ *
+ * Why: the helper throws SYNCHRONOUSLY when the Convex URL is unresolved (a
+ * missing CONVEX_INTERNAL_URL/PUBLIC_CONVEX_URL, which happens on a freshly
+ * provisioned preview before env propagates). A per-query `.catch` does not
+ * cover the construction line, so an unguarded `const client = create...()`
+ * 500s the SSR page even though the client `useQuery` subscription would
+ * recover the real data after hydration (#594). This bug fails silently in
+ * local dev and review (env is always resolved there) and only surfaces on
+ * cold previews, and the construct-then-catch shape is copy-pasted into every
+ * new authenticated load, so it is a recurring class worth a structural guard.
+ *
+ * ❌ const client = createServerConvexHttpClient({ token });
+ *    const data = await client.query(...).catch(() => fallback);
+ * ✅ try {
+ *      const client = createServerConvexHttpClient({ token });
+ *      const data = await client.query(...);
+ *      return { data };
+ *    } catch (e) { return { data: fallback }; }
+ *
+ * The rule traverses downward from Program (instead of walking node.parent) so
+ * it is self-contained and testable with the repo's parent-less rule harness.
+ */
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Require createServerConvexHttpClient() construction inside a try block in SvelteKit server loads (#594)'
+		},
+		schema: [],
+		messages: {
+			unguardedConstruction:
+				'createServerConvexHttpClient() throws synchronously when the Convex URL is unresolved (e.g. a freshly provisioned preview before env propagates). Construct it inside a try so the SSR load degrades to a fallback instead of 500ing the page (#594). The per-query .catch does not cover the construction line.'
+		}
+	},
+	create(context) {
+		function isClientConstruction(node) {
+			return (
+				node.type === 'CallExpression' &&
+				node.callee?.type === 'Identifier' &&
+				node.callee.name === 'createServerConvexHttpClient'
+			);
+		}
+
+		function walk(node, insideTry) {
+			if (!node || typeof node !== 'object' || typeof node.type !== 'string') return;
+
+			if (isClientConstruction(node) && !insideTry) {
+				context.report({ node, messageId: 'unguardedConstruction' });
+			}
+
+			for (const key of Object.keys(node)) {
+				if (key === 'parent' || key === 'tokens' || key === 'comments') continue;
+				const value = node[key];
+				const children = Array.isArray(value) ? value : [value];
+				for (const child of children) {
+					if (!child || typeof child !== 'object' || typeof child.type !== 'string') continue;
+					// Only a try's protected `block` guards construction; descending
+					// into `handler` (catch) or `finalizer` (finally) does not. Once
+					// inside a guarded block, everything below stays guarded.
+					const childGuarded = insideTry || (node.type === 'TryStatement' && key === 'block');
+					walk(child, childGuarded);
+				}
+			}
+		}
+
+		return {
+			Program(node) {
+				walk(node, false);
+			}
+		};
+	}
+};

--- a/eslint/rules/require-guarded-server-convex-client.test.ts
+++ b/eslint/rules/require-guarded-server-convex-client.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { parser } from 'typescript-eslint';
+import rule from './require-guarded-server-convex-client.js';
+
+function lint(code: string): Array<{ messageId: string }> {
+	const reports: Array<{ messageId: string }> = [];
+	const ast = parser.parseForESLint(code, {});
+
+	const context = {
+		report: (opts: { messageId: string }) => reports.push(opts),
+		getFilename: () => 'src/routes/[[lang]]/app/example/+page.server.ts',
+		filename: 'src/routes/[[lang]]/app/example/+page.server.ts'
+	};
+
+	const listeners = rule.create(context) as Record<string, (n: unknown) => void>;
+
+	function walk(node: Record<string, unknown>) {
+		if (!node || typeof node !== 'object') return;
+		const type = node.type as string;
+		if (type && typeof listeners[type] === 'function') listeners[type](node);
+		for (const key of Object.keys(node)) {
+			if (key === 'parent') continue;
+			const val = node[key];
+			if (Array.isArray(val)) val.forEach((v) => walk(v as Record<string, unknown>));
+			else if (val && typeof val === 'object' && (val as Record<string, unknown>).type)
+				walk(val as Record<string, unknown>);
+		}
+	}
+
+	walk(ast.ast as unknown as Record<string, unknown>);
+	return reports;
+}
+
+describe('require-guarded-server-convex-client', () => {
+	it('flags bare construction outside a try', () => {
+		const reports = lint(`
+			export const load = async (event) => {
+				const client = createServerConvexHttpClient({ token: event.locals.token });
+				const viewer = await client.query(api.users.viewer, {}).catch(() => null);
+				return { viewer };
+			};
+		`);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('unguardedConstruction');
+	});
+
+	it('allows construction inside a try block', () => {
+		const reports = lint(`
+			export const load = async (event) => {
+				try {
+					const client = createServerConvexHttpClient({ token: event.locals.token });
+					const viewer = await client.query(api.users.viewer, {});
+					return { viewer };
+				} catch (e) {
+					return { viewer: null };
+				}
+			};
+		`);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows construction nested deeper inside a try block', () => {
+		const reports = lint(`
+			export const load = async (event) => {
+				try {
+					if (event.locals.token) {
+						const client = createServerConvexHttpClient({ token: event.locals.token });
+						return { viewer: await client.query(api.users.viewer, {}) };
+					}
+				} catch (e) {
+					return { viewer: null };
+				}
+				return { viewer: null };
+			};
+		`);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('flags construction in a catch block (handler is not the guarded path)', () => {
+		const reports = lint(`
+			export const load = async (event) => {
+				try {
+					noop();
+				} catch (e) {
+					const client = createServerConvexHttpClient({ token: event.locals.token });
+					return { viewer: await client.query(api.users.viewer, {}) };
+				}
+			};
+		`);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('unguardedConstruction');
+	});
+
+	it('flags each unguarded construction independently', () => {
+		const reports = lint(`
+			export const load = async () => {
+				const a = createServerConvexHttpClient({});
+				const b = createServerConvexHttpClient({});
+				return { a, b };
+			};
+		`);
+		expect(reports).toHaveLength(2);
+	});
+
+	it('ignores files that never construct the client', () => {
+		const reports = lint(`
+			export const load = async () => {
+				return { ok: true };
+			};
+		`);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('ignores unrelated call expressions', () => {
+		const reports = lint(`
+			export const load = async () => {
+				const x = someOtherFactory({});
+				return { x };
+			};
+		`);
+		expect(reports).toHaveLength(0);
+	});
+});

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -54,25 +54,38 @@ export const load: LayoutServerLoad = async (event) => {
 	let viewer = null;
 
 	if (isAuthenticated) {
-		const client = createServerConvexHttpClient({ token: event.locals.token });
+		// The whole block is guarded: client construction (a missing
+		// CONVEX_INTERNAL_URL/PUBLIC_CONVEX_URL throws here) and the autumn
+		// handler setup run before the per-query .catch, so an unguarded failure
+		// here would 500 every authenticated SSR page. Fall back to the JWT
+		// viewer + null customer; the client subscriptions recover after hydration.
+		try {
+			const client = createServerConvexHttpClient({ token: event.locals.token });
 
-		const { getCustomer } = createAutumnHandlers({
-			convexApi: (api as any).autumn,
-			createClient: () => client
-		});
+			const { getCustomer } = createAutumnHandlers({
+				convexApi: (api as any).autumn,
+				createClient: () => client
+			});
 
-		// Fetch customer and viewer in PARALLEL for faster initial load
-		// Wrap in try-catch to handle failures gracefully (e.g., in CI)
-		[customer, viewer] = await Promise.all([
-			getCustomer(event).catch((e) => {
-				console.error('[+layout.server.ts] Autumn getCustomer failed:', e);
-				return null;
-			}),
-			client.query(api.users.viewer, {}).catch((e) => {
-				console.error('[+layout.server.ts] Viewer lookup failed, falling back to JWT payload:', e);
-				return fallbackViewer;
-			})
-		]);
+			// Fetch customer and viewer in PARALLEL for faster initial load
+			[customer, viewer] = await Promise.all([
+				getCustomer(event).catch((e) => {
+					console.error('[+layout.server.ts] Autumn getCustomer failed:', e);
+					return null;
+				}),
+				client.query(api.users.viewer, {}).catch((e) => {
+					console.error(
+						'[+layout.server.ts] Viewer lookup failed, falling back to JWT payload:',
+						e
+					);
+					return fallbackViewer;
+				})
+			]);
+		} catch (e) {
+			console.error('[+layout.server.ts] Convex client unavailable, using JWT fallback:', e);
+			customer = null;
+			viewer = fallbackViewer;
+		}
 	}
 
 	return {

--- a/src/routes/[[lang]]/(auth)/signin/+page.server.ts
+++ b/src/routes/[[lang]]/(auth)/signin/+page.server.ts
@@ -3,12 +3,16 @@ import { api } from '$lib/convex/_generated/api.js';
 import { createServerConvexHttpClient } from '$lib/server/convex-http';
 
 export const load = (async () => {
-	const client = createServerConvexHttpClient({});
-	// Degrade gracefully on transient backend failure; the client useQuery
-	// subscription recovers the real provider availability after hydration.
-	const oauthProviders = await client.query(api.auth.getAvailableOAuthProviders, {}).catch((e) => {
+	// Degrade gracefully on any backend failure, including client construction
+	// (a missing CONVEX_INTERNAL_URL/PUBLIC_CONVEX_URL throws before the query):
+	// the client useQuery subscription recovers the real provider availability
+	// after hydration, so this SSR step must never 500 the page.
+	try {
+		const client = createServerConvexHttpClient({});
+		const oauthProviders = await client.query(api.auth.getAvailableOAuthProviders, {});
+		return { oauthProviders };
+	} catch (e) {
 		console.error('[signin/+page.server.ts] OAuth provider lookup failed:', e);
-		return { google: false, github: false };
-	});
-	return { oauthProviders };
+		return { oauthProviders: { google: false, github: false } };
+	}
 }) satisfies PageServerLoad;

--- a/src/routes/[[lang]]/(auth)/signup/+page.server.ts
+++ b/src/routes/[[lang]]/(auth)/signup/+page.server.ts
@@ -3,12 +3,16 @@ import { api } from '$lib/convex/_generated/api.js';
 import { createServerConvexHttpClient } from '$lib/server/convex-http';
 
 export const load = (async () => {
-	const client = createServerConvexHttpClient({});
-	// Degrade gracefully on transient backend failure; the client useQuery
-	// subscription recovers the real provider availability after hydration.
-	const oauthProviders = await client.query(api.auth.getAvailableOAuthProviders, {}).catch((e) => {
+	// Degrade gracefully on any backend failure, including client construction
+	// (a missing CONVEX_INTERNAL_URL/PUBLIC_CONVEX_URL throws before the query):
+	// the client useQuery subscription recovers the real provider availability
+	// after hydration, so this SSR step must never 500 the page.
+	try {
+		const client = createServerConvexHttpClient({});
+		const oauthProviders = await client.query(api.auth.getAvailableOAuthProviders, {});
+		return { oauthProviders };
+	} catch (e) {
 		console.error('[signup/+page.server.ts] OAuth provider lookup failed:', e);
-		return { google: false, github: false };
-	});
-	return { oauthProviders };
+		return { oauthProviders: { google: false, github: false } };
+	}
 }) satisfies PageServerLoad;

--- a/src/routes/[[lang]]/app/ai-chat/+page.server.ts
+++ b/src/routes/[[lang]]/app/ai-chat/+page.server.ts
@@ -3,13 +3,16 @@ import { api } from '$lib/convex/_generated/api.js';
 import { createServerConvexHttpClient } from '$lib/server/convex-http';
 
 export const load = (async (event) => {
-	const client = createServerConvexHttpClient({ token: event.locals.token });
-
-	// Degrade gracefully on transient backend failure; the client useQuery
-	// subscription recovers the viewer after hydration.
-	const viewer = await client.query(api.users.viewer, {}).catch((e) => {
+	// Degrade gracefully on any backend failure, including client construction
+	// (a missing CONVEX_INTERNAL_URL/PUBLIC_CONVEX_URL throws before the query):
+	// the client useQuery subscription recovers the viewer after hydration, so
+	// this SSR load must never 500 the page.
+	try {
+		const client = createServerConvexHttpClient({ token: event.locals.token });
+		const viewer = await client.query(api.users.viewer, {});
+		return { viewer };
+	} catch (e) {
 		console.error('[ai-chat/+page.server.ts] Viewer lookup failed:', e);
-		return null;
-	});
-	return { viewer };
+		return { viewer: null };
+	}
 }) satisfies PageServerLoad;

--- a/src/routes/[[lang]]/app/community-chat/+page.server.ts
+++ b/src/routes/[[lang]]/app/community-chat/+page.server.ts
@@ -3,22 +3,25 @@ import { api } from '$lib/convex/_generated/api.js';
 import { createServerConvexHttpClient } from '$lib/server/convex-http';
 
 export const load = (async (event) => {
-	const client = createServerConvexHttpClient({ token: event.locals.token });
-
-	// Degrade gracefully on transient backend failure; the client useQuery
-	// subscriptions recover viewer and messages after hydration.
-	const [viewer, messages] = await Promise.all([
-		client.query(api.users.viewer, {}).catch((e) => {
-			console.error('[community-chat/+page.server.ts] Viewer lookup failed:', e);
-			return null;
-		}),
-		client.query(api.messages.list, {}).catch((e) => {
-			console.error('[community-chat/+page.server.ts] Messages lookup failed:', e);
-			return [];
-		})
-	]);
-	return {
-		viewer,
-		messages
-	};
+	// Degrade gracefully on any backend failure, including client construction
+	// (a missing CONVEX_INTERNAL_URL/PUBLIC_CONVEX_URL throws before the query):
+	// the client useQuery subscriptions recover viewer and messages after
+	// hydration, so this SSR load must never 500 the page.
+	try {
+		const client = createServerConvexHttpClient({ token: event.locals.token });
+		const [viewer, messages] = await Promise.all([
+			client.query(api.users.viewer, {}).catch((e) => {
+				console.error('[community-chat/+page.server.ts] Viewer lookup failed:', e);
+				return null;
+			}),
+			client.query(api.messages.list, {}).catch((e) => {
+				console.error('[community-chat/+page.server.ts] Messages lookup failed:', e);
+				return [];
+			})
+		]);
+		return { viewer, messages };
+	} catch (e) {
+		console.error('[community-chat/+page.server.ts] Convex client unavailable:', e);
+		return { viewer: null, messages: [] };
+	}
 }) satisfies PageServerLoad;


### PR DESCRIPTION
Closes #594

Issue #458 wrapped the SSR Convex queries in a `.catch` so a transient backend hiccup degrades instead of 500ing the request, but the client construction stayed outside that guard. `createServerConvexHttpClient` throws synchronously when the Convex URL is unresolved, which happens on a freshly created preview before env propagates, and because that throw is outside the per-query `.catch` it 500s the page even though the client `useQuery` subscription would recover the real data after hydration. Five SSR loads had this shape: the signin and signup loads and the root `+layout.server.ts` authenticated block, plus the ai-chat and community-chat page loads.

This wraps construction and query together in try-catch across all five. The signin and signup loads degrade to `{ oauthProviders: { google: false, github: false } }`, the layout's authenticated block degrades to the JWT viewer with a null customer, ai-chat degrades to a null viewer, and community-chat to a null viewer with empty messages. The live subscriptions then heal the state once the client connects after hydration.

A new authenticated load could reintroduce the bare-construction pattern, which is invisible in local dev where the Convex URL always resolves and only surfaces on cold previews. A local ESLint rule now requires the construction to sit inside a try in `+page.server.ts`/`+layout.server.ts` loads.

Regression guard: added eslint/rules/require-guarded-server-convex-client.js, which flags `createServerConvexHttpClient` constructed outside a try in server loads. It is unit-tested and verified to flag the pre-fix ai-chat and community-chat loads.

`bun scripts/static-checks.ts` on the changed files passes and the new rule's unit tests pass.
