### PR TITLE
fix(brand): inline logo mark to remove first-paint flash

### DIFF
--- a/src/lib/components/icons/logo.svelte
+++ b/src/lib/components/icons/logo.svelte
@@ -1,14 +1,37 @@
 <script lang="ts">
 	import type { IconProps } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
+	// Inlined at build time from the single logo source (static/logo.svg), the same
+	// file that feeds favicon/PWA/email generation. Shipping the mark in the HTML
+	// payload avoids the runtime fetch of a CSS mask-image, which left the mark
+	// blank on first paint until /logo.svg loaded over the network. Trusted local
+	// build-time constant, so {@html} carries no injection risk.
+	import logoSvg from '$static/logo.svg?raw';
 
 	// Accept IconProps for compatibility with LucideIcon type, but only use class
 	let { class: className }: IconProps = $props();
 </script>
 
+<!-- The source SVG strokes in currentColor; text-[var(--logo-color,currentColor)]
+     preserves the optional --logo-color override the mask version exposed. -->
 <span
-	class={cn(
-		'inline-block bg-[var(--logo-color,currentColor)] [mask-image:url(/logo.svg)] [mask-size:contain] [mask-position:center] [mask-repeat:no-repeat]',
-		className
-	)}
-></span>
+	class={cn('logo-mark inline-block text-[var(--logo-color,currentColor)]', className)}
+	aria-hidden="true"
+>
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -- Trusted build-time constant inlined from static/logo.svg, no user input -->
+	{@html logoSvg}
+</span>
+
+<style>
+	/* The inlined SVG ships with width/height="24"; pin it to the wrapper box
+	   (sized via the size-* utility on .logo-mark) so the mark renders at exactly
+	   the dimensions the old mask-size:contain produced. Scoped to the component
+	   instead of a Tailwind [&>svg] variant so the sizing is atomic with the
+	   markup and can never momentarily fall back to the SVG's intrinsic 24px
+	   while JIT CSS catches up. */
+	.logo-mark > :global(svg) {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+</style>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -46,7 +46,8 @@ const config = {
 	kit: {
 		adapter,
 		alias: {
-			$blocks: 'src/blocks'
+			$blocks: 'src/blocks',
+			$static: 'static'
 		},
 		experimental: {
 			remoteFunctions: true


### PR DESCRIPTION
The brand mark in the header was invisible on first paint while inline-SVG icons rendered instantly. The mark is a `<span>` colored by a background that a CSS `[mask-image:url(/logo.svg)]` clips to the mark shape, so it depends on fetching the external `/logo.svg` before anything shows. Until that file arrives the masked span is fully transparent, so on a cold cache the mark pops in late, while inline-SVG icons in the HTML payload never wait on a fetch.

This keeps `static/logo.svg` as the single logo source, the same file that still feeds favicon, PWA, and email generation, but inlines it into `logo.svelte` at build time with a `?raw` import instead of fetching it at runtime. The mark now ships in the HTML payload and paints with the rest of the header. The source SVG strokes in `currentColor` and the wrapper keeps the optional `--logo-color` override, so theming is unchanged. A component-scoped `:global(svg)` rule pins the inlined SVG to the wrapper box so it always matches the `size-*` utility and never falls back to its intrinsic dimensions while utility CSS catches up. A `$static` alias addresses the single source cleanly, mirroring the existing `$blocks` alias and the `?raw` pattern already used in `src/lib/emails/renderer.ts`.

Regression guard: not warranted, single-site rendering change; the `mask-image` approach lived only in `logo.svelte`.

`bun scripts/static-checks.ts` on the changed files passes.
