### PR TITLE
fix(security): reject backslash-authority open redirect in safeRedirectPath

### DIFF
--- a/src/lib/utils/__tests__/url.test.ts
+++ b/src/lib/utils/__tests__/url.test.ts
@@ -26,6 +26,16 @@ describe('safeRedirectPath', () => {
 		expect(safeRedirectPath('javascript:alert(1)', '/')).toBe('/');
 	});
 
+	it('rejects the backslash authority bypass (/\\evil.com resolves cross-origin)', () => {
+		// A leading slash-backslash forms an authority in the URL parser, so it
+		// slips a naive `//` prefix check yet resolves to https://evil.com.
+		expect(safeRedirectPath('/\\evil.com', '/')).toBe('/');
+	});
+
+	it('rejects a mixed slash-backslash bypass', () => {
+		expect(safeRedirectPath('/\\/evil.com', '/')).toBe('/');
+	});
+
 	it('rejects an empty string', () => {
 		expect(safeRedirectPath('', '/')).toBe('/');
 	});

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -1,11 +1,20 @@
 /**
- * Whitelist-validates a redirect URL: only relative paths (starting with /)
- * are allowed. Everything else returns the fallback.
+ * Whitelist-validates a redirect URL: only same-origin relative paths are
+ * allowed. Everything else returns the fallback.
  *
- * Prevents open redirect attacks by rejecting absolute URLs, protocol-relative
- * URLs (//evil.com), javascript: URIs, and any other non-relative path.
+ * Resolves the candidate against a sentinel origin and keeps it only if the
+ * origin did not change. A prefix check ("starts with / but not //") is not
+ * enough: browsers and the WHATWG URL parser treat a backslash as a path
+ * separator, so `/\evil.com` slips past a `//` check yet resolves to
+ * `https://evil.com`. Resolving catches that, protocol-relative `//host`,
+ * absolute URLs, and `javascript:` URIs in one test.
  */
 export function safeRedirectPath(url: string, fallback: string): string {
-	if (!url || !url.startsWith('/') || url.startsWith('//')) return fallback;
-	return url;
+	if (!url) return fallback;
+	try {
+		const resolved = new URL(url, 'http://redirect.invalid');
+		return resolved.origin === 'http://redirect.invalid' ? url : fallback;
+	} catch {
+		return fallback;
+	}
 }


### PR DESCRIPTION
`safeRedirectPath` only rejected protocol-relative `//host` URLs, but the WHATWG URL parser treats a leading backslash as a path separator, so `/\evil.com` passes the whitelist and resolves to `https://evil.com`. That value is wired into a real redirect through the `redirectTo` query param the server redirect in `hooks.server.ts` consumes, and the same `redirectTo` on the signin, signup, and email-verified pages, so a crafted link is an open redirect on any fork.

The fix resolves the candidate against a sentinel origin and keeps it only when the origin does not change, which rejects the backslash bypass, protocol-relative URLs, absolute URLs, and `javascript:` URIs in one check, and adds regression cases for the bypass vectors.

Regression guard: added bypass-vector regression cases in src/lib/utils/__tests__/url.test.ts

`bun run test:unit` on url.test.ts passes; verified the resolved-origin logic against `/dashboard`, `/app?x=1`, `//evil.com`, `/\evil.com`, `/\/evil.com`, `http://evil.com`, `javascript:alert(1)`, and the empty string.
