### PR TITLE
fix(e2e): Bypass stale edge cache on CF previews

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,10 +51,21 @@ export default defineConfig({
 		baseURL,
 		/* Collect trace when retrying the failed test */
 		trace: 'on-first-retry',
-		/* Preview bypass headers for protected deployments */
-		...(Object.keys(bypass.headers).length > 0 && {
-			extraHTTPHeaders: bypass.headers
-		})
+		/* Preview bypass headers for protected deployments, plus a cache bypass:
+		 * the CF worker's worktop cache layer serves prerendered marketing HTML
+		 * per colo for up to s-maxage=3600. The branch alias URL is stable across
+		 * pushes, so after a re-deploy a colo can keep serving the PREVIOUS
+		 * build's HTML whose immutable chunk hashes now 404 — the page never
+		 * hydrates and auth-dependent UI (e.g. marketing-nav-dashboard in
+		 * prerender-auth-navigation.spec.ts) never appears, failing all retries
+		 * identically. A `cache-control: no-cache` REQUEST header takes worktop's
+		 * built-in lookup bypass, so E2E always tests the freshly deployed build.
+		 * Response headers are untouched (public-agent-surface.spec.ts asserts
+		 * them), and the response is still saved to the cache afterwards. */
+		extraHTTPHeaders: {
+			...bypass.headers,
+			'cache-control': 'no-cache'
+		}
 	},
 
 	/* Configure projects */


### PR DESCRIPTION
See also: #651

All five E2E failures of `prerender-auth-navigation.spec.ts` on 2026-07-06/07 (runs 28808070157, 28838940629, 28839845465, 28840383585, 28850574739) share one root cause. The worker's worktop cache layer serves prerendered marketing HTML per colo with `s-maxage=3600`, and the branch alias URL is stable across pushes. After a re-deploy, a colo that cached `/en` during the previous run keeps serving the old build's HTML while its immutable chunks are gone: the Playwright trace of run 28850574739 shows `_app/immutable/entry/start.DAeEQNZG.js` and dozens of chunks returning 404 right after the document load. The page never hydrates, no `get-session` call ever fires, so `marketing-nav-dashboard` cannot appear and all three attempts fail identically for up to an hour. The sign-in hardening in #642 could not help because the failure sits below the app: the SvelteKit entry point itself 404s.

Playwright now sends a `cache-control: no-cache` request header on every request, taking the worktop layer's built-in lookup bypass so E2E always tests the freshly deployed build. Verified live against a CF preview: without the header the colo answered with a 55-minute-old cached copy (`age: 3285`), with the header the fresh build's HTML is served. Response headers are untouched, so the edge-cacheability assertions in `e2e/public-agent-surface.spec.ts` still hold, and responses are still written to the cache, which additionally heals the colo for real visitors. The remaining product-level issue (real preview visitors hitting the stale shell) is tracked in #651.

Regression guard: not warranted, config-level suite-wide fix; a guard would need to simulate a stale CF colo cache in CI.

`bun scripts/static-checks.ts playwright.config.ts` passes. `bunx playwright test prerender-auth-navigation` passes against the local test stack with the header active.