### PR TITLE
fix(email): let Outlook load the logo cross-origin

### DIFF
--- a/_headers
+++ b/_headers
@@ -15,6 +15,7 @@
 # shows a broken-image glyph. Detach CORP for this one public asset so it loads.
 # CF joins duplicate header values with a comma, so a plain override would yield
 # "same-origin, cross-origin"; the "!" removal is the only way to drop it.
+# vercel.json carries the same carve-out (as an override) for Vercel deploys.
 /logo-email.png
   ! Cross-Origin-Resource-Policy
 

--- a/_headers
+++ b/_headers
@@ -9,6 +9,15 @@
   Cross-Origin-Opener-Policy: same-origin-allow-popups
   Cross-Origin-Resource-Policy: same-origin
 
+# The email logo is embedded cross-origin. Email clients that render HTML in a
+# browser context (new Outlook for macOS, Outlook mobile webview) enforce CORP
+# on <img> subresources, so the global same-origin value blocks the logo and it
+# shows a broken-image glyph. Detach CORP for this one public asset so it loads.
+# CF joins duplicate header values with a comma, so a plain override would yield
+# "same-origin, cross-origin"; the "!" removal is the only way to drop it.
+/logo-email.png
+  ! Cross-Origin-Resource-Policy
+
 /fonts/*
   Cache-Control: public, max-age=31536000, immutable
 

--- a/e2e/public-security-headers.spec.ts
+++ b/e2e/public-security-headers.spec.ts
@@ -23,4 +23,15 @@ test.describe('cross-origin isolation headers', () => {
 		test.skip(!hasGoogleOAuth, 'Google OAuth is disabled in this environment');
 		await expect(page.locator('[data-testid="signin-oauth-google-button"]')).toBeEnabled();
 	});
+
+	test('email logo is embeddable cross-origin (no same-origin CORP)', async ({ request }) => {
+		// Email clients render HTML in a browser context and load the logo cross-origin;
+		// same-origin CORP would block it. The _headers "!" removal must drop it on CF
+		// (which joins duplicate header values with a comma rather than overriding).
+		const response = await request.get('/logo-email.png');
+		expect(response.status()).toBe(200);
+		const h = response.headers();
+		expect(h['content-type']).toBe('image/png');
+		expect(h['cross-origin-resource-policy']).not.toBe('same-origin');
+	});
 });

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,10 @@
 				{ "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" },
 				{ "key": "Cross-Origin-Resource-Policy", "value": "same-origin" }
 			]
+		},
+		{
+			"source": "/logo-email.png",
+			"headers": [{ "key": "Cross-Origin-Resource-Policy", "value": "cross-origin" }]
 		}
 	]
 }


### PR DESCRIPTION
The email logo failed to render in the new Outlook for macOS and Outlook mobile, showing a broken-image glyph. The image itself is fine: it returns 200 with `content-type: image/png` and is reachable for Outlook user agents. The blocker is the global `Cross-Origin-Resource-Policy: same-origin` that both header configs apply to every static asset. Browser-context email clients (new Outlook is web-based, Outlook mobile renders in a webview) load the logo as a cross-origin `<img>` subresource, and same-origin CORP tells the browser to block it. Native and server-proxying clients (Apple Mail, classic Outlook) don't enforce CORP, so they were unaffected. Every template email shares the same header logo, so all of them were broken.

Detach CORP for `/logo-email.png` so it stays embeddable everywhere. The template deploys to Cloudflare Workers or Vercel, so the carve-out lives in both configs. In `_headers`, Cloudflare joins duplicate values with a comma rather than overriding, so a plain per-path override would produce an invalid `same-origin, cross-origin`; the documented `! Cross-Origin-Resource-Policy` removal is the way to drop it. In `vercel.json`, a per-path `/logo-email.png` entry overrides the value to `cross-origin`. The security-headers-sync test only parses the global blocks, so it stays green, and the app's own SSR responses keep same-origin CORP unchanged. The same emails also load a woff2 font cross-origin, but that is left as-is on purpose: the clients that enforce CORP strip email `@font-face` anyway, and WebKit clients that render it fetch it in CORS mode, so the font already loads under the current policy.

Regression guard: added e2e assertion in `public-security-headers.spec.ts` that `/logo-email.png` never returns same-origin CORP. It runs on both the CF and Vercel preview e2e suites, so it verifies the carve-out on whichever platform builds the preview.

Verified on a downstream fork's CF preview: the logo returns no CORP header while other assets keep same-origin. `bun run test:unit security-headers-sync` passes and `bun scripts/static-checks.ts` is clean.