### PR TITLE
feat(ui): Add page view transitions and motion tokens

### DIFF
--- a/scripts/version-config.test.ts
+++ b/scripts/version-config.test.ts
@@ -26,7 +26,8 @@ describe('kit.version config', () => {
 
 	it('registers the beforeNavigate recovery guard in the root layout', () => {
 		const layout = fs.readFileSync(path.resolve('src/routes/+layout.svelte'), 'utf-8');
-		expect(layout).toContain("import { beforeNavigate } from '$app/navigation'");
+		// Structural match so other navigation imports (e.g. onNavigate) can share the line.
+		expect(layout).toMatch(/import \{[^}]*\bbeforeNavigate\b[^}]*\} from '\$app\/navigation'/);
 		// updated must come from $app/state, not the deprecated $app/stores.
 		expect(layout).toMatch(/import \{[^}]*\bupdated\b[^}]*\} from '\$app\/state'/);
 		expect(layout).toContain('updated.current');

--- a/src/lib/components/ui/light-switch/light-switch.svelte
+++ b/src/lib/components/ui/light-switch/light-switch.svelte
@@ -25,8 +25,14 @@
 			return;
 		}
 
-		document.startViewTransition(() => {
+		// Mark the root so layout.css scopes the circular reveal to the theme
+		// toggle instead of the page-navigation fade.
+		document.documentElement.setAttribute('data-theme-transition', '');
+		const transition = document.startViewTransition(() => {
 			toggleMode();
+		});
+		transition.finished.finally(() => {
+			document.documentElement.removeAttribute('data-theme-transition');
 		});
 	}
 </script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import { beforeNavigate } from '$app/navigation';
+	import { beforeNavigate, onNavigate } from '$app/navigation';
 	import { page, updated } from '$app/state';
 	import { T, Tolgee, DevTools, TolgeeProvider } from '@tolgee/svelte';
 	import type { TolgeeStaticData } from '@tolgee/svelte';
@@ -38,6 +38,30 @@
 		if (updated.current && !willUnload && to?.url) {
 			location.href = to.url.href;
 		}
+	});
+
+	// Fade page navigations via the View Transitions API (see layout.css).
+	// Same-path navigations (table sort/pagination/search param churn) and
+	// reduced motion stay instant. Rendering is frozen on the old snapshot
+	// while the transition waits for the navigation, which would hide
+	// RouteProgress on slow loads - so slow navigations bail out of the
+	// transition and fall back to the progress bar.
+	onNavigate((navigation) => {
+		if (!document.startViewTransition) return;
+		if (navigation.to?.url.pathname === navigation.from?.url.pathname) return;
+		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+		return new Promise((resolve) => {
+			let completed = false;
+			const transition = document.startViewTransition(async () => {
+				resolve();
+				await navigation.complete;
+				completed = true;
+			});
+			setTimeout(() => {
+				if (!completed) transition.skipTransition();
+			}, 250);
+		});
 	});
 
 	// Detect a misconfigured device clock, which silently breaks cookie-based auth

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -220,7 +220,7 @@
 
 <div class="flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
 	<div class="flex w-full max-w-sm flex-col gap-6 md:max-w-3xl">
-		<Card.Root class="overflow-hidden p-0">
+		<Card.Root class="overflow-hidden p-0 [view-transition-name:auth-card]">
 			<Card.Content class="grid p-0 md:grid-cols-2">
 				<SignInForm
 					{id}

--- a/src/routes/[[lang]]/(auth)/signup/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signup/+page.svelte
@@ -218,7 +218,7 @@
 
 <div class="flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
 	<div class="flex w-full max-w-sm flex-col gap-6 md:max-w-3xl">
-		<Card.Root class="overflow-hidden p-0">
+		<Card.Root class="overflow-hidden p-0 [view-transition-name:auth-card]">
 			<Card.Content class="grid p-0 md:grid-cols-2">
 				{#if verificationStep}
 					<VerificationStep

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -350,26 +350,65 @@
 	}
 }
 
+/* Motion tokens - shared duration/easing scale for UI transitions */
+:root {
+	--motion-duration-fast: 120ms;
+	--motion-duration-base: 200ms;
+	--motion-duration-slow: 350ms;
+	--motion-ease-out: cubic-bezier(0.25, 1, 0.5, 1);
+	--motion-ease-in-out: cubic-bezier(0.45, 0, 0.55, 1);
+}
+
 /* View Transitions - Theme toggle circular reveal */
 :root {
 	--view-transition-x: 50%;
 	--view-transition-y: 50%;
 }
 
+/* View Transitions - page navigation fade (onNavigate in +layout.svelte).
+   The old snapshot stays frozen while the new page fades in on top, avoiding
+   the mid-fade opacity dip of a naive crossfade. The theme toggle marks the
+   root with data-theme-transition and keeps its own reveal below. */
+:root:not([data-theme-transition])::view-transition-old(root) {
+	animation: none;
+	mix-blend-mode: normal;
+}
+
+:root:not([data-theme-transition])::view-transition-new(root) {
+	animation: vt-page-in var(--motion-duration-base) var(--motion-ease-out) both;
+	mix-blend-mode: normal;
+	z-index: 1;
+}
+
+@keyframes vt-page-in {
+	from {
+		opacity: 0;
+	}
+}
+
+/* Shared-element morph between the signin and signup card shells. The 100%
+   sizing overrides the default aspect-ratio-preserving snapshot scaling so
+   the differing card heights morph cleanly. */
+::view-transition-old(auth-card),
+::view-transition-new(auth-card) {
+	width: 100%;
+	height: 100%;
+}
+
 @media (prefers-reduced-motion: no-preference) and (min-width: 768px) {
-	::view-transition-old(root) {
+	:root[data-theme-transition]::view-transition-old(root) {
 		animation: none;
 		z-index: 1;
 		mix-blend-mode: normal;
 	}
 
-	::view-transition-new(root) {
+	:root[data-theme-transition]::view-transition-new(root) {
 		animation: reveal-circular 0.7s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 		z-index: 2;
 		mix-blend-mode: normal;
 	}
 
-	::view-transition-image-pair(root) {
+	:root[data-theme-transition]::view-transition-image-pair(root) {
 		isolation: isolate;
 	}
 


### PR DESCRIPTION
See also: #605

Route changes swap the page with no transition at all, the only feedback is the top progress bar. The theme toggle's circular reveal CSS also targets every view transition on the root, which blocks using the View Transitions API for navigation.

Client-side navigations now run through onNavigate and fade the new page in over the frozen old snapshot, which avoids the opacity dip of a naive crossfade. Same-path navigations (table sort/pagination/search param churn) and reduced motion stay instant. Because a view transition freezes rendering while the navigation loads, slow loads bail out after 250ms so the progress bar stays visible. The theme toggle marks the root with data-theme-transition and its circular reveal is scoped behind that marker, so both effects coexist. The signin and signup pages share a view-transition-name on their card shell so the frame morphs between the two routes. A small motion token scale (three durations, two easings) lands in layout.css for the following transitions to share.

Verified in the browser on the local dev stack: navigation triggers exactly one view transition, same-path URL updates trigger none, and the theme toggle sets and removes its root marker with the reveal intact. `bun run test:unit` passes (739 tests).