### PR TITLE
test(e2e): Cover admin role gate and redirectTo

### DIFF
--- a/e2e/auth-gate-redirects.spec.ts
+++ b/e2e/auth-gate-redirects.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Guards the two authenticated redirect branches of authFirstPattern in
+ * hooks.server.ts that unauthenticated-redirect.spec.ts cannot reach:
+ *
+ * - the admin role gate: an authenticated non-admin visiting /admin is
+ *   307-redirected to /{lang}/app (role claim read from the JWT payload,
+ *   re-checked authoritatively in Convex for every admin query)
+ * - redirectTo consumption: an authenticated user visiting signin with a
+ *   redirectTo param is sent to that destination, not the /{lang}/app default
+ *
+ * Runs in the chromium project with the regular (non-admin) user session.
+ */
+
+test('authenticated non-admin visiting /admin is redirected into the app', async ({ page }) => {
+	await page.goto('/admin');
+
+	// Role gate sends non-admins to /{lang}/app, which forwards to the app's
+	// default landing route. Never an /admin URL, never signin.
+	await page.waitForURL(/\/[a-z]{2}\/app(\/|\?|$)/);
+	expect(new URL(page.url()).pathname).not.toContain('/admin');
+});
+
+test('authenticated visit to signin honors redirectTo', async ({ page }) => {
+	// Target must differ from the /{lang}/app fallback (which forwards to the
+	// default landing route), otherwise this would pass with redirectTo ignored.
+	await page.goto('/en/signin?redirectTo=%2Fen%2Fapp%2Fsettings');
+
+	await page.waitForURL(/\/en\/app\/settings/);
+});


### PR DESCRIPTION
Follow-up to #643 (review findings 2 and 3). See also #457.

The authenticated redirect branches of `authFirstPattern` in `hooks.server.ts` had no e2e coverage. No spec visited `/admin` with the regular user session, so a regression in the role check (`payload?.role !== 'admin'`) would ship the admin shell to every signed-in user with all specs staying green. And no spec asserted that an authenticated visit to `signin?redirectTo=X` actually lands on X, so the `redirectTo` param that `unauthenticated-redirect.spec.ts` pins could regress into dead weight silently.

The new spec runs in the chromium project with the regular user session and covers both branches. The role-gate test asserts the visitor lands in the app subtree and never on an `/admin` URL. The redirectTo test targets `/en/app/settings` deliberately: the `/{lang}/app` fallback forwards to the app's default landing route, so a fallback-shaped target would pass even with the param ignored.

Regression guard: added `e2e/auth-gate-redirects.spec.ts` (the spec is the guard).

`bunx playwright test auth-gate-redirects.spec.ts --project=chromium` passes against the isolated local test stack (setup + 2 tests). `bun scripts/static-checks.ts e2e/auth-gate-redirects.spec.ts` passes. Note: the full local chromium run has one failure in the pre-existing `upgrade-checkout-failure.spec.ts`, which fails identically in isolation on unmodified main state (local networkidle flake, unrelated).