### PR TITLE
fix(settings): Announce avatar upload to screen readers

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -853,6 +853,7 @@
 				"rate_limited": "Zu viele Upload-Versuche. Versuchen Sie es in {seconds}s erneut.",
 				"ready": "Bild bereit zum Speichern",
 				"removed": "Bild entfernt - klicken Sie auf Speichern zur Bestätigung",
+				"uploading": "Bild wird hochgeladen…",
 				"select_error": "Bitte wählen Sie eine Bilddatei aus",
 				"size_error": "Bild muss kleiner als {size} sein",
 				"upload_failed": "Bild konnte nicht hochgeladen werden"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -853,6 +853,7 @@
 				"rate_limited": "Too many upload attempts. Try again in {seconds}s.",
 				"ready": "Image ready to save",
 				"removed": "Image removed - click Save to confirm",
+				"uploading": "Uploading image…",
 				"select_error": "Please select an image file",
 				"size_error": "Image must be less than {size}",
 				"upload_failed": "Failed to upload image"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -853,6 +853,7 @@
 				"rate_limited": "Demasiados intentos de subida. Vuelve a intentarlo en {seconds}s.",
 				"ready": "Imagen lista para guardar",
 				"removed": "Imagen eliminada - haz clic en Guardar para confirmar",
+				"uploading": "Subiendo imagen…",
 				"select_error": "Por favor selecciona un archivo de imagen",
 				"size_error": "La imagen debe ser menor de {size}",
 				"upload_failed": "Error al subir la imagen"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -853,6 +853,7 @@
 				"rate_limited": "Trop de tentatives d'envoi. Réessayez dans {seconds}s.",
 				"ready": "Image prête à enregistrer",
 				"removed": "Image supprimée - cliquez sur Enregistrer pour confirmer",
+				"uploading": "Téléversement de l'image…",
 				"select_error": "Veuillez sélectionner un fichier image",
 				"size_error": "L'image doit être inférieure à {size}",
 				"upload_failed": "Échec du téléchargement de l'image"

--- a/src/routes/[[lang]]/app/settings/account-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/account-settings.svelte
@@ -199,8 +199,10 @@
 						{#if isUploading}
 							<div
 								class="flex h-16 w-16 items-center justify-center rounded-full border-2 border-border"
+								role="status"
 							>
 								<LoaderCircleIcon class="size-5 text-muted-foreground motion-safe:animate-spin" />
+								<span class="sr-only"><T keyName="settings.account.avatar.uploading" /></span>
 							</div>
 						{:else if image}
 							<img


### PR DESCRIPTION
Follow-up to #632.

The avatar upload spinner added in #632 was icon-only, so assistive technology got no signal that an upload was in progress. This wraps the spinner in a role=status region with a localized sr-only label, added as settings.account.avatar.uploading across all four locales.

Regression guard: not warranted, static sr-only label with no logic branch and the key is present in every locale file.
bun scripts/static-checks.ts passes. Unit tests pass.