### PR TITLE
fix(analytics): cookieless PostHog, identify by id

### DIFF
--- a/src/lib/analytics/posthog.ts
+++ b/src/lib/analytics/posthog.ts
@@ -65,7 +65,12 @@ export async function initPosthog(): Promise<PostHogClient | null> {
 			posthog.init(PUBLIC_POSTHOG_API_KEY, {
 				api_host: apiHost,
 				ui_host: 'https://eu.posthog.com',
-				person_profiles: 'identified_only'
+				person_profiles: 'identified_only',
+				// Cookieless: store nothing in cookies/localStorage so the privacy
+				// policy's "essential cookies only, no consent banner" claim holds
+				// (GDPR/§25 TDDDG). Autocapture, pageview, and identify keep working;
+				// only cross-reload anonymous attribution degrades.
+				persistence: 'memory'
 			});
 
 			client = posthog;

--- a/src/lib/components/analytics/PostHogIdentify.svelte
+++ b/src/lib/components/analytics/PostHogIdentify.svelte
@@ -36,15 +36,15 @@
 		const posthog = getPosthog();
 		if (!posthog) return;
 
-		if (isAuthenticated && sessionUser?.email) {
-			const properties: Record<string, string> = {
-				email: sessionUser.email
-			};
+		if (isAuthenticated && sessionUser?.id) {
+			// Identify by the stable user id, not email: email can change, and the
+			// id is the join key for any server-side events keyed by user id.
+			const properties: Record<string, string> = {};
 
+			if (sessionUser.email) properties.email = sessionUser.email;
 			if (sessionUser.name) properties.name = sessionUser.name;
-			if (sessionUser.id) properties.userId = sessionUser.id;
 
-			posthog.identify(sessionUser.email, properties);
+			posthog.identify(sessionUser.id, properties);
 			return;
 		}
 


### PR DESCRIPTION
Closes #601

`posthog.init` set no `persistence`, so posthog-js defaulted to `localStorage+cookie` and wrote the `ph_<token>_posthog` cookie. The privacy policy (`src/lib/content/privacy.ts`, Section V) claims only essential cookies are used and no consent banner is required, which is inaccurate as shipped under GDPR and German §25 TDDDG, and every fork inherits it.

Setting `persistence: 'memory'` makes PostHog cookieless, so the existing privacy copy becomes accurate with no banner needed. Autocapture, pageviews, and identify keep working; only cross-reload anonymous attribution degrades. The identify call now uses the stable user id as the `distinct_id` instead of email, keeping email and name as person properties, since email can change and the id is the join key for any server-side events.

Regression guard: not warranted, a single PostHog init option at the only init site.

`bun scripts/static-checks.ts` passes on both changed files.
