### PR TITLE
fix: recover from blank page after deploy

### DIFF
--- a/e2e/public-deploy-recovery.spec.ts
+++ b/e2e/public-deploy-recovery.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+
+// The deploy-recovery contract: after a new deploy replaces content-hashed chunks,
+// a dynamic import of a now-deleted hash makes Vite fire vite:preloadError. The root
+// layout listens for it and hard reloads once to pull the fresh shell, recovering
+// from what would otherwise be a blank page. A sessionStorage flag stops a reload
+// loop if the shell itself is still served stale.
+type SentinelWindow = Window & { __reloadSentinel?: boolean };
+
+test.describe('deploy stale-chunk recovery', () => {
+	test('a failed chunk preload triggers a single full reload', async ({ page }) => {
+		// A light prerendered page: the home hero is a heavy WebGL scene that delays
+		// hydration on a GPU-less CI runner, which would race the listener attaching.
+		await page.goto('/en/privacy');
+
+		// A full reload (what the backstop does) wipes this; a client update keeps it.
+		await page.evaluate(() => {
+			(window as SentinelWindow).__reloadSentinel = true;
+		});
+
+		// Fire vite:preloadError until hydration has wired the listener. It sets
+		// sk:preload-reloaded and hard reloads once; the flag persists across the
+		// reload, so the flag turning "1" proves the backstop ran. Re-firing is the
+		// only reliable way to bridge the unknown hydration delay.
+		await expect
+			.poll(
+				async () => {
+					await page
+						.evaluate(() => window.dispatchEvent(new Event('vite:preloadError')))
+						.catch(() => {});
+					return page
+						.evaluate(() => sessionStorage.getItem('sk:preload-reloaded'))
+						.catch(() => null);
+				},
+				{ timeout: 30_000, intervals: [250] }
+			)
+			.toBe('1');
+
+		// The reload cleared the sentinel.
+		await expect
+			.poll(() =>
+				page.evaluate(() => (window as SentinelWindow).__reloadSentinel).catch(() => undefined)
+			)
+			.toBeFalsy();
+
+		// A second failure in the same tab must not reload again: the sessionStorage
+		// guard short-circuits the listener, so the freshly set sentinel survives.
+		await page.evaluate(() => {
+			(window as SentinelWindow).__reloadSentinel = true;
+		});
+		for (let i = 0; i < 4; i++) {
+			await page
+				.evaluate(() => window.dispatchEvent(new Event('vite:preloadError')))
+				.catch(() => {});
+			await page.waitForTimeout(250);
+		}
+		expect(await page.evaluate(() => (window as SentinelWindow).__reloadSentinel)).toBe(true);
+	});
+});

--- a/scripts/patch-cf-worker.test.ts
+++ b/scripts/patch-cf-worker.test.ts
@@ -115,6 +115,15 @@ describe('patch-cf-worker', () => {
 		expect(result.match(/const __wantsMarkdown =/g)?.length).toBe(1);
 	});
 
+	it('forces browser revalidation of prerendered marketing HTML', () => {
+		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
+		// Browser must revalidate the shell so it never boots a stale version
+		// referencing deleted chunk hashes after a deploy.
+		expect(result).toContain(
+			'public, max-age=0, must-revalidate, s-maxage=3600, stale-while-revalidate=86400'
+		);
+	});
+
 	it('does not add a public cache header to the server.respond branch', () => {
 		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
 		const elseIdx = result.indexOf('res = await server.respond(req');
@@ -123,7 +132,9 @@ describe('patch-cf-worker', () => {
 
 	it('injects the marketing edge-cache on the no-cache fallback path', () => {
 		const result = applyMarkdownPatch(WORKER_FIXTURE_NO_CACHE)!;
-		expect(result).toContain('s-maxage=3600, stale-while-revalidate=86400');
+		expect(result).toContain(
+			'public, max-age=0, must-revalidate, s-maxage=3600, stale-while-revalidate=86400'
+		);
 		expect(result).toContain('res = new Response(res.body, res)');
 		expect(result.match(/s-maxage=3600/g)?.length).toBe(1);
 	});

--- a/scripts/patch-cf-worker.ts
+++ b/scripts/patch-cf-worker.ts
@@ -50,11 +50,19 @@ export const ASSET_SERVE_PATTERN = /res = await (\w+)\.ASSETS\.fetch\(req\);?/;
 const MARKETING_HTML_CACHE_INJECTION = `res = await $1.ASSETS.fetch(req);
         if (!__wantsMarkdown && prerendered.has(pathname) && /^\\/[a-z]{2}(\\/(about|privacy|terms|impressum))?$/.test(pathname)) {
           // Prerendered marketing HTML bypasses SvelteKit hooks on CF, so it ships
-          // with no Cache-Control. Apply the same s-maxage policy handleCacheControl
-          // gives the SSR /pricing route. ASSETS responses have immutable headers —
-          // reconstruct to mutate.
+          // with no Cache-Control. Apply the same policy handleCacheControl gives the
+          // SSR /pricing route. ASSETS responses have immutable headers, so
+          // reconstruct to mutate. max-age=0, must-revalidate asks the browser to
+          // revalidate the shell so the location.href recovery in the root layout
+          // fetches a fresh one instead of a stale shell with dead chunk hashes.
+          // Necessary but not sufficient: a fixed zone Browser Cache TTL (default 4h)
+          // is a floor that CF uses to rewrite the browser-facing max-age back up to
+          // 14400 while the response stays edge-cacheable. The zone must set Browser
+          // Cache TTL to "Respect Existing Headers" (or a Cache Rule on the marketing
+          // HTML paths) for max-age=0 to survive. This string must stay identical to
+          // handleCacheControl in src/hooks.server.ts.
           res = new Response(res.body, res);
-          res.headers.set("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=86400");
+          res.headers.set("Cache-Control", "public, max-age=0, must-revalidate, s-maxage=3600, stale-while-revalidate=86400");
         }`;
 
 /**

--- a/scripts/version-config.test.ts
+++ b/scripts/version-config.test.ts
@@ -1,0 +1,43 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Guards the deploy-recovery contract in svelte.config.js: the app version name
+// must be deterministic per commit (not the default build timestamp) and polling
+// must be enabled, otherwise updated.current never flips and the beforeNavigate
+// guard in the root layout cannot recover from a stale chunk hash after a deploy.
+describe('kit.version config', () => {
+	const config = fs.readFileSync(path.resolve('svelte.config.js'), 'utf-8');
+
+	it('derives version.name from a commit SHA, not a timestamp', () => {
+		expect(config).toContain('WORKERS_CI_COMMIT_SHA');
+		expect(config).toContain('VERCEL_GIT_COMMIT_SHA');
+		expect(config).toContain('git rev-parse HEAD');
+		// A timestamp or random source would defeat version detection.
+		expect(config).not.toMatch(/version[\s\S]{0,80}Date\.now/);
+		expect(config).not.toMatch(/version[\s\S]{0,80}Math\.random/);
+	});
+
+	it('sets a non-zero pollInterval so updated.current can flip', () => {
+		const match = config.match(/pollInterval:\s*(\d+)/);
+		expect(match, 'pollInterval not found in svelte.config.js').not.toBeNull();
+		expect(Number(match![1])).toBeGreaterThan(0);
+	});
+
+	it('registers the beforeNavigate recovery guard in the root layout', () => {
+		const layout = fs.readFileSync(path.resolve('src/routes/+layout.svelte'), 'utf-8');
+		expect(layout).toContain("import { beforeNavigate } from '$app/navigation'");
+		// updated must come from $app/state, not the deprecated $app/stores.
+		expect(layout).toMatch(/import \{[^}]*\bupdated\b[^}]*\} from '\$app\/state'/);
+		expect(layout).toContain('updated.current');
+		expect(layout).toContain('location.href = to.url.href');
+	});
+
+	it('registers a vite:preloadError backstop that reloads once', () => {
+		const layout = fs.readFileSync(path.resolve('src/routes/+layout.svelte'), 'utf-8');
+		expect(layout).toContain("addEventListener('vite:preloadError'");
+		expect(layout).toContain('location.reload()');
+		// A sessionStorage guard must gate the reload so a stale shell cannot loop.
+		expect(layout).toMatch(/sessionStorage\.getItem\(['"]sk:preload-reloaded['"]\)/);
+	});
+});

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -241,7 +241,27 @@ const handleCacheControl: Handle = async function handleCacheControl({ event, re
 		!event.locals.token &&
 		matchPublicMarketingRoute(event.url.pathname)
 	) {
-		response.headers.set('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=86400');
+		// max-age=0, must-revalidate asks the browser to revalidate the HTML shell on
+		// every navigation (a 304 keeps it cheap) so the location.href recovery in the
+		// root layout fetches a fresh shell instead of re-reading a stale one that
+		// references deleted chunk hashes. s-maxage keeps the shared edge cache.
+		//
+		// Necessary but not sufficient on Cloudflare. A fixed zone Browser Cache TTL
+		// (default 4h) acts as a floor: CF rewrites the browser-facing max-age back up
+		// to 14400 whenever the origin value is lower, and this response stays
+		// edge-cacheable (public + s-maxage), so max-age=0 is overridden until the zone
+		// is reconfigured. See developers.cloudflare.com/cache/how-to/edge-browser-cache-ttl/.
+		// Required CF change (zone-level, not expressible from origin headers): set
+		// Browser Cache TTL to "Respect Existing Headers", or add a Cache Rule scoped to
+		// the marketing HTML paths that does the same. Verify after deploy: the live
+		// Cache-Control on /en must NOT carry an injected max-age=14400.
+		//
+		// This string must stay in sync with the prerendered marketing HTML header in
+		// scripts/patch-cf-worker.ts.
+		response.headers.set(
+			'Cache-Control',
+			'public, max-age=0, must-revalidate, s-maxage=3600, stale-while-revalidate=86400'
+		);
 		// These URLs also serve markdown via Accept header. CF edge ignores Vary, so
 		// this is safe only because every route reaching this branch is non-prerendered
 		// and the markdown variant is private (kept out of shared caches).

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import { page } from '$app/state';
+	import { beforeNavigate } from '$app/navigation';
+	import { page, updated } from '$app/state';
 	import { T, Tolgee, DevTools, TolgeeProvider } from '@tolgee/svelte';
 	import type { TolgeeStaticData } from '@tolgee/svelte';
 	import { FormatIcu } from '@tolgee/format-icu';
@@ -26,6 +27,28 @@
 	const translations: TolgeeStaticData = { en, de, es, fr };
 
 	let { children } = $props();
+
+	// After a new deploy is detected (version.json poll flips updated.current),
+	// turn the next client navigation into a full document load so fresh chunk
+	// hashes are fetched instead of importing a now-deleted hash and blanking
+	// the page. Covers goto() and back/forward, unlike data-sveltekit-reload.
+	beforeNavigate(({ willUnload, to }) => {
+		if (updated.current && !willUnload && to?.url) {
+			location.href = to.url.href;
+		}
+	});
+
+	// Reactive backstop for the window between a deploy and the next version poll:
+	// when a dynamic import 404s because its chunk hash was replaced, Vite fires
+	// vite:preloadError. Hard reload once to pull the new shell. The sessionStorage
+	// flag prevents a reload loop if the shell itself is still served stale.
+	if (browser) {
+		window.addEventListener('vite:preloadError', () => {
+			if (sessionStorage.getItem('sk:preload-reloaded')) return;
+			sessionStorage.setItem('sk:preload-reloaded', '1');
+			location.reload();
+		});
+	}
 
 	const currentLang = $derived(getLanguage(page.params.lang).code);
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import auto from '@sveltejs/adapter-auto';
 import cloudflare from '@sveltejs/adapter-cloudflare';
 import node from '@sveltejs/adapter-node';
@@ -20,6 +21,22 @@ const prerenderEntries = LANGUAGES.flatMap((lang) =>
 	PRERENDER_MARKETING_PAGES.map((page) => `/${lang}${page}`)
 );
 
+// A deterministic, per-commit app version so the client can detect a new
+// deploy and recover from dead chunk hashes. The default build timestamp is
+// non-deterministic across the two CI build steps within one deploy, which
+// breaks the failed-import safety net. Prefer the commit SHA injected by the
+// build host (Workers Builds, then Vercel), fall back to a local git rev, and
+// finally to 'dev' so non-git build hosts still get a stable name.
+function appVersion() {
+	const sha = process.env.WORKERS_CI_COMMIT_SHA || process.env.VERCEL_GIT_COMMIT_SHA;
+	if (sha) return sha;
+	try {
+		return execSync('git rev-parse HEAD').toString().trim();
+	} catch {
+		return 'dev';
+	}
+}
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	// Consult https://svelte.dev/docs/kit/integrations
@@ -37,6 +54,13 @@ const config = {
 		prerender: {
 			entries: prerenderEntries,
 			handleMissingId: 'warn'
+		},
+		version: {
+			name: appVersion(),
+			// Poll /_app/version.json in the background so updated.current flips to
+			// true after a new deploy, letting the beforeNavigate guard in the root
+			// layout force a full document load before importing a dead chunk hash.
+			pollInterval: 300000
 		}
 	}
 };


### PR DESCRIPTION
After a deploy, a returning visitor can boot a stale app shell whose content-hashed `/_app/immutable/*` chunks were replaced. A client-side navigation then imports a chunk hash that no longer exists and the page renders blank until a manual hard refresh. The marketing HTML shell was also browser-cached for four hours (Cloudflare injects max-age=14400 because the origin sent no browser max-age), which widened the window, and the template had none of SvelteKit's version-recovery guards.

This adds the canonical SvelteKit version-recovery setup plus a reactive backstop. `svelte.config.js` sets a deterministic `kit.version.name` from the commit SHA (Workers Builds, then Vercel, then a local git rev, then `dev`) and a five minute `pollInterval`. The root layout registers the documented `beforeNavigate` guard that turns the next client navigation into a full document load once `updated.current` flips, plus a `vite:preloadError` listener that hard reloads once (sessionStorage-guarded against a loop). `handleCacheControl` and the prerendered-HTML header injected in `patch-cf-worker.ts` now send `public, max-age=0, must-revalidate, s-maxage=3600, stale-while-revalidate=86400` so the browser revalidates the shell while the edge keeps serving it.

One Cloudflare-side change is required for the header to take full effect on a deployed instance: the zone Browser Cache TTL must be set to Respect Existing Headers, otherwise the four hour default overrides the origin `max-age=0` back up to 14400. That is documented inline at both cache call sites.

Regression guard: added `scripts/version-config.test.ts` (the version config and root-layout guard contract) and `e2e/public-deploy-recovery.spec.ts` (the runtime reload backstop).

Verification: `bun run check`, `bun run lint`, `bun run test:unit` (including the new `scripts/version-config.test.ts` and the `patch-cf-worker` revalidation cases), and `bun run build` all pass. The new e2e spec passes locally against the `dev:test` stack.
