### PR TITLE
refactor(chat): Export uploadToStorage with cancelation support

### DIFF
--- a/src/lib/chat/core/file-uploader.ts
+++ b/src/lib/chat/core/file-uploader.ts
@@ -83,14 +83,27 @@ export async function uploadFileWithProgress(
 
 /**
  * Upload file to storage URL with progress tracking via XHR
+ *
+ * Exported for upload flows that presign/commit through their own mutations
+ * (e.g. profile images or app-specific file surfaces) but still want
+ * progress events and cancelation.
  */
-async function uploadToStorage(
+export async function uploadToStorage(
 	uploadUrl: string,
 	file: File | Blob,
-	onProgress: ProgressCallback
+	onProgress: ProgressCallback,
+	signal?: AbortSignal
 ): Promise<string> {
 	return new Promise<string>((resolve, reject) => {
 		const xhr = new XMLHttpRequest();
+
+		if (signal) {
+			if (signal.aborted) {
+				reject(new DOMException('Upload canceled', 'AbortError'));
+				return;
+			}
+			signal.addEventListener('abort', () => xhr.abort(), { once: true });
+		}
 
 		// Track upload progress
 		xhr.upload.addEventListener('progress', (e) => {
@@ -116,7 +129,7 @@ async function uploadToStorage(
 
 		// Handle errors
 		xhr.addEventListener('error', () => reject(new Error('Network error during upload')));
-		xhr.addEventListener('abort', () => reject(new Error('Upload canceled')));
+		xhr.addEventListener('abort', () => reject(new DOMException('Upload canceled', 'AbortError')));
 
 		// Start upload
 		xhr.open('POST', uploadUrl);

--- a/src/lib/chat/core/index.ts
+++ b/src/lib/chat/core/index.ts
@@ -58,6 +58,7 @@ export type { UploadResult, ProgressCallback } from './file-uploader.js';
 
 export {
 	uploadFileWithProgress,
+	uploadToStorage,
 	createUploadState,
 	createSuccessState,
 	createErrorState,

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -80,6 +80,7 @@ export {
 	combineStreamingUIMessages,
 	StreamCacheManager,
 	uploadFileWithProgress,
+	uploadToStorage,
 	createUploadState,
 	createSuccessState,
 	createErrorState,


### PR DESCRIPTION
The XHR transport with progress events was private to the chat upload
flow, so upload surfaces that presign and commit through their own
mutations had to fall back to fetch and lost progress feedback.

Export uploadToStorage and accept an optional AbortSignal so callers
can cancel an in-flight upload. Abort now rejects with a DOMException
AbortError so callers can tell cancelation from a network failure.