### PR TITLE
style(support): hug active filter pill to its label

### DIFF
--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -159,10 +159,17 @@
 			value={filterMode}
 			onValueChange={(v) => onFilterChange(v as 'all' | 'unassigned' | 'my-inbox')}
 		>
-			<Tabs.List class="grid w-full grid-cols-3">
-				<Tabs.Trigger value="my-inbox"><T keyName="admin.support.filter.my_inbox" /></Tabs.Trigger>
-				<Tabs.Trigger value="all"><T keyName="admin.support.filter.all" /></Tabs.Trigger>
-				<Tabs.Trigger value="unassigned"
+			<!-- Full-width bar, but each trigger hugs its label (flex-none) and the
+			     three are spread evenly, so the active pill wraps only the label
+			     instead of filling a rigid third. -->
+			<Tabs.List class="w-full justify-evenly">
+				<Tabs.Trigger value="my-inbox" class="flex-none"
+					><T keyName="admin.support.filter.my_inbox" /></Tabs.Trigger
+				>
+				<Tabs.Trigger value="all" class="flex-none"
+					><T keyName="admin.support.filter.all" /></Tabs.Trigger
+				>
+				<Tabs.Trigger value="unassigned" class="flex-none"
 					><T keyName="admin.support.filter.unassigned" /></Tabs.Trigger
 				>
 			</Tabs.List>


### PR DESCRIPTION
The support filter tabs (Inbox / All / Unassigned) override the shadcn Tabs.List with grid w-full grid-cols-3. That stretches each trigger to a rigid third, so the active pill fills the whole third and a short label like All floats in an oversized pill. (A plain flex w-full variant renders identically, so that is not the fix.)

This keeps the bar full width but makes each trigger size to its label (flex-none, overriding the component's flex-1) and spreads the three evenly (justify-evenly), so the active pill wraps only its label. Found while fixing the same bug in a downstream fork; verified by rendering the real Tabs component with these exact classes in isolation at mobile width.

static-checks on the file passes.