### PR TITLE
chore(lint): ban frozen page.data auth reads in marketing code

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,7 @@ import noModuleStateSingletonRule from './eslint/rules/no-module-state-singleton
 import requireMotionGuardTransitionRule from './eslint/rules/require-motion-guard-transition.js';
 import requireFieldErrorAssociationRule from './eslint/rules/require-field-error-association.js';
 import requireGuardedServerConvexClientRule from './eslint/rules/require-guarded-server-convex-client.js';
+import noFrozenAuthPageDataRule from './eslint/rules/no-frozen-auth-page-data.js';
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
 const localPlugin = {
@@ -35,7 +36,8 @@ const localPlugin = {
 		'no-module-state-singleton': noModuleStateSingletonRule,
 		'require-motion-guard-transition': requireMotionGuardTransitionRule,
 		'require-field-error-association': requireFieldErrorAssociationRule,
-		'require-guarded-server-convex-client': requireGuardedServerConvexClientRule
+		'require-guarded-server-convex-client': requireGuardedServerConvexClientRule,
+		'no-frozen-auth-page-data': noFrozenAuthPageDataRule
 	}
 };
 
@@ -189,6 +191,19 @@ export default defineConfig(
 			'local/no-hardcoded-aria-label': 'error',
 			'local/no-hardcoded-sr-only': 'error',
 			'local/require-field-error-association': 'error'
+		}
+	},
+	{
+		// Marketing pages prerender, freezing page.data auth/billing at build time
+		// (saas-starter #452). The rule internally narrows to the marketing surface
+		// (marketing routes/components + the customer-support widget) and covers both
+		// .svelte and .ts files. See eslint/rules/no-frozen-auth-page-data.js.
+		files: ['src/routes/**/*.{svelte,ts}', 'src/lib/components/**/*.{svelte,ts}'],
+		plugins: {
+			local: localPlugin
+		},
+		rules: {
+			'local/no-frozen-auth-page-data': 'error'
 		}
 	},
 	{

--- a/eslint/rules/no-frozen-auth-page-data.js
+++ b/eslint/rules/no-frozen-auth-page-data.js
@@ -1,0 +1,112 @@
+/**
+ * ESLint rule: no-frozen-auth-page-data
+ *
+ * Forbids reading auth/billing state from `page.data` (or the `data` prop) in
+ * code that renders on marketing pages. Marketing pages are prerendered, which
+ * freezes the root layout's server data at build time: `page.data.viewer` is
+ * null, `page.data.authState.isAuthenticated` is false, and
+ * `page.data.autumnState` never updates. Components on those pages must read
+ * from the client-recovering primitives instead (prerendering constraints in
+ * AGENTS.md; regression class from saas-starter #452).
+ *
+ * ❌ const viewer = page.data.viewer;
+ * ❌ if (data.authState.isAuthenticated) { ... }
+ * ❌ const products = page.data.autumnState?.products;
+ * ✅ authClient.useSession()  // profile data, recovers via cookies
+ * ✅ useAuth()                // auth state, recovers via cookies
+ * ✅ useCustomer()            // billing state, recovers via subscription
+ *
+ * Scope: only the marketing surface (marketing routes, marketing components,
+ * and the customer-support widget, which renders on marketing pages). The
+ * parallel /app and /admin fresh layout loads make page.data auth reads safe
+ * there, so those routes are intentionally out of scope.
+ *
+ * Limitation: this matches the member chains `page.data.<prop>` / `$page.data.<prop>`
+ * and the bare `data.<prop>` prop by identifier name. It does NOT do data-flow
+ * analysis, so a local variable coincidentally named `page` or `data` would also
+ * be matched. Given the narrow marketing-surface scope this is acceptable.
+ */
+
+import path from 'node:path';
+
+// Frozen auth/billing fields on the prerendered root layout's server data, and
+// the client-recovering primitive that replaces each one.
+const FROZEN_FIELDS = {
+	viewer: 'authClient.useSession() (from $lib/auth-client) for profile data',
+	authState: 'useAuth() (from @mmailaender/convex-better-auth-svelte/svelte) for auth state',
+	autumnState:
+		'useCustomer() (from @stickerdaniel/convex-autumn-svelte/sveltekit) for billing state'
+};
+
+// `page` from $app/state, or `$page` from the deprecated $app/stores.
+const PAGE_OBJECT_NAMES = new Set(['page', '$page']);
+
+// Marketing-surface path fragments (forward-slash normalized). The customer-support
+// widget renders on marketing pages, so it is included.
+const MARKETING_SURFACE_FRAGMENTS = [
+	'src/routes/[[lang]]/(marketing)/',
+	'src/lib/components/marketing/',
+	'src/lib/components/customer-support/'
+];
+
+/** Resolves the accessed property name for both `a.b` and `a['b']`, else null. */
+function propertyName(memberNode) {
+	const prop = memberNode.property;
+	if (!prop) return null;
+	if (!memberNode.computed && prop.type === 'Identifier') return prop.name;
+	if (memberNode.computed && prop.type === 'Literal' && typeof prop.value === 'string') {
+		return prop.value;
+	}
+	return null;
+}
+
+/** Is `objNode` the `page.data` / `$page.data` member chain? */
+function isPageDataChain(objNode) {
+	return (
+		objNode?.type === 'MemberExpression' &&
+		propertyName(objNode) === 'data' &&
+		objNode.object?.type === 'Identifier' &&
+		PAGE_OBJECT_NAMES.has(objNode.object.name)
+	);
+}
+
+/** Is `objNode` the bare `data` prop identifier? */
+function isDataProp(objNode) {
+	return objNode?.type === 'Identifier' && objNode.name === 'data';
+}
+
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Disallow reading frozen auth/billing fields (viewer, authState, autumnState) from page.data on prerendered marketing pages'
+		},
+		schema: [],
+		messages: {
+			frozenAuthRead:
+				"'{{field}}' from page.data is frozen at build time on prerendered marketing pages. Use {{replacement}}, which recovers client-side after hydration."
+		}
+	},
+	create(context) {
+		const filename = (context.filename ?? context.getFilename()).split(path.sep).join('/');
+		const onMarketingSurface = MARKETING_SURFACE_FRAGMENTS.some((f) => filename.includes(f));
+		if (!onMarketingSurface) {
+			return {};
+		}
+
+		return {
+			MemberExpression(node) {
+				const field = propertyName(node);
+				if (!field || !(field in FROZEN_FIELDS)) return;
+				if (isPageDataChain(node.object) || isDataProp(node.object)) {
+					context.report({
+						node,
+						messageId: 'frozenAuthRead',
+						data: { field, replacement: FROZEN_FIELDS[field] }
+					});
+				}
+			}
+		};
+	}
+};

--- a/eslint/rules/no-frozen-auth-page-data.test.ts
+++ b/eslint/rules/no-frozen-auth-page-data.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import parser from 'svelte-eslint-parser';
+import rule from './no-frozen-auth-page-data.js';
+
+const MARKETING_FILE = '/repo/src/lib/components/marketing/marketing-header.svelte';
+const MARKETING_ROUTE_FILE = '/repo/src/routes/[[lang]]/(marketing)/+page.svelte';
+const SUPPORT_FILE = '/repo/src/lib/components/customer-support/customer-support.svelte';
+const APP_FILE = '/repo/src/routes/[[lang]]/app/+page.svelte';
+
+function lint(template: string, filename: string): Array<{ messageId: string; data?: unknown }> {
+	const reports: Array<{ messageId: string; data?: unknown }> = [];
+	const ast = parser.parseForESLint(template, {});
+
+	const context = {
+		report: (opts: { messageId: string; data?: unknown }) => reports.push(opts),
+		getFilename: () => filename,
+		filename
+	};
+
+	const listeners = rule.create(context);
+
+	function walk(node: Record<string, unknown>) {
+		if (!node || typeof node !== 'object') return;
+		const type = node.type as string;
+		if (type && typeof listeners[type] === 'function') {
+			(listeners[type] as (n: unknown) => void)(node);
+		}
+		for (const key of Object.keys(node)) {
+			if (key === 'parent') continue;
+			const val = node[key];
+			if (Array.isArray(val)) val.forEach((v) => walk(v as Record<string, unknown>));
+			else if (val && typeof val === 'object' && (val as Record<string, unknown>).type)
+				walk(val as Record<string, unknown>);
+		}
+	}
+
+	walk(ast.ast as unknown as Record<string, unknown>);
+	return reports;
+}
+
+describe('no-frozen-auth-page-data', () => {
+	it('flags page.data.viewer in a marketing component', () => {
+		const reports = lint('<script>const v = page.data.viewer;</script>', MARKETING_FILE);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('frozenAuthRead');
+		expect((reports[0].data as { field: string }).field).toBe('viewer');
+	});
+
+	it('flags page.data.autumnState in a (marketing) route file', () => {
+		const reports = lint(
+			'<script>const p = page.data.autumnState?.products;</script>',
+			MARKETING_ROUTE_FILE
+		);
+		expect(reports).toHaveLength(1);
+		expect((reports[0].data as { field: string }).field).toBe('autumnState');
+	});
+
+	it('flags page.data.authState in the customer-support widget', () => {
+		const reports = lint(
+			'<script>const a = page.data.authState.isAuthenticated;</script>',
+			SUPPORT_FILE
+		);
+		expect(reports).toHaveLength(1);
+		expect((reports[0].data as { field: string }).field).toBe('authState');
+	});
+
+	it('flags the bare data prop (data.viewer) in a marketing component', () => {
+		const reports = lint(
+			'<script>let { data } = $props(); const v = data.viewer;</script>',
+			MARKETING_FILE
+		);
+		expect(reports).toHaveLength(1);
+		expect((reports[0].data as { field: string }).field).toBe('viewer');
+	});
+
+	it('flags the $page store form ($page.data.viewer)', () => {
+		const reports = lint('<span>{$page.data.viewer}</span>', MARKETING_FILE);
+		expect(reports).toHaveLength(1);
+	});
+
+	it('flags computed access (page.data["autumnState"])', () => {
+		const reports = lint(
+			'<script>const p = page.data["autumnState"];</script>',
+			MARKETING_ROUTE_FILE
+		);
+		expect(reports).toHaveLength(1);
+	});
+
+	it('allows page.data.lang (not an auth/billing field)', () => {
+		const reports = lint('<script>const l = page.data.lang;</script>', MARKETING_FILE);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('allows authClient.useSession() usage', () => {
+		const reports = lint(
+			'<script>const id = authClient.useSession().data?.user?.id;</script>',
+			SUPPORT_FILE
+		);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('ignores page.data.viewer inside an /app route file', () => {
+		const reports = lint('<script>const v = page.data.viewer;</script>', APP_FILE);
+		expect(reports).toHaveLength(0);
+	});
+
+	it('does not attach listeners outside the marketing surface', () => {
+		const context = {
+			report: () => {},
+			getFilename: () => APP_FILE,
+			filename: APP_FILE
+		};
+		expect(Object.keys(rule.create(context))).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
Marketing pages prerender, so the root layout's server data is frozen at build time. `page.data.viewer` stays null, `page.data.authState.isAuthenticated` stays false, and `page.data.autumnState` never updates after the build. A component on the marketing surface that reads any of these ships stale auth or billing UI that never recovers, and nothing catches it in review (saas-starter #452). The customer-support and feedback widgets already work around this by reading `authClient.useSession()` instead, but the convention only lives in comments.

This adds an ESLint rule, `no-frozen-auth-page-data`, that flags reads of `viewer`, `authState`, and `autumnState` through `page.data`, `$page.data`, or a bare `data` prop, and points to the client-recovering primitive for each one (`authClient.useSession()`, `useAuth()`, `useCustomer()`). The rule narrows itself to the marketing surface (`src/routes/[[lang]]/(marketing)/`, `src/lib/components/marketing/`, and `src/lib/components/customer-support/`); app and admin routes use fresh layout loads where `page.data` auth reads are safe, so they stay out of scope. It matches member chains and computed access by identifier name without data-flow analysis, which the narrow scope makes acceptable. No existing code violates the rule, the flagged widgets already read the client primitives.

`bun run test:unit -- eslint/rules/no-frozen-auth-page-data.test.ts` passes (10 tests). `bunx eslint src` exits clean. `bun scripts/static-checks.ts` passes on the changed files.