### PR TITLE
feat(admin): Bring audit log table to parity with users table

### DIFF
--- a/e2e/admin-audit-log.spec.ts
+++ b/e2e/admin-audit-log.spec.ts
@@ -189,5 +189,37 @@ test.describe('Admin Audit Log', () => {
 		await expect(page.getByTestId('admin-audit-log-filter-clear')).toHaveCount(0);
 		await expect.poll(() => new URL(page.url()).searchParams.get('action')).toBeNull();
 		await expect(page.getByTestId('audit-log-row').first()).toBeVisible({ timeout: 10000 });
+
+		// The footer reports the unfiltered entry count (at least the ban + unban
+		// pair created above).
+		await expect(page.getByTestId('admin-audit-log-selection-text')).toHaveText(
+			/[1-9]\d*\s+entries/,
+			{ timeout: 10000 }
+		);
+
+		// The Time column header sorts. The default view is newest-first, so flipping
+		// to ascending (oldest-first) must change which entry leads the table.
+		const newestAction = (
+			await page.getByTestId('audit-log-action-badge').first().textContent()
+		)?.trim();
+
+		await page.getByTestId('admin-audit-log-sort-time').click();
+		await expect
+			.poll(() => new URL(page.url()).searchParams.get('sort'))
+			.toMatch(/^timestamp\.(asc|desc)$/);
+		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+
+		// A first toggle can land on desc (same visual order); click once more for asc.
+		if (new URL(page.url()).searchParams.get('sort') !== 'timestamp.asc') {
+			await page.getByTestId('admin-audit-log-sort-time').click();
+			await expect.poll(() => new URL(page.url()).searchParams.get('sort')).toBe('timestamp.asc');
+			await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+		}
+
+		await expect(page.getByTestId('audit-log-row').first()).toBeVisible({ timeout: 10000 });
+		const oldestAction = (
+			await page.getByTestId('audit-log-action-badge').first().textContent()
+		)?.trim();
+		expect(oldestAction).not.toBe(newestAction);
 	});
 });

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -36,7 +36,8 @@
 				"clear": "Zurücksetzen"
 			},
 			"loading": "Audit-Log wird geladen …",
-			"title": "Audit-Log"
+			"title": "Audit-Log",
+			"total_entries": "{count} Einträge"
 		},
 		"dashboard": {
 			"database_backend": "Datenbank & Backend",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -36,7 +36,8 @@
 				"clear": "Clear"
 			},
 			"loading": "Loading audit log…",
-			"title": "Audit Log"
+			"title": "Audit Log",
+			"total_entries": "{count} entries"
 		},
 		"dashboard": {
 			"database_backend": "Database & backend",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -36,7 +36,8 @@
 				"clear": "Limpiar"
 			},
 			"loading": "Cargando registro de auditoría…",
-			"title": "Registro de auditoría"
+			"title": "Registro de auditoría",
+			"total_entries": "{count} entradas"
 		},
 		"dashboard": {
 			"database_backend": "Base de datos y backend",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -36,7 +36,8 @@
 				"clear": "Effacer"
 			},
 			"loading": "Chargement du journal d'audit…",
-			"title": "Journal d'audit"
+			"title": "Journal d'audit",
+			"total_entries": "{count} entrées"
 		},
 		"dashboard": {
 			"database_backend": "Base de données & backend",

--- a/src/lib/components/tables/convex-cursor-table-shell.svelte
+++ b/src/lib/components/tables/convex-cursor-table-shell.svelte
@@ -35,6 +35,7 @@
 		showSearch?: boolean;
 		tableTestId?: string;
 		searchTestId?: string;
+		selectionTextTestId?: string;
 		pageIndicatorTestId?: string;
 		paginationPrevTestId?: string;
 		paginationNextTestId?: string;
@@ -66,6 +67,7 @@
 		showSearch = true,
 		tableTestId = `${testIdPrefix}-table`,
 		searchTestId = `${testIdPrefix}-search`,
+		selectionTextTestId = `${testIdPrefix}-selection-text`,
 		pageIndicatorTestId = `${testIdPrefix}-page-indicator`,
 		paginationPrevTestId = `${testIdPrefix}-pagination-prev`,
 		paginationNextTestId = `${testIdPrefix}-pagination-next`,
@@ -106,7 +108,10 @@
 	</div>
 
 	<div class="flex items-center justify-between px-2">
-		<div class="hidden flex-1 text-sm text-muted-foreground lg:flex">
+		<div
+			class="hidden flex-1 text-sm text-muted-foreground lg:flex"
+			data-testid={selectionTextTestId}
+		>
 			{selectionText}
 		</div>
 

--- a/src/lib/convex/admin/auditLog/queries.ts
+++ b/src/lib/convex/admin/auditLog/queries.ts
@@ -74,40 +74,56 @@ type AuditLogFilters = {
 };
 
 /**
+ * Sort configuration for the audit log table. Only the timestamp column is
+ * sortable; the UI flips between newest-first and oldest-first. Direction
+ * defaults to 'desc' (newest first) when the arg is omitted.
+ */
+export const auditLogSortByValidator = v.object({
+	field: v.literal('timestamp'),
+	direction: v.union(v.literal('asc'), v.literal('desc'))
+});
+
+type AuditLogDirection = 'asc' | 'desc';
+
+/**
  * Pick the single most selective index for the given filter and return the
- * newest-first ordered query.
+ * query ordered by `direction` (defaults to newest-first).
  *
  * Filters are treated as mutually exclusive: the UI sends at most one of
  * actionFilter, adminUserId, or targetUserId, so we choose exactly one index
  * and do NOT apply the remaining filters as extra conditions (v1). Priority if
  * several are somehow set: action -> admin -> target -> unfiltered
  * (by_timestamp). For the single-value index branches, ordering by the index
- * resolves to `_creationTime desc` within the pinned value, which matches the
+ * resolves to `_creationTime` within the pinned value, which matches the
  * `timestamp` insertion order used by the writers in admin/mutations.ts.
  */
-function queryAuditLogs(ctx: QueryCtx, filters: AuditLogFilters) {
+function queryAuditLogs(
+	ctx: QueryCtx,
+	filters: AuditLogFilters,
+	direction: AuditLogDirection = 'desc'
+) {
 	if (filters.actionFilter !== undefined) {
 		const action = filters.actionFilter;
 		return ctx.db
 			.query('adminAuditLogs')
 			.withIndex('by_action', (q) => q.eq('action', action))
-			.order('desc');
+			.order(direction);
 	}
 	if (filters.adminUserId !== undefined) {
 		const adminUserId = filters.adminUserId;
 		return ctx.db
 			.query('adminAuditLogs')
 			.withIndex('by_admin', (q) => q.eq('adminUserId', adminUserId))
-			.order('desc');
+			.order(direction);
 	}
 	if (filters.targetUserId !== undefined) {
 		const targetUserId = filters.targetUserId;
 		return ctx.db
 			.query('adminAuditLogs')
 			.withIndex('by_target', (q) => q.eq('targetUserId', targetUserId))
-			.order('desc');
+			.order(direction);
 	}
-	return ctx.db.query('adminAuditLogs').withIndex('by_timestamp').order('desc');
+	return ctx.db.query('adminAuditLogs').withIndex('by_timestamp').order(direction);
 }
 
 /**
@@ -156,6 +172,7 @@ export const listAuditLogs = adminQuery({
 	args: {
 		cursor: v.optional(v.string()),
 		numItems: v.number(),
+		sortBy: v.optional(auditLogSortByValidator),
 		...auditLogFilterArgs
 	},
 	returns: v.object({
@@ -164,7 +181,8 @@ export const listAuditLogs = adminQuery({
 		isDone: v.boolean()
 	}),
 	handler: async (ctx, args) => {
-		const result = await queryAuditLogs(ctx, args).paginate({
+		const direction = args.sortBy?.direction ?? 'desc';
+		const result = await queryAuditLogs(ctx, args, direction).paginate({
 			numItems: args.numItems,
 			cursor: args.cursor ?? null
 		});
@@ -228,6 +246,7 @@ export const getAuditLogCount = adminQuery({
 export const resolveAuditLogLastPage = adminQuery({
 	args: {
 		numItems: v.number(),
+		sortBy: v.optional(auditLogSortByValidator),
 		...auditLogFilterArgs
 	},
 	returns: v.object({
@@ -235,6 +254,7 @@ export const resolveAuditLogLastPage = adminQuery({
 		cursor: v.union(v.string(), v.null())
 	}),
 	handler: async (ctx, args): Promise<{ page: number; cursor: string | null }> => {
+		const direction = args.sortBy?.direction ?? 'desc';
 		const pageSize = Number.isFinite(args.numItems) && args.numItems > 0 ? args.numItems : 10;
 		const maxPages = Math.ceil(5001 / pageSize);
 
@@ -246,7 +266,10 @@ export const resolveAuditLogLastPage = adminQuery({
 		let found = false;
 
 		for (let step = 0; step < maxPages; step++) {
-			const result = await queryAuditLogs(ctx, args).paginate({ numItems: pageSize, cursor });
+			const result = await queryAuditLogs(ctx, args, direction).paginate({
+				numItems: pageSize,
+				cursor
+			});
 
 			if (result.page.length > 0) {
 				lastNonEmptyIndex = index;

--- a/src/lib/hooks/admin-cache.svelte.ts
+++ b/src/lib/hooks/admin-cache.svelte.ts
@@ -2,6 +2,7 @@ import { PersistedState } from 'runed';
 
 export const adminCache = {
 	userCount: new PersistedState<number | null>('admin-cache:userCount', null),
+	auditLogCount: new PersistedState<number | null>('admin-cache:auditLogCount', null),
 	recipientCount: new PersistedState<number | null>('admin-cache:recipientCount', null),
 	supportThreadCounts: new PersistedState<Record<string, number>>(
 		'admin-cache:supportThreadCounts',

--- a/src/routes/[[lang]]/admin/audit-log/+page.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/+page.svelte
@@ -2,11 +2,12 @@
 	import SEOHead from '$lib/components/SEOHead.svelte';
 	import * as v from 'valibot';
 	import { clamp } from '$lib/utils/math';
-	import { getCoreRowModel } from '@tanstack/table-core';
+	import { type SortingState, getCoreRowModel } from '@tanstack/table-core';
 	import * as Table from '$lib/components/ui/table/index.js';
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { useConvexClient } from 'convex-svelte';
+	import { adminCache } from '$lib/hooks/admin-cache.svelte';
 	import { api } from '$lib/convex/_generated/api.js';
 	import { createSvelteTable, FlexRender } from '$lib/components/ui/data-table/index.js';
 	import ConvexCursorTableShell from '$lib/components/tables/convex-cursor-table-shell.svelte';
@@ -57,7 +58,7 @@
 	const auditTable = createConvexCursorTable<
 		AuditLogItem,
 		'action',
-		never,
+		'timestamp',
 		typeof api.admin.auditLog.queries.listAuditLogs,
 		typeof api.admin.auditLog.queries.getAuditLogCount,
 		v.InferOutput<typeof auditLogTableParamsSchema>
@@ -68,19 +69,22 @@
 		defaultFilters: { action: 'all' },
 		pageSizeOptions: PAGE_SIZE_OPTIONS,
 		defaultPageSize: '20',
-		sortFields: [],
-		buildListArgs: ({ cursor, pageSize, filters }) => ({
+		sortFields: ['timestamp'],
+		buildListArgs: ({ cursor, pageSize, filters, sortBy }) => ({
 			cursor: cursor ?? undefined,
 			numItems: pageSize,
-			actionFilter: filters.action === 'all' ? undefined : (filters.action as AuditLogAction)
+			actionFilter: filters.action === 'all' ? undefined : (filters.action as AuditLogAction),
+			sortBy: sortBy ? { field: 'timestamp', direction: sortBy.direction } : undefined
 		}),
+		// Count is order-independent, so the sort direction is intentionally omitted.
 		buildCountArgs: ({ filters }) => ({
 			actionFilter: filters.action === 'all' ? undefined : (filters.action as AuditLogAction)
 		}),
-		resolveLastPage: async ({ pageSize, filters }) => {
+		resolveLastPage: async ({ pageSize, filters, sortBy }) => {
 			const result = await client.query(api.admin.auditLog.queries.resolveAuditLogLastPage, {
 				numItems: pageSize,
-				actionFilter: filters.action === 'all' ? undefined : (filters.action as AuditLogAction)
+				actionFilter: filters.action === 'all' ? undefined : (filters.action as AuditLogAction),
+				sortBy: sortBy ? { field: 'timestamp', direction: sortBy.direction } : undefined
 			});
 			return { page: result.page, cursor: result.cursor };
 		},
@@ -95,13 +99,36 @@
 	const actionFilter = $derived.by(() =>
 		auditTable.filters.action === 'all' ? undefined : (auditTable.filters.action as AuditLogAction)
 	);
+	const sorting = $derived.by<SortingState>(() => {
+		const sortBy = auditTable.sortBy;
+		if (!sortBy) return [];
+		return [{ id: 'timestamp', desc: sortBy.direction === 'desc' }];
+	});
 
+	// Total entry count for the footer: prefer the freshly loaded count, falling
+	// back to the persisted cache so it shows immediately on first paint. Renders
+	// "5000+" at the getAuditLogCount 5001-row cap.
+	const totalEntries = $derived(
+		auditTable.hasLoadedCount ? auditTable.totalCount : (adminCache.auditLogCount.current ?? 0)
+	);
+	const totalEntriesLabel = $derived(totalEntries >= 5001 ? '5000+' : `${totalEntries}`);
+
+	// Skeleton prediction: use the cached count so first paint renders only as
+	// many skeleton rows as the current page will actually hold (falls back to a
+	// full page when nothing is cached yet).
 	const skeletonCount = $derived.by(() => {
-		if (auditTable.hasLoadedCount) {
-			const remaining = auditTable.totalCount - pageIndex * pageSize;
+		if (adminCache.auditLogCount.current !== null) {
+			const remaining = adminCache.auditLogCount.current - pageIndex * pageSize;
 			return clamp(remaining, 0, pageSize);
 		}
 		return pageSize;
+	});
+
+	// Persist the audit log count once it loads so later visits predict skeletons.
+	$effect(() => {
+		if (auditTable.hasLoadedCount) {
+			adminCache.auditLogCount.current = auditTable.totalCount;
+		}
 	});
 
 	function handleFilterChange(action: AuditLogAction | undefined) {
@@ -118,6 +145,9 @@
 		state: {
 			get pagination() {
 				return { pageIndex, pageSize };
+			},
+			get sorting() {
+				return sorting;
 			}
 		},
 		manualPagination: true,
@@ -127,7 +157,23 @@
 			return auditTable.pageCount;
 		},
 		getRowId: (row) => row.id,
-		getCoreRowModel: getCoreRowModel()
+		getCoreRowModel: getCoreRowModel(),
+		onSortingChange: (updater) => {
+			const nextSorting = typeof updater === 'function' ? updater(sorting) : updater;
+			if (nextSorting.length === 0) {
+				auditTable.setSort(undefined);
+				return;
+			}
+			const primarySort = nextSorting[0]!;
+			if (primarySort.id !== 'timestamp') {
+				auditTable.setSort(undefined);
+				return;
+			}
+			auditTable.setSort({
+				field: 'timestamp',
+				direction: primarySort.desc ? 'desc' : 'asc'
+			});
+		}
 	});
 </script>
 
@@ -160,6 +206,7 @@
 			onNextPage={auditTable.goNext}
 			onLastPage={auditTable.goLast}
 			onPageSizeChange={auditTable.setPageSize}
+			selectionText={$t('admin.audit_log.total_entries', { count: totalEntriesLabel })}
 		>
 			{#snippet toolbarFilters()}
 				<DataTableFilters {actionFilter} onFilterChange={handleFilterChange} />
@@ -195,17 +242,23 @@
 							</Table.Row>
 							{#each Array(skeletonCount) as _, i (i)}
 								<Table.Row>
-									<Table.Cell><Skeleton class="h-4 w-32" /></Table.Cell>
-									<Table.Cell><Skeleton class="h-5 w-20 rounded-md" /></Table.Cell>
-									<Table.Cell>
-										<Skeleton class="h-4 w-24" />
-										<Skeleton class="mt-1 h-3 w-32" />
+									<Table.Cell class="align-top">
+										<div class="flex h-5 items-center"><Skeleton class="h-4 w-32" /></div>
 									</Table.Cell>
-									<Table.Cell>
-										<Skeleton class="h-4 w-24" />
-										<Skeleton class="mt-1 h-3 w-32" />
+									<Table.Cell class="align-top">
+										<Skeleton class="h-5 w-20 rounded-4xl" />
 									</Table.Cell>
-									<Table.Cell><Skeleton class="h-4 w-40" /></Table.Cell>
+									<Table.Cell class="align-top">
+										<div class="flex h-5 items-center"><Skeleton class="h-4 w-24" /></div>
+										<div class="flex h-4 items-center"><Skeleton class="h-3 w-32" /></div>
+									</Table.Cell>
+									<Table.Cell class="align-top">
+										<div class="flex h-5 items-center"><Skeleton class="h-4 w-24" /></div>
+										<div class="flex h-4 items-center"><Skeleton class="h-3 w-32" /></div>
+									</Table.Cell>
+									<Table.Cell class="align-top">
+										<div class="flex h-5 items-center"><Skeleton class="h-4 w-40" /></div>
+									</Table.Cell>
 								</Table.Row>
 							{/each}
 						{:else if loadError}

--- a/src/routes/[[lang]]/admin/audit-log/columns.ts
+++ b/src/routes/[[lang]]/admin/audit-log/columns.ts
@@ -14,10 +14,12 @@ export function createColumns(lang: string): Array<ColumnDef<AuditLogItem>> {
 			accessorKey: 'timestamp',
 			size: 170,
 			minSize: 150,
-			enableSorting: false,
-			header: () =>
+			enableSorting: true,
+			header: ({ column }) =>
 				renderComponent(DataTableColumnHeader, {
-					titleKey: 'admin.audit_log.column.time'
+					column,
+					titleKey: 'admin.audit_log.column.time',
+					testId: 'admin-audit-log-sort-time'
 				}),
 			cell: ({ row }) => {
 				const timeSnippet = createRawSnippet<[{ timestamp: number }]>((getData) => {


### PR DESCRIPTION
Closes #653

The audit log shipped with a minimal table while the other admin tables have a richer, more consistent experience. This brings it up to the same cadence and fixes a loading-state regression, without adding features that are wrong for a read-only log.

Four changes. The entry count is now cached in local storage (a new `adminCache.auditLogCount`, mirroring `userCount`), so the loading skeleton predicts how many rows the current page will actually hold instead of always rendering a full page of placeholders on first paint. The skeleton rows no longer jump when data loads: they were missing `align-top` and reserved 4px-too-short line boxes with a spurious `mt-1`, so each row grew and single-line cells shifted up on load; the skeleton cells now reserve the real line-box heights (20px + 16px for the two-line admin/target cells) and align top, so a skeleton row and a real row are both 53px and line up exactly. The Time column is now sortable and toggles newest-first / oldest-first via a `direction` threaded through the backend queries over the existing timestamp index (the count query stays order-independent). The footer shows the total entry count.

Deliberately out of scope: row selection and bulk actions (no write path on a read-only log), the never-wired column-visibility state (not a real feature in any table), and name-based search/sort (expensive enrichment-then-filter). Filtering the log by a specific admin or target user is a self-contained follow-up tracked in #659 (the backend indexes already exist).

Verified against the local stack: `bun run check:convex`, `bun run test:unit` (762 tests), and `bun run test:e2e --grep audit` pass; static-checks pass on every changed file. Visual QA with network throttling confirmed the skeleton row measures 53px identical to the real row with top alignment, the cached count renders exactly 2 skeleton rows for 2 entries instead of 20, the Time header flips `sort=timestamp.desc`/`asc` and the row order with it, and the footer shows the entry count.

Regression guard: extended e2e/admin-audit-log.spec.ts with sort-toggle and total-count assertions.

Note: the one new i18n key (admin.audit_log.total_entries) is committed to the locale JSONs but not yet pushed to Tolgee (self-hosted instance is down); I'll push once it's back.