### PR TITLE
feat(marketing): Add hero entrance stagger and scroll reveals

### DIFF
--- a/src/blocks/hero/hero-five.svelte
+++ b/src/blocks/hero/hero-five.svelte
@@ -32,14 +32,20 @@
 		<div class="pointer-events-none w-full pt-20 pb-56 lg:pt-40 lg:pb-36">
 			<div class="relative mx-auto flex max-w-6xl flex-col px-6 lg:block lg:px-12">
 				<div class="mx-auto max-w-lg text-center lg:ml-0 lg:max-w-full lg:text-left">
-					<h1 class="mt-8 max-w-4xl text-5xl md:text-6xl lg:mt-16 xl:text-7xl">
+					<h1
+						class="mt-8 max-w-4xl animate-enter-blur-up text-5xl md:text-6xl lg:mt-16 xl:text-7xl"
+					>
 						<span class="whitespace-pre-line"><T keyName="hero.tagline" /></span>
 					</h1>
-					<p class="mt-8 max-w-3xl text-lg text-balance">
+					<p
+						style="--enter-delay: 80ms;"
+						class="mt-8 max-w-3xl animate-enter-blur-up text-lg text-balance"
+					>
 						<T keyName="hero.description" />
 					</p>
 					<div
-						class="mt-12 flex flex-col items-center justify-center gap-2 sm:flex-row lg:justify-start"
+						style="--enter-delay: 160ms;"
+						class="mt-12 flex animate-enter-blur-up flex-col items-center justify-center gap-2 sm:flex-row lg:justify-start"
 					>
 						<Button
 							size="lg"

--- a/src/blocks/integration/integration-one.svelte
+++ b/src/blocks/integration/integration-one.svelte
@@ -14,6 +14,7 @@
 	import Shadcn from '../logos/Shadcn.svelte';
 	import Stripe from '../logos/Stripe.svelte';
 	import { T, getTranslate } from '@tolgee/svelte';
+	import { scrollReveal } from '$lib/utils/scroll-reveal';
 
 	const { t } = getTranslate();
 </script>
@@ -21,7 +22,7 @@
 <section>
 	<div class="py-30">
 		<div class="mx-auto flex max-w-6xl flex-col px-6 lg:block lg:px-12">
-			<div class="text-center lg:text-left">
+			<div use:scrollReveal class="text-center lg:text-left">
 				<h2 class="text-3xl font-semibold text-balance md:text-4xl">
 					<T keyName="integrations.title" params={{ year: new Date().getFullYear() }} />
 				</h2>
@@ -29,7 +30,7 @@
 					<T keyName="integrations.description" />
 				</p>
 			</div>
-			<div class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+			<div use:scrollReveal={{ delay: 100 }} class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
 				<IntegrationCard
 					title={$t('integrations.cards.svelte.title')}
 					description={$t('integrations.cards.svelte.description')}

--- a/src/blocks/pricing/pricing-three.svelte
+++ b/src/blocks/pricing/pricing-three.svelte
@@ -19,6 +19,7 @@
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { scrollReveal } from '$lib/utils/scroll-reveal';
 
 	const { customer, checkout, openBillingPortal } = useCustomer();
 	const upgradeOperation = useAutumnOperation(checkout);
@@ -122,7 +123,7 @@
 			</div>
 		</div>
 
-		<div class="mt-12 grid gap-6 md:mt-24 md:grid-cols-2 lg:grid-cols-3">
+		<div use:scrollReveal class="mt-12 grid gap-6 md:mt-24 md:grid-cols-2 lg:grid-cols-3">
 			<Card>
 				<CardHeader>
 					<CardTitle class="font-medium">

--- a/src/lib/utils/scroll-reveal.ts
+++ b/src/lib/utils/scroll-reveal.ts
@@ -1,0 +1,42 @@
+import type { Action } from 'svelte/action';
+
+/**
+ * Reveal an element with the enter-blur-up animation the first time it
+ * scrolls into view. Runs only with JS and skips elements already inside
+ * the initial viewport, so prerendered marketing content stays visible for
+ * crawlers, noscript, and above-the-fold paint. Both utility classes are
+ * reduced-motion-safe (see layout.css).
+ */
+export const scrollReveal: Action<HTMLElement, { delay?: number } | undefined> = (
+	node,
+	options
+) => {
+	if (typeof IntersectionObserver === 'undefined') return;
+	if (node.getBoundingClientRect().top < window.innerHeight) return;
+
+	if (options?.delay) {
+		node.style.setProperty('--enter-delay', `${options.delay}ms`);
+	}
+	node.classList.add('enter-blur-up-wait');
+
+	const observer = new IntersectionObserver(
+		(entries) => {
+			if (!entries.some((entry) => entry.isIntersecting)) return;
+			observer.disconnect();
+			node.classList.remove('enter-blur-up-wait');
+			node.classList.add('animate-enter-blur-up');
+		},
+		// The huge top margin keeps elements ABOVE the viewport intersecting, so
+		// an instant jump past a section (End key, anchor link) still reveals
+		// it; the observer only fires on status changes, and a single-frame jump
+		// from below to above the viewport never changes plain intersection.
+		{ rootMargin: '9999px 0px -10% 0px' }
+	);
+	observer.observe(node);
+
+	return {
+		destroy() {
+			observer.disconnect();
+		}
+	};
+};


### PR DESCRIPTION
Closes #605

The marketing pages render completely static: the hero paints all at once and the sections below the fold appear with no entrance, even though the enter-blur-up utility already exists in layout.css.

The hero heading, description, and CTA row now enter on a small stagger using that existing utility. This is pure CSS, so it also plays on prerendered pages without JS. Sections below the fold (the integrations header and grid, the pricing card grid) reveal once on scroll through a new scrollReveal action. The action only hides content when JS is running and the element starts outside the initial viewport, so crawler and noscript output stays fully visible. Its observer uses a large top rootMargin so an instant jump past a section (End key, anchor link) still reveals it instead of leaving it hidden. Both utility classes carry their own reduced-motion fallbacks.

Verified in the browser on the local dev stack: two sections arm on load from the top, an instant jump to the page bottom reveals both, and a reload while scrolled down leaves everything visible. `bun run test:unit` passes.