### PR TITLE
fix(deploy): never prune a live branch's preview backend

### DIFF
--- a/scripts/deploy/prune-previews.test.ts
+++ b/scripts/deploy/prune-previews.test.ts
@@ -115,6 +115,53 @@ describe('selectPrunable', () => {
 		const target = selectPrunable(previews, 'current', NOW);
 		expect(target?.previewIdentifier).toBe('stale');
 	});
+
+	it('never prunes a live branch even when it is the absolute oldest', () => {
+		const previews = [
+			preview({ id: 'open-pr', ageMin: 500 }),
+			preview({ id: 'abandoned', ageMin: 100 }),
+			preview({ id: 'newest', ageMin: 1 })
+		];
+		const liveBranches = new Set(['open-pr']);
+		const target = selectPrunable(previews, 'unrelated', NOW, liveBranches);
+		// 'open-pr' is the oldest but live, so the oldest non-live candidate wins.
+		expect(target?.previewIdentifier).toBe('abandoned');
+	});
+
+	it('matches live branches via normalized identifier', () => {
+		const previews = [
+			preview({ id: 'Feature/Foo-Bar', ageMin: 500 }),
+			preview({ id: 'abandoned', ageMin: 100 }),
+			preview({ id: 'newest', ageMin: 1 })
+		];
+		// liveBranches is expected to already be normalized by the caller.
+		const liveBranches = new Set([normalizeIdentifier('Feature/Foo-Bar')]);
+		const target = selectPrunable(previews, 'unrelated', NOW, liveBranches);
+		expect(target?.previewIdentifier).toBe('abandoned');
+	});
+
+	it('returns null when every non-current/non-newest candidate is live', () => {
+		const previews = [
+			preview({ id: 'current', ageMin: 300 }),
+			preview({ id: 'live-a', ageMin: 200 }),
+			preview({ id: 'live-b', ageMin: 100 }),
+			preview({ id: 'newest', ageMin: 1 })
+		];
+		const liveBranches = new Set(['live-a', 'live-b']);
+		expect(selectPrunable(previews, 'current', NOW, liveBranches)).toBeNull();
+	});
+
+	it('back-compat: omitting liveBranches behaves exactly as before', () => {
+		const previews = [
+			preview({ id: 'oldest', ageMin: 200 }),
+			preview({ id: 'middle', ageMin: 100 }),
+			preview({ id: 'newest', ageMin: 1 })
+		];
+		// Identical to the bare-call result with no live set.
+		expect(selectPrunable(previews, 'unrelated', NOW)?.previewIdentifier).toBe('oldest');
+		expect(selectPrunable(previews, 'unrelated', NOW, undefined)?.previewIdentifier).toBe('oldest');
+		expect(selectPrunable(previews, 'unrelated', NOW, new Set())?.previewIdentifier).toBe('oldest');
+	});
 });
 
 describe('pruneOldestPreview', () => {

--- a/scripts/deploy/prune-previews.ts
+++ b/scripts/deploy/prune-previews.ts
@@ -58,7 +58,8 @@ export function normalizeIdentifier(value: string): string {
 export function selectPrunable(
 	previews: Preview[],
 	currentBranch: string | null,
-	now: number
+	now: number,
+	liveBranches?: Set<string>
 ): Preview | null {
 	if (previews.length === 0) return null;
 	// Without a current branch we cannot honour the "never prune current branch"
@@ -74,9 +75,15 @@ export function selectPrunable(
 	// preview unnecessarily.
 	const absoluteNewest = previews.reduce((a, b) => (a.createTime >= b.createTime ? a : b));
 	const candidates = previews.filter((p) => {
-		const isCurrentBranch = normalizeIdentifier(p.previewIdentifier) === normalizedBranch;
+		const normalizedId = normalizeIdentifier(p.previewIdentifier);
+		const isCurrentBranch = normalizedId === normalizedBranch;
 		const isAbsoluteNewest = p.name === absoluteNewest.name;
-		return !isCurrentBranch && !isAbsoluteNewest;
+		// Never prune a preview whose branch still exists on the remote: that
+		// branch may have an open PR or running E2E that depends on its backend.
+		// liveBranches holds normalized branch names; an undefined/empty set
+		// degrades to the original age-based behaviour.
+		const isLiveBranch = liveBranches?.has(normalizedId) ?? false;
+		return !isCurrentBranch && !isAbsoluteNewest && !isLiveBranch;
 	});
 	if (candidates.length === 0) return null;
 
@@ -96,6 +103,7 @@ export async function pruneOldestPreview(args: {
 	currentBranch: string | null;
 	now?: number;
 	deps?: PruneDeps;
+	liveBranches?: Set<string>;
 }): Promise<PruneResult> {
 	const deps = args.deps ?? defaultDeps;
 	const now = args.now ?? Date.now();
@@ -107,7 +115,7 @@ export async function pruneOldestPreview(args: {
 		return { pruned: null, reason: `list failed: ${errMessage(err)}` };
 	}
 
-	const target = selectPrunable(previews, args.currentBranch, now);
+	const target = selectPrunable(previews, args.currentBranch, now, args.liveBranches);
 	if (!target) {
 		return { pruned: null, reason: 'no candidates' };
 	}

--- a/scripts/deploy/steps.ts
+++ b/scripts/deploy/steps.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import type { PlatformContext } from './platform';
-import { pruneOldestPreview } from './prune-previews';
+import { normalizeIdentifier, pruneOldestPreview } from './prune-previews';
 import {
 	colors,
 	runCommand,
@@ -170,6 +170,51 @@ const MAX_RECOVERY_ATTEMPTS = 3;
 const POST_PRUNE_DELAY_MS = 10_000;
 
 /**
+ * Fetch the set of branches that still exist on the remote, normalized so
+ * they join against a preview's normalized previewIdentifier (the branch
+ * Convex was given via --preview-create). Host-agnostic: uses only
+ * `git ls-remote`, never a GitHub/GitLab API. Fail-safe: any failure or
+ * unparseable output yields an empty set, so recovery degrades to the
+ * original age-based prune instead of hard-failing the deploy.
+ */
+function fetchLiveBranches(): Set<string> {
+	const live = new Set<string>();
+	let result: { success: boolean; stdout: string; stderr: string };
+	try {
+		result = runCommandCapture('git', ['ls-remote', '--heads', 'origin']);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.warn(
+			`${colors.yellow}Could not list remote branches (git ls-remote threw: ${message}); pruning by age only${colors.reset}`
+		);
+		return live;
+	}
+
+	if (!result.success || !result.stdout) {
+		console.warn(
+			`${colors.yellow}Could not list remote branches (git ls-remote failed or returned nothing); pruning by age only${colors.reset}`
+		);
+		return live;
+	}
+
+	for (const line of result.stdout.split('\n')) {
+		// Lines look like: "<sha>\trefs/heads/<branch>"
+		const match = line.match(/^[0-9a-f]+\s+refs\/heads\/(.+)$/);
+		if (!match) continue;
+		const normalized = normalizeIdentifier(match[1]);
+		if (normalized) live.add(normalized);
+	}
+
+	if (live.size === 0) {
+		console.warn(
+			`${colors.yellow}No remote branches parsed from git ls-remote output; pruning by age only${colors.reset}`
+		);
+	}
+
+	return live;
+}
+
+/**
  * On DeploymentQuotaReached: adaptively prune one eligible preview per
  * attempt, wait for quota propagation, and retry `convex deploy`. Stops
  * early if one prune is enough. Bounded at MAX_RECOVERY_ATTEMPTS deletes
@@ -195,13 +240,21 @@ async function tryRecoverFromQuota(
 		`${colors.yellow}DeploymentQuotaReached detected. Adaptive recovery (up to ${MAX_RECOVERY_ATTEMPTS} prune+retry rounds)...${colors.reset}`
 	);
 
+	// Branches that still exist on the remote keep their preview backend; a
+	// concurrent build's open PR / running E2E depends on it. Never prune those.
+	const liveBranches = fetchLiveBranches();
+	if (liveBranches.size > 0) {
+		console.log(`  Protecting ${liveBranches.size} live remote branch(es) from pruning`);
+	}
+
 	let lastResult: { success: boolean; stdout: string; stderr: string } | null = null;
 
 	for (let attempt = 1; attempt <= MAX_RECOVERY_ATTEMPTS; attempt++) {
 		const pruneResult = await pruneOldestPreview({
 			token,
 			projectId,
-			currentBranch: platform.gitRef ?? null
+			currentBranch: platform.gitRef ?? null,
+			liveBranches
 		});
 		if (pruneResult.pruned === null) {
 			console.error(


### PR DESCRIPTION
Closes #599

When a Convex deploy hits DeploymentQuotaReached, `tryRecoverFromQuota` prunes the oldest preview deployment and retries. `selectPrunable` excluded only the current branch and the absolute newest preview, so the oldest preview was fair game by age. That oldest preview often belongs to a branch that still has an open PR or a running E2E, and pruning it deletes that branch's preview backend out from under a concurrent build, breaking a sibling PR's preview deploy or E2E run for no reason of its own.

This adds an optional `liveBranches` set (normalized branch names) to `selectPrunable` and `pruneOldestPreview` and excludes any preview whose branch is in it. The recovery path builds that set from `git ls-remote --heads origin`, so it is host-agnostic with no GitHub or GitLab API dependency, and it is fail-safe: any git failure or unparseable output yields an empty set, so the prune degrades to the original age-based behaviour rather than hard-failing the deploy. Omitting the argument is fully back-compatible.

Regression guard: added scripts/deploy/prune-previews.test.ts cases covering live-branch exclusion, normalized matching, all-candidates-live returning null, and back-compat when the set is omitted.

`bun run test:unit` on the deploy specs passes (20 selectPrunable/prune + 4 steps cases) and pre-commit checks pass.