### PR TITLE
feat(worktree): branch off origin, add prune task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,15 @@ When you need up-to-date information about technologies used in this project, us
 
 When starting work that needs its own branch/PR, always create a worktree first with `bun run worktree <type/short-description>` (e.g. `feature/dark-mode`, `fix/422-password-reset`, `chore/upgrade-svelte-5`, `hotfix/rate-limit-bypass`, `docs/api-reference`).
 
+The script fetches and branches from `origin/<trunk>` by default, so a new worktree always starts from current remote `main` even when your local `main` lags behind (which it routinely does, since the main checkout carries uncommitted work). No `reset --hard origin/main` afterwards is needed. Pass `--base <branch>` to stack intentionally on another branch, or `--no-fetch` to branch from local refs offline.
+
 Worktrees live in a sibling directory next to the main repo at `<repo>.worktrees/<folder-name>/`. The folder name flattens branch slashes to dashes: `feat/dark-mode` creates `saas-starter.worktrees/feat-dark-mode/`. The git branch name keeps its original slashes; only the on-disk folder name is flattened. Edge case: branches like `feat/sentry` and `feat-sentry` map to the same folder — the script catches this as a loud error before touching git state.
 
 NEVER use the `EnterWorktree` tool. Always use `bun run worktree` instead and add the worktree path before all consecutive actions. You must do this, the cwd is reset after each action and theres currently no better way to do this.
 
 **Before committing:** Always check `git branch` first. If you're in a worktree, the branch already exists and was created by `bun run worktree`. Use `git commit` to add commits.
+
+**After merging a PR:** run `bun run worktree:prune`. This is the moment to pull local `main` forward, and the one command that does the whole cleanup: for each local branch whose remote was deleted, it confirms the merge (a merged GitHub PR, or the branch being an ancestor of trunk) so it never deletes unmerged work, removes that worktree + branch, prunes stale worktree metadata, and fast-forwards local `main` when the main checkout is clean and hasn't diverged. `--dry-run` previews; `--force` also discards uncommitted changes in a confirmed-merged worktree. Do it promptly: a leftover branch keeps its Convex preview deployment alive, eating the deployment quota and breaking other PRs' preview deploys. It never resets or stashes an uncommitted main checkout, just skips the fast-forward and leaves your work alone; a lagging local `main` is only cosmetic anyway, since new worktrees branch off `origin/main` regardless.
 
 ### Commit Message Format
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"_tolgee:cleanup": "TOLGEE_API_KEY=$VITE_TOLGEE_API_KEY tolgee tag --filter-not-extracted --filter-tag production --tag deprecated --untag production",
 		"worktree": "bun scripts/create-worktree.ts",
 		"worktree:setup": "bun scripts/create-worktree.ts --setup-only",
+		"worktree:prune": "bun scripts/prune-worktrees.ts",
 		"setup": "bun scripts/template-setup.ts",
 		"upstream:sync": "bun skills/upstream-sync/scripts/find-fork-point.ts"
 	},

--- a/scripts/create-worktree.ts
+++ b/scripts/create-worktree.ts
@@ -1,6 +1,10 @@
 /**
  * Worktree management (cross-platform TypeScript version)
  *
+ * New worktrees branch from a freshly fetched origin/<trunk> by default, so a
+ * stale local main can never seed one with old code. Pass --base to override or
+ * --no-fetch to skip the fetch.
+ *
  * Usage:
  *   bun scripts/create-worktree.ts feature/dark-mode           # Full mode: create + setup
  *   bun scripts/create-worktree.ts --setup-only               # Setup mode: setup only (for Cursor)
@@ -31,6 +35,7 @@ function parseCliArgs() {
 				'setup-only': { type: 'boolean', default: false },
 				'open-editor': { type: 'string' },
 				base: { type: 'string', short: 'b' },
+				'no-fetch': { type: 'boolean', default: false },
 				help: { type: 'boolean', short: 'h', default: false }
 			},
 			strict: true,
@@ -50,7 +55,7 @@ const openEditor = values['open-editor'];
 const branchName = positionals[0];
 
 // A second positional is always a mistake (usually an attempted base branch);
-// dropping it silently would branch off the CURRENT branch instead.
+// dropping it silently would branch off the default base instead.
 if (positionals.length > 1) {
 	console.error(
 		`${'\x1b[31m'}Error: Unexpected extra argument(s): ${positionals.slice(1).join(' ')}${'\x1b[0m'}`
@@ -118,6 +123,18 @@ function getRootWorktree(): string {
 		process.exit(1);
 	}
 	return mainRepoPath;
+}
+
+/**
+ * Resolve the trunk branch name (the default base for new worktrees) from
+ * origin's HEAD. Falls back to "main" when origin/HEAD is unset (e.g. a brand
+ * new clone that never ran `git remote set-head`).
+ */
+function getTrunk(): string {
+	const result = runCommand('git', ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], {
+		silent: true
+	});
+	return result.success && result.stdout ? result.stdout.replace(/^origin\//, '') : 'main';
 }
 
 /**
@@ -234,7 +251,10 @@ function showHelp(): void {
 	);
 	console.log('');
 	console.log('Options:');
-	console.log('  -b, --base <branch>            Base branch (default: current branch)');
+	console.log(
+		'  -b, --base <branch>            Base branch (default: origin/<trunk>, fetched fresh)'
+	);
+	console.log('  --no-fetch                      Skip the pre-branch git fetch (use local refs)');
 	console.log('  --open-editor code|cursor       Open the worktree in VS Code or Cursor');
 	console.log('');
 	console.log('Example:');
@@ -321,44 +341,40 @@ function main(): void {
 		process.exit(1);
 	}
 
-	// Determine base branch: current branch by default, or --base override
+	// Determine base branch. Default is the REMOTE trunk (origin/<trunk>), NOT
+	// the current local branch: branching off origin keeps a new worktree
+	// independent of whatever stale state the local checkout is in, so a
+	// forgotten `git pull` on main can no longer seed a worktree with old code.
+	// Pass --base <branch> to stack intentionally (e.g. on another feature branch).
 	const baseArgRaw = values['base'] as string | undefined;
 	const baseArg = baseArgRaw?.trim();
 	if (baseArgRaw !== undefined && !baseArg) {
 		console.error(`${colors.red}Error: --base requires a non-empty branch name${colors.reset}`);
 		process.exit(1);
 	}
-	let baseBranch: string;
-	if (baseArg) {
-		baseBranch = baseArg;
-	} else {
-		const result = runCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { silent: true });
-		if (!result.success || !result.stdout) {
-			console.error(
-				`${colors.red}Error: Cannot determine current branch. Use --base <branch> explicitly.${colors.reset}`
-			);
-			process.exit(1);
-		}
-		baseBranch = result.stdout;
-	}
-	console.log(`Base branch: ${baseBranch}`);
+	const trunk = getTrunk();
 
-	// Warn when the implicit base is not the trunk: the default is the CURRENT
-	// branch, so invoking from a feature branch silently stacks the new worktree
-	// on it, and a later gt submit then submits that whole stack.
-	if (!baseArg) {
-		const trunkResult = runCommand('git', ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], {
-			silent: true
-		});
-		const trunk = trunkResult.success ? trunkResult.stdout.replace(/^origin\//, '') : 'main';
-		if (baseBranch !== trunk) {
+	// Refresh the base from the remote before branching (unless --no-fetch). This
+	// is what makes "forgot to pull main" harmless: the worktree always starts
+	// from the current origin/<trunk>, not the local ref, which routinely lags.
+	const noFetch = values['no-fetch'] ?? false;
+	if (!noFetch) {
+		console.log(baseArg ? 'Fetching origin...' : `Fetching origin/${trunk}...`);
+		const fetchArgs = baseArg ? ['fetch', 'origin'] : ['fetch', 'origin', trunk];
+		const fetched = runCommand('git', fetchArgs, { silent: true });
+		if (!fetched.success) {
 			console.log(
-				`${colors.yellow}Warning: branching off "${baseBranch}" (current branch), not "${trunk}".${colors.reset}`
-			);
-			console.log(
-				`${colors.yellow}Pass --base ${trunk} if this branch should be independent of ${baseBranch}.${colors.reset}`
+				`${colors.yellow}Warning: git fetch failed; branching from last-known refs.${colors.reset}`
 			);
 		}
+	}
+
+	const baseBranch = baseArg ?? `origin/${trunk}`;
+	console.log(`Base branch: ${baseBranch}`);
+	if (baseArg && baseArg !== trunk && baseArg !== `origin/${trunk}`) {
+		console.log(
+			`${colors.yellow}Note: stacking this worktree on "${baseArg}", not ${trunk}.${colors.reset}`
+		);
 	}
 
 	// Create worktree
@@ -368,6 +384,23 @@ function main(): void {
 		process.exit(1);
 	}
 	console.log(`${colors.green}Worktree created${colors.reset}`);
+
+	// Branching off a remote-tracking ref (origin/<trunk>) makes git auto-set the
+	// new branch's upstream to the trunk (branch.autoSetupMerge). Unset it so
+	// `git status` doesn't compare against the trunk and the first
+	// `git push -u origin HEAD` sets the correct upstream.
+	const unset = runCommand('git', ['-C', worktreePath, 'branch', '--unset-upstream'], {
+		silent: true
+	});
+	// With an origin/<trunk> base an upstream definitely existed, so a failed
+	// unset (e.g. a config.lock race with a parallel create) left the wrong
+	// upstream set — warn so it gets fixed before the first push. A local --base
+	// has no upstream, making the failure an expected no-op we ignore.
+	if (!unset.success && baseBranch.startsWith('origin/')) {
+		console.log(
+			`${colors.yellow}Warning: could not unset the auto-configured upstream; run \`git branch --unset-upstream\` in the worktree before pushing.${colors.reset}`
+		);
+	}
 
 	// Change to new worktree and run setup
 	process.chdir(worktreePath);

--- a/scripts/prune-worktrees.test.ts
+++ b/scripts/prune-worktrees.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+	classifyMerge,
+	parseWorktreePorcelain,
+	selectGoneBranches,
+	type BranchInfo
+} from './prune-worktrees';
+
+describe('selectGoneBranches', () => {
+	const branches: BranchInfo[] = [
+		{ name: 'main', track: '' },
+		{ name: 'feat/merged-a', track: '[gone]' },
+		{ name: 'feat/merged-b', track: '[gone]' },
+		{ name: 'feat/in-progress', track: '[ahead 2]' },
+		{ name: 'feat/behind', track: '[behind 1]' },
+		{ name: 'feat/never-pushed', track: '' }
+	];
+
+	it('selects only branches whose upstream is gone', () => {
+		expect(selectGoneBranches(branches, { trunk: 'main', currentBranch: 'main' })).toEqual([
+			'feat/merged-a',
+			'feat/merged-b'
+		]);
+	});
+
+	it('never selects the trunk even if it somehow reads as gone', () => {
+		const withGoneTrunk: BranchInfo[] = [{ name: 'main', track: '[gone]' }, ...branches.slice(1)];
+		const result = selectGoneBranches(withGoneTrunk, { trunk: 'main', currentBranch: 'feat/x' });
+		expect(result).not.toContain('main');
+	});
+
+	it('never selects the currently checked-out branch', () => {
+		const result = selectGoneBranches(branches, {
+			trunk: 'main',
+			currentBranch: 'feat/merged-a'
+		});
+		expect(result).toEqual(['feat/merged-b']);
+	});
+
+	it('returns empty when nothing is gone', () => {
+		const clean: BranchInfo[] = [
+			{ name: 'main', track: '' },
+			{ name: 'feat/active', track: '[ahead 1]' }
+		];
+		expect(selectGoneBranches(clean, { trunk: 'main', currentBranch: 'main' })).toEqual([]);
+	});
+});
+
+describe('classifyMerge', () => {
+	it('treats git ancestry as merged regardless of gh (proof content is in trunk)', () => {
+		expect(classifyMerge({ ghSucceeded: false, ghFoundMergedPr: false, gitAncestor: true })).toBe(
+			'merged'
+		);
+		// ancestry wins even when gh ran and found no merged PR
+		expect(classifyMerge({ ghSucceeded: true, ghFoundMergedPr: false, gitAncestor: true })).toBe(
+			'merged'
+		);
+	});
+
+	it('treats a merged PR as merged (covers squash-merges, no ancestry)', () => {
+		expect(classifyMerge({ ghSucceeded: true, ghFoundMergedPr: true, gitAncestor: false })).toBe(
+			'merged'
+		);
+	});
+
+	it('is not-merged when gh ran but found no merged PR and there is no ancestry', () => {
+		expect(classifyMerge({ ghSucceeded: true, ghFoundMergedPr: false, gitAncestor: false })).toBe(
+			'not-merged'
+		);
+	});
+
+	it('is unknown when gh could not run and there is no ancestry', () => {
+		expect(classifyMerge({ ghSucceeded: false, ghFoundMergedPr: false, gitAncestor: false })).toBe(
+			'unknown'
+		);
+	});
+});
+
+describe('parseWorktreePorcelain', () => {
+	it('maps branch names to worktree paths', () => {
+		const stdout = [
+			'worktree /repo',
+			'HEAD abc123',
+			'branch refs/heads/main',
+			'',
+			'worktree /repo.worktrees/feat-a',
+			'HEAD def456',
+			'branch refs/heads/feat/a',
+			''
+		].join('\n');
+		const map = parseWorktreePorcelain(stdout);
+		expect(map.get('main')).toBe('/repo');
+		expect(map.get('feat/a')).toBe('/repo.worktrees/feat-a');
+		expect(map.size).toBe(2);
+	});
+
+	it('omits detached-HEAD worktrees (no branch line)', () => {
+		const stdout = [
+			'worktree /repo',
+			'HEAD abc123',
+			'branch refs/heads/main',
+			'',
+			'worktree /repo.worktrees/detached',
+			'HEAD def456',
+			'detached',
+			''
+		].join('\n');
+		const map = parseWorktreePorcelain(stdout);
+		expect(map.size).toBe(1);
+		expect(map.has('main')).toBe(true);
+	});
+});

--- a/scripts/prune-worktrees.ts
+++ b/scripts/prune-worktrees.ts
@@ -1,0 +1,364 @@
+/**
+ * Prune merged worktrees + local branches after PRs land, and fast-forward the
+ * local trunk when it is safe to do so.
+ *
+ * After `gh pr merge --squash --delete-branch`, the remote branch is gone but
+ * the local branch and its worktree linger. Left alone they pile up, and a
+ * leftover branch also keeps its Convex preview deployment alive (eating deploy
+ * quota). This finds every local branch whose upstream was deleted on the
+ * remote, confirms via a merged GitHub PR (or git ancestry) that its content is
+ * actually in trunk, then removes its worktree, deletes the branch, prunes
+ * stale worktree metadata, and finally fast-forwards the trunk in the main
+ * checkout when that checkout is clean and has not diverged.
+ *
+ * Usage:
+ *   bun scripts/prune-worktrees.ts            # remove merged worktrees + branches, ff trunk
+ *   bun scripts/prune-worktrees.ts --dry-run  # show what would be removed, change nothing
+ *   bun scripts/prune-worktrees.ts --force    # also remove worktrees with uncommitted changes
+ */
+
+import { spawnSync } from 'child_process';
+import { parseArgs } from 'util';
+
+const colors = {
+	reset: '\x1b[0m',
+	bold: '\x1b[1m',
+	green: '\x1b[32m',
+	yellow: '\x1b[33m',
+	red: '\x1b[31m'
+};
+
+function runCommand(
+	command: string,
+	args: string[],
+	options?: { silent?: boolean }
+): { success: boolean; stdout: string; stderr: string } {
+	const result = spawnSync(command, args, { encoding: 'utf-8' });
+	if (!options?.silent && result.status !== 0) {
+		console.error(`${colors.red}Command failed: ${command} ${args.join(' ')}${colors.reset}`);
+		if (result.stderr) console.error(result.stderr);
+	}
+	return {
+		success: result.status === 0,
+		stdout: result.stdout?.trim() ?? '',
+		stderr: result.stderr?.trim() ?? ''
+	};
+}
+
+export interface BranchInfo {
+	name: string;
+	/** `git`'s upstream track marker, e.g. '[gone]', '[behind 2]', '[ahead 1]', ''. */
+	track: string;
+}
+
+/**
+ * Select local branches that are safe to delete: their upstream was deleted on
+ * the remote ('[gone]' = the PR merged and `--delete-branch` removed it),
+ * excluding the trunk and the currently checked-out branch. '[gone]' is the
+ * reliable signal here because squash-merges do not register as `--merged`.
+ */
+export function selectGoneBranches(
+	branches: BranchInfo[],
+	opts: { trunk: string; currentBranch: string | null }
+): string[] {
+	return branches
+		.filter((b) => b.track === '[gone]')
+		.filter((b) => b.name !== opts.trunk && b.name !== opts.currentBranch)
+		.map((b) => b.name);
+}
+
+/**
+ * Parse `git worktree list --porcelain` into a branch-name -> worktree-path map.
+ * Detached-HEAD worktrees have no `branch` line and are simply omitted.
+ */
+export function parseWorktreePorcelain(stdout: string): Map<string, string> {
+	const map = new Map<string, string>();
+	let currentPath: string | null = null;
+	for (const rawLine of stdout.split('\n')) {
+		const line = rawLine.trim();
+		if (line.startsWith('worktree ')) {
+			currentPath = line.slice('worktree '.length);
+		} else if (line.startsWith('branch ') && currentPath) {
+			const branch = line.slice('branch '.length).replace(/^refs\/heads\//, '');
+			map.set(branch, currentPath);
+		} else if (line === '') {
+			currentPath = null;
+		}
+	}
+	return map;
+}
+
+/** First line of `git worktree list --porcelain` is always the main worktree. */
+function getRootWorktree(): string {
+	const result = runCommand('git', ['worktree', 'list', '--porcelain'], { silent: true });
+	if (!result.success || !result.stdout) {
+		console.error(`${colors.red}Error: Not in a git repository${colors.reset}`);
+		process.exit(1);
+	}
+	return result.stdout
+		.split('\n')[0]
+		.trim()
+		.replace(/^worktree /, '');
+}
+
+/** Resolve the trunk branch name from origin's HEAD, falling back to "main". */
+function getTrunk(): string {
+	const result = runCommand('git', ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], {
+		silent: true
+	});
+	return result.success && result.stdout ? result.stdout.replace(/^origin\//, '') : 'main';
+}
+
+export type MergeVerdict = 'merged' | 'not-merged' | 'unknown';
+
+/**
+ * Decide whether a [gone] branch is safe to delete, from the raw probe results.
+ * '[gone]' alone only means the upstream was deleted on the remote — which also
+ * happens when a PR is closed unmerged or a branch is deleted by hand — so it is
+ * never sufficient on its own.
+ *
+ * git ancestry ranks first: if the branch tip is already an ancestor of trunk,
+ * its content is provably in trunk and deleting it can't lose work, regardless
+ * of gh. It catches real merges/rebases but never squash-merges (the squash
+ * commit is not the branch tip). gh then covers squash-merges: a merged PR head
+ * is authoritative. If neither can confirm (offline, gh missing), stay 'unknown'
+ * and the caller leaves the branch alone.
+ */
+export function classifyMerge(input: {
+	ghSucceeded: boolean;
+	ghFoundMergedPr: boolean;
+	gitAncestor: boolean;
+}): MergeVerdict {
+	if (input.gitAncestor) return 'merged';
+	if (input.ghSucceeded) return input.ghFoundMergedPr ? 'merged' : 'not-merged';
+	return 'unknown';
+}
+
+/** Probe gh + git to decide whether a [gone] branch's content is really in trunk. */
+function confirmMerged(branch: string, trunk: string): MergeVerdict {
+	const pr = runCommand(
+		'gh',
+		['pr', 'list', '--head', branch, '--state', 'merged', '--json', 'number', '--limit', '1'],
+		{ silent: true }
+	);
+	// exit 0 iff the branch tip is already an ancestor of origin/<trunk>.
+	const ancestor = runCommand('git', ['merge-base', '--is-ancestor', branch, `origin/${trunk}`], {
+		silent: true
+	});
+	return classifyMerge({
+		ghSucceeded: pr.success,
+		ghFoundMergedPr: pr.success && pr.stdout !== '' && pr.stdout !== '[]',
+		gitAncestor: ancestor.success
+	});
+}
+
+/**
+ * Fast-forward the trunk in the main checkout — best effort only. We never
+ * reset, stash, or force: the main checkout often carries uncommitted work, so
+ * a dirty tree means `merge --ff-only` would abort anyway. Skip it and leave
+ * that work untouched. New worktrees already branch off origin/<trunk>, so a
+ * lagging local trunk is only cosmetic.
+ */
+function fastForwardTrunk(rootPath: string, trunk: string, dryRun: boolean): void {
+	const head = runCommand('git', ['-C', rootPath, 'rev-parse', '--abbrev-ref', 'HEAD'], {
+		silent: true
+	});
+	if (head.stdout !== trunk) {
+		console.log(
+			`${colors.yellow}Skipping trunk fast-forward: "${head.stdout}" is checked out in the main worktree, not "${trunk}".${colors.reset}`
+		);
+		return;
+	}
+	const dirty = runCommand('git', ['-C', rootPath, 'status', '--porcelain'], { silent: true });
+	if (dirty.stdout) {
+		console.log(
+			`${colors.yellow}Skipping trunk fast-forward: main checkout has uncommitted changes.${colors.reset}`
+		);
+		return;
+	}
+	const behind = runCommand(
+		'git',
+		['-C', rootPath, 'rev-list', '--count', `${trunk}..origin/${trunk}`],
+		{ silent: true }
+	);
+	if (!behind.success || behind.stdout === '0') {
+		console.log(`${colors.green}Local ${trunk} already up to date with origin.${colors.reset}`);
+		return;
+	}
+	// origin is ahead. If the local trunk ALSO has commits origin lacks, it has
+	// diverged and --ff-only cannot help — skip with a clear message instead of
+	// letting the merge fail on a clean tree.
+	const ahead = runCommand(
+		'git',
+		['-C', rootPath, 'rev-list', '--count', `origin/${trunk}..${trunk}`],
+		{ silent: true }
+	);
+	if (ahead.success && ahead.stdout !== '0') {
+		console.log(
+			`${colors.yellow}Skipping trunk fast-forward: local ${trunk} diverged (${ahead.stdout} local commit(s), ${behind.stdout} on origin). Reconcile manually.${colors.reset}`
+		);
+		return;
+	}
+	if (dryRun) {
+		console.log(`[dry-run] would fast-forward ${trunk} by ${behind.stdout} commit(s)`);
+		return;
+	}
+	const ff = runCommand('git', ['-C', rootPath, 'merge', '--ff-only', `origin/${trunk}`]);
+	if (ff.success) {
+		console.log(
+			`${colors.green}Fast-forwarded ${trunk} by ${behind.stdout} commit(s).${colors.reset}`
+		);
+	}
+}
+
+function main(): void {
+	const { values } = parseArgs({
+		args: Bun.argv.slice(2),
+		options: {
+			'dry-run': { type: 'boolean', default: false },
+			force: { type: 'boolean', default: false },
+			help: { type: 'boolean', short: 'h', default: false }
+		},
+		strict: true,
+		allowPositionals: false
+	});
+
+	if (values.help) {
+		console.log('Usage:');
+		console.log(
+			'  bun scripts/prune-worktrees.ts            Remove merged worktrees + branches, ff trunk'
+		);
+		console.log(
+			'  bun scripts/prune-worktrees.ts --dry-run  Show what would be removed, change nothing'
+		);
+		console.log(
+			'  bun scripts/prune-worktrees.ts --force    Discard uncommitted changes in a merged worktree too'
+		);
+		process.exit(0);
+	}
+
+	const dryRun = values['dry-run'] ?? false;
+	const force = values.force ?? false;
+
+	const rootPath = getRootWorktree();
+	const trunk = getTrunk();
+
+	console.log('');
+	console.log('======================================================');
+	console.log(`Pruning merged worktrees${dryRun ? ' (dry run)' : ''}`);
+	console.log('======================================================');
+	console.log('');
+
+	// Refresh remote-tracking refs and drop the ones deleted on the remote, so
+	// merged branches surface as [gone] below.
+	console.log('Fetching origin (pruning deleted remote branches)...');
+	const fetched = runCommand('git', ['fetch', 'origin', '--prune'], { silent: true });
+	if (!fetched.success) {
+		console.log(
+			`${colors.yellow}Warning: git fetch failed; [gone] status may be stale. Deletion still requires a confirmed merge, so no unmerged work is at risk.${colors.reset}`
+		);
+	}
+
+	const currentBranch =
+		runCommand('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { silent: true }).stdout || null;
+
+	const refList = runCommand(
+		'git',
+		['for-each-ref', '--format=%(refname:short)|%(upstream:track)', 'refs/heads/'],
+		{ silent: true }
+	);
+	const branches: BranchInfo[] = refList.stdout
+		.split('\n')
+		.filter(Boolean)
+		.map((line) => {
+			const [name, track = ''] = line.split('|');
+			return { name, track };
+		});
+
+	const gone = selectGoneBranches(branches, { trunk, currentBranch });
+	const worktrees = parseWorktreePorcelain(
+		runCommand('git', ['worktree', 'list', '--porcelain'], { silent: true }).stdout
+	);
+
+	if (gone.length === 0) {
+		console.log(`${colors.green}No local branches with a deleted remote to check.${colors.reset}`);
+	} else {
+		console.log(
+			`Found ${gone.length} local branch(es) whose remote was deleted; verifying merge status:`
+		);
+		console.log('');
+		for (const branch of gone) {
+			// [gone] is only a prefilter. Never delete without a confirmed merge:
+			// a closed-unmerged PR or a hand-deleted remote is also [gone], and
+			// `branch -D` would be unrecoverable loss of committed work.
+			const verdict = confirmMerged(branch, trunk);
+			if (verdict !== 'merged') {
+				const reason =
+					verdict === 'not-merged'
+						? 'remote deleted without a merged PR'
+						: 'cannot confirm the merge (gh unavailable)';
+				console.log(
+					`${colors.yellow}  skip ${branch}: ${reason}. Delete manually with \`git branch -D ${branch}\` if intended.${colors.reset}`
+				);
+				continue;
+			}
+
+			const path = worktrees.get(branch);
+			if (path) {
+				const dirty = runCommand('git', ['-C', path, 'status', '--porcelain'], { silent: true });
+				if (dirty.stdout && !force) {
+					console.log(
+						`${colors.yellow}  skip ${branch}: merged, but its worktree has uncommitted changes (use --force to discard).${colors.reset}`
+					);
+					console.log(`       ${path}`);
+					continue;
+				}
+				if (dryRun) {
+					console.log(`  [dry-run] would remove worktree ${path} and branch ${branch} (merged)`);
+					continue;
+				}
+				const removeArgs = ['worktree', 'remove', path];
+				if (force) removeArgs.push('--force');
+				const removed = runCommand('git', removeArgs);
+				if (!removed.success) {
+					console.log(
+						`${colors.yellow}  could not remove worktree ${path}; leaving branch ${branch} in place.${colors.reset}`
+					);
+					continue;
+				}
+				console.log(`${colors.green}  removed worktree ${path}${colors.reset}`);
+			}
+			if (dryRun) {
+				if (!path) console.log(`  [dry-run] would delete branch ${branch} (merged)`);
+				continue;
+			}
+			const deleted = runCommand('git', ['branch', '-D', branch], { silent: true });
+			if (deleted.success) {
+				// git prints "Deleted branch X (was <sha>)"; surface the sha as a
+				// reflog anchor in case a deletion ever needs undoing.
+				const wasSha = deleted.stdout.match(/\(was [0-9a-f]+\)/)?.[0] ?? '';
+				console.log(`${colors.green}  deleted branch ${branch} ${wasSha}${colors.reset}`);
+			} else {
+				console.log(`${colors.yellow}  could not delete branch ${branch}${colors.reset}`);
+			}
+		}
+	}
+
+	console.log('');
+	// Clean up administrative files for worktrees whose directory is already gone.
+	if (dryRun) {
+		console.log('[dry-run] would run git worktree prune');
+	} else {
+		runCommand('git', ['worktree', 'prune']);
+		console.log(`${colors.green}Pruned stale worktree metadata.${colors.reset}`);
+	}
+
+	console.log('');
+	fastForwardTrunk(rootPath, trunk, dryRun);
+	console.log('');
+}
+
+// Only run when executed directly, so the pure helpers above can be unit-tested.
+if (import.meta.main) {
+	main();
+}


### PR DESCRIPTION
New worktrees were created from the local branch HEAD without fetching, so whenever local `main` lagged `origin/main` (which it routinely does, since the main checkout carries uncommitted work) a new worktree started from stale code and needed a manual reset. There was also no single cleanup step after a merge, so merged branches and their worktrees piled up locally, and a leftover branch keeps its Convex preview deployment alive and eats deploy quota.

`create-worktree.ts` now fetches and branches from `origin/<trunk>` by default, with `--base` to stack intentionally on another branch and `--no-fetch` to work offline. It also clears the upstream that git auto-sets when you branch off a remote-tracking ref, so `git status` and the first `git push -u` behave normally. This makes the state of local `main` irrelevant to a new worktree, so a forgotten pull can no longer seed old code.

A new `bun run worktree:prune` handles the post-merge cleanup in one command: it removes merged worktrees and branches, prunes stale worktree metadata, and fast-forwards local `main` when the main checkout is clean and has not diverged. Deletion is gated on a confirmed merge, either a merged GitHub PR (which recognizes squash-merges, unlike a local patch-id check) or the branch being an ancestor of trunk, so a branch whose remote was deleted without merging is never removed. It skips worktrees with uncommitted changes unless `--force` is passed, and it never resets or stashes the main checkout. AGENTS.md documents the new base behavior and the prune step.

`bun scripts/static-checks.ts` passes on the changed files and the 10 unit tests for the branch-selection and merge-classification logic pass. Verified live: a new worktree branches from `origin/main` with no leftover upstream, and a synthetic `[gone]` branch carrying an unmerged commit with no merged PR is skipped by prune rather than deleted.
