### PR TITLE
fix(cf): Salt edge cache key with deploy version

### DIFF
--- a/scripts/patch-cf-worker.test.ts
+++ b/scripts/patch-cf-worker.test.ts
@@ -1,8 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { applyMarkdownPatch } from './patch-cf-worker';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import {
+	applyMarkdownPatch,
+	applyVersionedCacheKeyPatch,
+	findVersionFile
+} from './patch-cf-worker';
 
 // Realistic worker snippet matching adapter-cloudflare@7.2.8 output
-// Includes both the worktop cache lookup AND the static-serving condition
+// Includes the worktop cache lookup, the static-serving condition, AND the
+// tail return that saves the response to the edge cache
 const WORKER_FIXTURE = `
     let pragma = req.headers.get("cache-control") || "";
     let res = !pragma.includes("no-cache") && await r2(req);
@@ -20,6 +29,8 @@ const WORKER_FIXTURE = `
     } else {
       res = await server.respond(req, { platform: { env: env2, ctx } });
     }
+    pragma = res.headers.get("cache-control") || "";
+    return pragma && res.status < 400 ? c(req, res, ctx) : res;
 `;
 
 // Fixture without the cache lookup (fallback path)
@@ -137,5 +148,124 @@ describe('patch-cf-worker', () => {
 		);
 		expect(result).toContain('res = new Response(res.body, res)');
 		expect(result.match(/s-maxage=3600/g)?.length).toBe(1);
+	});
+});
+
+describe('applyVersionedCacheKeyPatch', () => {
+	it('salts both lookup and save with the same versioned key', () => {
+		const result = applyVersionedCacheKeyPatch(WORKER_FIXTURE, 'abc123')!;
+
+		expect(result).toContain('!pragma.includes("no-cache") && await r2(__cacheKey)');
+		expect(result).toContain('? c(__cacheKey, res, ctx) : res;');
+		// The bare-req call sites must be gone, or lookup and save diverge
+		expect(result).not.toContain('await r2(req)');
+		expect(result).not.toContain('c(req, res, ctx)');
+	});
+
+	it('embeds the deployment version in the key', () => {
+		const result = applyVersionedCacheKeyPatch(WORKER_FIXTURE, 'abc123')!;
+		// append, not set: a client-supplied __v param must not collapse into the
+		// clean URL's cache entry
+		expect(result).toContain('__cacheKeyUrl.searchParams.append("__v", "abc123")');
+	});
+
+	it('throws on a missing or empty version instead of salting with "undefined"', () => {
+		expect(() =>
+			applyVersionedCacheKeyPatch(WORKER_FIXTURE, undefined as unknown as string)
+		).toThrow(/non-empty version/);
+		expect(() => applyVersionedCacheKeyPatch(WORKER_FIXTURE, '')).toThrow(/non-empty version/);
+	});
+
+	it('declares the key before the lookup so both call sites share it', () => {
+		const result = applyVersionedCacheKeyPatch(WORKER_FIXTURE, 'abc123')!;
+		const declIdx = result.indexOf('const __cacheKey = new Request(__cacheKeyUrl, req);');
+		const lookupIdx = result.indexOf('await r2(__cacheKey)');
+		const saveIdx = result.indexOf('c(__cacheKey, res, ctx)');
+		expect(declIdx).toBeGreaterThan(-1);
+		expect(declIdx).toBeLessThan(lookupIdx);
+		expect(lookupIdx).toBeLessThan(saveIdx);
+	});
+
+	it('composes with applyMarkdownPatch (markdown first, the CLI order)', () => {
+		const md = applyMarkdownPatch(WORKER_FIXTURE)!;
+		const result = applyVersionedCacheKeyPatch(md, 'abc123')!;
+
+		expect(result).toContain(
+			'!__wantsMarkdown && !pragma.includes("no-cache") && await r2(__cacheKey)'
+		);
+		expect(result).toContain('? c(__cacheKey, res, ctx) : res;');
+		expect(result.match(/const __cacheKey =/g)?.length).toBe(1);
+	});
+
+	it('returns null when the worker has no worktop cache layer', () => {
+		expect(applyVersionedCacheKeyPatch(WORKER_FIXTURE_NO_CACHE, 'abc123')).toBeNull();
+	});
+
+	it('throws when only one of lookup/save matches (half-salted cache)', () => {
+		const lookupOnly = WORKER_FIXTURE.replace('? c(req, res, ctx) : res;', '? res : res;');
+		expect(() => applyVersionedCacheKeyPatch(lookupOnly, 'abc123')).toThrow(/half-salted/i);
+
+		const saveOnly = WORKER_FIXTURE.replace(
+			'!pragma.includes("no-cache") && await r2(req)',
+			'await r2(req, opts)'
+		);
+		expect(() => applyVersionedCacheKeyPatch(saveOnly, 'abc123')).toThrow(/half-salted/i);
+	});
+
+	it('does not touch ASSETS.fetch or server.respond call sites', () => {
+		const result = applyVersionedCacheKeyPatch(WORKER_FIXTURE, 'abc123')!;
+		expect(result).toContain('res = await env2.ASSETS.fetch(req);');
+		expect(result).toContain('res = await server.respond(req');
+	});
+
+	it('applies cleanly to the real adapter worker template', () => {
+		// Guard against adapter upgrades drifting the patterns: patch the actual
+		// template the installed adapter bundles into _worker.js. Fails here in
+		// unit tests instead of failing the CI build (or worse, silently
+		// disabling the edge cache).
+		const require = createRequire(import.meta.url);
+		const templatePath = require
+			.resolve('@sveltejs/adapter-cloudflare/package.json')
+			.replace(/package\.json$/, 'files/worker.js');
+		const template = fs.readFileSync(templatePath, 'utf-8');
+
+		const md = applyMarkdownPatch(template);
+		expect(md).not.toBeNull();
+
+		const result = applyVersionedCacheKeyPatch(md!, 'abc123');
+		expect(result).not.toBeNull();
+		expect(result).toContain('await r2(__cacheKey)');
+		expect(result).toContain('? c(__cacheKey, res, ctx) : res;');
+		expect(result).toContain('__cacheKeyUrl.searchParams.append("__v", "abc123")');
+	});
+});
+
+describe('findVersionFile', () => {
+	it('locates version.json under a non-default appDir and skips decoys', () => {
+		const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'patch-cf-worker-'));
+		try {
+			// Decoy: a user-provided static/version.json copied to the output root
+			// (no immutable/ sibling)
+			fs.writeFileSync(path.join(outDir, 'version.json'), '{"version":"decoy"}');
+			// Decoy: prerendered page directory
+			fs.mkdirSync(path.join(outDir, 'en'));
+			fs.writeFileSync(path.join(outDir, 'en', 'index.html'), '<html></html>');
+			// The real app dir, renamed via kit.appDir
+			fs.mkdirSync(path.join(outDir, 'custom-app', 'immutable'), { recursive: true });
+			fs.writeFileSync(path.join(outDir, 'custom-app', 'version.json'), '{"version":"abc"}');
+
+			expect(findVersionFile(outDir)).toBe(path.join(outDir, 'custom-app', 'version.json'));
+		} finally {
+			fs.rmSync(outDir, { recursive: true, force: true });
+		}
+	});
+
+	it('returns null when no app dir exists', () => {
+		const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'patch-cf-worker-'));
+		try {
+			expect(findVersionFile(outDir)).toBeNull();
+		} finally {
+			fs.rmSync(outDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/scripts/patch-cf-worker.ts
+++ b/scripts/patch-cf-worker.ts
@@ -31,11 +31,14 @@ import * as path from 'node:path';
 // so we match from `if (` up to the `) {` that closes the if-condition.
 export const STATIC_SERVING_PATTERN = /(if\s*\()(is_static_asset\b.+?\.startsWith\(immutable\))\)/;
 
+// Core of the worktop cache lookup call, shared by CACHE_LOOKUP_PATTERN and
+// CACHE_KEY_LOOKUP_PATTERN so adapter drift is fixed in one place.
+const WORKTOP_LOOKUP_CORE = /!pragma\.includes\("no-cache"\) && await /.source;
+
 // Match the worktop cache lookup: `let res = !pragma.includes("no-cache") && await r2(req);`
 // We inject the __wantsMarkdown check here so markdown requests bypass the cache entirely.
 // CF Cache API ignores Vary headers, so cached HTML would be served for markdown requests.
-export const CACHE_LOOKUP_PATTERN =
-	/(let res = )(!pragma\.includes\("no-cache"\) && await \w+\(req\))/;
+export const CACHE_LOOKUP_PATTERN = new RegExp(`(let res = )(${WORKTOP_LOOKUP_CORE}\\w+\\(req\\))`);
 
 // Match the static-asset serving call: `res = await env2.ASSETS.fetch(req);`
 // We append the marketing edge-cache injection right after it, capturing the
@@ -123,6 +126,118 @@ export function applyMarkdownPatch(source: string): string | null {
 	return patched === source ? null : patched;
 }
 
+// Match the worktop cache lookup call so its `req` argument can be swapped for
+// a versioned cache key. Anchored on the `!pragma.includes("no-cache") &&`
+// prefix so `env2.ASSETS.fetch(req)` and `server.respond(req, ...)` can never
+// match. Tolerates the `!__wantsMarkdown && ` prefix applyMarkdownPatch
+// prepends. Order matters: run applyMarkdownPatch FIRST (as the CLI does).
+// Reversed, its patterns expect the bare `(req)` argument, miss the salted
+// call, and silently skip the markdown cache bypass.
+export const CACHE_KEY_LOOKUP_PATTERN = new RegExp(`(${WORKTOP_LOOKUP_CORE})(\\w+)\\(req\\)`);
+
+// Match the tail save call `c(req, res, ctx)` in the worker's single return.
+export const CACHE_KEY_SAVE_PATTERN = /(\? )(\w+)\(req, (res, ctx\))/;
+
+/**
+ * Salt the worktop cache key with the deployment version (issue #651).
+ *
+ * The worktop layer caches responses per colo keyed on the bare URL. Branch
+ * alias and workers.dev URLs stay constant across deploys, so after a push a
+ * colo keeps serving the previous build's marketing HTML for up to
+ * s-maxage=3600 while its immutable chunk hashes 404 on the new deployment:
+ * the page never hydrates. workers.dev cannot purge, so the stale copy can
+ * only age out. Keying lookup AND save on `?__v=<version>` gives every deploy
+ * a cold cache namespace; old entries expire unreferenced.
+ *
+ * Returns the patched source, null when the worker has no worktop cache layer
+ * (nothing to salt), and throws when only one of the two call sites matches:
+ * a half-salted cache never hits (save and lookup use different keys), which
+ * would silently disable edge caching entirely.
+ */
+export function applyVersionedCacheKeyPatch(source: string, version: string): string | null {
+	// A missing version must fail the build, not ship: JSON.stringify(undefined)
+	// would interpolate the literal text `undefined`, salting every deploy with
+	// the same constant and silently reintroducing the stale-cache bug.
+	if (typeof version !== 'string' || version.length === 0) {
+		throw new Error(
+			`applyVersionedCacheKeyPatch needs a non-empty version string, got ${JSON.stringify(version)}. ` +
+				'Check the version.json read in the CLI entry point.'
+		);
+	}
+
+	const hasLookup = CACHE_KEY_LOOKUP_PATTERN.test(source);
+	const hasSave = CACHE_KEY_SAVE_PATTERN.test(source);
+	if (!hasLookup && !hasSave) {
+		return null;
+	}
+	if (!hasLookup || !hasSave) {
+		throw new Error(
+			`Found the worktop cache ${hasLookup ? 'lookup' : 'save'} but not the ` +
+				`${hasLookup ? 'save' : 'lookup'} call. A half-salted cache key means ` +
+				'save and lookup never agree, silently disabling the edge cache. ' +
+				'Update CACHE_KEY_LOOKUP_PATTERN / CACHE_KEY_SAVE_PATTERN to match ' +
+				'the new adapter output.'
+		);
+	}
+
+	// Build the key once, right before the lookup, so lookup and save share it.
+	// new Request(url, req) preserves the method, keeping worktop's HEAD->GET
+	// cache-key normalization intact. The salted request is only ever used as a
+	// Cache API key; it is never fetched. append, not set: set would overwrite a
+	// client-supplied __v param and collapse /page?__v=x and /page into one
+	// cache entry; append keeps the original-URL-to-key mapping injective.
+	const keyConst =
+		`const __cacheKeyUrl = new URL(req.url);\n` +
+		`    __cacheKeyUrl.searchParams.append("__v", ${JSON.stringify(version)});\n` +
+		`    const __cacheKey = new Request(__cacheKeyUrl, req);\n    `;
+
+	let patched = source.replace(CACHE_KEY_LOOKUP_PATTERN, `$1$2(__cacheKey)`);
+	patched = patched.replace(CACHE_KEY_SAVE_PATTERN, `$1$2(__cacheKey, $3`);
+
+	// Anchor the key declaration on the pragma read that immediately precedes
+	// the lookup, so __cacheKey is in scope for both call sites.
+	const PRAGMA_ANCHOR = /let pragma = req\.headers\.get\("cache-control"\) \|\| "";/;
+	if (!PRAGMA_ANCHOR.test(patched)) {
+		throw new Error(
+			'Found the worktop cache calls but not the pragma read to anchor the ' +
+				'__cacheKey declaration on. Update the anchor in applyVersionedCacheKeyPatch.'
+		);
+	}
+	patched = patched.replace(PRAGMA_ANCHOR, (m) => `${keyConst}${m}`);
+
+	return patched;
+}
+
+/**
+ * Locate SvelteKit's version.json in the built output without assuming the
+ * default appDir: forks may set kit.appDir, which moves the file to
+ * <appDir>/version.json. The app dir is the one directory that contains both
+ * version.json and immutable/, which disambiguates it from a user-provided
+ * static/version.json (copied to the output root, no immutable/ sibling).
+ */
+export function findVersionFile(outDir: string): string | null {
+	const stack = [outDir];
+	while (stack.length > 0) {
+		const dir = stack.pop()!;
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(dir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		const names = new Set(entries.map((entry) => entry.name));
+		if (names.has('version.json') && names.has('immutable')) {
+			return path.join(dir, 'version.json');
+		}
+		for (const entry of entries) {
+			if (entry.isDirectory() && entry.name !== 'immutable') {
+				stack.push(path.join(dir, entry.name));
+			}
+		}
+	}
+	return null;
+}
+
 // --- CLI entry point (skipped when imported for testing) ---
 if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
 	const WORKER_PATH = path.resolve('.svelte-kit/cloudflare/_worker.js');
@@ -147,6 +262,32 @@ if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.met
 				'The adapter-cloudflare output may have changed. ' +
 				'Without this patch, prerendered marketing pages lose Accept: text/markdown support.'
 		);
+		process.exit(1);
+	}
+
+	// Salt the worktop cache key with the deployment version (issue #651).
+	// version.json carries the deterministic per-commit version from
+	// svelte.config.js, so every deploy starts with a cold edge-cache namespace
+	// instead of serving the previous build's HTML with dead chunk hashes.
+	try {
+		const versionPath = findVersionFile(path.resolve('.svelte-kit/cloudflare'));
+		if (versionPath === null) {
+			throw new Error(
+				'Could not locate version.json in .svelte-kit/cloudflare. Without it the ' +
+					'edge cache key cannot be salted and stale HTML with dead chunk hashes ' +
+					'would be served after deploys (issue #651).'
+			);
+		}
+		const version: string = JSON.parse(fs.readFileSync(versionPath, 'utf-8')).version;
+		const versioned = applyVersionedCacheKeyPatch(patched, version);
+		if (versioned === null) {
+			console.log('[patch-cf-worker] No worktop cache layer found — cache key left unsalted.');
+		} else {
+			patched = versioned;
+			console.log(`[patch-cf-worker] Salted the edge cache key with version ${version}.`);
+		}
+	} catch (err) {
+		console.error(`[patch-cf-worker] ${err instanceof Error ? err.message : String(err)}`);
 		process.exit(1);
 	}
 


### PR DESCRIPTION
Closes #651

The worktop cache layer in the generated CF worker caches responses per colo keyed on the bare URL. Branch alias and workers.dev URLs stay constant across deploys, so for up to an hour after a push a colo keeps serving the previous build's prerendered marketing HTML (and the SSR pricing page) while its immutable chunks are gone from the new deployment. The SvelteKit entry point 404s, the page never hydrates, and workers.dev cannot purge. This is the stale shell that broke E2E five times before #652 and still hits real preview visitors.

The postbuild patch now rewrites the worker's cache lookup and save to share one request keyed on an appended `__v=<version>` query param, where the version is the deterministic per-commit app version already defined in `svelte.config.js`. Every deploy therefore starts with a cold cache namespace and the previous build's entries expire unreferenced. The param is appended rather than set so a client-supplied `__v` cannot collapse distinct URLs into one cache entry, `version.json` is located by its `immutable/` sibling so forks that change `kit.appDir` keep building, and a missing or empty version fails the build loudly instead of salting every deploy with the same constant. The patch composes with the existing markdown passthrough in the CLI order (markdown first); the pattern comments document that the reverse order is unsupported.

Verified on a real local CF build: the patched worker declares the salted key once before the lookup, both `r2()` and the tail save use it, and the markdown gating is unchanged. Cache behavior of the deployed preview stays observable via the `age` header (worktop hits carry it, the content-addressed assets layer does not).

Regression guard: added real-adapter-template patch test in `scripts/patch-cf-worker.test.ts` (patches the installed adapter's worker template, so pattern drift fails unit tests instead of silently disabling the salt or the markdown bypass on the next adapter upgrade).

`bunx vitest run scripts/patch-cf-worker.test.ts` passes (23 tests). `WORKERS_CI=1 bun run build` patches the worker end to end. `bun scripts/static-checks.ts` passes on the changed files.