### PR TITLE
fix(ai-chat): Require auth for file helpers

### DIFF
--- a/e2e/prerender-auth-navigation.spec.ts
+++ b/e2e/prerender-auth-navigation.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect, type Page } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { waitForAuthenticated } from './utils/auth';
+import type { TestCredentials } from './utils/types';
 
 // Regression guard for the prerendered-marketing -> /app navigation dead end
 // (third regression in the app:auth invalidation series, #289 -> #575 -> this
@@ -36,6 +40,24 @@ async function gotoStable(page: Page, url: string) {
 	}
 }
 
+async function signInRegularUser(page: Page) {
+	const credentialsPath = path.join(process.cwd(), 'e2e', '.auth', 'test-credentials.json');
+
+	if (!fs.existsSync(credentialsPath)) {
+		throw new Error('test-credentials.json not found. globalSetup may have failed.');
+	}
+
+	const credentials: TestCredentials = JSON.parse(fs.readFileSync(credentialsPath, 'utf-8'));
+	const { email, password } = credentials.user;
+
+	await gotoStable(page, '/signin');
+	await expect(page.locator('[data-testid="email-input"]')).toBeVisible({ timeout: 30000 });
+	await page.fill('[data-testid="email-input"]', email);
+	await page.fill('[data-testid="password-input"]', password);
+	await page.click('[data-testid="signin-button"]');
+	await waitForAuthenticated(page);
+}
+
 test.describe('prerendered marketing to app navigation', () => {
 	test('logged-in user reaches the app via SPA navigation from home', async ({ page }) => {
 		test.setTimeout(180000);
@@ -59,7 +81,16 @@ test.describe('prerendered marketing to app navigation', () => {
 		// /convex/token -> Convex WebSocket confirm) can take a while against a
 		// cold preview Convex deployment before isAuthenticated flips.
 		const dashboardLink = page.getByTestId('marketing-nav-dashboard');
-		await expect(dashboardLink).toBeVisible({ timeout: 60000 });
+		try {
+			await expect(dashboardLink).toBeVisible({ timeout: 60000 });
+		} catch {
+			// Some earlier authenticated specs can invalidate the shared storageState
+			// session. Re-establish it here so this regression guard owns its auth
+			// precondition and still enters /app from the prerendered marketing page.
+			await signInRegularUser(page);
+			await gotoStable(page, '/en');
+			await expect(dashboardLink).toBeVisible({ timeout: 60000 });
+		}
 
 		// Ensure the client router has hydrated before clicking. On the dev server
 		// the link is SSR-rendered (authenticated SSR), so it is visible before

--- a/e2e/prerender-auth-navigation.spec.ts
+++ b/e2e/prerender-auth-navigation.spec.ts
@@ -51,6 +51,12 @@ async function signInRegularUser(page: Page) {
 	const { email, password } = credentials.user;
 
 	await gotoStable(page, '/signin');
+
+	if (/\/[a-z]{2}\/app/.test(new URL(page.url()).pathname)) {
+		await waitForAuthenticated(page);
+		return;
+	}
+
 	await expect(page.locator('[data-testid="email-input"]')).toBeVisible({ timeout: 30000 });
 	await page.fill('[data-testid="email-input"]', email);
 	await page.fill('[data-testid="password-input"]', password);

--- a/e2e/prerender-auth-navigation.spec.ts
+++ b/e2e/prerender-auth-navigation.spec.ts
@@ -50,6 +50,7 @@ async function signInRegularUser(page: Page) {
 	const credentials: TestCredentials = JSON.parse(fs.readFileSync(credentialsPath, 'utf-8'));
 	const { email, password } = credentials.user;
 
+	await page.context().clearCookies();
 	await gotoStable(page, '/signin');
 
 	if (/\/[a-z]{2}\/app/.test(new URL(page.url()).pathname)) {
@@ -67,6 +68,11 @@ async function signInRegularUser(page: Page) {
 test.describe('prerendered marketing to app navigation', () => {
 	test('logged-in user reaches the app via SPA navigation from home', async ({ page }) => {
 		test.setTimeout(180000);
+
+		// Own this spec's session instead of inheriting shared storageState from
+		// earlier authenticated specs. The regression it guards needs a valid
+		// session before landing on the prerendered marketing page.
+		await signInRegularUser(page);
 
 		// Land on the (prerendered) marketing home with authenticated cookies.
 		await gotoStable(page, '/en');
@@ -87,16 +93,7 @@ test.describe('prerendered marketing to app navigation', () => {
 		// /convex/token -> Convex WebSocket confirm) can take a while against a
 		// cold preview Convex deployment before isAuthenticated flips.
 		const dashboardLink = page.getByTestId('marketing-nav-dashboard');
-		try {
-			await expect(dashboardLink).toBeVisible({ timeout: 60000 });
-		} catch {
-			// Some earlier authenticated specs can invalidate the shared storageState
-			// session. Re-establish it here so this regression guard owns its auth
-			// precondition and still enters /app from the prerendered marketing page.
-			await signInRegularUser(page);
-			await gotoStable(page, '/en');
-			await expect(dashboardLink).toBeVisible({ timeout: 60000 });
-		}
+		await expect(dashboardLink).toBeVisible({ timeout: 60000 });
 
 		// Ensure the client router has hydrated before clicking. On the dev server
 		// the link is SSR-rendered (authenticated SSR), so it is visible before

--- a/src/lib/convex/aiChat/files.ts
+++ b/src/lib/convex/aiChat/files.ts
@@ -33,6 +33,20 @@ export const generateUploadUrl = authedMutation({
 });
 
 /**
+ * Actions cannot use the custom authedMutation wrapper directly. This internal
+ * mutation gives aiChat actions the same authenticated boundary before they
+ * touch storage.
+ */
+export const requireFileAccess = internalMutation({
+	args: {},
+	returns: v.null(),
+	handler: async (ctx) => {
+		await authComponent.getAuthUser(ctx);
+		return null;
+	}
+});
+
+/**
  * Register uploaded file with agent component
  *
  * Validates file type/size, creates download grant, registers with agent.
@@ -65,6 +79,8 @@ export const saveUploadedFile = action({
 		filename: string | undefined;
 		isImage: boolean;
 	}> => {
+		await ctx.runMutation(internal.aiChat.files.requireFileAccess, {});
+
 		const accessKey = args.accessKey?.trim() || 'ai-chat';
 		await ctx.runMutation(components.convexFilesControl.upload.finalizeUpload, {
 			uploadToken: args.uploadToken,

--- a/src/lib/convex/aiChat/files.ts
+++ b/src/lib/convex/aiChat/files.ts
@@ -50,6 +50,7 @@ export const requireFileAccess = internalMutation({
  * Register uploaded file with agent component
  *
  * Validates file type/size, creates download grant, registers with agent.
+ * Requires an authenticated user before the upload token is finalized.
  */
 export const saveUploadedFile = action({
 	args: {

--- a/src/lib/convex/aiChat/messages.ts
+++ b/src/lib/convex/aiChat/messages.ts
@@ -1,4 +1,4 @@
-import { internalAction, query } from '../_generated/server';
+import { internalAction } from '../_generated/server';
 import { v, ConvexError } from 'convex/values';
 import { internal } from '../_generated/api';
 import { aiChatAgent } from './agent';
@@ -253,7 +253,7 @@ export const listMessages = authedQuery({
 /**
  * Get file metadata (dimensions) for multiple files by URL
  */
-export const getFileMetadataBatch = query({
+export const getFileMetadataBatch = authedQuery({
 	args: {
 		urls: v.array(v.string())
 	},

--- a/src/lib/convex/aiChat/messages.ts
+++ b/src/lib/convex/aiChat/messages.ts
@@ -252,6 +252,9 @@ export const listMessages = authedQuery({
 
 /**
  * Get file metadata (dimensions) for multiple files by URL
+ *
+ * Authenticated because AI chat attachment metadata belongs to the signed-in app
+ * surface, unlike support attachments which may be submitted anonymously.
  */
 export const getFileMetadataBatch = authedQuery({
 	args: {

--- a/src/lib/convex/files/metadata.ts
+++ b/src/lib/convex/files/metadata.ts
@@ -13,8 +13,8 @@ import type { QueryCtx } from '../_generated/server';
  * Look up image dimensions for a batch of file URLs.
  *
  * Shared by `aiChat.messages.getFileMetadataBatch` and
- * `support.messages.getFileMetadataBatch`, which both expose this over their
- * own public query for the frontend.
+ * `support.messages.getFileMetadataBatch`; each wrapper applies that surface's
+ * access policy before exposing the lookup to the frontend.
  */
 export async function getFileMetadataByUrls(
 	ctx: QueryCtx,


### PR DESCRIPTION
## Summary
- require authenticated access before aiChat upload finalization touches storage
- make aiChat file metadata lookup use the authenticated query wrapper

Regression guard: covered by existing aiChat ownership/visibility tests, Convex type checking, and the hardened prerender-auth navigation E2E spec

## Verification
- bun scripts/static-checks.ts src/lib/convex/aiChat/files.ts src/lib/convex/aiChat/messages.ts
- bun run check:convex
- bunx vitest run src/lib/convex/aiChat/__tests__/ownership.test.ts src/lib/convex/aiChat/__tests__/visibility.test.ts
