### PR TITLE
fix(auth): recover from blank page on auth failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,7 +427,7 @@ Decision tree for new routes:
 
 4. **Is the page an API endpoint or static file?**
    - Yes → `+server.ts` with custom Response
-   - Examples: `/api/auth/[...all]`, `/llms.txt`, `/robots.txt`, `/sitemap.xml`
+   - Examples: `/api/auth/[...all]`, `/llms.txt`, `/robots.txt`, `/sitemap.xml`, `/api/time` (runtime JSON, `prerender = false`, `cache-control: no-store` — server wall-clock for client clock-skew detection)
 
 #### Data-fetching patterns (decision tree)
 

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -511,6 +511,22 @@
 		"load_error": "Daten konnten nicht geladen werden. Bitte versuchen Sie es später erneut.",
 		"you": "Sie"
 	},
+	"connection": {
+		"clock_skew": {
+			"message": "Deine Systemuhr geht etwa {offset} falsch. Das kann Anmeldung und Live-Updates blockieren.",
+			"action": "Stell Datum und Uhrzeit auf automatisch und lade die Seite neu.",
+			"reload": "Neu laden",
+			"dismiss": "Ausblenden"
+		},
+		"fallback": {
+			"connecting": "Verbindung wird hergestellt…",
+			"offline_title": "Server nicht erreichbar",
+			"offline_description": "Dein Arbeitsbereich konnte nicht geladen werden. Prüf deine Verbindung und versuch es erneut.",
+			"clock_title": "Deine Systemuhr blockiert die Verbindung",
+			"clock_description": "Deine Uhr geht etwa {offset} falsch, deshalb wird die sichere Sitzung immer wieder abgewiesen. Stell Datum und Uhrzeit auf automatisch und versuch es erneut.",
+			"retry": "Erneut versuchen"
+		}
+	},
 	"email": {
 		"admin_reply": {
 			"button": "Unterhaltung ansehen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -511,6 +511,22 @@
 		"load_error": "Failed to load data. Please try again later.",
 		"you": "You"
 	},
+	"connection": {
+		"clock_skew": {
+			"message": "Your device clock is off by about {offset}, which can block sign-in and live updates.",
+			"action": "Set your date and time to automatic, then reload.",
+			"reload": "Reload",
+			"dismiss": "Dismiss"
+		},
+		"fallback": {
+			"connecting": "Connecting…",
+			"offline_title": "Can't reach the server",
+			"offline_description": "We couldn't load your workspace. Check your connection and try again.",
+			"clock_title": "Your device clock is blocking the connection",
+			"clock_description": "Your clock is off by about {offset}, so the secure session keeps getting rejected. Set your date and time to automatic, then retry.",
+			"retry": "Retry"
+		}
+	},
 	"email": {
 		"admin_reply": {
 			"button": "View Conversation",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -511,6 +511,22 @@
 		"load_error": "No se pudieron cargar los datos. Por favor, inténtalo de nuevo más tarde.",
 		"you": "Tú"
 	},
+	"connection": {
+		"clock_skew": {
+			"message": "El reloj de tu dispositivo está desviado unos {offset}, lo que puede bloquear el inicio de sesión y las actualizaciones en vivo.",
+			"action": "Pon la fecha y la hora en automático y vuelve a cargar la página.",
+			"reload": "Recargar",
+			"dismiss": "Descartar"
+		},
+		"fallback": {
+			"connecting": "Conectando…",
+			"offline_title": "No se puede conectar con el servidor",
+			"offline_description": "No pudimos cargar tu espacio de trabajo. Revisa tu conexión e inténtalo de nuevo.",
+			"clock_title": "El reloj de tu dispositivo bloquea la conexión",
+			"clock_description": "Tu reloj está desviado unos {offset}, por eso la sesión segura se rechaza una y otra vez. Pon la fecha y la hora en automático e inténtalo de nuevo.",
+			"retry": "Reintentar"
+		}
+	},
 	"email": {
 		"admin_reply": {
 			"button": "Ver conversación",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -511,6 +511,22 @@
 		"load_error": "Échec du chargement des données. Veuillez réessayer plus tard.",
 		"you": "Vous"
 	},
+	"connection": {
+		"clock_skew": {
+			"message": "L'horloge de ton appareil est décalée d'environ {offset}, ce qui peut bloquer la connexion et les mises à jour en direct.",
+			"action": "Règle la date et l'heure sur automatique, puis recharge la page.",
+			"reload": "Recharger",
+			"dismiss": "Ignorer"
+		},
+		"fallback": {
+			"connecting": "Connexion…",
+			"offline_title": "Serveur injoignable",
+			"offline_description": "Impossible de charger ton espace de travail. Vérifie ta connexion et réessaie.",
+			"clock_title": "L'horloge de ton appareil bloque la connexion",
+			"clock_description": "Ton horloge est décalée d'environ {offset}, la session sécurisée est donc refusée à chaque fois. Règle la date et l'heure sur automatique, puis réessaie.",
+			"retry": "Réessayer"
+		}
+	},
 	"email": {
 		"admin_reply": {
 			"button": "Voir la conversation",

--- a/src/lib/components/authenticated/auth-connection-fallback.svelte
+++ b/src/lib/components/authenticated/auth-connection-fallback.svelte
@@ -2,6 +2,7 @@
 	import { T } from '@tolgee/svelte';
 	import { onMount } from 'svelte';
 	import { clockSkewContext } from '$lib/hooks/clock-skew.svelte';
+	import * as Empty from '$lib/components/ui/empty/index.js';
 	import { Button } from '$lib/components/ui/button';
 	import LoaderIcon from '@lucide/svelte/icons/loader-circle';
 	import ClockIcon from '@lucide/svelte/icons/clock';
@@ -26,34 +27,51 @@
 	}
 </script>
 
-<div
-	class="flex min-h-svh flex-col items-center justify-center gap-4 p-6 text-center"
+<main
+	id="main-content"
+	class="grid min-h-[100dvh] w-full place-items-center px-4 py-8"
 	data-testid="auth-connection-fallback"
 >
-	{#if !timedOut && !skewed}
-		<LoaderIcon class="size-6 text-muted-foreground motion-safe:animate-spin" />
-		<p class="text-sm text-muted-foreground"><T keyName="connection.fallback.connecting" /></p>
-	{:else}
-		<div class="flex max-w-md flex-col items-center gap-3">
-			{#if skewed}
-				<ClockIcon class="size-8 text-warning" />
-				<h1 class="text-lg font-medium"><T keyName="connection.fallback.clock_title" /></h1>
-				<p class="text-sm text-muted-foreground">
-					<T
-						keyName="connection.fallback.clock_description"
-						params={{ offset: skew?.magnitude ?? '' }}
-					/>
-				</p>
-			{:else}
-				<WifiOffIcon class="size-8 text-muted-foreground" />
-				<h1 class="text-lg font-medium"><T keyName="connection.fallback.offline_title" /></h1>
-				<p class="text-sm text-muted-foreground">
-					<T keyName="connection.fallback.offline_description" />
-				</p>
-			{/if}
-			<Button variant="outline" onclick={retry} data-testid="auth-connection-retry">
-				<T keyName="connection.fallback.retry" />
-			</Button>
-		</div>
-	{/if}
-</div>
+	<Empty.Root class="w-full max-w-xl">
+		{#if !timedOut && !skewed}
+			<Empty.Header>
+				<Empty.Media>
+					<LoaderIcon class="size-6 text-muted-foreground motion-safe:animate-spin" />
+				</Empty.Media>
+				<Empty.Title><T keyName="connection.fallback.connecting" /></Empty.Title>
+			</Empty.Header>
+		{:else}
+			<Empty.Header>
+				<Empty.Media variant="icon">
+					{#if skewed}
+						<ClockIcon class="text-warning" />
+					{:else}
+						<WifiOffIcon class="text-muted-foreground" />
+					{/if}
+				</Empty.Media>
+				<Empty.Title>
+					{#if skewed}
+						<T keyName="connection.fallback.clock_title" />
+					{:else}
+						<T keyName="connection.fallback.offline_title" />
+					{/if}
+				</Empty.Title>
+				<Empty.Description>
+					{#if skewed}
+						<T
+							keyName="connection.fallback.clock_description"
+							params={{ offset: skew?.magnitude ?? '' }}
+						/>
+					{:else}
+						<T keyName="connection.fallback.offline_description" />
+					{/if}
+				</Empty.Description>
+			</Empty.Header>
+			<Empty.Content>
+				<Button variant="outline" onclick={retry} data-testid="auth-connection-retry">
+					<T keyName="connection.fallback.retry" />
+				</Button>
+			</Empty.Content>
+		{/if}
+	</Empty.Root>
+</main>

--- a/src/lib/components/authenticated/auth-connection-fallback.svelte
+++ b/src/lib/components/authenticated/auth-connection-fallback.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { T } from '@tolgee/svelte';
+	import { onMount } from 'svelte';
+	import { clockSkewContext } from '$lib/hooks/clock-skew.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import LoaderIcon from '@lucide/svelte/icons/loader-circle';
+	import ClockIcon from '@lucide/svelte/icons/clock';
+	import WifiOffIcon from '@lucide/svelte/icons/wifi-off';
+
+	// Rendered by AuthenticatedLayout when there is no server-resolved user, instead
+	// of a blank page. The client may still recover a session from cookies right
+	// after hydration (AppAuthProvider revalidates app:auth), so show a calm
+	// "connecting" state first and only escalate to an error after a grace window.
+	const skew = clockSkewContext.getOr(undefined);
+
+	let timedOut = $state(false);
+	onMount(() => {
+		const id = setTimeout(() => (timedOut = true), 8000);
+		return () => clearTimeout(id);
+	});
+
+	const skewed = $derived(!!skew?.isSkewed);
+
+	function retry() {
+		location.reload();
+	}
+</script>
+
+<div
+	class="flex min-h-svh flex-col items-center justify-center gap-4 p-6 text-center"
+	data-testid="auth-connection-fallback"
+>
+	{#if !timedOut && !skewed}
+		<LoaderIcon class="size-6 text-muted-foreground motion-safe:animate-spin" />
+		<p class="text-sm text-muted-foreground"><T keyName="connection.fallback.connecting" /></p>
+	{:else}
+		<div class="flex max-w-md flex-col items-center gap-3">
+			{#if skewed}
+				<ClockIcon class="size-8 text-warning" />
+				<h1 class="text-lg font-medium"><T keyName="connection.fallback.clock_title" /></h1>
+				<p class="text-sm text-muted-foreground">
+					<T
+						keyName="connection.fallback.clock_description"
+						params={{ offset: skew?.magnitude ?? '' }}
+					/>
+				</p>
+			{:else}
+				<WifiOffIcon class="size-8 text-muted-foreground" />
+				<h1 class="text-lg font-medium"><T keyName="connection.fallback.offline_title" /></h1>
+				<p class="text-sm text-muted-foreground">
+					<T keyName="connection.fallback.offline_description" />
+				</p>
+			{/if}
+			<Button variant="outline" onclick={retry} data-testid="auth-connection-retry">
+				<T keyName="connection.fallback.retry" />
+			</Button>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/authenticated/authenticated-layout.svelte
+++ b/src/lib/components/authenticated/authenticated-layout.svelte
@@ -3,6 +3,7 @@
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import AuthenticatedSidebar from './authenticated-sidebar.svelte';
 	import AuthenticatedHeader from './authenticated-header.svelte';
+	import AuthConnectionFallback from './auth-connection-fallback.svelte';
 	import { ScrollArea } from '$lib/components/ui/scroll-area';
 	import type { Snippet } from 'svelte';
 	import type { NavSubItem, SidebarConfig, User } from './types';
@@ -79,4 +80,10 @@
 			{/if}
 		</Sidebar.Inset>
 	</Sidebar.Provider>
+{:else}
+	<!-- No server-resolved user: render a recover/retry state instead of a blank
+	     page. Happens when SSR could not authenticate (e.g. a wrong device clock
+	     made the browser drop the short-lived auth cookie), where a plain reload
+	     would otherwise show nothing. -->
+	<AuthConnectionFallback />
 {/if}

--- a/src/lib/components/clock-skew-banner.svelte
+++ b/src/lib/components/clock-skew-banner.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { T } from '@tolgee/svelte';
+	import { PersistedState } from 'runed';
+	import { clockSkewContext } from '$lib/hooks/clock-skew.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
+
+	const skew = clockSkewContext.get();
+
+	// Dismiss for the session only: a wrong clock is rare and the user may be
+	// mid-fix, so don't nag across reloads, but reappear in a fresh session if
+	// still skewed.
+	const dismissed = new PersistedState<boolean>('clock-skew-dismissed', false, {
+		storage: 'session'
+	});
+
+	const visible = $derived(browser && skew.isSkewed && !dismissed.current);
+
+	function reload() {
+		location.reload();
+	}
+</script>
+
+{#if visible}
+	<div
+		role="alert"
+		data-testid="clock-skew-banner"
+		class="sticky top-0 z-[60] flex flex-wrap items-center justify-center gap-x-3 gap-y-2 border-b border-warning/20 bg-warning/10 px-4 py-2 text-center text-sm text-foreground backdrop-blur"
+	>
+		<TriangleAlertIcon class="size-4 shrink-0 text-warning" />
+		<span class="min-w-0">
+			<T keyName="connection.clock_skew.message" params={{ offset: skew.magnitude }} />
+			<T keyName="connection.clock_skew.action" />
+		</span>
+		<span class="flex shrink-0 gap-2">
+			<Button variant="outline" size="sm" onclick={reload} data-testid="clock-skew-reload">
+				<T keyName="connection.clock_skew.reload" />
+			</Button>
+			<Button
+				variant="ghost"
+				size="sm"
+				onclick={() => (dismissed.current = true)}
+				data-testid="clock-skew-dismiss"
+			>
+				<T keyName="connection.clock_skew.dismiss" />
+			</Button>
+		</span>
+	</div>
+{/if}

--- a/src/lib/hooks/clock-skew.svelte.ts
+++ b/src/lib/hooks/clock-skew.svelte.ts
@@ -1,0 +1,48 @@
+import { Context } from 'runed';
+import { browser } from '$app/environment';
+import { computeSkewMs, isClockSkewed, formatSkewMagnitude } from '$lib/utils/clock-skew';
+
+/**
+ * Per-request clock-skew state, shared via context.
+ *
+ * A misconfigured device clock silently breaks cookie-based auth: the browser
+ * treats freshly minted short-TTL auth cookies as already expired (RFC 6265), so
+ * the authenticated session never establishes and a plain reload can't fix it.
+ * We measure the client/server offset once after hydration and let the UI surface
+ * an actionable notice.
+ *
+ * Instantiated per request in the root layout — never a module-level singleton,
+ * which would leak across SSR requests.
+ */
+export class ClockSkewState {
+	/** Client minus server, in ms; `null` until measured. */
+	skewMs = $state<number | null>(null);
+
+	get isSkewed(): boolean {
+		return isClockSkewed(this.skewMs);
+	}
+
+	/** Compact magnitude (e.g. "6 h") for embedding in localized copy. */
+	get magnitude(): string {
+		return formatSkewMagnitude(this.skewMs);
+	}
+
+	/** Sample server time once and record the offset. No-op on the server or after a first read. */
+	async measure(): Promise<void> {
+		if (!browser || this.skewMs !== null) return;
+		try {
+			const requestStart = Date.now();
+			const res = await fetch('/api/time', { cache: 'no-store' });
+			const requestEnd = Date.now();
+			const body = (await res.json()) as { now?: unknown };
+			if (typeof body.now === 'number') {
+				this.skewMs = computeSkewMs(requestStart, requestEnd, body.now);
+			}
+		} catch {
+			// Offline / network error: leave unmeasured. The connection fallback
+			// covers the generic "can't reach the server" case.
+		}
+	}
+}
+
+export const clockSkewContext = new Context<ClockSkewState>('clock-skew');

--- a/src/lib/utils/clock-skew.test.ts
+++ b/src/lib/utils/clock-skew.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { computeSkewMs, isClockSkewed, formatSkewMagnitude, SKEW_THRESHOLD_MS } from './clock-skew';
+
+describe('computeSkewMs', () => {
+	it('returns ~0 for a synced clock, correcting for latency', () => {
+		// 200ms round trip; server time captured at the midpoint
+		expect(computeSkewMs(1000, 1200, 1100)).toBe(0);
+	});
+
+	it('detects a fast client clock as positive', () => {
+		const sixHours = 6 * 3_600_000;
+		expect(computeSkewMs(sixHours + 1000, sixHours + 1200, 1100)).toBe(sixHours);
+	});
+
+	it('detects a slow client clock as negative', () => {
+		expect(computeSkewMs(1000, 1200, 1100 + 600_000)).toBe(-600_000);
+	});
+});
+
+describe('isClockSkewed', () => {
+	it('is false before a measurement exists', () => {
+		expect(isClockSkewed(null)).toBe(false);
+	});
+
+	it('is false within the threshold', () => {
+		expect(isClockSkewed(SKEW_THRESHOLD_MS - 1)).toBe(false);
+		expect(isClockSkewed(-(SKEW_THRESHOLD_MS - 1))).toBe(false);
+	});
+
+	it('is true at or past the threshold in either direction', () => {
+		expect(isClockSkewed(SKEW_THRESHOLD_MS)).toBe(true);
+		expect(isClockSkewed(-SKEW_THRESHOLD_MS)).toBe(true);
+	});
+});
+
+describe('formatSkewMagnitude', () => {
+	it('formats hours, minutes, and seconds', () => {
+		expect(formatSkewMagnitude(6 * 3_600_000)).toBe('6 h');
+		expect(formatSkewMagnitude(12 * 60_000)).toBe('12 min');
+		expect(formatSkewMagnitude(45_000)).toBe('45 s');
+	});
+
+	it('is empty when unmeasured and ignores direction', () => {
+		expect(formatSkewMagnitude(null)).toBe('');
+		expect(formatSkewMagnitude(-6 * 3_600_000)).toBe('6 h');
+	});
+});

--- a/src/lib/utils/clock-skew.ts
+++ b/src/lib/utils/clock-skew.ts
@@ -1,0 +1,40 @@
+/**
+ * Threshold above which the device clock is treated as misconfigured. NTP keeps
+ * real clocks within a few seconds, so 2 minutes is far beyond normal drift or
+ * request latency, yet well under the auth cookie TTL where skew starts breaking
+ * sign-in.
+ */
+export const SKEW_THRESHOLD_MS = 120_000;
+
+/**
+ * Estimate client-minus-server skew from a round-tripped time sample, correcting
+ * for network latency by anchoring the client reading to the midpoint of the
+ * request window.
+ *
+ * @param requestStart client `Date.now()` before the fetch
+ * @param requestEnd   client `Date.now()` after the response resolved
+ * @param serverNow    server `Date.now()` carried in the response body
+ * @returns positive => client clock ahead of the server; negative => behind
+ */
+export function computeSkewMs(requestStart: number, requestEnd: number, serverNow: number): number {
+	const clientMidpoint = requestStart + (requestEnd - requestStart) / 2;
+	return clientMidpoint - serverNow;
+}
+
+/** A measured skew counts as a problem only past the threshold; `null` = not yet measured. */
+export function isClockSkewed(skewMs: number | null): boolean {
+	return skewMs !== null && Math.abs(skewMs) >= SKEW_THRESHOLD_MS;
+}
+
+/**
+ * Compact, locale-neutral magnitude of the skew for display inside a localized
+ * sentence (e.g. "6 h", "12 min", "45 s"). Direction is intentionally omitted:
+ * "your clock is off by ~6 h" is the actionable part; ahead-vs-behind is noise.
+ */
+export function formatSkewMagnitude(skewMs: number | null): string {
+	if (skewMs === null) return '';
+	const abs = Math.abs(skewMs);
+	if (abs >= 3_600_000) return `${Math.round(abs / 3_600_000)} h`;
+	if (abs >= 60_000) return `${Math.round(abs / 60_000)} min`;
+	return `${Math.round(abs / 1000)} s`;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,6 +9,8 @@
 	import AppAuthProvider from '$lib/components/app/app-auth-provider.svelte';
 	import AppAutumnProvider from '$lib/components/app/app-autumn-provider.svelte';
 	import AppPostHogBootstrap from '$lib/components/app/app-posthog-bootstrap.svelte';
+	import ClockSkewBanner from '$lib/components/clock-skew-banner.svelte';
+	import { ClockSkewState, clockSkewContext } from '$lib/hooks/clock-skew.svelte';
 	import { setGlobalSearchContext } from '$lib/components/global-search/context.svelte';
 	import GlobalSearchShell from '$lib/components/global-search/global-search-shell.svelte';
 	import { languageContext } from '$lib/i18n/context';
@@ -48,6 +50,22 @@
 			sessionStorage.setItem('sk:preload-reloaded', '1');
 			location.reload();
 		});
+	}
+
+	// Detect a misconfigured device clock, which silently breaks cookie-based auth
+	// (the browser drops freshly minted short-TTL auth cookies it thinks are
+	// already expired). Shared via context so the banner and the authenticated
+	// connection fallback can both explain it. Measured once, deferred after
+	// hydration so it never blocks first paint.
+	const clockSkew = new ClockSkewState();
+	clockSkewContext.set(clockSkew);
+	if (browser) {
+		const measure = () => void clockSkew.measure();
+		if ('requestIdleCallback' in window) {
+			requestIdleCallback(measure, { timeout: 3000 });
+		} else {
+			setTimeout(measure, 1500);
+		}
 	}
 
 	const currentLang = $derived(getLanguage(page.params.lang).code);
@@ -116,6 +134,7 @@
 				>
 					<T keyName="a11y.skip_to_content" />
 				</a>
+				<ClockSkewBanner />
 				<GlobalSearchShell />
 				{@render children()}
 			</TolgeeProvider>

--- a/src/routes/api/time/+server.ts
+++ b/src/routes/api/time/+server.ts
@@ -1,0 +1,16 @@
+import type { RequestHandler } from './$types';
+
+// Server wall-clock time, so the client can detect a misconfigured device clock.
+// A skewed clock silently breaks cookie-based auth: a fast clock makes the
+// browser treat freshly minted short-TTL auth cookies as already expired
+// (RFC 6265), so the authenticated session never establishes and a reload can't
+// fix it. Never cached — the value must reflect the moment of the request.
+export const prerender = false;
+
+export const GET: RequestHandler = () =>
+	new Response(JSON.stringify({ now: Date.now() }), {
+		headers: {
+			'content-type': 'application/json',
+			'cache-control': 'no-store'
+		}
+	});


### PR DESCRIPTION
The authenticated layout rendered nothing when the server resolved no viewer (`AuthenticatedLayout` had an `{#if user}` block with no `{:else}`), so a failed auth handshake produced a blank white page that a reload could not fix. One real-world trigger is a misconfigured device clock: a clock that is far ahead makes the browser treat the freshly minted short-lived auth cookie as already expired (RFC 6265) and drop it, so every SSR request, including reloads, sees no token. The realtime auth layer itself is clock-agnostic (Convex schedules token refresh from the token's own lifetime and validates against the server clock), so the failure surfaces below the app, at the cookie and render layers.

The authenticated layout now renders a recover state instead of nothing: a calm "connecting" view first, since the client may still recover a session from cookies right after hydration, escalating to a retry state after a short grace window. Independently, a small `/api/time` endpoint lets the client measure its offset against server time once after hydration; past a 2 minute threshold a root-level banner explains the wrong clock and tells the user to set date and time to automatic, because a reload alone will not fix it. Both surfaces use the `warning` theme token and share the skew state via context, and the banner is intentionally not a forced reload, which would loop without fixing the clock.

Regression guard: added src/lib/utils/clock-skew.test.ts (skew computation, threshold, and magnitude formatting).
Verification: static-checks pass on all changed files and the new unit test plus the locale-parity test pass.