### PR TITLE
feat(admin): Add audit log reader page

### DIFF
--- a/e2e/admin-audit-log.spec.ts
+++ b/e2e/admin-audit-log.spec.ts
@@ -1,0 +1,193 @@
+import { test, expect, type Page } from '@playwright/test';
+import 'varlock/auto-load';
+import { ConvexHttpClient } from 'convex/browser';
+import { api } from '../src/lib/convex/_generated/api';
+import { resolveConvexUrl } from './utils/convex-url';
+import { resolveSiteUrl } from './utils/site-url';
+import { getPreviewBypass } from './utils/preview-bypass';
+
+const SITE_URL = resolveSiteUrl();
+const TEST_PASSWORD = 'TestPassword123!';
+const bypass = getPreviewBypass();
+
+function getRequestHeaders(): Record<string, string> {
+	return {
+		'Content-Type': 'application/json',
+		Origin: SITE_URL,
+		...bypass.headers
+	};
+}
+
+async function createAuthUser(email: string, name: string) {
+	const response = await fetch(`${SITE_URL}/api/auth/sign-up/email`, {
+		method: 'POST',
+		headers: getRequestHeaders(),
+		body: JSON.stringify({ email, password: TEST_PASSWORD, name })
+	});
+
+	if (!response.ok) {
+		const errorBody = await response.text().catch(() => 'unknown error');
+		throw new Error(`Failed to create seed user ${email}: ${response.status} ${errorBody}`);
+	}
+}
+
+async function waitForAuditLogReady(page: Page) {
+	await expect(page.getByTestId('admin-audit-log-page')).toBeVisible();
+	await expect(page.getByTestId('admin-audit-log-table')).toBeVisible();
+	await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+}
+
+async function selectActionFilter(page: Page, action: string) {
+	await page.getByTestId('admin-audit-log-action-filter').click();
+	await page.getByTestId(`admin-audit-log-action-filter-${action}`).click();
+	await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+}
+
+// Drive a real ban + unban through the admin users UI so the backend writes
+// genuine ban_user / unban_user audit entries (the mutations require the admin
+// session, so they cannot be triggered from an unauthenticated HTTP client).
+async function banAndUnbanTarget(page: Page, email: string) {
+	await page.goto('/en/admin/users');
+	await page.waitForLoadState('domcontentloaded');
+	await expect(page.getByTestId('admin-users-page')).toBeVisible();
+	await expect(page.getByTestId('admin-users-search')).toBeVisible({ timeout: 30000 });
+
+	await page.getByTestId('admin-users-search').fill(email);
+	await expect(page.getByTestId('admin-users-email-cell').filter({ hasText: email })).toHaveCount(
+		1,
+		{ timeout: 10000 }
+	);
+	await expect(page.getByTestId('admin-users-row-actions')).toHaveCount(1);
+
+	// Ban with a reason
+	await page.getByTestId('admin-users-row-actions').click();
+	await page.getByTestId('admin-users-action-ban').click();
+	await page.getByTestId('admin-users-ban-reason-input').fill('Audit log e2e ban');
+	await page.getByTestId('admin-users-dialog-confirm').click();
+	await expect(page.getByTestId('admin-users-dialog-confirm')).toHaveCount(0, { timeout: 10000 });
+	await expect
+		.poll(
+			async () =>
+				(await page.getByTestId('admin-users-status-badge').textContent())?.trim().toLowerCase(),
+			{ timeout: 10000 }
+		)
+		.toBe('banned');
+
+	// Unban restores the verified status
+	await page.getByTestId('admin-users-row-actions').click();
+	await page.getByTestId('admin-users-action-unban').click();
+	await page.getByTestId('admin-users-dialog-confirm').click();
+	await expect(page.getByTestId('admin-users-dialog-confirm')).toHaveCount(0, { timeout: 10000 });
+	await expect
+		.poll(
+			async () =>
+				(await page.getByTestId('admin-users-status-badge').textContent())?.trim().toLowerCase(),
+			{ timeout: 10000 }
+		)
+		.toBe('verified');
+}
+
+test.describe('Admin Audit Log', () => {
+	test.describe.configure({ mode: 'serial', timeout: 180000 });
+
+	const testSecret = process.env.AUTH_E2E_TEST_SECRET;
+	const convexUrl = resolveConvexUrl();
+
+	let client: ConvexHttpClient;
+	let targetEmail = '';
+	const createdEmails: string[] = [];
+	let uncaughtPageErrors: string[] = [];
+
+	test.beforeAll(async () => {
+		test.setTimeout(180000);
+
+		if (!testSecret) {
+			throw new Error('AUTH_E2E_TEST_SECRET is required in .env.test');
+		}
+		if (!convexUrl) {
+			throw new Error(
+				'Convex URL not configured (set PUBLIC_CONVEX_URL or start local dev server)'
+			);
+		}
+
+		client = new ConvexHttpClient(convexUrl);
+		targetEmail = `audit-target-${Date.now()}@e2e.example.com`;
+
+		await createAuthUser(targetEmail, 'Audit Log Target');
+		createdEmails.push(targetEmail);
+		await client.mutation(api.tests.verifyTestUserEmail, {
+			email: targetEmail,
+			secret: testSecret
+		});
+	});
+
+	test.afterAll(async () => {
+		if (!testSecret || !client) return;
+
+		for (const email of createdEmails) {
+			try {
+				await client.mutation(api.tests.deleteTestUser, { email, secret: testSecret });
+			} catch (error) {
+				console.warn(`[admin-audit-log] cleanup failed for ${email}:`, error);
+			}
+		}
+	});
+
+	test.beforeEach(async ({ page }) => {
+		uncaughtPageErrors = [];
+		page.on('pageerror', (error) => {
+			uncaughtPageErrors.push(error.message);
+		});
+	});
+
+	test.afterEach(() => {
+		expect(
+			uncaughtPageErrors,
+			`Uncaught browser runtime errors:\n${uncaughtPageErrors.join('\n')}`
+		).toEqual([]);
+	});
+
+	test('records admin actions and filters the log by action', async ({ page }) => {
+		await banAndUnbanTarget(page, targetEmail);
+
+		await page.goto('/en/admin/audit-log');
+		await page.waitForLoadState('domcontentloaded');
+		await waitForAuditLogReady(page);
+
+		// The ban + unban above produced at least two rows, newest first.
+		await expect(page.getByTestId('audit-log-row').first()).toBeVisible({ timeout: 10000 });
+
+		// Filter to ban_user: every visible badge is a ban, the URL carries the
+		// canonical `action` param, and the target cell resolves to our user.
+		await selectActionFilter(page, 'ban_user');
+		await expect.poll(() => new URL(page.url()).searchParams.get('action')).toBe('ban_user');
+		const banBadges = (await page.getByTestId('audit-log-action-badge').allTextContents()).map(
+			(value) => value.trim()
+		);
+		expect(banBadges.length).toBeGreaterThan(0);
+		expect(banBadges.every((label) => label === 'Ban user')).toBe(true);
+		await expect(
+			page.getByTestId('audit-log-target-cell').filter({ hasText: targetEmail })
+		).toHaveCount(1, { timeout: 10000 });
+
+		// Narrow to unban_user: the badge set changes and our target reappears
+		// under the unban entry, proving the filter re-queries the log.
+		await selectActionFilter(page, 'unban_user');
+		await expect.poll(() => new URL(page.url()).searchParams.get('action')).toBe('unban_user');
+		const unbanBadges = (await page.getByTestId('audit-log-action-badge').allTextContents()).map(
+			(value) => value.trim()
+		);
+		expect(unbanBadges.length).toBeGreaterThan(0);
+		expect(unbanBadges.every((label) => label === 'Unban user')).toBe(true);
+		await expect(
+			page.getByTestId('audit-log-target-cell').filter({ hasText: targetEmail })
+		).toHaveCount(1, { timeout: 10000 });
+
+		// Clearing the filter drops the param and widens the log again.
+		await page.getByTestId('admin-audit-log-filter-clear').click();
+		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+		await expect(page.getByTestId('admin-audit-log-filter-clear')).toHaveCount(0);
+		await expect.poll(() => new URL(page.url()).searchParams.get('action')).toBeNull();
+		await expect(page.getByTestId('audit-log-row').first()).toBeVisible({ timeout: 10000 });
+	});
+});

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -10,6 +10,34 @@
 			"set_role": "Rolle ändern",
 			"unban": "Sperre aufheben"
 		},
+		"audit_log": {
+			"action": {
+				"ban_user": "Benutzer sperren",
+				"impersonate": "Identität annehmen",
+				"revoke_sessions": "Sitzungen widerrufen",
+				"set_role": "Rolle festlegen",
+				"stop_impersonation": "Identität verlassen",
+				"unban_user": "Sperre aufheben"
+			},
+			"column": {
+				"action": "Aktion",
+				"admin": "Admin",
+				"details": "Details",
+				"target": "Ziel",
+				"time": "Zeit"
+			},
+			"deleted_user": "Gelöschter Benutzer",
+			"details": {
+				"role_change": "{previousRole} → {newRole}"
+			},
+			"empty": "Noch keine Audit-Log-Einträge.",
+			"filter": {
+				"all_actions": "Alle Aktionen",
+				"clear": "Zurücksetzen"
+			},
+			"loading": "Audit-Log wird geladen …",
+			"title": "Audit-Log"
+		},
 		"dashboard": {
 			"database_backend": "Datenbank & Backend",
 			"email_service": "E-Mail-Zustelldienst",
@@ -108,6 +136,7 @@
 			"type_custom": "Benutzerdefiniert"
 		},
 		"sidebar": {
+			"audit_log": "Audit-Log",
 			"back_to_app": "Zurück zur App",
 			"dashboard": "Dashboard",
 			"settings": "Einstellungen",
@@ -680,6 +709,10 @@
 			"title": "Über uns"
 		},
 		"admin": {
+			"audit_log": {
+				"description": "Admin-Aktionen auf der Plattform überprüfen.",
+				"title": "Audit-Log"
+			},
 			"dashboard": {
 				"description": "Überwachen Sie Plattformmetriken und externe Dienste.",
 				"title": "Admin-Dashboard"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -10,6 +10,34 @@
 			"set_role": "Set Role",
 			"unban": "Unban User"
 		},
+		"audit_log": {
+			"action": {
+				"ban_user": "Ban user",
+				"impersonate": "Impersonate",
+				"revoke_sessions": "Revoke sessions",
+				"set_role": "Set role",
+				"stop_impersonation": "Stop impersonation",
+				"unban_user": "Unban user"
+			},
+			"column": {
+				"action": "Action",
+				"admin": "Admin",
+				"details": "Details",
+				"target": "Target",
+				"time": "Time"
+			},
+			"deleted_user": "Deleted user",
+			"details": {
+				"role_change": "{previousRole} → {newRole}"
+			},
+			"empty": "No audit log entries yet.",
+			"filter": {
+				"all_actions": "All actions",
+				"clear": "Clear"
+			},
+			"loading": "Loading audit log…",
+			"title": "Audit Log"
+		},
 		"dashboard": {
 			"database_backend": "Database & backend",
 			"email_service": "Email delivery service",
@@ -108,6 +136,7 @@
 			"type_custom": "Custom"
 		},
 		"sidebar": {
+			"audit_log": "Audit Log",
 			"back_to_app": "Back to App",
 			"dashboard": "Dashboard",
 			"settings": "Settings",
@@ -680,6 +709,10 @@
 			"title": "About Us"
 		},
 		"admin": {
+			"audit_log": {
+				"description": "Review admin actions across the platform.",
+				"title": "Audit Log"
+			},
 			"dashboard": {
 				"description": "Monitor platform metrics and external services.",
 				"title": "Admin Dashboard"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -10,6 +10,34 @@
 			"set_role": "Cambiar Rol",
 			"unban": "Desbloquear Usuario"
 		},
+		"audit_log": {
+			"action": {
+				"ban_user": "Bloquear usuario",
+				"impersonate": "Suplantar",
+				"revoke_sessions": "Revocar sesiones",
+				"set_role": "Asignar rol",
+				"stop_impersonation": "Detener suplantación",
+				"unban_user": "Desbloquear usuario"
+			},
+			"column": {
+				"action": "Acción",
+				"admin": "Administrador",
+				"details": "Detalles",
+				"target": "Objetivo",
+				"time": "Hora"
+			},
+			"deleted_user": "Usuario eliminado",
+			"details": {
+				"role_change": "{previousRole} → {newRole}"
+			},
+			"empty": "Aún no hay entradas en el registro de auditoría.",
+			"filter": {
+				"all_actions": "Todas las acciones",
+				"clear": "Limpiar"
+			},
+			"loading": "Cargando registro de auditoría…",
+			"title": "Registro de auditoría"
+		},
 		"dashboard": {
 			"database_backend": "Base de datos y backend",
 			"email_service": "Servicio de entrega de correo",
@@ -108,6 +136,7 @@
 			"type_custom": "Personalizado"
 		},
 		"sidebar": {
+			"audit_log": "Auditoría",
 			"back_to_app": "Volver a la App",
 			"dashboard": "Panel",
 			"settings": "Configuración",
@@ -680,6 +709,10 @@
 			"title": "Acerca de nosotros"
 		},
 		"admin": {
+			"audit_log": {
+				"description": "Revisa las acciones de administración en la plataforma.",
+				"title": "Registro de auditoría"
+			},
 			"dashboard": {
 				"description": "Supervisa métricas de la plataforma y servicios externos.",
 				"title": "Panel de Admin"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -10,6 +10,34 @@
 			"set_role": "Changer le Rôle",
 			"unban": "Débannir l'Utilisateur"
 		},
+		"audit_log": {
+			"action": {
+				"ban_user": "Bannir l'utilisateur",
+				"impersonate": "Usurper l'identité",
+				"revoke_sessions": "Révoquer les sessions",
+				"set_role": "Définir le rôle",
+				"stop_impersonation": "Arrêter l'usurpation",
+				"unban_user": "Réintégrer l'utilisateur"
+			},
+			"column": {
+				"action": "Action",
+				"admin": "Admin",
+				"details": "Détails",
+				"target": "Cible",
+				"time": "Heure"
+			},
+			"deleted_user": "Utilisateur supprimé",
+			"details": {
+				"role_change": "{previousRole} → {newRole}"
+			},
+			"empty": "Aucune entrée dans le journal d'audit pour le moment.",
+			"filter": {
+				"all_actions": "Toutes les actions",
+				"clear": "Effacer"
+			},
+			"loading": "Chargement du journal d'audit…",
+			"title": "Journal d'audit"
+		},
 		"dashboard": {
 			"database_backend": "Base de données & backend",
 			"email_service": "Service d'envoi d'e-mails",
@@ -108,6 +136,7 @@
 			"type_custom": "Personnalisé"
 		},
 		"sidebar": {
+			"audit_log": "Journal d'audit",
 			"back_to_app": "Retour à l'App",
 			"dashboard": "Tableau de bord",
 			"settings": "Paramètres",
@@ -680,6 +709,10 @@
 			"title": "À propos"
 		},
 		"admin": {
+			"audit_log": {
+				"description": "Consultez les actions d'administration sur la plateforme.",
+				"title": "Journal d'audit"
+			},
 			"dashboard": {
 				"description": "Surveillez les métriques de la plateforme et les services externes.",
 				"title": "Tableau de bord Admin"

--- a/src/lib/components/authenticated/configs/admin-sidebar-config.ts
+++ b/src/lib/components/authenticated/configs/admin-sidebar-config.ts
@@ -4,6 +4,7 @@ import LayoutDashboardIcon from '@lucide/svelte/icons/layout-dashboard';
 import UsersIcon from '@lucide/svelte/icons/users';
 import MessagesSquareIcon from '@lucide/svelte/icons/messages-square';
 import SettingsIcon from '@lucide/svelte/icons/settings';
+import ScrollTextIcon from '@lucide/svelte/icons/scroll-text';
 import ServerCogIcon from '@lucide/svelte/icons/server-cog';
 import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 import HomeIcon from '@lucide/svelte/icons/home';
@@ -66,6 +67,13 @@ export function getAdminSidebarConfig(pageState: PageState): SidebarConfig {
 				icon: SettingsIcon,
 				isActive: pathname.startsWith(`/${lang}/admin/settings`),
 				kbd: [ctrlSymbol, '⇧', '4']
+			},
+			{
+				translationKey: 'admin.sidebar.audit_log',
+				url: localizedHref('/admin/audit-log'),
+				icon: ScrollTextIcon,
+				isActive: pathname.startsWith(`/${lang}/admin/audit-log`),
+				kbd: [ctrlSymbol, '⇧', '5']
 			}
 		],
 		footerLinks: [

--- a/src/lib/convex/_generated/api.d.ts
+++ b/src/lib/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as admin_adminHttpPaths from "../admin/adminHttpPaths.js";
+import type * as admin_auditLog_queries from "../admin/auditLog/queries.js";
 import type * as admin_counters from "../admin/counters.js";
 import type * as admin_founderWelcome_mutations from "../admin/founderWelcome/mutations.js";
 import type * as admin_founderWelcome_queries from "../admin/founderWelcome/queries.js";
@@ -91,6 +92,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   "admin/adminHttpPaths": typeof admin_adminHttpPaths;
+  "admin/auditLog/queries": typeof admin_auditLog_queries;
   "admin/counters": typeof admin_counters;
   "admin/founderWelcome/mutations": typeof admin_founderWelcome_mutations;
   "admin/founderWelcome/queries": typeof admin_founderWelcome_queries;

--- a/src/lib/convex/admin/auditLog/queries.ts
+++ b/src/lib/convex/admin/auditLog/queries.ts
@@ -1,0 +1,269 @@
+import { v, type Infer } from 'convex/values';
+import { components } from '../../_generated/api';
+import type { QueryCtx } from '../../_generated/server';
+import { adminQuery } from '../../functions';
+import type { BetterAuthUser } from '../types';
+
+/**
+ * The six admin actions recorded in the adminAuditLogs table.
+ * Mirrors the `action` union in schema.ts. Exported so the frontend can build
+ * the action filter without redeclaring the literals.
+ */
+export const auditLogActionValidator = v.union(
+	v.literal('impersonate'),
+	v.literal('stop_impersonation'),
+	v.literal('ban_user'),
+	v.literal('unban_user'),
+	v.literal('revoke_sessions'),
+	v.literal('set_role')
+);
+
+/**
+ * Typed metadata per action, mirroring the schema's optional metadata union.
+ */
+const auditLogMetadataValidator = v.optional(
+	v.union(
+		v.object({ reason: v.string() }), // ban_user, unban_user
+		v.object({ newRole: v.string(), previousRole: v.string() }), // set_role
+		v.object({}) // impersonate, stop_impersonation, revoke_sessions
+	)
+);
+
+/**
+ * A resolved user reference for an audit log row. The raw Better Auth id is
+ * always present; name/email are filled only while the user still exists.
+ * `exists: false` means the user was deleted after the action was logged, but
+ * the id stays available so the UI can still reference the original actor/target.
+ */
+const auditLogUserRefValidator = v.object({
+	id: v.string(),
+	name: v.optional(v.string()),
+	email: v.optional(v.string()),
+	exists: v.boolean()
+});
+
+/**
+ * Full item shape returned by `listAuditLogs`. The frontend imports this
+ * validator (or the inferred {@link AuditLogItem} type) to render the table.
+ */
+export const auditLogItemValidator = v.object({
+	id: v.string(), // adminAuditLogs document _id
+	action: auditLogActionValidator,
+	timestamp: v.number(),
+	metadata: auditLogMetadataValidator,
+	admin: auditLogUserRefValidator,
+	target: auditLogUserRefValidator
+});
+
+export type AuditLogItem = Infer<typeof auditLogItemValidator>;
+
+/**
+ * Shared filter args. The UI sends at most one filter at a time; see
+ * {@link queryAuditLogs} for how a single index is chosen from them.
+ */
+const auditLogFilterArgs = {
+	actionFilter: v.optional(auditLogActionValidator),
+	adminUserId: v.optional(v.string()),
+	targetUserId: v.optional(v.string())
+};
+
+type AuditLogFilters = {
+	actionFilter?: Infer<typeof auditLogActionValidator>;
+	adminUserId?: string;
+	targetUserId?: string;
+};
+
+/**
+ * Pick the single most selective index for the given filter and return the
+ * newest-first ordered query.
+ *
+ * Filters are treated as mutually exclusive: the UI sends at most one of
+ * actionFilter, adminUserId, or targetUserId, so we choose exactly one index
+ * and do NOT apply the remaining filters as extra conditions (v1). Priority if
+ * several are somehow set: action -> admin -> target -> unfiltered
+ * (by_timestamp). For the single-value index branches, ordering by the index
+ * resolves to `_creationTime desc` within the pinned value, which matches the
+ * `timestamp` insertion order used by the writers in admin/mutations.ts.
+ */
+function queryAuditLogs(ctx: QueryCtx, filters: AuditLogFilters) {
+	if (filters.actionFilter !== undefined) {
+		const action = filters.actionFilter;
+		return ctx.db
+			.query('adminAuditLogs')
+			.withIndex('by_action', (q) => q.eq('action', action))
+			.order('desc');
+	}
+	if (filters.adminUserId !== undefined) {
+		const adminUserId = filters.adminUserId;
+		return ctx.db
+			.query('adminAuditLogs')
+			.withIndex('by_admin', (q) => q.eq('adminUserId', adminUserId))
+			.order('desc');
+	}
+	if (filters.targetUserId !== undefined) {
+		const targetUserId = filters.targetUserId;
+		return ctx.db
+			.query('adminAuditLogs')
+			.withIndex('by_target', (q) => q.eq('targetUserId', targetUserId))
+			.order('desc');
+	}
+	return ctx.db.query('adminAuditLogs').withIndex('by_timestamp').order('desc');
+}
+
+/**
+ * Resolve a set of Better Auth user ids to { name, email }. Deleted users are
+ * simply absent from the returned map. Lookups are bounded by page size: a page
+ * holds at most `2 * numItems` unique ids (admin + target), each resolved with
+ * a single point read, so this never scans the user table.
+ */
+async function resolveUsers(
+	ctx: QueryCtx,
+	ids: Set<string>
+): Promise<Map<string, { name?: string; email?: string }>> {
+	const resolved = new Map<string, { name?: string; email?: string }>();
+	for (const id of ids) {
+		const user = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
+			model: 'user',
+			where: [{ field: '_id', operator: 'eq', value: id }]
+		})) as BetterAuthUser | null;
+		if (user) {
+			resolved.set(id, { name: user.name, email: user.email });
+		}
+	}
+	return resolved;
+}
+
+function toUserRef(
+	id: string,
+	resolved: Map<string, { name?: string; email?: string }>
+): Infer<typeof auditLogUserRefValidator> {
+	const info = resolved.get(id);
+	if (!info) {
+		return { id, exists: false };
+	}
+	return { id, name: info.name, email: info.email, exists: true };
+}
+
+/**
+ * List admin audit log entries, newest first, with cursor pagination.
+ *
+ * Backend half of the project table-kit contract: returns
+ * `{ items, continueCursor, isDone }` where `continueCursor` is null exactly
+ * when `isDone` is true. Each page is enriched with the admin/target user
+ * details (bounded by page size, see {@link resolveUsers}).
+ */
+export const listAuditLogs = adminQuery({
+	args: {
+		cursor: v.optional(v.string()),
+		numItems: v.number(),
+		...auditLogFilterArgs
+	},
+	returns: v.object({
+		items: v.array(auditLogItemValidator),
+		continueCursor: v.union(v.string(), v.null()),
+		isDone: v.boolean()
+	}),
+	handler: async (ctx, args) => {
+		const result = await queryAuditLogs(ctx, args).paginate({
+			numItems: args.numItems,
+			cursor: args.cursor ?? null
+		});
+
+		const ids = new Set<string>();
+		for (const row of result.page) {
+			ids.add(row.adminUserId);
+			ids.add(row.targetUserId);
+		}
+		const resolved = await resolveUsers(ctx, ids);
+
+		const items = result.page.map((row) => ({
+			id: row._id,
+			action: row.action,
+			timestamp: row.timestamp,
+			metadata: row.metadata,
+			admin: toUserRef(row.adminUserId, resolved),
+			target: toUserRef(row.targetUserId, resolved)
+		}));
+
+		return {
+			items,
+			continueCursor: result.isDone ? null : result.continueCursor,
+			isDone: result.isDone
+		};
+	}
+});
+
+/**
+ * Count audit log entries matching the same (mutually exclusive) filter as
+ * {@link listAuditLogs}. Count half of the table-kit contract.
+ *
+ * Capped at 5001 via .take() — this is a template-scale table, so we avoid an
+ * unbounded .collect(). A returned 5001 means "5000+"; the UI can render a
+ * "5000+" indicator if it ever reaches the cap.
+ */
+export const getAuditLogCount = adminQuery({
+	args: auditLogFilterArgs,
+	returns: v.number(),
+	handler: async (ctx, args) => {
+		const rows = await queryAuditLogs(ctx, args).take(5001);
+		return rows.length;
+	}
+});
+
+/**
+ * Resolve the last page for the audit log table in one server call, so the
+ * table-kit "jump to last page" action does not have to walk cursors from the
+ * client. Same mutually-exclusive filter semantics as {@link listAuditLogs}
+ * (reuses {@link queryAuditLogs}).
+ *
+ * Returns the 1-indexed last page and the cursor that fetches it (null for a
+ * single-page result), matching the { page, cursor } contract of
+ * resolveUsersLastPage and resolveNotificationRecipientsLastPage.
+ *
+ * The walk is bounded to ceil(5001 / numItems) pages, mirroring the 5001-row
+ * cap in getAuditLogCount: on a table larger than that it lands on the capped
+ * last page instead of scanning unbounded. Native Convex cursors are
+ * position-based, so re-fetching a page with the recorded cursor is stable.
+ */
+export const resolveAuditLogLastPage = adminQuery({
+	args: {
+		numItems: v.number(),
+		...auditLogFilterArgs
+	},
+	returns: v.object({
+		page: v.number(),
+		cursor: v.union(v.string(), v.null())
+	}),
+	handler: async (ctx, args): Promise<{ page: number; cursor: string | null }> => {
+		const pageSize = Number.isFinite(args.numItems) && args.numItems > 0 ? args.numItems : 10;
+		const maxPages = Math.ceil(5001 / pageSize);
+
+		// Cursor that fetches the page currently being read (null for page 0).
+		let cursor: string | null = null;
+		let index = 0;
+		let lastNonEmptyIndex = 0;
+		let lastNonEmptyCursor: string | null = null;
+		let found = false;
+
+		for (let step = 0; step < maxPages; step++) {
+			const result = await queryAuditLogs(ctx, args).paginate({ numItems: pageSize, cursor });
+
+			if (result.page.length > 0) {
+				lastNonEmptyIndex = index;
+				lastNonEmptyCursor = cursor;
+				found = true;
+			}
+
+			if (result.isDone || !result.continueCursor) break;
+
+			cursor = result.continueCursor;
+			index++;
+		}
+
+		if (!found) {
+			return { page: 1, cursor: null };
+		}
+
+		return { page: lastNonEmptyIndex + 1, cursor: lastNonEmptyCursor };
+	}
+});

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -48,6 +48,7 @@ export default defineSchema({
 	})
 		.index('by_admin', ['adminUserId'])
 		.index('by_target', ['targetUserId'])
+		.index('by_action', ['action'])
 		.index('by_timestamp', ['timestamp']),
 
 	// Internal notes for users - visible only to admins, not to users

--- a/src/routes/[[lang]]/admin/+layout.svelte
+++ b/src/routes/[[lang]]/admin/+layout.svelte
@@ -42,7 +42,7 @@
 	// svelte-ignore state_referenced_locally
 	setContext('currentUserId', viewer?._id);
 
-	// Keyboard shortcuts for admin sidebar navigation (⌃⇧1-4, ⌘.)
+	// Keyboard shortcuts for admin sidebar navigation (⌃⇧1-5, ⌘.)
 	function handleKeydown(e: KeyboardEvent) {
 		const target = e.target as HTMLElement;
 		if (target.closest('input, textarea, [contenteditable]')) return;
@@ -55,7 +55,8 @@
 				Digit1: localizedHref('/admin/dashboard'),
 				Digit2: localizedHref('/admin/users'),
 				Digit3: localizedHref('/admin/support'),
-				Digit4: localizedHref('/admin/settings')
+				Digit4: localizedHref('/admin/settings'),
+				Digit5: localizedHref('/admin/audit-log')
 			};
 			url = shiftRoutes[e.code];
 		} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === '.') {

--- a/src/routes/[[lang]]/admin/audit-log/+page.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/+page.svelte
@@ -1,0 +1,249 @@
+<script lang="ts">
+	import SEOHead from '$lib/components/SEOHead.svelte';
+	import * as v from 'valibot';
+	import { clamp } from '$lib/utils/math';
+	import { getCoreRowModel } from '@tanstack/table-core';
+	import * as Table from '$lib/components/ui/table/index.js';
+	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
+	import { T, getTranslate } from '@tolgee/svelte';
+	import { useConvexClient } from 'convex-svelte';
+	import { api } from '$lib/convex/_generated/api.js';
+	import { createSvelteTable, FlexRender } from '$lib/components/ui/data-table/index.js';
+	import ConvexCursorTableShell from '$lib/components/tables/convex-cursor-table-shell.svelte';
+	import { createConvexCursorTable } from '$lib/tables/convex/create-convex-cursor-table.svelte';
+	import type { CursorListResult } from '$lib/tables/convex/contract';
+	import type { AuditLogItem } from '$lib/convex/admin/auditLog/queries';
+	import { browser } from '$app/environment';
+	import { createColumns } from './columns.js';
+	import DataTableFilters from './data-table-filters.svelte';
+	import type { PageData } from './$types';
+
+	const { t } = getTranslate();
+
+	let { data }: { data: PageData } = $props();
+
+	type AuditLogAction = AuditLogItem['action'];
+
+	const client = useConvexClient();
+
+	const columns = $derived(createColumns(data.lang ?? 'en'));
+
+	const PAGE_SIZE_OPTIONS = ['1', '10', '20', '30', '40', '50'] as const;
+	const PAGE_SIZE_NUM_OPTIONS = [1, 10, 20, 30, 40, 50] as const;
+
+	const auditLogTableParamsSchema = v.object({
+		search: v.optional(v.fallback(v.string(), ''), ''),
+		action: v.optional(
+			v.fallback(
+				v.picklist([
+					'all',
+					'impersonate',
+					'stop_impersonation',
+					'ban_user',
+					'unban_user',
+					'revoke_sessions',
+					'set_role'
+				]),
+				'all'
+			),
+			'all'
+		),
+		sort: v.optional(v.fallback(v.string(), ''), ''),
+		page: v.optional(v.fallback(v.string(), '1'), '1'),
+		page_size: v.optional(v.fallback(v.picklist(PAGE_SIZE_OPTIONS), '20'), '20'),
+		cursor: v.optional(v.fallback(v.string(), ''), '')
+	});
+
+	const auditTable = createConvexCursorTable<
+		AuditLogItem,
+		'action',
+		never,
+		typeof api.admin.auditLog.queries.listAuditLogs,
+		typeof api.admin.auditLog.queries.getAuditLogCount,
+		v.InferOutput<typeof auditLogTableParamsSchema>
+	>({
+		listQuery: api.admin.auditLog.queries.listAuditLogs,
+		countQuery: api.admin.auditLog.queries.getAuditLogCount,
+		urlSchema: auditLogTableParamsSchema,
+		defaultFilters: { action: 'all' },
+		pageSizeOptions: PAGE_SIZE_OPTIONS,
+		defaultPageSize: '20',
+		sortFields: [],
+		buildListArgs: ({ cursor, pageSize, filters }) => ({
+			cursor: cursor ?? undefined,
+			numItems: pageSize,
+			actionFilter: filters.action === 'all' ? undefined : (filters.action as AuditLogAction)
+		}),
+		buildCountArgs: ({ filters }) => ({
+			actionFilter: filters.action === 'all' ? undefined : (filters.action as AuditLogAction)
+		}),
+		resolveLastPage: async ({ pageSize, filters }) => {
+			const result = await client.query(api.admin.auditLog.queries.resolveAuditLogLastPage, {
+				numItems: pageSize,
+				actionFilter: filters.action === 'all' ? undefined : (filters.action as AuditLogAction)
+			});
+			return { page: result.page, cursor: result.cursor };
+		},
+		toListResult: (result) => result as CursorListResult<AuditLogItem>,
+		toCount: (result) => result
+	});
+
+	const pageIndex = $derived(auditTable.pageIndex);
+	const pageSize = $derived(auditTable.pageSize);
+	const isLoading = $derived(auditTable.isLoading);
+	const loadError = $derived(auditTable.error);
+	const actionFilter = $derived.by(() =>
+		auditTable.filters.action === 'all' ? undefined : (auditTable.filters.action as AuditLogAction)
+	);
+
+	const skeletonCount = $derived.by(() => {
+		if (auditTable.hasLoadedCount) {
+			const remaining = auditTable.totalCount - pageIndex * pageSize;
+			return clamp(remaining, 0, pageSize);
+		}
+		return pageSize;
+	});
+
+	function handleFilterChange(action: AuditLogAction | undefined) {
+		auditTable.setFilter('action', action ?? 'all');
+	}
+
+	const table = createSvelteTable({
+		get data() {
+			return auditTable.rows;
+		},
+		get columns() {
+			return columns;
+		},
+		state: {
+			get pagination() {
+				return { pageIndex, pageSize };
+			}
+		},
+		manualPagination: true,
+		manualFiltering: true,
+		manualSorting: true,
+		get pageCount() {
+			return auditTable.pageCount;
+		},
+		getRowId: (row) => row.id,
+		getCoreRowModel: getCoreRowModel()
+	});
+</script>
+
+<SEOHead
+	title={$t('meta.admin.audit_log.title')}
+	description={$t('meta.admin.audit_log.description')}
+	noindex
+/>
+
+<div class="flex flex-col gap-6 px-4 lg:px-6 xl:px-8 2xl:px-16" data-testid="admin-audit-log-page">
+	<div class="flex items-center justify-between">
+		<h1 class="text-2xl font-bold"><T keyName="admin.audit_log.title" /></h1>
+	</div>
+
+	{#if browser}<ConvexCursorTableShell
+			testIdPrefix="admin-audit-log"
+			tableTestId="admin-audit-log-table"
+			showSearch={false}
+			searchValue=""
+			searchPlaceholder=""
+			onSearchChange={() => {}}
+			pageIndex={auditTable.pageIndex}
+			pageCount={auditTable.pageCount}
+			pageSize={auditTable.pageSize}
+			pageSizeOptions={PAGE_SIZE_NUM_OPTIONS}
+			canPreviousPage={auditTable.canPreviousPage}
+			canNextPage={auditTable.canNextPage}
+			onFirstPage={auditTable.goFirst}
+			onPreviousPage={auditTable.goPrevious}
+			onNextPage={auditTable.goNext}
+			onLastPage={auditTable.goLast}
+			onPageSizeChange={auditTable.setPageSize}
+		>
+			{#snippet toolbarFilters()}
+				<DataTableFilters {actionFilter} onFilterChange={handleFilterChange} />
+			{/snippet}
+
+			{#snippet tableContent()}
+				<Table.Root class="table-fixed">
+					<Table.Header class="sticky top-0 z-10 bg-muted dark:bg-background">
+						{#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
+							<Table.Row class="hover:[&>th]:bg-muted dark:hover:[&>th]:bg-background">
+								{#each headerGroup.headers as header (header.id)}
+									<Table.Head
+										style="width: {header.getSize()}px; min-width: {header.column.columnDef
+											.minSize}px;"
+									>
+										{#if !header.isPlaceholder}
+											<FlexRender
+												content={header.column.columnDef.header}
+												context={header.getContext()}
+											/>
+										{/if}
+									</Table.Head>
+								{/each}
+							</Table.Row>
+						{/each}
+					</Table.Header>
+					<Table.Body>
+						{#if isLoading && skeletonCount > 0}
+							<Table.Row data-testid="admin-audit-log-loading" class="hidden">
+								<Table.Cell colspan={columns.length}>
+									<T keyName="admin.audit_log.loading" />
+								</Table.Cell>
+							</Table.Row>
+							{#each Array(skeletonCount) as _, i (i)}
+								<Table.Row>
+									<Table.Cell><Skeleton class="h-4 w-32" /></Table.Cell>
+									<Table.Cell><Skeleton class="h-5 w-20 rounded-md" /></Table.Cell>
+									<Table.Cell>
+										<Skeleton class="h-4 w-24" />
+										<Skeleton class="mt-1 h-3 w-32" />
+									</Table.Cell>
+									<Table.Cell>
+										<Skeleton class="h-4 w-24" />
+										<Skeleton class="mt-1 h-3 w-32" />
+									</Table.Cell>
+									<Table.Cell><Skeleton class="h-4 w-40" /></Table.Cell>
+								</Table.Row>
+							{/each}
+						{:else if loadError}
+							<Table.Row class="hover:!bg-transparent">
+								<Table.Cell
+									colspan={columns.length}
+									class="h-24 text-center text-destructive"
+									data-testid="admin-audit-log-error"
+								>
+									<T keyName="common.load_error" />
+								</Table.Cell>
+							</Table.Row>
+						{:else if table.getRowModel().rows.length === 0 || (isLoading && skeletonCount === 0)}
+							<Table.Row class="hover:!bg-transparent">
+								<Table.Cell
+									colspan={columns.length}
+									class="h-24 text-center text-muted-foreground"
+									data-testid="admin-audit-log-empty"
+								>
+									<T keyName="admin.audit_log.empty" />
+								</Table.Cell>
+							</Table.Row>
+						{:else}
+							{#each table.getRowModel().rows as row (row.id)}
+								<Table.Row data-testid="audit-log-row">
+									{#each row.getVisibleCells() as cell (cell.id)}
+										<Table.Cell class="align-top">
+											<FlexRender
+												content={cell.column.columnDef.cell}
+												context={cell.getContext()}
+											/>
+										</Table.Cell>
+									{/each}
+								</Table.Row>
+							{/each}
+						{/if}
+					</Table.Body>
+				</Table.Root>
+			{/snippet}
+		</ConvexCursorTableShell>{/if}
+</div>

--- a/src/routes/[[lang]]/admin/audit-log/action-badge.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/action-badge.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { T } from '@tolgee/svelte';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import type { AuditLogItem } from '$lib/convex/admin/auditLog/queries';
+
+	type AuditLogAction = AuditLogItem['action'];
+
+	interface Props {
+		action: AuditLogAction;
+		testId?: string;
+	}
+
+	let { action, testId }: Props = $props();
+
+	// Subtle per-action tints in the app's badge idiom, mirroring the Badge
+	// `destructive` variant (/10 fill in light, /20 in dark, colored text). The
+	// semantic color still helps scanning the log. stop_impersonation keeps the
+	// plain `secondary` variant, which is already subtle.
+	const TINTS: Record<AuditLogAction, string> = {
+		ban_user: 'bg-destructive/10 text-destructive dark:bg-destructive/20',
+		unban_user: 'bg-success/10 text-success dark:bg-success/20',
+		revoke_sessions: 'bg-warning/10 text-warning dark:bg-warning/20',
+		impersonate: 'bg-info/10 text-info dark:bg-info/20',
+		set_role: 'bg-primary/10 text-primary dark:bg-primary/20',
+		stop_impersonation: ''
+	};
+
+	const tint = $derived(TINTS[action]);
+</script>
+
+<Badge variant="secondary" class={tint} data-testid={testId}>
+	<T keyName={`admin.audit_log.action.${action}`} />
+</Badge>

--- a/src/routes/[[lang]]/admin/audit-log/columns.ts
+++ b/src/routes/[[lang]]/admin/audit-log/columns.ts
@@ -1,0 +1,94 @@
+import type { ColumnDef } from '@tanstack/table-core';
+import { createRawSnippet } from 'svelte';
+import { renderComponent, renderSnippet } from '$lib/components/ui/data-table/index.js';
+import DataTableColumnHeader from '$lib/components/admin/data-table-column-header.svelte';
+import type { AuditLogItem } from '$lib/convex/admin/auditLog/queries';
+import { DEFAULT_LANGUAGE } from '$lib/i18n/languages';
+import ActionBadge from './action-badge.svelte';
+import UserRefCell from './user-ref-cell.svelte';
+import DetailsCell from './details-cell.svelte';
+
+export function createColumns(lang: string): Array<ColumnDef<AuditLogItem>> {
+	return [
+		{
+			accessorKey: 'timestamp',
+			size: 170,
+			minSize: 150,
+			enableSorting: false,
+			header: () =>
+				renderComponent(DataTableColumnHeader, {
+					titleKey: 'admin.audit_log.column.time'
+				}),
+			cell: ({ row }) => {
+				const timeSnippet = createRawSnippet<[{ timestamp: number }]>((getData) => {
+					const { timestamp } = getData();
+					const formatted = new Date(timestamp).toLocaleString(lang || DEFAULT_LANGUAGE);
+					return {
+						render: () => `<div class="whitespace-nowrap text-sm">${formatted}</div>`
+					};
+				});
+				return renderSnippet(timeSnippet, { timestamp: row.original.timestamp });
+			}
+		},
+		{
+			accessorKey: 'action',
+			size: 150,
+			minSize: 130,
+			enableSorting: false,
+			header: () =>
+				renderComponent(DataTableColumnHeader, {
+					titleKey: 'admin.audit_log.column.action'
+				}),
+			cell: ({ row }) =>
+				renderComponent(ActionBadge, {
+					action: row.original.action,
+					testId: 'audit-log-action-badge'
+				})
+		},
+		{
+			id: 'admin',
+			size: 220,
+			minSize: 180,
+			enableSorting: false,
+			header: () =>
+				renderComponent(DataTableColumnHeader, {
+					titleKey: 'admin.audit_log.column.admin'
+				}),
+			cell: ({ row }) =>
+				renderComponent(UserRefCell, {
+					user: row.original.admin,
+					testId: 'audit-log-admin-cell'
+				})
+		},
+		{
+			id: 'target',
+			size: 220,
+			minSize: 180,
+			enableSorting: false,
+			header: () =>
+				renderComponent(DataTableColumnHeader, {
+					titleKey: 'admin.audit_log.column.target'
+				}),
+			cell: ({ row }) =>
+				renderComponent(UserRefCell, {
+					user: row.original.target,
+					testId: 'audit-log-target-cell'
+				})
+		},
+		{
+			id: 'details',
+			size: 260,
+			minSize: 200,
+			enableSorting: false,
+			header: () =>
+				renderComponent(DataTableColumnHeader, {
+					titleKey: 'admin.audit_log.column.details'
+				}),
+			cell: ({ row }) =>
+				renderComponent(DetailsCell, {
+					metadata: row.original.metadata,
+					testId: 'audit-log-details-cell'
+				})
+		}
+	];
+}

--- a/src/routes/[[lang]]/admin/audit-log/data-table-filters.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/data-table-filters.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import * as Select from '$lib/components/ui/select/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import XIcon from '@lucide/svelte/icons/x';
+	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { T, getTranslate } from '@tolgee/svelte';
+	import type { AuditLogItem } from '$lib/convex/admin/auditLog/queries';
+
+	const { t } = getTranslate();
+
+	type AuditLogAction = AuditLogItem['action'];
+
+	type Props = {
+		actionFilter: AuditLogAction | undefined;
+		onFilterChange: (action: AuditLogAction | undefined) => void;
+	};
+
+	let { actionFilter, onFilterChange }: Props = $props();
+
+	const ACTIONS: AuditLogAction[] = [
+		'impersonate',
+		'stop_impersonation',
+		'ban_user',
+		'unban_user',
+		'revoke_sessions',
+		'set_role'
+	];
+
+	const actionValue = $derived(actionFilter ?? 'all');
+	const hasActiveFilter = $derived(actionFilter !== undefined);
+
+	function handleActionChange(value: string) {
+		haptic.trigger('light');
+		onFilterChange(value === 'all' ? undefined : (value as AuditLogAction));
+	}
+
+	function clearFilter() {
+		onFilterChange(undefined);
+	}
+
+	const options = $derived([
+		{ value: 'all', label: $t('admin.audit_log.filter.all_actions') },
+		...ACTIONS.map((action) => ({
+			value: action,
+			label: $t(`admin.audit_log.action.${action}`)
+		}))
+	]);
+</script>
+
+<div class="flex items-center gap-2">
+	<Select.Root type="single" value={actionValue} onValueChange={handleActionChange}>
+		<Select.Trigger class="h-8 w-[180px]" data-testid="admin-audit-log-action-filter">
+			{options.find((opt) => opt.value === actionValue)?.label ??
+				$t('admin.audit_log.filter.all_actions')}
+		</Select.Trigger>
+		<Select.Content>
+			{#each options as option (option.value)}
+				<Select.Item
+					value={option.value}
+					data-testid={`admin-audit-log-action-filter-${option.value}`}
+				>
+					{option.label}
+				</Select.Item>
+			{/each}
+		</Select.Content>
+	</Select.Root>
+
+	{#if hasActiveFilter}
+		<Button
+			variant="ghost"
+			size="sm"
+			class="h-8 px-2"
+			onclick={clearFilter}
+			data-testid="admin-audit-log-filter-clear"
+		>
+			<XIcon class="mr-1 size-4" />
+			<T keyName="admin.audit_log.filter.clear" />
+		</Button>
+	{/if}
+</div>

--- a/src/routes/[[lang]]/admin/audit-log/details-cell.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/details-cell.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { T } from '@tolgee/svelte';
+	import type { AuditLogItem } from '$lib/convex/admin/auditLog/queries';
+
+	interface Props {
+		metadata: AuditLogItem['metadata'];
+		testId?: string;
+	}
+
+	let { metadata, testId }: Props = $props();
+
+	const reason = $derived(metadata && 'reason' in metadata ? metadata.reason : undefined);
+	const roleChange = $derived(
+		metadata && 'newRole' in metadata
+			? { previousRole: metadata.previousRole, newRole: metadata.newRole }
+			: undefined
+	);
+</script>
+
+<div class="min-w-0 text-sm" data-testid={testId}>
+	{#if reason}
+		<span class="text-muted-foreground">{reason}</span>
+	{:else if roleChange}
+		<span class="text-muted-foreground">
+			<T
+				keyName="admin.audit_log.details.role_change"
+				params={{ previousRole: roleChange.previousRole, newRole: roleChange.newRole }}
+			/>
+		</span>
+	{:else}
+		<span class="text-muted-foreground/50">-</span>
+	{/if}
+</div>

--- a/src/routes/[[lang]]/admin/audit-log/user-ref-cell.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/user-ref-cell.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { T } from '@tolgee/svelte';
+	import type { AuditLogItem } from '$lib/convex/admin/auditLog/queries';
+
+	interface Props {
+		user: AuditLogItem['admin'];
+		testId?: string;
+	}
+
+	let { user, testId }: Props = $props();
+</script>
+
+{#if user.exists}
+	<div class="min-w-0" data-testid={testId}>
+		<div class="truncate font-medium">{user.name ?? user.email ?? user.id}</div>
+		{#if user.name && user.email}
+			<div class="truncate text-xs text-muted-foreground">{user.email}</div>
+		{/if}
+	</div>
+{:else}
+	<div class="min-w-0" data-testid={testId}>
+		<div class="truncate font-mono text-xs text-muted-foreground">{user.id}</div>
+		<div class="text-xs text-muted-foreground italic">
+			<T keyName="admin.audit_log.deleted_user" />
+		</div>
+	</div>
+{/if}


### PR DESCRIPTION
Closes #653

Since the admin audit trail became server-issued and atomic, the `adminAuditLogs` table has been write-only: every ban, unban, session revocation, role change, and impersonation start/end is recorded, but the only way to read the trail was the Convex dashboard. This adds a reader so admins can review it in-app.

The new /admin/audit-log page uses the project table kit (`createConvexCursorTable` + `ConvexCursorTableShell`) backed by three `adminQuery`s over the log: `listAuditLogs` (cursor-paginated, newest first), `getAuditLogCount` (capped at 5001 to avoid an unbounded scan), and `resolveAuditLogLastPage` for the jump-to-last control, matching the users and notification-recipients tables. Each row resolves the admin and target through the Better Auth adapter, so a deleted user still shows its id with a localized hint instead of a blank. An action-type filter writes the canonical `action` URL param and selects the most specific index (a new `by_action` index alongside the existing `by_admin`, `by_target`, and `by_timestamp`). The page ships a sidebar entry with a ctrl+shift+5 shortcut, English/German/Spanish/French copy, and an e2e spec that drives a real ban and unban through the users UI, then asserts the log records them and the filter narrows correctly.

Verified end to end against the local stack: `bun run check:convex`, `bun run test:unit` (751 tests), and `bun run test:e2e --grep audit` pass; static-checks pass on every changed file. Visual QA confirmed layout, badges, pagination, and sidebar are consistent with /admin/users in light and dark, the table scrolls inside its own container at 375px without the body scrolling, and the German locale renders with no raw keys.

Regression guard: added e2e/admin-audit-log.spec.ts, which exercises the write-to-read audit flow and the action filter.

Note: the new i18n keys are committed to the locale JSON files but not yet pushed to Tolgee (the self-hosted instance is currently unreachable); I will push them once it is back.