### PR TITLE
feat(auth): Make loading bar track transparent

### DIFF
--- a/src/routes/[[lang]]/(auth)/email-verified/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/email-verified/+page.svelte
@@ -65,7 +65,7 @@
 		<Card.Root class="overflow-hidden p-0">
 			<Card.Content class="grid p-0 md:grid-cols-2">
 				<div class="min-h-96">
-					<LoadingBar mode="loading" class="h-1 rounded-none" />
+					<LoadingBar mode="loading" showBackground={false} class="h-1 rounded-none" />
 					<div class="flex h-full flex-col justify-center p-6 md:p-8">
 						<div class="flex flex-col items-center gap-2 text-center">
 							<h1 class="text-2xl font-bold">

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -149,6 +149,7 @@
 					<LoadingBar
 						value={progress}
 						mode={isLoading ? 'loading' : 'progress'}
+						showBackground={false}
 						class="h-1 rounded-none"
 					/>
 					<div class="p-6 md:p-8">

--- a/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
@@ -175,6 +175,7 @@
 					<LoadingBar
 						value={progress}
 						mode={isLoading ? 'loading' : 'progress'}
+						showBackground={false}
 						class="h-1 rounded-none"
 					/>
 					<div class="p-6 md:p-8">

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -105,6 +105,7 @@
 	<LoadingBar
 		value={signInProgress}
 		mode={isLoading ? 'loading' : 'progress'}
+		showBackground={false}
 		class="h-1 rounded-none"
 	/>
 	<div class="p-6 md:p-8">

--- a/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
@@ -84,6 +84,7 @@
 	<LoadingBar
 		value={signUpProgress}
 		mode={isLoading ? 'loading' : 'progress'}
+		showBackground={false}
 		class="h-1 rounded-none"
 	/>
 	<div class="p-6 md:p-8">

--- a/src/routes/[[lang]]/(auth)/signin/VerificationStep.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/VerificationStep.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <div class="min-h-96" data-testid="signup-verification-step">
-	<LoadingBar value={100} mode="progress" class="h-1 rounded-none" />
+	<LoadingBar value={100} mode="progress" showBackground={false} class="h-1 rounded-none" />
 	<div class="flex h-full flex-col justify-center p-6 md:p-8">
 		<Field.Group>
 			<div class="flex flex-col items-center gap-2 text-center">


### PR DESCRIPTION
The progress indicator at the top of the auth cards rendered its track as a permanent thin `bg-primary/20` line, visible even before anything is filled out.

The LoadingBar component already supports a transparent track via its `showBackground` prop, so the six auth surfaces (signin, signup, verification step, forgot password, reset password, email verified) now pass `showBackground={false}`. The track blends into the card and only the filled progress portion is visible, matching the cadenza.page auth pages. The shadcn-demo keeps the default track.

`bun scripts/static-checks.ts` on the six files and `bun run test:unit` (751 tests) pass.