### PR TITLE
fix(test): stub required secrets for local e2e

### DIFF
--- a/.env.convex.example
+++ b/.env.convex.example
@@ -4,25 +4,29 @@
 # Source of truth: .env-convex.schema (varlock)
 # Platform: Convex Dashboard (via CLI: bunx convex env set KEY value)
 # Purpose: Backend configuration for Convex serverless functions
-# For local dev: put values in .env.convex.local instead
+# For local dev: put values in .env.convex.local instead.
+# For local e2e (`bun run dev:test`): the required email/billing/AI secrets below
+# are auto-stubbed with inert dummies by vite.config.ts, so a fresh test backend
+# boots with no setup. A fresh `bun run dev` backend still needs the real values
+# (Convex validates the declared-required vars at push time).
 
 # ====================================
 # Email System (Resend) - REQUIRED for cloud email flows
 # ====================================
 
-# Resend API Key (REQUIRED for cloud / OPTIONAL for `bun run dev` boot)
+# Resend API Key (REQUIRED for cloud; auto-stubbed for local e2e)
 # Get from: https://resend.com/api-keys
 # Used for sending transactional emails (verification, password reset, etc.)
-# Mirror this into `.env.local` only if you want real signup, verification, and reset emails
-# while using `bun run dev`. Local boot itself can use the seeded admin without this.
+# Set this in `.env.convex.local` only if you want real signup, verification, and
+# reset emails while using `bun run dev`.
 # Command: bunx convex env set RESEND_API_KEY re_your_api_key_here
 RESEND_API_KEY=re_your_api_key_here
 
-# Auth Email Sender (REQUIRED for cloud / OPTIONAL for `bun run dev` boot)
+# Auth Email Sender (REQUIRED for cloud; auto-stubbed for local e2e)
 # The "from" email address for authentication emails
 # Must be a verified domain in Resend
 # Example: noreply@yourdomain.com
-# Mirror this into `.env.local` only if you want real Better Auth emails while using `bun run dev`.
+# Set this in `.env.convex.local` only if you want real Better Auth emails while using `bun run dev`.
 # Command: bunx convex env set AUTH_EMAIL noreply@yourdomain.com
 AUTH_EMAIL=noreply@yourdomain.com
 

--- a/scripts/env-schema-parity.test.ts
+++ b/scripts/env-schema-parity.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { TEST_ONLY_ENV_PLACEHOLDERS } from './local-convex-env';
 
 /**
  * The Convex `env` block in `src/lib/convex/convex.config.ts` and the varlock
@@ -101,6 +102,34 @@ describe('Convex env declaration parity', () => {
 		expect(
 			mismatches,
 			`required/optional mismatch between schema and env block: ${mismatches}`
+		).toEqual([]);
+	});
+
+	// A fresh `bun run dev:test` backend gets its env only from vite.config.ts:
+	// auto-generated dev defaults, the TEST_ONLY_ENV_PLACEHOLDERS, and the
+	// forwarded test secret. Any var convex.config.ts declares required but that
+	// isn't provided here fails Convex's push-time validation, so a fresh worktree
+	// can't boot e2e — and CI wouldn't catch it (it uses real preview-default env).
+	it('every required env-block var is provided to a fresh local test backend', () => {
+		// Always injected by vite.config.ts for a local backend (runtime values).
+		const alwaysProvided = new Set([
+			'BETTER_AUTH_SECRET',
+			'SITE_URL',
+			'LOCAL_CONVEX_DEV',
+			'LOCAL_SEEDED_ADMIN_EMAIL',
+			'LOCAL_SEEDED_ADMIN_PASSWORD',
+			'LOCAL_SEEDED_ADMIN_NAME',
+			'AUTH_E2E_TEST_SECRET'
+		]);
+		const provided = new Set([...alwaysProvided, ...Object.keys(TEST_ONLY_ENV_PLACEHOLDERS)]);
+
+		const requiredButUnprovided = [...envBlock.entries()]
+			.filter(([name, { required }]) => required && !provided.has(name))
+			.map(([name]) => name);
+		expect(
+			requiredButUnprovided,
+			`convex.config.ts requires these vars but a fresh local test backend isn't given them ` +
+				`(add to TEST_ONLY_ENV_PLACEHOLDERS in scripts/local-convex-env.ts): ${requiredButUnprovided}`
 		).toEqual([]);
 	});
 });

--- a/scripts/local-convex-env.ts
+++ b/scripts/local-convex-env.ts
@@ -1,0 +1,22 @@
+/**
+ * Inert placeholder values injected into the local embedded Convex backend in
+ * TEST mode (`bun run dev:test`).
+ *
+ * `convex.config.ts` declares these secrets required, so Convex rejects a fresh
+ * test backend's push if they are absent. The e2e suite never exercises the
+ * underlying services (Resend skips `@e2e.example.com` recipients, Autumn fails
+ * open, OpenRouter is unused), so these dummies satisfy the push-time validation
+ * with no real secret. Real values in `.env.convex.local` override them.
+ *
+ * Single source of truth: `vite.config.ts` spreads this when injecting the
+ * backend env, and `scripts/env-schema-parity.test.ts` asserts that every
+ * required var in `convex.config.ts` is covered here (or always provided), so a
+ * newly added required secret can't silently break fresh-worktree e2e.
+ */
+export const TEST_ONLY_ENV_PLACEHOLDERS = {
+	RESEND_API_KEY: 're_local_e2e_dummy',
+	AUTH_EMAIL: 'noreply@e2e.example.com',
+	EMAIL_ASSET_URL: 'http://localhost',
+	AUTUMN_SECRET_KEY: 'am_sk_local_e2e_dummy',
+	OPENROUTER_API_KEY: 'sk-or-local-e2e-dummy'
+} as const;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import { convexLocal } from 'convex-vite-plugin';
 import { resetRedactionMap } from 'varlock/env';
 import { DEV_FEATURES, type DevFeature } from './src/lib/dev/features';
 import { findAvailablePort, portlessOwnsPort } from './scripts/dev-ports';
+import { TEST_ONLY_ENV_PLACEHOLDERS } from './scripts/local-convex-env';
 import { sentrySvelteKit } from '@sentry/sveltekit';
 import devtoolsJson from 'vite-plugin-devtools-json';
 import tailwindcss from '@tailwindcss/vite';
@@ -324,6 +325,11 @@ export default defineConfig(async ({ mode }) => {
 						LOCAL_SEEDED_ADMIN_EMAIL: 'admin@local.dev',
 						LOCAL_SEEDED_ADMIN_PASSWORD: 'LocalDevAdmin123!',
 						LOCAL_SEEDED_ADMIN_NAME: 'Local Admin',
+						// Test mode: inert placeholders for the deploy-required secrets the
+						// e2e suite never exercises, so a fresh test backend passes Convex's
+						// push-time env validation with no real secret. See local-convex-env.ts;
+						// real values in .env.convex.local override them (spread below).
+						...(isTestMode ? TEST_ONLY_ENV_PLACEHOLDERS : {}),
 						// User overrides from .env.convex.local (takes precedence)
 						...convexLocalEnv,
 						// Test mode: forward AUTH_E2E_TEST_SECRET so api.tests.* mutations


### PR DESCRIPTION
A fresh `bun run dev:test` backend (a new git worktree, or after `RESET_LOCAL_BACKEND`) fails to deploy with `MissingEnvironmentVariables`. `convex.config.ts` declares `RESEND_API_KEY`, `AUTH_EMAIL`, `EMAIL_ASSET_URL`, `AUTUMN_SECRET_KEY`, and `OPENROUTER_API_KEY` as required, and Convex validates the declared env block at push time. The local embedded backend only receives env that `vite.config.ts` injects, which did not include these five, so a fresh checkout could not run e2e locally without manually setting real secrets first.

Inject inert placeholders for those five in test mode, before the `.env.convex.local` spread so real values still override. The e2e suite never exercises the underlying services, Resend skips `@e2e.example.com` recipients, Autumn fails open, and OpenRouter is unused, so the dummies satisfy Convex's push-time validation with no real secret. The placeholders live in `scripts/local-convex-env.ts` as a single source of truth. Regular `bun run dev` is unchanged, the placeholders are test-mode only, so a developer's persisted backend keys are never clobbered, and for real local email/billing/AI you still put real or sandbox keys in `.env.convex.local`. The prod deploy gate, the CI env preflight, and preview/prod env wiring are untouched. The stale `.env.convex.example` note that claimed these were optional for `bun run dev` boot is corrected.

Verified by running a public e2e spec in a fresh worktree with a clean `.env.convex.local` and no manual env: the backend deploys and the tests pass (`4 passed`). `bun run test:unit` passes, including the extended `env-schema-parity` guard.

Regression guard: added env-schema-parity coverage asserting every required `convex.config.ts` var is provided to a fresh local test backend (catches a newly added required secret that CI would miss, since CI uses real preview-default env).
