### PR TITLE
fix(usage): Correct and harden LLM cost tracking

### DIFF
--- a/src/lib/convex/aiUsage/agentUsage.ts
+++ b/src/lib/convex/aiUsage/agentUsage.ts
@@ -1,19 +1,10 @@
 import type { UsageHandler } from '@convex-dev/agent';
-import { type CapturedModelUsage, mergeByModel, readOpenRouterCost } from './capture';
+import { type CapturedModelUsage, captureDirect, mergeByModel } from './capture';
 
 export function makeAgentUsageSink() {
 	const steps: CapturedModelUsage[] = [];
 	const usageHandler: UsageHandler = (_ctx, a) => {
-		steps.push({
-			model: a.model,
-			provider: a.provider,
-			inputTokens: a.usage.inputTokens ?? 0,
-			outputTokens: a.usage.outputTokens ?? 0,
-			totalTokens: a.usage.totalTokens,
-			reasoningTokens: a.usage.reasoningTokens,
-			cachedInputTokens: a.usage.cachedInputTokens,
-			nativeCostUsd: readOpenRouterCost(a.providerMetadata)
-		});
+		steps.push(captureDirect(a.usage, a.providerMetadata, a.model, a.provider));
 	};
 	return { usageHandler, collect: () => mergeByModel(steps) };
 }

--- a/src/lib/convex/aiUsage/capture.test.ts
+++ b/src/lib/convex/aiUsage/capture.test.ts
@@ -60,6 +60,26 @@ describe('mergeByModel', () => {
 		const out = mergeByModel([u({ model: 'qwen', inputTokens: 100, outputTokens: 50 })]);
 		expect(out[0]!.totalTokens).toBe(150);
 	});
+
+	it('keeps reasoning/cached undefined when no step reported them', () => {
+		// Merging used to coerce absent reasoning/cached to 0, so non-reasoning
+		// models persisted a spurious reasoningTokens: 0 on multi-step rows.
+		const out = mergeByModel([
+			u({ model: 'qwen', inputTokens: 100, outputTokens: 50 }),
+			u({ model: 'qwen', inputTokens: 20, outputTokens: 10 })
+		]);
+		expect(out[0]!.reasoningTokens).toBeUndefined();
+		expect(out[0]!.cachedInputTokens).toBeUndefined();
+	});
+
+	it('sums reasoning/cached when at least one step reports them', () => {
+		const out = mergeByModel([
+			u({ model: 'qwen', inputTokens: 100, outputTokens: 50, reasoningTokens: 30 }),
+			u({ model: 'qwen', inputTokens: 20, outputTokens: 10, cachedInputTokens: 5 })
+		]);
+		expect(out[0]!.reasoningTokens).toBe(30);
+		expect(out[0]!.cachedInputTokens).toBe(5);
+	});
 });
 
 describe('readOpenRouterCost', () => {

--- a/src/lib/convex/aiUsage/capture.test.ts
+++ b/src/lib/convex/aiUsage/capture.test.ts
@@ -43,6 +43,23 @@ describe('mergeByModel', () => {
 		expect(out[0]).toMatchObject({ inputTokens: 500, outputTokens: 50 });
 		expect(out[0]!.nativeCostUsd).toBeUndefined();
 	});
+
+	it('counts the first step in totalTokens when it lacks totalTokens', () => {
+		// Providers may omit totalTokens. The first captured step used to be
+		// inserted with totalTokens undefined, so a later merge started the sum
+		// at 0 and the first step's tokens vanished from the persisted total.
+		const out = mergeByModel([
+			u({ model: 'qwen', inputTokens: 100, outputTokens: 50 }),
+			u({ model: 'qwen', inputTokens: 20, outputTokens: 10 })
+		]);
+		expect(out).toHaveLength(1);
+		expect(out[0]!.totalTokens).toBe(180);
+	});
+
+	it('approximates totalTokens for a single step without one', () => {
+		const out = mergeByModel([u({ model: 'qwen', inputTokens: 100, outputTokens: 50 })]);
+		expect(out[0]!.totalTokens).toBe(150);
+	});
 });
 
 describe('readOpenRouterCost', () => {

--- a/src/lib/convex/aiUsage/capture.test.ts
+++ b/src/lib/convex/aiUsage/capture.test.ts
@@ -1,10 +1,55 @@
 import { describe, it, expect } from 'vitest';
-import { mergeByModel, readOpenRouterCost, type CapturedModelUsage } from './capture';
+import type { LanguageModelUsage } from 'ai';
+import {
+	captureDirect,
+	mergeByModel,
+	readOpenRouterCost,
+	type CapturedModelUsage
+} from './capture';
 
 const u = (p: Partial<CapturedModelUsage> & { model: string }): CapturedModelUsage => ({
 	inputTokens: 0,
 	outputTokens: 0,
+	...p,
+	// Mirrors captureDirect's normalization so merge inputs are realistic.
+	totalTokens: p.totalTokens ?? (p.inputTokens ?? 0) + (p.outputTokens ?? 0)
+});
+
+const sdkUsage = (p: Partial<LanguageModelUsage>): LanguageModelUsage => ({
+	inputTokens: undefined,
+	outputTokens: undefined,
+	totalTokens: undefined,
+	inputTokenDetails: {
+		noCacheTokens: undefined,
+		cacheReadTokens: undefined,
+		cacheWriteTokens: undefined
+	},
+	outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
 	...p
+});
+
+describe('captureDirect', () => {
+	it('approximates a missing totalTokens from input + output', () => {
+		// Providers may omit totalTokens; captureDirect is the single place that
+		// normalizes it, so merged/persisted totals never silently drop a step.
+		const out = captureDirect(sdkUsage({ inputTokens: 100, outputTokens: 50 }), undefined, 'qwen');
+		expect(out.totalTokens).toBe(150);
+	});
+
+	it('passes reported totals, provider, and native cost through', () => {
+		const out = captureDirect(
+			sdkUsage({ inputTokens: 1, outputTokens: 2, totalTokens: 7 }),
+			{ openrouter: { usage: { cost: 0.5 } } },
+			'qwen',
+			'openrouter'
+		);
+		expect(out).toMatchObject({
+			model: 'qwen',
+			provider: 'openrouter',
+			totalTokens: 7,
+			nativeCostUsd: 0.5
+		});
+	});
 });
 
 describe('mergeByModel', () => {
@@ -44,21 +89,15 @@ describe('mergeByModel', () => {
 		expect(out[0]!.nativeCostUsd).toBeUndefined();
 	});
 
-	it('counts the first step in totalTokens when it lacks totalTokens', () => {
-		// Providers may omit totalTokens. The first captured step used to be
-		// inserted with totalTokens undefined, so a later merge started the sum
-		// at 0 and the first step's tokens vanished from the persisted total.
+	it('sums totalTokens across merged steps, reported and approximated alike', () => {
+		// First step reports its own total (160 > input + output), second step's
+		// total was approximated at capture time (30). Both must survive the merge.
 		const out = mergeByModel([
-			u({ model: 'qwen', inputTokens: 100, outputTokens: 50 }),
+			u({ model: 'qwen', inputTokens: 100, outputTokens: 50, totalTokens: 160 }),
 			u({ model: 'qwen', inputTokens: 20, outputTokens: 10 })
 		]);
 		expect(out).toHaveLength(1);
-		expect(out[0]!.totalTokens).toBe(180);
-	});
-
-	it('approximates totalTokens for a single step without one', () => {
-		const out = mergeByModel([u({ model: 'qwen', inputTokens: 100, outputTokens: 50 })]);
-		expect(out[0]!.totalTokens).toBe(150);
+		expect(out[0]!.totalTokens).toBe(190);
 	});
 
 	it('keeps reasoning/cached undefined when no step reported them', () => {

--- a/src/lib/convex/aiUsage/capture.ts
+++ b/src/lib/convex/aiUsage/capture.ts
@@ -7,7 +7,7 @@ export type CapturedModelUsage = {
 	provider?: string;
 	inputTokens: number;
 	outputTokens: number;
-	totalTokens?: number;
+	totalTokens: number;
 	reasoningTokens?: number;
 	cachedInputTokens?: number;
 	nativeCostUsd?: number;
@@ -26,16 +26,29 @@ export function orModel(modelId: string, opts?: Record<string, unknown>): Langua
 	return openrouter(modelId, { usage: { include: true }, ...opts });
 }
 
+// Sum two optional counters, staying undefined when neither side reported one,
+// so merged/aggregated rows don't persist a spurious 0 (the recorder only
+// stores these fields when present).
+export function sumOptional(a: number | undefined, b: number | undefined): number | undefined {
+	return a === undefined && b === undefined ? undefined : (a ?? 0) + (b ?? 0);
+}
+
 export function captureDirect(
 	usage: LanguageModelUsage,
 	pm: unknown,
-	model: string
+	model: string,
+	provider?: string
 ): CapturedModelUsage {
+	const inputTokens = usage.inputTokens ?? 0;
+	const outputTokens = usage.outputTokens ?? 0;
 	return {
 		model,
-		inputTokens: usage.inputTokens ?? 0,
-		outputTokens: usage.outputTokens ?? 0,
-		totalTokens: usage.totalTokens,
+		...(provider !== undefined ? { provider } : {}),
+		inputTokens,
+		outputTokens,
+		// Providers may omit totalTokens; approximate it once here so every
+		// downstream consumer (merge, recorder) can rely on it being present.
+		totalTokens: usage.totalTokens ?? inputTokens + outputTokens,
 		reasoningTokens: usage.reasoningTokens,
 		cachedInputTokens: usage.cachedInputTokens,
 		nativeCostUsd: readOpenRouterCost(pm)
@@ -53,25 +66,14 @@ export function mergeByModel(steps: CapturedModelUsage[]): CapturedModelUsage[] 
 		const key = `${s.model} ${s.nativeCostUsd !== undefined ? 'native' : 'tokens'}`;
 		const prev = byModel.get(key);
 		if (!prev) {
-			// Approximate a missing totalTokens on insert too, not just on merge:
-			// otherwise a first step without totalTokens contributes 0 to the
-			// merged total and the persisted row undercounts. Same fallback the
-			// recorder applies (record.ts).
-			byModel.set(key, { ...s, totalTokens: s.totalTokens ?? s.inputTokens + s.outputTokens });
+			byModel.set(key, { ...s });
 			continue;
 		}
 		prev.inputTokens += s.inputTokens;
 		prev.outputTokens += s.outputTokens;
-		prev.totalTokens = (prev.totalTokens ?? 0) + (s.totalTokens ?? s.inputTokens + s.outputTokens);
-		// Keep reasoning/cached undefined when no step reported them, so merged
-		// rows of non-reasoning models don't persist a spurious 0 (the recorder
-		// only stores these fields when present).
-		if (prev.reasoningTokens !== undefined || s.reasoningTokens !== undefined) {
-			prev.reasoningTokens = (prev.reasoningTokens ?? 0) + (s.reasoningTokens ?? 0);
-		}
-		if (prev.cachedInputTokens !== undefined || s.cachedInputTokens !== undefined) {
-			prev.cachedInputTokens = (prev.cachedInputTokens ?? 0) + (s.cachedInputTokens ?? 0);
-		}
+		prev.totalTokens += s.totalTokens;
+		prev.reasoningTokens = sumOptional(prev.reasoningTokens, s.reasoningTokens);
+		prev.cachedInputTokens = sumOptional(prev.cachedInputTokens, s.cachedInputTokens);
 		if (s.nativeCostUsd !== undefined)
 			prev.nativeCostUsd = (prev.nativeCostUsd ?? 0) + s.nativeCostUsd;
 	}

--- a/src/lib/convex/aiUsage/capture.ts
+++ b/src/lib/convex/aiUsage/capture.ts
@@ -53,7 +53,11 @@ export function mergeByModel(steps: CapturedModelUsage[]): CapturedModelUsage[] 
 		const key = `${s.model} ${s.nativeCostUsd !== undefined ? 'native' : 'tokens'}`;
 		const prev = byModel.get(key);
 		if (!prev) {
-			byModel.set(key, { ...s });
+			// Approximate a missing totalTokens on insert too, not just on merge:
+			// otherwise a first step without totalTokens contributes 0 to the
+			// merged total and the persisted row undercounts. Same fallback the
+			// recorder applies (record.ts).
+			byModel.set(key, { ...s, totalTokens: s.totalTokens ?? s.inputTokens + s.outputTokens });
 			continue;
 		}
 		prev.inputTokens += s.inputTokens;

--- a/src/lib/convex/aiUsage/capture.ts
+++ b/src/lib/convex/aiUsage/capture.ts
@@ -63,8 +63,15 @@ export function mergeByModel(steps: CapturedModelUsage[]): CapturedModelUsage[] 
 		prev.inputTokens += s.inputTokens;
 		prev.outputTokens += s.outputTokens;
 		prev.totalTokens = (prev.totalTokens ?? 0) + (s.totalTokens ?? s.inputTokens + s.outputTokens);
-		prev.reasoningTokens = (prev.reasoningTokens ?? 0) + (s.reasoningTokens ?? 0);
-		prev.cachedInputTokens = (prev.cachedInputTokens ?? 0) + (s.cachedInputTokens ?? 0);
+		// Keep reasoning/cached undefined when no step reported them, so merged
+		// rows of non-reasoning models don't persist a spurious 0 (the recorder
+		// only stores these fields when present).
+		if (prev.reasoningTokens !== undefined || s.reasoningTokens !== undefined) {
+			prev.reasoningTokens = (prev.reasoningTokens ?? 0) + (s.reasoningTokens ?? 0);
+		}
+		if (prev.cachedInputTokens !== undefined || s.cachedInputTokens !== undefined) {
+			prev.cachedInputTokens = (prev.cachedInputTokens ?? 0) + (s.cachedInputTokens ?? 0);
+		}
 		if (s.nativeCostUsd !== undefined)
 			prev.nativeCostUsd = (prev.nativeCostUsd ?? 0) + s.nativeCostUsd;
 	}

--- a/src/lib/convex/aiUsage/record.ts
+++ b/src/lib/convex/aiUsage/record.ts
@@ -129,8 +129,8 @@ export const insert = internalMutation({
 
 /**
  * Fire-and-forget recorder for action call sites. No-ops when nothing was used,
- * otherwise hands the captured per-model usage to the `record` mutation, which
- * resolves cost and persists the row.
+ * otherwise schedules the `insert` mutation, which resolves cost and persists
+ * the row.
  */
 export async function recordAiUsage(
 	ctx: ActionCtx,
@@ -144,11 +144,14 @@ export async function recordAiUsage(
 ): Promise<void> {
 	if (args.models.length === 0) return;
 	try {
-		await ctx.runMutation(internal.aiUsage.record.insert, args);
+		// Scheduled mutations run exactly-once with automatic retry on internal
+		// errors, so a transient backend failure can't silently drop the usage
+		// row the way an awaited runMutation from this action could.
+		await ctx.scheduler.runAfter(0, internal.aiUsage.record.insert, args);
 	} catch (error) {
 		// Metering must never fail the feature call that produced the usage:
 		// callers invoke this after a successful stream/generation, so a
-		// throwing insert would surface a metering problem as an LLM failure.
+		// throwing schedule would surface a metering problem as an LLM failure.
 		console.error('[aiUsage] Failed to record usage', error);
 	}
 }

--- a/src/lib/convex/aiUsage/record.ts
+++ b/src/lib/convex/aiUsage/record.ts
@@ -3,7 +3,7 @@ import { internalMutation } from '../_generated/server';
 import type { ActionCtx } from '../_generated/server';
 import { internal } from '../_generated/api';
 import { costOf } from '../pricing/prices';
-import type { CapturedModelUsage } from './capture';
+import { sumOptional, type CapturedModelUsage } from './capture';
 
 export type { CapturedModelUsage } from './capture';
 
@@ -17,12 +17,14 @@ const vFeature = v.union(
 );
 
 // Raw per-model usage as captured at the call site (cost not yet resolved).
+// totalTokens is required: captureDirect normalizes a provider-omitted value
+// to input + output once at capture time.
 const vCapturedModel = v.object({
 	model: v.string(),
 	provider: v.optional(v.string()),
 	inputTokens: v.number(),
 	outputTokens: v.number(),
-	totalTokens: v.optional(v.number()),
+	totalTokens: v.number(),
 	reasoningTokens: v.optional(v.number()),
 	cachedInputTokens: v.optional(v.number()),
 	nativeCostUsd: v.optional(v.number())
@@ -46,7 +48,6 @@ export const insert = internalMutation({
 	returns: v.null(),
 	handler: async (ctx, args) => {
 		const models = args.models.map((m) => {
-			const totalTokens = m.totalTokens ?? m.inputTokens + m.outputTokens;
 			let costUsd: number;
 			let costSource: 'native' | 'computed' | 'unknown';
 			if (m.nativeCostUsd !== undefined) {
@@ -72,7 +73,7 @@ export const insert = internalMutation({
 				...(m.provider !== undefined ? { provider: m.provider } : {}),
 				inputTokens: m.inputTokens,
 				outputTokens: m.outputTokens,
-				totalTokens,
+				totalTokens: m.totalTokens,
 				...(m.reasoningTokens !== undefined ? { reasoningTokens: m.reasoningTokens } : {}),
 				...(m.cachedInputTokens !== undefined ? { cachedInputTokens: m.cachedInputTokens } : {}),
 				costUsd,
@@ -84,23 +85,15 @@ export const insert = internalMutation({
 		let outputTokens = 0;
 		let totalTokens = 0;
 		let costUsd = 0;
-		let reasoningTokens = 0;
-		let hasReasoning = false;
-		let cachedInputTokens = 0;
-		let hasCached = false;
+		let reasoningTokens: number | undefined;
+		let cachedInputTokens: number | undefined;
 		for (const m of models) {
 			inputTokens += m.inputTokens;
 			outputTokens += m.outputTokens;
 			totalTokens += m.totalTokens;
 			costUsd += m.costUsd;
-			if (m.reasoningTokens !== undefined) {
-				reasoningTokens += m.reasoningTokens;
-				hasReasoning = true;
-			}
-			if (m.cachedInputTokens !== undefined) {
-				cachedInputTokens += m.cachedInputTokens;
-				hasCached = true;
-			}
+			reasoningTokens = sumOptional(reasoningTokens, m.reasoningTokens);
+			cachedInputTokens = sumOptional(cachedInputTokens, m.cachedInputTokens);
 		}
 
 		const sources = new Set(models.map((m) => m.costSource));
@@ -124,8 +117,8 @@ export const insert = internalMutation({
 			inputTokens,
 			outputTokens,
 			totalTokens,
-			...(hasReasoning ? { reasoningTokens } : {}),
-			...(hasCached ? { cachedInputTokens } : {}),
+			...(reasoningTokens !== undefined ? { reasoningTokens } : {}),
+			...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
 			costUsd,
 			costSource,
 			at: Date.now()

--- a/src/lib/convex/aiUsage/record.ts
+++ b/src/lib/convex/aiUsage/record.ts
@@ -150,5 +150,12 @@ export async function recordAiUsage(
 	}
 ): Promise<void> {
 	if (args.models.length === 0) return;
-	await ctx.runMutation(internal.aiUsage.record.insert, args);
+	try {
+		await ctx.runMutation(internal.aiUsage.record.insert, args);
+	} catch (error) {
+		// Metering must never fail the feature call that produced the usage:
+		// callers invoke this after a successful stream/generation, so a
+		// throwing insert would surface a metering problem as an LLM failure.
+		console.error('[aiUsage] Failed to record usage', error);
+	}
 }

--- a/src/lib/convex/pricing/prices.test.ts
+++ b/src/lib/convex/pricing/prices.test.ts
@@ -13,15 +13,36 @@ describe('costOf', () => {
 	});
 
 	it('splits fresh vs cached input and falls reasoning back to the output rate', () => {
-		// Model 'm' has no cachedIn/reasoning rate, so cached input bills at the input
-		// rate and reasoning bills at the output rate. With in=1, out=2 ($/Mtok):
-		// fresh 600*1 + cached 400*1 + out 500*2 + reasoning 200*2 = 2400 micro-$
+		// Reasoning (200) and cached input (400) are subsets of output (500) and
+		// input (1000). Model 'm' has no cachedIn/reasoning rate, so both subsets
+		// bill at their parent rate. With in=1, out=2 ($/Mtok):
+		// fresh 600*1 + cached 400*1 + text 300*2 + reasoning 200*2 = 2000 micro-$
 		const usd = costOf(
 			'm',
 			{ input: 1000, output: 500, reasoning: 200, cachedInput: 400 },
 			{ m: { in: 1, out: 2 } }
 		);
-		expect(usd).toBeCloseTo(0.0024, 12);
+		expect(usd).toBeCloseTo(0.002, 12);
+	});
+
+	it('does not double-bill reasoning tokens without a separate reasoning rate', () => {
+		// outputTokens already includes reasoning tokens (AI SDK usage semantics),
+		// so reporting reasoning must not change the cost when it bills at the
+		// output rate anyway.
+		const table = { m: { in: 1, out: 2 } };
+		const withReasoning = costOf('m', { input: 0, output: 500, reasoning: 200 }, table);
+		const withoutReasoning = costOf('m', { input: 0, output: 500 }, table);
+		expect(withReasoning).toBe(withoutReasoning);
+	});
+
+	it('bills only the reasoning subset at a separate reasoning rate', () => {
+		// text 300*2 + reasoning 200*4 = 1400 micro-$
+		const usd = costOf(
+			'm',
+			{ input: 0, output: 500, reasoning: 200 },
+			{ m: { in: 1, out: 2, reasoning: 4 } }
+		);
+		expect(usd).toBeCloseTo(0.0014, 12);
 	});
 
 	it('returns null for an unpriced model', () => {

--- a/src/lib/convex/pricing/prices.ts
+++ b/src/lib/convex/pricing/prices.ts
@@ -18,10 +18,16 @@ export function costOf(
 	if (!p) return null;
 	const cachedIn = t.cachedInput ?? 0;
 	const freshIn = Math.max(0, t.input - cachedIn);
+	// Reasoning tokens are a subset of output tokens (AI SDK usage semantics:
+	// outputTokens = text + reasoning), so split them out like cached input —
+	// pricing the full output AND adding reasoning on top would bill the
+	// reasoning tokens twice.
+	const reasoning = t.reasoning ?? 0;
+	const textOut = Math.max(0, t.output - reasoning);
 	const usd =
 		freshIn * p.in +
 		cachedIn * (p.cachedIn ?? p.in) +
-		t.output * p.out +
-		(t.reasoning ?? 0) * (p.reasoning ?? p.out);
+		textOut * p.out +
+		reasoning * (p.reasoning ?? p.out);
 	return usd * PER_TOKEN;
 }


### PR DESCRIPTION
See also: #615, #626.

The per-call LLM cost tracking shipped in #615 had four gaps. Computed cost billed reasoning tokens twice, because reasoning tokens are a subset of output tokens in AI SDK v6 usage semantics while `costOf` priced the full output and added reasoning on top. A first captured step without `totalTokens` was inserted as undefined into the merge, so a later merge of the same model started the sum at 0 and the step's tokens vanished from the persisted total. A metering write failure propagated out of `recordAiUsage` and could fail a chat or support action after the LLM stream had already succeeded. And merged steps coerced absent reasoning and cached-token counts to 0, so non-reasoning models persisted a spurious `reasoningTokens: 0`.

`costOf` now splits the reasoning subset out of output the same way cached input is split out of input, so reasoning bills once, at the reasoning rate when configured and at the output rate otherwise. `totalTokens` is normalized once in `captureDirect` and required on `CapturedModelUsage`, which removes the three scattered fallbacks (one of them was missing and caused the undercount); the agent usage sink reuses `captureDirect` instead of hand-building the same object. `recordAiUsage` schedules the insert mutation instead of awaiting `runMutation`, so a transient backend error cannot silently drop the row (scheduled mutations execute exactly-once with automatic retry on internal errors) and the fire-and-forget contract for callers is unchanged. A `sumOptional` helper expresses the absent-vs-zero rule once for the merge and aggregate paths.

Regression guard: added unit tests in `prices.test.ts` (reasoning billed once, split billing at a separate reasoning rate) and `capture.test.ts` (merged totals include approximated steps, absent reasoning/cached fields stay undefined).

`bun scripts/static-checks.ts` on the changed files, `bun run check:convex`, and `bun run test:unit` (703 tests) pass.