### PR TITLE
feat(ui): Animate tab switches, chat message arrival, metric updates

### DIFF
--- a/src/lib/chat/ui/ChatMessages.svelte
+++ b/src/lib/chat/ui/ChatMessages.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { fly } from 'svelte/transition';
+	import { prefersReducedMotion } from 'svelte/motion';
 	import { getTranslate } from '@tolgee/svelte';
 	import {
 		ChatContainerRoot,
@@ -161,6 +163,27 @@
 			? (msg: DisplayMessage) => extractAttachments(msg, fileMetadata)
 			: (msg: DisplayMessage) => defaultExtractAttachments(msg, fileMetadata)
 	);
+
+	// Arm per-message enter animations one frame after the initial batch has
+	// rendered, so loading a thread's history doesn't replay an intro for
+	// every message. messagesFade resets on thread navigation, which re-arms.
+	let animateNewMessages = $state(false);
+	$effect(() => {
+		if (!ctx.messagesFade.hasLoadedOnce) {
+			animateNewMessages = false;
+			return;
+		}
+		const raf = requestAnimationFrame(() => (animateNewMessages = true));
+		return () => cancelAnimationFrame(raf);
+	});
+
+	function messageEnterDuration(message: DisplayMessage): number {
+		if (!animateNewMessages || prefersReducedMotion.current) return 0;
+		// A confirmed row replaces its optimistic twin under a new key; skip
+		// that remount so an own send animates once, on the optimistic append.
+		if (message.role === 'user' && !message.metadata?.optimistic) return 0;
+		return 200;
+	}
 </script>
 
 <div bind:this={wrapperEl} class="relative h-full {className}">
@@ -180,17 +203,19 @@
 					class="mx-auto w-full max-w-3xl px-8 py-20 {ctx.messagesFade.animationClass}"
 				>
 					{#each ctx.displayMessages as message, index (message.id)}
-						<ChatMessage
-							{message}
-							attachments={getAttachments(message)}
-							isFirstInGroup={isFirstInGroup(index, ctx.displayMessages)}
-							isHandoffMessage={message.displayText?.startsWith(HANDOFF_MESSAGE)}
-							{showEmailPrompt}
-							{currentEmail}
-							{isEmailPending}
-							{defaultEmail}
-							{onSubmitEmail}
-						/>
+						<div in:fly={{ y: 8, duration: messageEnterDuration(message) }}>
+							<ChatMessage
+								{message}
+								attachments={getAttachments(message)}
+								isFirstInGroup={isFirstInGroup(index, ctx.displayMessages)}
+								isHandoffMessage={message.displayText?.startsWith(HANDOFF_MESSAGE)}
+								{showEmailPrompt}
+								{currentEmail}
+								{isEmailPending}
+								{defaultEmail}
+								{onSubmitEmail}
+							/>
+						</div>
 					{/each}
 				</div>
 			{/if}

--- a/src/lib/components/ui/metric-card.svelte
+++ b/src/lib/components/ui/metric-card.svelte
@@ -55,11 +55,13 @@
 			<span class="relative inline-block">
 				<!-- Invisible placeholder to reserve space -->
 				<span class="invisible">{value}</span>
-				<!-- Animated value positioned on top -->
+				<!-- Animated value positioned on top; keyed so live updates replay the reveal -->
 				{#if !loading}
-					<span style="--enter-delay: 40ms;" class="absolute inset-0 animate-enter-blur-up">
-						{value}
-					</span>
+					{#key value}
+						<span style="--enter-delay: 40ms;" class="absolute inset-0 animate-enter-blur-up">
+							{value}
+						</span>
+					{/key}
 				{/if}
 			</span>
 		</Card.Title>

--- a/src/lib/components/ui/tabs/tabs-content.svelte
+++ b/src/lib/components/ui/tabs/tabs-content.svelte
@@ -12,6 +12,9 @@
 <TabsPrimitive.Content
 	bind:ref
 	data-slot="tabs-content"
-	class={cn('flex-1 text-sm outline-none', className)}
+	class={cn(
+		'flex-1 text-sm outline-none data-[state=active]:fade-in-0 data-[state=active]:slide-in-from-bottom-1 motion-safe:data-[state=active]:animate-in',
+		className
+	)}
 	{...restProps}
 />

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -26,6 +26,8 @@
 	import { toast } from 'svelte-sonner';
 	import { mode } from 'mode-watcher';
 	import { tick, onMount } from 'svelte';
+	import { fly } from 'svelte/transition';
+	import { prefersReducedMotion } from 'svelte/motion';
 
 	import { page } from '$app/state';
 	import { getTranslate } from '@tolgee/svelte';
@@ -81,6 +83,23 @@
 			messagesFade.markLoaded();
 		}
 	});
+
+	// Arm per-message enter animations one frame after the initial batch has
+	// rendered, so the loaded history doesn't replay an intro per message.
+	let animateNewMessages = $state(false);
+	$effect(() => {
+		if (!messagesFade.hasLoadedOnce) return;
+		const raf = requestAnimationFrame(() => (animateNewMessages = true));
+		return () => cancelAnimationFrame(raf);
+	});
+
+	function messageEnterDuration(message: { _id: string; userId: string }): number {
+		if (!animateNewMessages || prefersReducedMotion.current) return 0;
+		// The confirmed row replaces its optimistic twin under a new _id; skip
+		// that remount so an own send animates once, on the optimistic append.
+		if (isOwnMessage(message.userId) && !message._id.startsWith('temp_')) return 0;
+		return 200;
+	}
 
 	// Resolve background color for bottom gradient
 	let wrapperEl: HTMLDivElement | undefined = $state();
@@ -219,6 +238,7 @@
 								{@const own = isOwnMessage(message.userId)}
 								{@const firstInGroup = isFirstInGroup(index)}
 								<div
+									in:fly={{ y: 8, duration: messageEnterDuration(message) }}
 									class="flex w-full gap-2 {own ? 'flex-row-reverse' : 'flex-row'} {firstInGroup
 										? 'mt-6'
 										: 'mt-1'}"


### PR DESCRIPTION
See also: #605

Tab panels hard-swap their content on activation, chat messages pop into all three chat surfaces with no transition, and dashboard metric values update silently even though the data is live.

Tab content now fades and rises slightly on activation via the shared shadcn tabs-content, gated with motion-safe. Messages in the AI chat, admin support chat, and community chat enter with a short fade and rise. The animation arms one frame after the initial history renders, so loading a thread stays quiet, and confirmed rows that replace an optimistic twin under a new key are skipped, so an own send animates exactly once. Metric card values replay their existing blur-up reveal when a live Convex update changes the value.

Verified in the browser on the local dev stack: settings tab switches animate and keep their URL state, and a community chat send renders the optimistic append plus server confirm without a double animation. `bun run test:unit` passes.