### PR TITLE
fix(auth): self-heal connection fallback before erroring

### DIFF
--- a/src/lib/components/authenticated/auth-connection-fallback.svelte
+++ b/src/lib/components/authenticated/auth-connection-fallback.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import { T } from '@tolgee/svelte';
 	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
+	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 	import { clockSkewContext } from '$lib/hooks/clock-skew.svelte';
+	import { shouldAutoReload } from './auth-fallback-recovery';
 	import * as Empty from '$lib/components/ui/empty/index.js';
 	import { Button } from '$lib/components/ui/button';
 	import LoaderIcon from '@lucide/svelte/icons/loader-circle';
@@ -9,14 +12,51 @@
 	import WifiOffIcon from '@lucide/svelte/icons/wifi-off';
 
 	// Rendered by AuthenticatedLayout when there is no server-resolved user, instead
-	// of a blank page. The client may still recover a session from cookies right
-	// after hydration (AppAuthProvider revalidates app:auth), so show a calm
-	// "connecting" state first and only escalate to an error after a grace window.
+	// of a blank page. A healthy network can still land here after a transient SSR
+	// auth miss, so before ever escalating to an error we try to self-heal in two
+	// stages, both keyed on the client already holding a session from cookies:
+	//
+	//  Stage 1 (on mount): re-run the server loads that produce `viewer` by
+	//    invalidating app:auth once. When the server can now resolve the session the
+	//    parent re-renders with a user and unmounts this component, no reload needed.
+	//    AppAuthProvider only invalidates once per client-auth transition, so the
+	//    fallback issues its own attempt rather than leaning on the provider.
+	//  Stage 2 (at the 8s grace timeout): still mounted means stage 1 did not recover,
+	//    so fall back to one full document reload. The sessionStorage guard caps this
+	//    at a single automatic reload; a persistent failure then shows the manual
+	//    error state instead of reload-looping. sessionStorage (not localStorage)
+	//    means a brand-new tab starts fresh, so the guard never permanently suppresses
+	//    a legitimately needed future reload.
+	const RELOAD_GUARD_KEY = 'auth-fallback-reloaded';
+
 	const skew = clockSkewContext.getOr(undefined);
+	const auth = useAuth();
 
 	let timedOut = $state(false);
+
+	// onMount runs client-only and once per mount, which satisfies the "browser only"
+	// and "at most once" guards for both stages without extra flags.
 	onMount(() => {
-		const id = setTimeout(() => (timedOut = true), 8000);
+		// Stage 1: recover without a reload when the client session is already valid.
+		if (!auth.isLoading && auth.isAuthenticated) {
+			invalidate('app:auth');
+		}
+
+		const id = setTimeout(() => {
+			// Stage 2: stage 1 did not recover within the grace window.
+			if (
+				shouldAutoReload({
+					isAuthenticated: auth.isAuthenticated,
+					isSkewed: !!skew?.isSkewed,
+					alreadyReloaded: sessionStorage.getItem(RELOAD_GUARD_KEY) !== null
+				})
+			) {
+				sessionStorage.setItem(RELOAD_GUARD_KEY, '1');
+				location.reload();
+				return;
+			}
+			timedOut = true;
+		}, 8000);
 		return () => clearTimeout(id);
 	});
 

--- a/src/lib/components/authenticated/auth-fallback-recovery.test.ts
+++ b/src/lib/components/authenticated/auth-fallback-recovery.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { shouldAutoReload } from './auth-fallback-recovery';
+
+describe('shouldAutoReload', () => {
+	it('reloads once when signed in, clock sane, and not yet reloaded', () => {
+		expect(
+			shouldAutoReload({ isAuthenticated: true, isSkewed: false, alreadyReloaded: false })
+		).toBe(true);
+	});
+
+	it('does not reload when the client is not authenticated', () => {
+		expect(
+			shouldAutoReload({ isAuthenticated: false, isSkewed: false, alreadyReloaded: false })
+		).toBe(false);
+	});
+
+	it('does not reload when the clock is skewed', () => {
+		expect(
+			shouldAutoReload({ isAuthenticated: true, isSkewed: true, alreadyReloaded: false })
+		).toBe(false);
+	});
+
+	it('does not reload a second time in the same session', () => {
+		expect(
+			shouldAutoReload({ isAuthenticated: true, isSkewed: false, alreadyReloaded: true })
+		).toBe(false);
+	});
+});

--- a/src/lib/components/authenticated/auth-fallback-recovery.ts
+++ b/src/lib/components/authenticated/auth-fallback-recovery.ts
@@ -1,0 +1,22 @@
+/** Inputs to the connection fallback's stage-2 auto-reload decision. */
+export interface AutoReloadState {
+	/** Client-side auth believes a session exists (cookies survived). */
+	isAuthenticated: boolean;
+	/** Device clock is far enough off to break cookie auth on its own. */
+	isSkewed: boolean;
+	/** An automatic reload already happened this browser session. */
+	alreadyReloaded: boolean;
+}
+
+/**
+ * Whether the auth connection fallback should silently reload once to recover.
+ *
+ * A reload only helps when the client is actually signed in, so a fresh document
+ * load can re-resolve the server session, and the clock is sane, since skew is not
+ * fixable by reloading and carries its own actionable message. The already-reloaded
+ * flag caps this at a single automatic reload per session so a persistent failure
+ * degrades to the manual error state instead of looping.
+ */
+export function shouldAutoReload(state: AutoReloadState): boolean {
+	return state.isAuthenticated && !state.isSkewed && !state.alreadyReloaded;
+}


### PR DESCRIPTION
The authenticated layout renders the connection fallback whenever a page loads without a server-resolved user. A healthy client can land there after a transient SSR auth miss (cookies present, but the server load did not resolve the session that request), and today the fallback just waits out an 8s grace window and then shows a "can't reach the server" error even though the client is signed in and a plain recovery would have worked.

The fallback now self-heals in two stages before escalating, both gated on the client already holding a session (useAuth). On mount, when the client is authenticated and not still loading, it invalidates app:auth once to re-run the server loads that produce the viewer, so the parent re-renders with a user and unmounts the fallback without any reload. If it is still mounted at the grace timeout, it performs a single guarded document reload as a last resort. The reload decision lives in a pure helper, shouldAutoReload, which only reloads when the client is authenticated, the clock is not skewed (skew is not fixable by reloading and carries its own message), and no automatic reload has happened yet this browser session. A sessionStorage key caps it at one reload so a persistent failure degrades to the manual error state instead of looping, and using sessionStorage rather than localStorage lets a fresh tab start clean.

Regression guard: added src/lib/components/authenticated/auth-fallback-recovery.test.ts
Verification: bun scripts/static-checks.ts over the three changed files passes and bun run test:unit passes (707 tests, including the 4 new shouldAutoReload cases).