### PR TITLE
fix(billing): return to app after closing billing portal

### DIFF
--- a/src/blocks/pricing/pricing-three.svelte
+++ b/src/blocks/pricing/pricing-three.svelte
@@ -87,7 +87,9 @@
 	}
 
 	async function handleManageBilling() {
-		await portalOperation.execute({});
+		// Return the user to the current page after the portal; without returnUrl
+		// Autumn falls back to its org success_url, which defaults to useautumn.com.
+		await portalOperation.execute({ returnUrl: window.location.href });
 		if (portalOperation.error) {
 			haptic.trigger('error');
 			toast.error($t('billing.portal_failed'));

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -68,7 +68,8 @@
 
 	async function handleBilling() {
 		haptic.trigger('light');
-		await portalOperation.execute({});
+		// Return here after the portal; without returnUrl Autumn defaults to useautumn.com.
+		await portalOperation.execute({ returnUrl: window.location.href });
 		if (portalOperation.error) {
 			haptic.trigger('error');
 			toast.error($t('billing.portal_failed'));


### PR DESCRIPTION
The Stripe billing portal's back button sent users to useautumn.com instead of back into the app. `openBillingPortal` was called with no `returnUrl`, so Autumn used its org `success_url`, which defaults to `https://useautumn.com`.

Passing `returnUrl: window.location.href` at both manage-billing call sites (pricing cards, nav user menu) returns the user to the page they came from. Checkout already passes a `successUrl`, so only the portal was affected.

Regression guard: not warranted, two fixed call sites; reliably detecting a missing returnUrl needs type-aware lint, not a regex.

Spotted while QAing a live billing portal.