### PR TITLE
fix(auth): resolve auth data fresh in app layouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,6 +523,8 @@ These recover independently after hydration:
 
 Components that need user data on prerendered pages must use `authClient.useSession()` instead of `page.data.viewer`.
 
+Note (2026-07-04): this frozen-data caveat applies to `page.data` read on a prerendered marketing page. Inside the `/app` and `/admin` subtrees it does not. Each has its own `+layout.server.ts` that re-resolves the auth block (`authState`, `viewer`, `autumnState`) fresh via `resolveAuthLayoutData` (`$lib/server/auth-layout-data`) on a client-side navigation, guarded on `event.isDataRequest` (a full document load defers to the root, which already ran with the cookie). Their returned keys override the frozen root snapshot in the merged `page.data`, so reading `page.data.viewer`, `page.data.authState`, or `page.data.autumnState` is safe within `/app` and `/admin`. Marketing pages still keep the client primitives above (`authClient.useSession()`), since they have no such override.
+
 Request-time values needed for an SSR render that shares a layout with prerendered routes (e.g. a `sidebar_state` cookie) must be read in `hooks.server.ts` into `event.locals`, not via `event.cookies.get` in a `+layout.server.ts` load. A cookie read in the shared root layout load breaks prerendering of the marketing pages; the JWT token flows through the same `locals` channel.
 
 #### Cache-control for marketing pages
@@ -574,6 +576,7 @@ Examples: marketing pages must be registered in `public-routes.ts`, marketing pa
 → **ESLint custom rule** that checks filesystem or reads a registry file. Use when the check is "the file I'm editing is missing something" — fires immediately in the editor and on save.
 Pattern: `eslint/rules/require-marketing-route-registration.js`, `eslint/rules/require-marketing-markdown.js`.
 How to add: create rule in `eslint/rules/`, register in `eslint.config.js`, add test in `eslint/rules/<name>.test.ts`.
+Sibling-invariant variant enforced as a unit test instead of ESLint, because it asserts a route-tree invariant across files rather than a single-file miss: `scripts/authenticated-subtree-layouts.test.ts` requires every authenticated subtree (`/app`, `/admin`) to have a `+layout.server.ts` that calls `resolveAuthLayoutData`, or a client-side navigation into it from a prerendered marketing page renders the frozen unauthenticated root data.
 
 #### "This pattern must never appear in code"
 

--- a/e2e/prerender-auth-navigation.spec.ts
+++ b/e2e/prerender-auth-navigation.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Regression guard for the prerendered-marketing -> /app navigation dead end
+// (third regression in the app:auth invalidation series, #289 -> #575 -> this
+// fix):
+//
+// Marketing pages prerender the root layout with an unauthenticated build-time
+// snapshot (viewer: null). SvelteKit never reruns a parent server load on
+// client-side navigation (sveltejs/kit#4426) and invalidate() on a prerendered
+// route fetches the frozen static __data.json. Before the /app layout got its
+// own server load, entering /app via SPA navigation from a marketing page kept
+// the frozen viewer and rendered AuthConnectionFallback ("Connecting..." then
+// "Can't reach the server") until a manual reload.
+//
+// Local test runs serve marketing pages via the dev server (no prerendering),
+// so the frozen-data precondition only exists on CF preview/production
+// deployments, where this spec runs against a real build. Locally it still
+// pins the flow itself (session recovery on home, SPA navigation, app shell
+// render without the fallback).
+
+/**
+ * Full-page navigation that tolerates the dev server's on-demand dependency
+ * optimization. The first visit to a route makes Vite optimize newly seen deps
+ * and force a reload, which surfaces as net::ERR_ABORTED on the in-flight
+ * page.goto; the retry lands on the now-optimized route. Prebuilt CF/production
+ * assets never trigger this, so it is a no-op there.
+ */
+async function gotoStable(page: Page, url: string) {
+	for (let attempt = 0; ; attempt++) {
+		try {
+			await page.goto(url, { waitUntil: 'domcontentloaded' });
+			return;
+		} catch (error) {
+			if (attempt >= 2 || !String(error).includes('ERR_ABORTED')) throw error;
+		}
+	}
+}
+
+test.describe('prerendered marketing to app navigation', () => {
+	test('logged-in user reaches the app via SPA navigation from home', async ({ page }) => {
+		// Local-only warmup: warm the dev server's on-demand compilation for the
+		// heavy authenticated tree (AuthenticatedLayout + the community-chat landing)
+		// and the marketing home before the timed SPA assertion, so the SPA
+		// navigation below imports already-built chunks instead of racing a cold
+		// compile. CF preview/production serve prebuilt assets, so this is a no-op
+		// there and does not weaken the assertion (the SPA load chain still runs
+		// fresh below).
+		test.setTimeout(120000);
+		await gotoStable(page, '/en/app');
+		await expect(page.locator('#user-menu-trigger')).toBeVisible({ timeout: 60000 });
+
+		// Land on the (prerendered) marketing home with authenticated cookies.
+		await gotoStable(page, '/en');
+
+		// Wait for the client to recover the session from cookies: the header
+		// swaps its CTAs for the Dashboard button once useAuth() reports
+		// authenticated. This visibility is also the hydration signal — the button
+		// renders only when the client-side useAuth() store flips to authenticated,
+		// which cannot happen before the app has hydrated and is running client JS.
+		// So once it is visible, the SvelteKit client router is active and will
+		// intercept the click as a real client-side navigation (the path the fix
+		// targets), with no separate network-settle wait needed. At this point the
+		// AppAuthProvider divergence effect has also fired (and, pre-fix, consumed
+		// its one invalidation against the frozen prerendered data). On a
+		// prerendered deploy the pre-fix bug reproduces regardless of timing (the
+		// root __data.json is a frozen static file that invalidate can never clear).
+		const dashboardLink = page.getByTestId('marketing-nav-dashboard');
+		await expect(dashboardLink).toBeVisible({ timeout: 30000 });
+
+		// SPA-navigate into the app (SvelteKit intercepts the link click; no
+		// full document load, which is exactly the broken path).
+		await dashboardLink.click();
+		await page.waitForURL(/\/en\/app/, { timeout: 30000 });
+
+		// The authenticated shell must render from the /app layout's fresh server
+		// data. #user-menu-trigger is the shell's user menu, rendered only when the
+		// layout resolved a viewer, so its visibility proves the frozen null viewer
+		// was overridden. /app redirects to /app/community-chat.
+		await expect(page.locator('#user-menu-trigger')).toBeVisible({ timeout: 30000 });
+		await expect(page).toHaveURL(/\/en\/app\/community-chat/);
+
+		// ...and the connection fallback (the old dead end) must not be shown.
+		await expect(page.getByTestId('auth-connection-fallback')).toHaveCount(0);
+	});
+});

--- a/e2e/prerender-auth-navigation.spec.ts
+++ b/e2e/prerender-auth-navigation.spec.ts
@@ -38,39 +38,54 @@ async function gotoStable(page: Page, url: string) {
 
 test.describe('prerendered marketing to app navigation', () => {
 	test('logged-in user reaches the app via SPA navigation from home', async ({ page }) => {
-		// Local-only warmup: warm the dev server's on-demand compilation for the
-		// heavy authenticated tree (AuthenticatedLayout + the community-chat landing)
-		// and the marketing home before the timed SPA assertion, so the SPA
-		// navigation below imports already-built chunks instead of racing a cold
-		// compile. CF preview/production serve prebuilt assets, so this is a no-op
-		// there and does not weaken the assertion (the SPA load chain still runs
-		// fresh below).
-		test.setTimeout(120000);
-		await gotoStable(page, '/en/app');
-		await expect(page.locator('#user-menu-trigger')).toBeVisible({ timeout: 60000 });
+		test.setTimeout(180000);
 
 		// Land on the (prerendered) marketing home with authenticated cookies.
 		await gotoStable(page, '/en');
 
 		// Wait for the client to recover the session from cookies: the header
 		// swaps its CTAs for the Dashboard button once useAuth() reports
-		// authenticated. This visibility is also the hydration signal — the button
+		// authenticated. This visibility is also the hydration signal, the button
 		// renders only when the client-side useAuth() store flips to authenticated,
-		// which cannot happen before the app has hydrated and is running client JS.
-		// So once it is visible, the SvelteKit client router is active and will
-		// intercept the click as a real client-side navigation (the path the fix
-		// targets), with no separate network-settle wait needed. At this point the
-		// AppAuthProvider divergence effect has also fired (and, pre-fix, consumed
-		// its one invalidation against the frozen prerendered data). On a
-		// prerendered deploy the pre-fix bug reproduces regardless of timing (the
-		// root __data.json is a frozen static file that invalidate can never clear).
+		// which cannot happen before the app has hydrated and is running client JS,
+		// so once it is visible the SvelteKit client router is active and the click
+		// below is a real client-side navigation (the path the fix targets). At
+		// this point the AppAuthProvider divergence effect has also fired (and,
+		// pre-fix, consumed its one invalidation against the frozen prerendered
+		// data). On a prerendered deploy the pre-fix bug reproduces regardless of
+		// timing (the root __data.json is a frozen static file that invalidate can
+		// never clear).
+		// Generous timeout: the fork's client auth recovery (session fetch ->
+		// /convex/token -> Convex WebSocket confirm) can take a while against a
+		// cold preview Convex deployment before isAuthenticated flips.
 		const dashboardLink = page.getByTestId('marketing-nav-dashboard');
-		await expect(dashboardLink).toBeVisible({ timeout: 30000 });
+		await expect(dashboardLink).toBeVisible({ timeout: 60000 });
 
-		// SPA-navigate into the app (SvelteKit intercepts the link click; no
-		// full document load, which is exactly the broken path).
-		await dashboardLink.click();
-		await page.waitForURL(/\/en\/app/, { timeout: 30000 });
+		// Ensure the client router has hydrated before clicking. On the dev server
+		// the link is SSR-rendered (authenticated SSR), so it is visible before
+		// hydration; a click mid-hydration gets hijacked and the navigation is
+		// lost, leaving the page on home. Wait for the network to settle as the
+		// hydration signal, bounded because Tolgee's dev translation polling can
+		// keep the network busy indefinitely; the cap still elapses well after
+		// hydration completes.
+		await page.waitForLoadState('networkidle', { timeout: 20000 }).catch(() => {});
+
+		// SPA-navigate into the app. Retry once if the dev server aborts the
+		// in-flight navigation while optimizing the (heavier) authenticated route
+		// tree on first visit; prebuilt CF/production assets never abort.
+		for (let attempt = 0; ; attempt++) {
+			try {
+				await dashboardLink.click();
+				// Generous: a cold dev server compiles the heavier authenticated
+				// route tree on first entry; prebuilt CF/production navigates fast.
+				await page.waitForURL(/\/en\/app/, { timeout: 90000 });
+				break;
+			} catch (error) {
+				if (attempt >= 1 || !String(error).includes('ERR_ABORTED')) throw error;
+				await gotoStable(page, '/en');
+				await expect(dashboardLink).toBeVisible({ timeout: 30000 });
+			}
+		}
 
 		// The authenticated shell must render from the /app layout's fresh server
 		// data. #user-menu-trigger is the shell's user menu, rendered only when the

--- a/scripts/authenticated-subtree-layouts.test.ts
+++ b/scripts/authenticated-subtree-layouts.test.ts
@@ -1,0 +1,49 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Regression guard for the prerendered-marketing -> authed-subtree navigation
+// dead end (#289 -> #575 -> the app/admin layout fix).
+//
+// The root +layout.server.ts resolves auth data, but marketing pages freeze it
+// at build time (viewer null). SvelteKit never reruns a parent server load on
+// client-side navigation (sveltejs/kit#4426), so every authenticated top-level
+// subtree needs its own +layout.server.ts that re-resolves the auth block via
+// resolveAuthLayoutData, or a client-side navigation into it from a prerendered
+// page renders the frozen unauthenticated data and dead-ends in
+// AuthConnectionFallback.
+//
+// hooks.server.ts gates exactly two top-level subtrees behind auth
+// (isProtectedRoute -> /app, isAdminRoute -> /admin). If a third is ever added
+// there, add it here too and give it a layout load, or it inherits the bug.
+
+const AUTHED_SUBTREES = ['app', 'admin'];
+
+describe('authenticated subtree layout loads', () => {
+	for (const subtree of AUTHED_SUBTREES) {
+		it(`/${subtree} re-resolves auth data in its own +layout.server.ts`, () => {
+			const file = path.resolve('src/routes/[[lang]]', subtree, '+layout.server.ts');
+			expect(fs.existsSync(file), `${subtree}/+layout.server.ts is missing`).toBe(true);
+
+			const content = fs.readFileSync(file, 'utf-8');
+			expect(
+				content.includes('resolveAuthLayoutData'),
+				`${subtree}/+layout.server.ts must call resolveAuthLayoutData to override the frozen root data`
+			).toBe(true);
+		});
+	}
+
+	it('hooks.server.ts still gates only the guarded subtrees (add new ones above)', () => {
+		const hooks = fs.readFileSync(path.resolve('src/hooks.server.ts'), 'utf-8');
+		// Pins the assumption that /app and /admin are the authenticated subtrees.
+		// If these route matchers change, AUTHED_SUBTREES above must be revisited.
+		expect(hooks).toContain('isProtectedRoute');
+		expect(hooks).toContain('isAdminRoute');
+		for (const subtree of AUTHED_SUBTREES) {
+			expect(
+				hooks.includes(`/${subtree}(`),
+				`hooks.server.ts no longer matches /${subtree}; revisit AUTHED_SUBTREES`
+			).toBe(true);
+		}
+	});
+});

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -157,7 +157,11 @@
 								)}
 							>
 								{#if isAuthenticated}
-									<Button size="sm" href={localizedHref('/app')}>
+									<Button
+										size="sm"
+										href={localizedHref('/app')}
+										data-testid="marketing-nav-dashboard"
+									>
 										<T keyName="nav.dashboard" />
 									</Button>
 									<Button
@@ -252,7 +256,12 @@
 						)}
 					>
 						{#if isAuthenticated}
-							<Button size="sm" href={localizedHref('/app')} class="w-full">
+							<Button
+								size="sm"
+								href={localizedHref('/app')}
+								class="w-full"
+								data-testid="marketing-nav-dashboard-mobile"
+							>
 								<T keyName="nav.dashboard" />
 							</Button>
 						{:else if isAtTop}

--- a/src/lib/server/auth-layout-data.ts
+++ b/src/lib/server/auth-layout-data.ts
@@ -1,0 +1,115 @@
+import type { ServerLoadEvent } from '@sveltejs/kit';
+import { api } from '$lib/convex/_generated/api';
+import { createAutumnHandlers } from '@stickerdaniel/convex-autumn-svelte/sveltekit/server';
+import { createServerConvexHttpClient } from '$lib/server/convex-http';
+import { decodeJwtPayload } from '$lib/server/jwt';
+
+type JwtViewer = {
+	_id: string;
+	name?: string | null;
+	email?: string | null;
+	image?: string | null;
+	role?: string;
+	emailVerified?: boolean;
+	createdAt?: number;
+	updatedAt?: number;
+	banned?: boolean;
+	locale?: string;
+};
+
+function getViewerFromJwt(token: string | undefined): JwtViewer | null {
+	const decoded = decodeJwtPayload(token);
+	if (!decoded) return null;
+
+	return {
+		_id: decoded.sub,
+		name: decoded.name ?? null,
+		email: decoded.email ?? null,
+		image: decoded.image ?? null,
+		role: decoded.role,
+		emailVerified: decoded.emailVerified,
+		createdAt: decoded.createdAt,
+		updatedAt: decoded.updatedAt,
+		banned: decoded.banned,
+		locale: decoded.locale
+	};
+}
+
+/**
+ * Resolves the auth-coupled layout data (authState, viewer, autumnState) for a
+ * server load. Shared by the root layout (marketing/auth SSR) and the /app and
+ * /admin layouts.
+ *
+ * Why the /app and /admin layouts resolve this again instead of relying on the
+ * root layout: marketing pages prerender, which freezes the root layout's data
+ * at build time (unauthenticated: viewer null, isAuthenticated false).
+ * SvelteKit never reruns a parent server load on client-side navigation
+ * (sveltejs/kit#4426), and invalidate() against a prerendered route fetches the
+ * static __data.json, so the frozen values survive into /app after a
+ * client-side navigation from a marketing page. A layout server load inside the
+ * authenticated group can never be prerendered, so on a client-side navigation
+ * (isDataRequest) it resolves fresh against the live cookie and its returned
+ * keys override the frozen root values in the merged page.data. On a full
+ * document load the group layouts defer to the root, which already ran with the
+ * cookie, so this is resolved once per request (see the isDataRequest guard in
+ * the group layout loads).
+ */
+export async function resolveAuthLayoutData(event: ServerLoadEvent) {
+	// Enables targeted invalidation via invalidate('autumn:customer') to refetch only customer data
+	event.depends('autumn:customer');
+	// Enables targeted invalidation when client-side auth state diverges from server state.
+	// Prerendered pages bake authState.isAuthenticated: false at build time — when the client
+	// recovers a session from cookies, AppAuthProvider detects the mismatch and calls
+	// invalidate('app:auth') to re-run this load with fresh cookies.
+	event.depends('app:auth');
+
+	// Check if JWT token exists (set by handleAuth in hooks.server.ts)
+	const isAuthenticated = !!event.locals.token;
+	const authState = { isAuthenticated };
+	const fallbackViewer = getViewerFromJwt(event.locals.token);
+
+	// Only create Convex/Autumn clients when authenticated (avoids invalid URL during prerendering)
+	let customer = null;
+	let viewer = null;
+
+	if (isAuthenticated) {
+		// The whole block is guarded: client construction (a missing
+		// CONVEX_INTERNAL_URL/PUBLIC_CONVEX_URL throws here) and the autumn
+		// handler setup run before the per-query .catch, so an unguarded failure
+		// here would 500 every authenticated SSR page. Fall back to the JWT
+		// viewer + null customer; the client subscriptions recover after hydration.
+		try {
+			const client = createServerConvexHttpClient({ token: event.locals.token });
+
+			const { getCustomer } = createAutumnHandlers({
+				convexApi: (api as any).autumn,
+				createClient: () => client
+			});
+
+			// Fetch customer and viewer in PARALLEL for faster initial load
+			[customer, viewer] = await Promise.all([
+				getCustomer(event).catch((e) => {
+					console.error('[auth-layout-data] Autumn getCustomer failed:', e);
+					return null;
+				}),
+				client.query(api.users.viewer, {}).catch((e) => {
+					console.error('[auth-layout-data] Viewer lookup failed, falling back to JWT payload:', e);
+					return fallbackViewer;
+				})
+			]);
+		} catch (e) {
+			console.error('[auth-layout-data] Convex client unavailable, using JWT fallback:', e);
+			customer = null;
+			viewer = fallbackViewer;
+		}
+	}
+
+	return {
+		authState,
+		autumnState: {
+			customer,
+			_timeFetched: Date.now()
+		},
+		viewer
+	};
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,100 +1,14 @@
 import type { LayoutServerLoad } from './$types';
-import { api } from '$lib/convex/_generated/api';
-import { createAutumnHandlers } from '@stickerdaniel/convex-autumn-svelte/sveltekit/server';
-import { createServerConvexHttpClient } from '$lib/server/convex-http';
-import { decodeJwtPayload } from '$lib/server/jwt';
-
-type JwtViewer = {
-	_id: string;
-	name?: string | null;
-	email?: string | null;
-	image?: string | null;
-	role?: string;
-	emailVerified?: boolean;
-	createdAt?: number;
-	updatedAt?: number;
-	banned?: boolean;
-	locale?: string;
-};
-
-function getViewerFromJwt(token: string | undefined): JwtViewer | null {
-	const decoded = decodeJwtPayload(token);
-	if (!decoded) return null;
-
-	return {
-		_id: decoded.sub,
-		name: decoded.name ?? null,
-		email: decoded.email ?? null,
-		image: decoded.image ?? null,
-		role: decoded.role,
-		emailVerified: decoded.emailVerified,
-		createdAt: decoded.createdAt,
-		updatedAt: decoded.updatedAt,
-		banned: decoded.banned,
-		locale: decoded.locale
-	};
-}
+import { resolveAuthLayoutData } from '$lib/server/auth-layout-data';
 
 export const load: LayoutServerLoad = async (event) => {
-	// Enables targeted invalidation via invalidate('autumn:customer') to refetch only customer data
-	event.depends('autumn:customer');
-	// Enables targeted invalidation when client-side auth state diverges from server state.
-	// Prerendered pages bake authState.isAuthenticated: false at build time — when the client
-	// recovers a session from cookies, AppAuthProvider detects the mismatch and calls
-	// invalidate('app:auth') to re-run this load with fresh cookies.
-	event.depends('app:auth');
-
-	// Check if JWT token exists (set by handleAuth in hooks.server.ts)
-	const isAuthenticated = !!event.locals.token;
-	const authState = { isAuthenticated };
-	const fallbackViewer = getViewerFromJwt(event.locals.token);
-
-	// Only create Convex/Autumn clients when authenticated (avoids invalid URL during prerendering)
-	let customer = null;
-	let viewer = null;
-
-	if (isAuthenticated) {
-		// The whole block is guarded: client construction (a missing
-		// CONVEX_INTERNAL_URL/PUBLIC_CONVEX_URL throws here) and the autumn
-		// handler setup run before the per-query .catch, so an unguarded failure
-		// here would 500 every authenticated SSR page. Fall back to the JWT
-		// viewer + null customer; the client subscriptions recover after hydration.
-		try {
-			const client = createServerConvexHttpClient({ token: event.locals.token });
-
-			const { getCustomer } = createAutumnHandlers({
-				convexApi: (api as any).autumn,
-				createClient: () => client
-			});
-
-			// Fetch customer and viewer in PARALLEL for faster initial load
-			[customer, viewer] = await Promise.all([
-				getCustomer(event).catch((e) => {
-					console.error('[+layout.server.ts] Autumn getCustomer failed:', e);
-					return null;
-				}),
-				client.query(api.users.viewer, {}).catch((e) => {
-					console.error(
-						'[+layout.server.ts] Viewer lookup failed, falling back to JWT payload:',
-						e
-					);
-					return fallbackViewer;
-				})
-			]);
-		} catch (e) {
-			console.error('[+layout.server.ts] Convex client unavailable, using JWT fallback:', e);
-			customer = null;
-			viewer = fallbackViewer;
-		}
-	}
+	// On prerendered marketing pages this resolves at build time without a
+	// cookie and freezes as unauthenticated. The /app and /admin layout loads
+	// re-resolve the same keys fresh (see $lib/server/auth-layout-data).
+	const authData = await resolveAuthLayoutData(event);
 
 	return {
-		authState,
-		autumnState: {
-			customer,
-			_timeFetched: Date.now()
-		},
-		viewer,
+		...authData,
 		// Persisted sidebar state (set by handleSidebarState in hooks.server.ts).
 		// Forwarded to Sidebar.Provider so the authenticated shell renders the
 		// correct open/collapsed state on first paint.

--- a/src/routes/[[lang]]/admin/+layout.server.ts
+++ b/src/routes/[[lang]]/admin/+layout.server.ts
@@ -1,0 +1,23 @@
+import type { LayoutServerLoad } from './$types';
+import { resolveAuthLayoutData } from '$lib/server/auth-layout-data';
+
+/**
+ * Overrides the frozen root layout auth data for the /admin subtree on a
+ * client-side navigation from a prerendered marketing page, deferring to the
+ * root's resolution on a full document load. See
+ * src/routes/[[lang]]/app/+layout.server.ts and $lib/server/auth-layout-data
+ * for the full rationale.
+ */
+export const load: LayoutServerLoad = async (event) => {
+	event.depends('app:auth');
+	event.depends('autumn:customer');
+
+	if (!event.isDataRequest) {
+		return {};
+	}
+
+	return {
+		...(await resolveAuthLayoutData(event)),
+		sidebarOpen: event.locals.sidebarOpen
+	};
+};

--- a/src/routes/[[lang]]/app/+layout.server.ts
+++ b/src/routes/[[lang]]/app/+layout.server.ts
@@ -1,0 +1,43 @@
+import type { LayoutServerLoad } from './$types';
+import { resolveAuthLayoutData } from '$lib/server/auth-layout-data';
+
+/**
+ * Overrides the root layout's auth-coupled data (authState, viewer,
+ * autumnState, sidebarOpen) for the /app subtree when the root data is the
+ * frozen prerendered snapshot.
+ *
+ * Marketing pages prerender the root layout with a build-time unauthenticated
+ * snapshot (viewer null). SvelteKit never reruns a parent server load on
+ * client-side navigation (sveltejs/kit#4426) and invalidate() on a prerendered
+ * route fetches the static __data.json, so entering /app via a client-side
+ * navigation from a marketing page kept the frozen viewer and dead-ended in
+ * AuthConnectionFallback ("Connecting...") until a manual reload.
+ *
+ * Only client-side navigation hits the frozen data. A full document load
+ * (isDataRequest false) runs the whole layout chain server-side, so the root
+ * layout already resolves a live session against the request cookie and is
+ * authoritative; this load defers to it to avoid resolving the auth block
+ * (an external Autumn call plus a Convex query) a second time. On a data
+ * request (isDataRequest true) the client keeps its frozen root snapshot and
+ * only the newly entered subtree loads run, so this load resolves fresh.
+ */
+export const load: LayoutServerLoad = async (event) => {
+	// Register the invalidation deps unconditionally so invalidate('app:auth')
+	// and invalidate('autumn:customer') rerun this load even on the full-load
+	// path where it defers to the root without resolving.
+	event.depends('app:auth');
+	event.depends('autumn:customer');
+
+	if (!event.isDataRequest) {
+		// Full document load: the root layout ran with the cookie and is the
+		// authoritative source for the inlined page data.
+		return {};
+	}
+
+	// Client-side navigation: the root data is the frozen prerendered snapshot
+	// (or a stale reused one), so resolve fresh against the live cookie here.
+	return {
+		...(await resolveAuthLayoutData(event)),
+		sidebarOpen: event.locals.sidebarOpen
+	};
+};


### PR DESCRIPTION
Marketing pages prerender the root `+layout.server.ts`, which freezes its auth data (viewer null, `isAuthenticated` false) at build time. SvelteKit never reruns a parent server load on client-side navigation (sveltejs/kit#4426), and `invalidate()` against a prerendered route fetches the static `__data.json`, so entering `/app` via SPA navigation from a prerendered marketing page kept the frozen viewer and dead-ended in the connection fallback ("Connecting..." then "Can't reach the server") until a manual reload. This is the third regression in the same series as #289 and #575.

The fix extracts the root layout's auth resolution into a shared `resolveAuthLayoutData` helper and adds `/app` and `/admin` `+layout.server.ts` loads that re-resolve it. A layout load inside the authenticated group can never be prerendered, so it resolves fresh against the live cookie and its returned keys override the frozen root values in the merged `page.data`. The group loads guard on `event.isDataRequest`: on a full document load the root already ran with the cookie and is authoritative, so they return an empty object to avoid resolving the auth block a second time; on a client-side navigation (`isDataRequest` true, root frozen) they resolve fresh. Both register `event.depends('app:auth')` and `event.depends('autumn:customer')` unconditionally so targeted invalidation still reruns them. The two authenticated Dashboard links in the marketing header gain `data-testid`s so the regression spec can drive the SPA navigation.

Regression guard: added e2e/prerender-auth-navigation.spec.ts and scripts/authenticated-subtree-layouts.test.ts
Verification: `bun scripts/static-checks.ts` passes on all changed files, `bun run test:unit -- scripts/authenticated-subtree-layouts.test.ts` passes (3/3), and `bun run test:e2e -- prerender-auth-navigation.spec.ts` passes (2 consecutive runs).