### PR TITLE
fix(dev): Wipe local backend state before writing the auth secret

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,20 +39,14 @@ function computeLocalConvexStateId(projectDir: string, suffix?: string): string 
 	return `${sanitizedBranch}${sanitizedSuffix}-${hash}`;
 }
 
-function getPersistentBetterAuthSecret(
-	projectDir: string,
-	reset: boolean,
-	suffix?: string
-): string {
+function getPersistentBetterAuthSecret(projectDir: string, suffix?: string): string {
 	const stateId = computeLocalConvexStateId(projectDir, suffix);
 	const stateDir = path.join(projectDir, '.convex', stateId);
 	const secretPath = path.join(stateDir, 'better-auth-secret');
 
-	if (!reset) {
-		const existing = fs.existsSync(secretPath) ? fs.readFileSync(secretPath, 'utf-8').trim() : '';
-		if (existing) {
-			return existing;
-		}
+	const existing = fs.existsSync(secretPath) ? fs.readFileSync(secretPath, 'utf-8').trim() : '';
+	if (existing) {
+		return existing;
 	}
 
 	const secret = crypto.randomBytes(32).toString('hex');
@@ -225,6 +219,20 @@ export default defineConfig(async ({ mode }) => {
 		const siteProxyUrl = `http://localhost:${siteProxyPort}`;
 		const resetLocalBackend = process.env.RESET_LOCAL_BACKEND === 'true';
 
+		// Wipe the state dir HERE, not via the plugin's reset option: the plugin
+		// rm's the whole dir at boot, i.e. AFTER getPersistentBetterAuthSecret
+		// below has written the fresh secret file into it. The reset run itself
+		// stays green (the backend keeps the secret in memory), but every
+		// following run then re-rolls the secret against this run's surviving
+		// JWKS rows and /api/auth/convex/token 500s with "Failed to decrypt
+		// private key" until the next reset.
+		if (resetLocalBackend) {
+			fs.rmSync(path.join(cwd, '.convex', computeLocalConvexStateId(cwd, stateIdSuffix)), {
+				recursive: true,
+				force: true
+			});
+		}
+
 		// Write backend URL so E2E tests (Playwright) can discover it.
 		// Test mode writes to a separate file so dev's .backend-url isn't clobbered when
 		// `bun run dev` and `bun run dev:test` run concurrently.
@@ -233,8 +241,7 @@ export default defineConfig(async ({ mode }) => {
 		const backendUrlFile = isTestMode ? '.test-backend-url' : '.backend-url';
 		fs.writeFileSync(path.join(convexStateDir, backendUrlFile), backendUrl);
 		const betterAuthSecret =
-			loadedEnv.BETTER_AUTH_SECRET?.trim() ||
-			getPersistentBetterAuthSecret(cwd, resetLocalBackend, stateIdSuffix);
+			loadedEnv.BETTER_AUTH_SECRET?.trim() || getPersistentBetterAuthSecret(cwd, stateIdSuffix);
 
 		// Load Convex backend env vars from .env.convex.local.
 		// SITE_URL is stripped: locally it must always track the running dev server
@@ -301,7 +308,9 @@ export default defineConfig(async ({ mode }) => {
 				port: backendPort,
 				siteProxyPort,
 				stateIdSuffix,
-				reset: resetLocalBackend,
+				// Never let the plugin wipe the state dir itself: the reset already
+				// happened above, BEFORE the better-auth secret file was written.
+				reset: false,
 				onReady: [{ name: 'localDev:ensureSeededAdmin' }],
 				envVars: ({ vitePort, resolvedUrls }) => {
 					// When portless fronts vite, resolvedUrls.local[0] is vite's own


### PR DESCRIPTION
Closes #625

RESET_LOCAL_BACKEND=true wrote the fresh better-auth secret into the state dir and then let convex-vite-plugin rm the whole dir at boot, deleting the file. The reset run kept working off the in-memory value, but every following run re-rolled the secret against the surviving JWKS rows, so /api/auth/convex/token returned 500 (BetterAuthError: Failed to decrypt private key) and every sign-in looped back to /signin until the next reset.

The config now wipes the state dir right after reading RESET_LOCAL_BACKEND, before the secret file is written, and passes reset: false to convexLocal so the plugin never deletes the dir itself. The reset parameter of getPersistentBetterAuthSecret is gone since the wipe already removed the file by the time it runs.

Regression guard: not warranted, the failure lives in the cross-process ordering between config evaluation and the plugin's boot-time rm, which unit tests can't observe; guarded manually by paired reset/plain boots.

bun scripts/static-checks.ts vite.config.ts passes. Verified with a reset boot followed by a plain boot: the secret file survives the reset run, the second run logs "Resuming backend from existing state" with the same secret, and the token endpoint keeps working.