### PR TITLE
refactor(support): extract launcher icon component

### DIFF
--- a/src/lib/components/customer-support/feedback-button.svelte
+++ b/src/lib/components/customer-support/feedback-button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button/index.js';
-	import MessageSquareIcon from '@lucide/svelte/icons/message-square';
+	import LauncherIcon from './launcher-icon.svelte';
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import FeedbackWidget from './feedback-widget.svelte';
 	import { on } from 'svelte/events';
@@ -60,13 +60,11 @@
 						? 'blur-0 scale-100 opacity-100'
 						: 'scale-75 opacity-0 blur-sm'}"
 				/>
-				<div class="-scale-x-100">
-					<MessageSquareIcon
-						class="absolute inset-0 size-6 fill-current transition-[transform,opacity,filter] duration-200 ease-out {isFeedbackOpen
-							? 'scale-75 opacity-0 blur-sm'
-							: 'blur-0 scale-100 opacity-100'}"
-					/>
-				</div>
+				<LauncherIcon
+					class="absolute inset-0 transition-[transform,opacity,filter] duration-200 ease-out {isFeedbackOpen
+						? 'scale-75 opacity-0 blur-sm'
+						: 'blur-0 scale-100 opacity-100'}"
+				/>
 			</div>
 		</Button>
 	</div>

--- a/src/lib/components/customer-support/launcher-icon.svelte
+++ b/src/lib/components/customer-support/launcher-icon.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import MessageSquareIcon from '@lucide/svelte/icons/message-square';
+	import { cn } from '$lib/utils.js';
+
+	let { class: className }: { class?: string } = $props();
+</script>
+
+<!-- Single source of truth for the support launcher glyph (mirrored). -->
+<div class="-scale-x-100">
+	<MessageSquareIcon class={cn('size-6 fill-current', className)} />
+</div>

--- a/src/lib/components/customer-support/lazy-customer-support.svelte
+++ b/src/lib/components/customer-support/lazy-customer-support.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import MessageSquareIcon from '@lucide/svelte/icons/message-square';
+	import LauncherIcon from './launcher-icon.svelte';
 	import { getTranslate } from '@tolgee/svelte';
 	import type { Component } from 'svelte';
 
@@ -100,9 +100,7 @@
 			aria-label={$t('aria.feedback_open')}
 			class="h-12 w-12 rounded-xl transition-[color,background-color,border-color,transform] duration-200 ease-out hover:scale-105 hover:bg-primary active:scale-[0.97]"
 		>
-			<div class="-scale-x-100">
-				<MessageSquareIcon class="size-6 fill-current" />
-			</div>
+			<LauncherIcon />
 		</Button>
 	</div>
 {/if}


### PR DESCRIPTION
The chat launcher glyph lived in two files: the lazy-load placeholder in `lazy-customer-support.svelte` and the loaded `feedback-button.svelte`. Keeping them in sync by hand is fragile.

This moves the glyph, the `-scale-x-100` mirror wrapper, and the default `size-6 fill-current` into a single `launcher-icon.svelte`. Both consumers now render `<LauncherIcon />` and pass only their own layout and animation classes, merged with `cn()`. Changing the launcher icon is now a one-line edit in one file. No behavior or visual change.

Verified with `bun scripts/static-checks.ts` on the three files (all checks pass).