### PR TITLE
fix(auth): re-mint Convex JWT from session cookie in SSR

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import { sequence } from '@sveltejs/kit/hooks';
-import { redirect, type Handle, type HandleServerError, type Cookies } from '@sveltejs/kit';
+import { redirect, type Handle, type HandleServerError } from '@sveltejs/kit';
 import { dev } from '$app/environment';
 import { PUBLIC_SENTRY_DSN } from '$env/static/public';
 import { isSupportedLanguage, DEFAULT_LANGUAGE, LANGUAGE_COOKIE_NAME } from '$lib/i18n/languages';
@@ -10,6 +10,7 @@ import {
 import { createMarketingMarkdownResponse, isMarkdownRequest } from '$lib/markdown/marketing';
 import { devNotice } from '$lib/dev/notice';
 import { decodeJwtPayload } from '$lib/server/jwt';
+import { resolveConvexToken } from '$lib/server/convex-jwt';
 import { loadSentry } from '$lib/monitoring/sentry';
 import { safeRedirectPath } from '$lib/utils/url';
 import { SIDEBAR_COOKIE_NAME } from '$lib/components/ui/sidebar/constants.js';
@@ -20,16 +21,6 @@ if (!PUBLIC_SENTRY_DSN) {
 		missing: ['PUBLIC_SENTRY_DSN'],
 		scope: 'vite-public'
 	});
-}
-
-/**
- * Get JWT token directly from cookies (no createAuth needed)
- * Cookie name depends on whether we're on HTTPS or HTTP
- */
-function getJwtToken(cookies: Cookies, request: Request): string | undefined {
-	const isSecure = new URL(request.url).protocol === 'https:';
-	const cookieName = isSecure ? '__Secure-better-auth.convex_jwt' : 'better-auth.convex_jwt';
-	return cookies.get(cookieName);
 }
 
 // Route matchers
@@ -102,10 +93,14 @@ const handleDevOnlyRoutes: Handle = async function handleDevOnlyRoutes({ event, 
 };
 
 /**
- * Extract authentication token from cookies
+ * Resolve the Convex JWT for SSR: from the short-lived JWT cookie when it is
+ * still alive, otherwise re-minted from the Better Auth session cookie (see
+ * $lib/server/convex-jwt). Without the re-mint, a tab idle past the JWT TTL
+ * gets bounced to /signin on the next full load even though the session is
+ * still valid.
  */
 const handleAuth: Handle = async function handleAuth({ event, resolve }) {
-	event.locals.token = getJwtToken(event.cookies, event.request);
+	event.locals.token = await resolveConvexToken(event);
 	return resolve(event);
 };
 

--- a/src/lib/server/convex-jwt.test.ts
+++ b/src/lib/server/convex-jwt.test.ts
@@ -113,6 +113,18 @@ describe('resolveConvexToken', () => {
 		expect(setCookie.mock.calls[0]![2]).toMatchObject({ secure: true });
 	});
 
+	it('returns a token without readable exp for this request but does not mirror it', async () => {
+		// A session-scoped cookie (no maxAge) could outlive the JWT and pin an
+		// expired token, because the read path prefers an existing cookie.
+		const token = fakeJwt({ sub: 'user_1' });
+		const { event, setCookie } = fakeEvent({
+			cookies: { 'better-auth.session_token': 'session-alive' },
+			tokenResponse: { ok: true, token }
+		});
+		await expect(resolveConvexToken(event)).resolves.toBe(token);
+		expect(setCookie).not.toHaveBeenCalled();
+	});
+
 	it('never mints on /api/auth requests (the token endpoint runs through this hook)', async () => {
 		const { event, fetch } = fakeEvent({
 			url: 'http://localhost:5173/api/auth/convex/token',

--- a/src/lib/server/convex-jwt.test.ts
+++ b/src/lib/server/convex-jwt.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { resolveConvexToken } from './convex-jwt';
+
+import type { RequestEvent } from '@sveltejs/kit';
+
+// ---------------------------------------------------------------------------
+// resolveConvexToken: the convex_jwt cookie dies with the JWT (15 min) while
+// the Better Auth session cookie lives much longer. When only the session
+// cookie survives, the token must be re-minted via the Better Auth token
+// endpoint instead of treating the request as signed out.
+// ---------------------------------------------------------------------------
+
+/** Base64url-encodes a JWT with the given payload (signature is not verified). */
+function fakeJwt(payload: Record<string, unknown>): string {
+	const encode = (value: Record<string, unknown>) =>
+		Buffer.from(JSON.stringify(value)).toString('base64url');
+	return `${encode({ alg: 'RS256' })}.${encode(payload)}.signature`;
+}
+
+function fakeEvent(options: {
+	url?: string;
+	cookies?: Record<string, string>;
+	tokenResponse?: { ok: boolean; token?: string } | Error;
+}): {
+	event: RequestEvent;
+	fetch: ReturnType<typeof vi.fn>;
+	setCookie: ReturnType<typeof vi.fn>;
+} {
+	const url = new URL(options.url ?? 'http://localhost:5173/en/app');
+	const jar = options.cookies ?? {};
+	const setCookie = vi.fn();
+	const fetch = vi.fn(async () => {
+		if (options.tokenResponse instanceof Error) throw options.tokenResponse;
+		const { ok, token } = options.tokenResponse ?? { ok: false };
+		return {
+			ok,
+			json: async () => ({ token })
+		} as Response;
+	});
+	const event = {
+		url,
+		request: new Request(url),
+		cookies: {
+			get: (name: string) => jar[name],
+			set: setCookie
+		},
+		fetch
+	} as unknown as RequestEvent;
+	return { event, fetch, setCookie };
+}
+
+describe('resolveConvexToken', () => {
+	it('returns the JWT cookie when it is still alive, without fetching', async () => {
+		const { event, fetch } = fakeEvent({
+			cookies: { 'better-auth.convex_jwt': 'jwt-alive' }
+		});
+		await expect(resolveConvexToken(event)).resolves.toBe('jwt-alive');
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it('reads the __Secure- prefixed cookies on HTTPS origins', async () => {
+		const { event, fetch } = fakeEvent({
+			url: 'https://example.com/en/app',
+			cookies: { '__Secure-better-auth.convex_jwt': 'jwt-secure' }
+		});
+		await expect(resolveConvexToken(event)).resolves.toBe('jwt-secure');
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it('returns undefined for signed-out requests, without fetching', async () => {
+		const { event, fetch } = fakeEvent({ cookies: {} });
+		await expect(resolveConvexToken(event)).resolves.toBeUndefined();
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it('re-mints the JWT from the session cookie when the JWT cookie is gone', async () => {
+		const token = fakeJwt({ sub: 'user_1', exp: Math.floor(Date.now() / 1000) + 900 });
+		const { event, fetch } = fakeEvent({
+			cookies: { 'better-auth.session_token': 'session-alive' },
+			tokenResponse: { ok: true, token }
+		});
+		await expect(resolveConvexToken(event)).resolves.toBe(token);
+		expect(fetch).toHaveBeenCalledWith('/api/auth/convex/token', expect.anything());
+	});
+
+	it('mirrors the re-minted JWT as a cookie with maxAge from the exp claim', async () => {
+		const exp = Math.floor(Date.now() / 1000) + 900;
+		const token = fakeJwt({ sub: 'user_1', exp });
+		const { event, setCookie } = fakeEvent({
+			cookies: { 'better-auth.session_token': 'session-alive' },
+			tokenResponse: { ok: true, token }
+		});
+		await resolveConvexToken(event);
+		expect(setCookie).toHaveBeenCalledTimes(1);
+		const [name, value, attributes] = setCookie.mock.calls[0]!;
+		expect(name).toBe('better-auth.convex_jwt');
+		expect(value).toBe(token);
+		expect(attributes).toMatchObject({ path: '/', httpOnly: true, sameSite: 'lax' });
+		expect(attributes.maxAge).toBeGreaterThan(890);
+		expect(attributes.maxAge).toBeLessThanOrEqual(900);
+	});
+
+	it('uses the __Secure- prefixed cookie names when minting on HTTPS', async () => {
+		const token = fakeJwt({ sub: 'user_1', exp: Math.floor(Date.now() / 1000) + 900 });
+		const { event, setCookie } = fakeEvent({
+			url: 'https://example.com/en/app',
+			cookies: { '__Secure-better-auth.session_token': 'session-alive' },
+			tokenResponse: { ok: true, token }
+		});
+		await expect(resolveConvexToken(event)).resolves.toBe(token);
+		expect(setCookie.mock.calls[0]![0]).toBe('__Secure-better-auth.convex_jwt');
+		expect(setCookie.mock.calls[0]![2]).toMatchObject({ secure: true });
+	});
+
+	it('never mints on /api/auth requests (the token endpoint runs through this hook)', async () => {
+		const { event, fetch } = fakeEvent({
+			url: 'http://localhost:5173/api/auth/convex/token',
+			cookies: { 'better-auth.session_token': 'session-alive' }
+		});
+		await expect(resolveConvexToken(event)).resolves.toBeUndefined();
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it('falls back to signed out when the token endpoint rejects (expired session)', async () => {
+		const { event, setCookie } = fakeEvent({
+			cookies: { 'better-auth.session_token': 'session-stale' },
+			tokenResponse: { ok: false }
+		});
+		await expect(resolveConvexToken(event)).resolves.toBeUndefined();
+		expect(setCookie).not.toHaveBeenCalled();
+	});
+
+	it('falls back to signed out when the token endpoint is unreachable', async () => {
+		const { event, setCookie } = fakeEvent({
+			cookies: { 'better-auth.session_token': 'session-alive' },
+			tokenResponse: new Error('fetch failed')
+		});
+		await expect(resolveConvexToken(event)).resolves.toBeUndefined();
+		expect(setCookie).not.toHaveBeenCalled();
+	});
+
+	it('falls back to signed out when the response carries no token', async () => {
+		const { event, setCookie } = fakeEvent({
+			cookies: { 'better-auth.session_token': 'session-alive' },
+			tokenResponse: { ok: true }
+		});
+		await expect(resolveConvexToken(event)).resolves.toBeUndefined();
+		expect(setCookie).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/server/convex-jwt.ts
+++ b/src/lib/server/convex-jwt.ts
@@ -1,0 +1,81 @@
+/**
+ * Server-side resolution of the Better Auth Convex JWT for SSR.
+ *
+ * The `convex_jwt` cookie expires together with the JWT itself (15 minutes by
+ * default) while the Better Auth session cookie lives much longer. An idle tab
+ * therefore makes authenticated requests without a JWT cookie, and treating
+ * those as signed out bounces the user to /signin on full loads and returns
+ * viewer-less root layout data on invalidated data requests. When the session
+ * cookie is present but the JWT cookie is gone, a fresh JWT is minted from the
+ * session via the Better Auth token endpoint instead.
+ */
+
+import { decodeJwtPayload } from './jwt';
+
+import type { RequestEvent } from '@sveltejs/kit';
+
+const JWT_COOKIE_BASE = 'better-auth.convex_jwt';
+const SESSION_COOKIE_BASE = 'better-auth.session_token';
+const TOKEN_ENDPOINT = '/api/auth/convex/token';
+const MINT_TIMEOUT_MS = 5000;
+
+/** Better Auth prefixes its cookies with `__Secure-` on HTTPS origins. */
+function cookieName(base: string, isSecure: boolean): string {
+	return isSecure ? `__Secure-${base}` : base;
+}
+
+/**
+ * Resolve the Convex JWT for the current request: from the JWT cookie when it
+ * is still alive, otherwise re-minted from the Better Auth session. Returns
+ * undefined for signed-out requests and when minting fails, which is the same
+ * signed-out path the caller took before.
+ */
+export async function resolveConvexToken(event: RequestEvent): Promise<string | undefined> {
+	const isSecure = new URL(event.request.url).protocol === 'https:';
+	const jwtCookie = event.cookies.get(cookieName(JWT_COOKIE_BASE, isSecure));
+	if (jwtCookie) return jwtCookie;
+
+	if (!event.cookies.get(cookieName(SESSION_COOKIE_BASE, isSecure))) return undefined;
+
+	// The Better Auth routes run through this hook themselves; minting there
+	// would recurse into the token endpoint.
+	if (event.url.pathname.startsWith('/api/auth')) return undefined;
+
+	return mintConvexToken(event, isSecure);
+}
+
+async function mintConvexToken(
+	event: RequestEvent,
+	isSecure: boolean
+): Promise<string | undefined> {
+	try {
+		const response = await event.fetch(TOKEN_ENDPOINT, {
+			signal: AbortSignal.timeout(MINT_TIMEOUT_MS)
+		});
+		if (!response.ok) return undefined;
+		const body = (await response.json()) as { token?: unknown };
+		const token = typeof body.token === 'string' && body.token !== '' ? body.token : undefined;
+		if (!token) return undefined;
+
+		// Mirror the cookie Better Auth would set so subsequent requests in the
+		// same window skip the extra roundtrip. maxAge derives from the JWT's own
+		// exp claim; without a readable exp the cookie lives for the browser
+		// session, which is at most as long as Better Auth would allow.
+		const exp = decodeJwtPayload(token)?.exp;
+		const nowSeconds = Math.floor(Date.now() / 1000);
+		const maxAge = typeof exp === 'number' ? Math.max(0, exp - nowSeconds) : undefined;
+		event.cookies.set(cookieName(JWT_COOKIE_BASE, isSecure), token, {
+			path: '/',
+			httpOnly: true,
+			sameSite: 'lax',
+			secure: isSecure,
+			...(maxAge !== undefined ? { maxAge } : {})
+		});
+
+		return token;
+	} catch {
+		// Transient failure (deploy window, timeout): fall back to the signed-out
+		// path, which is what every such request hit unconditionally before.
+		return undefined;
+	}
+}

--- a/src/lib/server/convex-jwt.ts
+++ b/src/lib/server/convex-jwt.ts
@@ -59,18 +59,20 @@ async function mintConvexToken(
 
 		// Mirror the cookie Better Auth would set so subsequent requests in the
 		// same window skip the extra roundtrip. maxAge derives from the JWT's own
-		// exp claim; without a readable exp the cookie lives for the browser
-		// session, which is at most as long as Better Auth would allow.
+		// exp claim; a token without a readable exp is still returned for this
+		// request but not mirrored, since a session-scoped cookie could outlive
+		// the JWT and pin an expired token on every following request (the read
+		// path prefers an existing cookie and never re-mints while it is set).
 		const exp = decodeJwtPayload(token)?.exp;
-		const nowSeconds = Math.floor(Date.now() / 1000);
-		const maxAge = typeof exp === 'number' ? Math.max(0, exp - nowSeconds) : undefined;
-		event.cookies.set(cookieName(JWT_COOKIE_BASE, isSecure), token, {
-			path: '/',
-			httpOnly: true,
-			sameSite: 'lax',
-			secure: isSecure,
-			...(maxAge !== undefined ? { maxAge } : {})
-		});
+		if (typeof exp === 'number') {
+			event.cookies.set(cookieName(JWT_COOKIE_BASE, isSecure), token, {
+				path: '/',
+				httpOnly: true,
+				sameSite: 'lax',
+				secure: isSecure,
+				maxAge: Math.max(0, exp - Math.floor(Date.now() / 1000))
+			});
+		}
 
 		return token;
 	} catch {

--- a/src/lib/server/jwt.ts
+++ b/src/lib/server/jwt.ts
@@ -11,6 +11,8 @@
 /** Claims Better Auth puts into the Convex JWT that this app reads. */
 export type ConvexJwtPayload = {
 	sub: string;
+	/** Expiry as unix seconds; used to derive the re-minted cookie lifetime. */
+	exp?: number;
 	name?: string;
 	email?: string;
 	image?: string | null;


### PR DESCRIPTION
Closes #621

The `convex_jwt` cookie that `handleAuth` reads expires together with the JWT itself (15 minutes), while the Better Auth session cookie lives much longer. A tab idle past the JWT TTL therefore made its next server-rendered request look signed out: full loads of protected routes bounced to `/signin?redirectTo=...`, and an invalidated root layout data request came back with `viewer: null`, which the authenticated layout renders as a blank page with no client-side recovery (client and server auth state agree at that point, so `AppAuthProvider` never re-invalidates).

`handleAuth` now resolves the token through `resolveConvexToken` in `$lib/server/convex-jwt`: the JWT cookie when it is still alive, otherwise a fresh JWT minted from the session via `event.fetch('/api/auth/convex/token')`. The fresh token is mirrored as a cookie with the lifetime derived from its own `exp` claim, so subsequent requests in the window skip the extra roundtrip. Minting is skipped on `/api/auth` routes because the token endpoint itself runs through this hook, and any mint failure (expired session, deploy window, timeout) falls back to the previous signed-out path, so nothing gets worse than before.

`bun scripts/static-checks.ts` on the changed files passes. `bunx vitest run src/lib/server/` passes (23 tests, 10 new covering cookie precedence, secure-prefix names, the recursion guard, cookie mirroring with derived maxAge, and the failure fallbacks).

Regression guard: covered by the new unit tests in `src/lib/server/convex-jwt.test.ts` (cookie precedence, secure-prefix names, the /api/auth recursion guard, cookie mirroring with derived maxAge, failure fallbacks).
