### PR TITLE
test(seo): guard meta titles against brand duplication

### DIFF
--- a/src/lib/components/SEOHead.svelte
+++ b/src/lib/components/SEOHead.svelte
@@ -75,6 +75,10 @@
 </script>
 
 <svelte:head>
+	<!-- The brand is appended here, so the `title` prop and every meta.*.title in
+	     src/i18n must be page-name only. A title that already ends in the brand
+	     renders it twice ("Pricing | Brand | Brand"). The meta-title unit test
+	     guards the i18n side. -->
 	{#if title}
 		<title>{title} | {LEGAL_CONFIG.brandName}</title>
 		<meta property="og:title" content={title} />

--- a/src/lib/i18n/meta-titles.test.ts
+++ b/src/lib/i18n/meta-titles.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { LEGAL_CONFIG } from '$lib/config/legal';
+import en from '../../i18n/en.json';
+import de from '../../i18n/de.json';
+import es from '../../i18n/es.json';
+import fr from '../../i18n/fr.json';
+
+// SEOHead.svelte renders `<title>{title} | {brandName}</title>`, so every
+// meta.*.title must be page-name only. A title that already ends in the brand
+// renders it twice (e.g. "Pricing | Brand | Brand"). Guard the i18n side here
+// so the duplication cannot ship regardless of where a title is edited.
+const locales: Record<string, unknown> = { en, de, es, fr };
+const suffix = ` | ${LEGAL_CONFIG.brandName}`;
+
+describe('SEO meta titles never include the brand suffix', () => {
+	for (const [lang, data] of Object.entries(locales)) {
+		const meta = (data as { meta?: Record<string, { title?: unknown }> }).meta ?? {};
+		for (const [page, entry] of Object.entries(meta)) {
+			const title = entry?.title;
+			if (typeof title !== 'string') continue;
+			it(`${lang} meta.${page}.title`, () => {
+				expect(
+					title.includes(suffix),
+					`"${title}" must be page-name only; SEOHead appends "${suffix}"`
+				).toBe(false);
+			});
+		}
+	}
+});


### PR DESCRIPTION
`SEOHead.svelte` renders `<title>{title} | {brandName}</title>`, appending the brand to every page title. A `meta.*.title` that already ends in the brand renders it twice. The AGENTS.md note has documented this for a while, but a note is only as good as the next person reading it.

This adds a comment at the title-append site so the contract sits where the title is built, and a unit test that fails if any `meta.*.title` in the four locale files contains the ` | {brandName}` suffix. The test reads the brand from `LEGAL_CONFIG`, so it keeps working after a fork rebrands.