### PR TITLE
feat(admin): Add avatars to audit log user cells

### DIFF
--- a/src/lib/convex/admin/auditLog/queries.ts
+++ b/src/lib/convex/admin/auditLog/queries.ts
@@ -31,7 +31,7 @@ const auditLogMetadataValidator = v.optional(
 
 /**
  * A resolved user reference for an audit log row. The raw Better Auth id is
- * always present; name/email are filled only while the user still exists.
+ * always present; name/email/image are filled only while the user still exists.
  * `exists: false` means the user was deleted after the action was logged, but
  * the id stays available so the UI can still reference the original actor/target.
  */
@@ -39,6 +39,7 @@ const auditLogUserRefValidator = v.object({
 	id: v.string(),
 	name: v.optional(v.string()),
 	email: v.optional(v.string()),
+	image: v.optional(v.string()),
 	exists: v.boolean()
 });
 
@@ -127,23 +128,23 @@ function queryAuditLogs(
 }
 
 /**
- * Resolve a set of Better Auth user ids to { name, email }. Deleted users are
- * simply absent from the returned map. Lookups are bounded by page size: a page
- * holds at most `2 * numItems` unique ids (admin + target), each resolved with
- * a single point read, so this never scans the user table.
+ * Resolve a set of Better Auth user ids to { name, email, image }. Deleted
+ * users are simply absent from the returned map. Lookups are bounded by page
+ * size: a page holds at most `2 * numItems` unique ids (admin + target), each
+ * resolved with a single point read, so this never scans the user table.
  */
 async function resolveUsers(
 	ctx: QueryCtx,
 	ids: Set<string>
-): Promise<Map<string, { name?: string; email?: string }>> {
-	const resolved = new Map<string, { name?: string; email?: string }>();
+): Promise<Map<string, { name?: string; email?: string; image?: string }>> {
+	const resolved = new Map<string, { name?: string; email?: string; image?: string }>();
 	for (const id of ids) {
 		const user = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
 			model: 'user',
 			where: [{ field: '_id', operator: 'eq', value: id }]
 		})) as BetterAuthUser | null;
 		if (user) {
-			resolved.set(id, { name: user.name, email: user.email });
+			resolved.set(id, { name: user.name, email: user.email, image: user.image ?? undefined });
 		}
 	}
 	return resolved;
@@ -151,13 +152,13 @@ async function resolveUsers(
 
 function toUserRef(
 	id: string,
-	resolved: Map<string, { name?: string; email?: string }>
+	resolved: Map<string, { name?: string; email?: string; image?: string }>
 ): Infer<typeof auditLogUserRefValidator> {
 	const info = resolved.get(id);
 	if (!info) {
 		return { id, exists: false };
 	}
-	return { id, name: info.name, email: info.email, exists: true };
+	return { id, name: info.name, email: info.email, image: info.image, exists: true };
 }
 
 /**

--- a/src/routes/[[lang]]/admin/audit-log/+page.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/+page.svelte
@@ -242,21 +242,31 @@
 							</Table.Row>
 							{#each Array(skeletonCount) as _, i (i)}
 								<Table.Row>
-									<Table.Cell class="align-top">
+									<Table.Cell>
 										<div class="flex h-5 items-center"><Skeleton class="h-4 w-32" /></div>
 									</Table.Cell>
-									<Table.Cell class="align-top">
+									<Table.Cell>
 										<Skeleton class="h-5 w-20 rounded-4xl" />
 									</Table.Cell>
-									<Table.Cell class="align-top">
-										<div class="flex h-5 items-center"><Skeleton class="h-4 w-24" /></div>
-										<div class="flex h-4 items-center"><Skeleton class="h-3 w-32" /></div>
+									<Table.Cell>
+										<div class="flex items-center gap-2">
+											<Skeleton class="size-8 shrink-0 rounded-full" />
+											<div class="min-w-0">
+												<div class="flex h-5 items-center"><Skeleton class="h-4 w-24" /></div>
+												<div class="flex h-4 items-center"><Skeleton class="h-3 w-32" /></div>
+											</div>
+										</div>
 									</Table.Cell>
-									<Table.Cell class="align-top">
-										<div class="flex h-5 items-center"><Skeleton class="h-4 w-24" /></div>
-										<div class="flex h-4 items-center"><Skeleton class="h-3 w-32" /></div>
+									<Table.Cell>
+										<div class="flex items-center gap-2">
+											<Skeleton class="size-8 shrink-0 rounded-full" />
+											<div class="min-w-0">
+												<div class="flex h-5 items-center"><Skeleton class="h-4 w-24" /></div>
+												<div class="flex h-4 items-center"><Skeleton class="h-3 w-32" /></div>
+											</div>
+										</div>
 									</Table.Cell>
-									<Table.Cell class="align-top">
+									<Table.Cell>
 										<div class="flex h-5 items-center"><Skeleton class="h-4 w-40" /></div>
 									</Table.Cell>
 								</Table.Row>
@@ -285,7 +295,7 @@
 							{#each table.getRowModel().rows as row (row.id)}
 								<Table.Row data-testid="audit-log-row">
 									{#each row.getVisibleCells() as cell (cell.id)}
-										<Table.Cell class="align-top">
+										<Table.Cell>
 											<FlexRender
 												content={cell.column.columnDef.cell}
 												context={cell.getContext()}

--- a/src/routes/[[lang]]/admin/audit-log/user-ref-cell.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/user-ref-cell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { T } from '@tolgee/svelte';
+	import * as Avatar from '$lib/components/ui/avatar/index.js';
 	import type { AuditLogItem } from '$lib/convex/admin/auditLog/queries';
 
 	interface Props {
@@ -8,20 +9,32 @@
 	}
 
 	let { user, testId }: Props = $props();
+
+	// Same initials derivation as the users table avatar; '?' for deleted users.
+	const initials = $derived(
+		user.exists ? (user.name ?? user.email ?? 'U').slice(0, 2).toUpperCase() : '?'
+	);
 </script>
 
-{#if user.exists}
-	<div class="min-w-0" data-testid={testId}>
-		<div class="truncate font-medium">{user.name ?? user.email ?? user.id}</div>
-		{#if user.name && user.email}
-			<div class="truncate text-xs text-muted-foreground">{user.email}</div>
+<div class="flex min-w-0 items-center gap-2" data-testid={testId}>
+	<Avatar.Root class="size-8 shrink-0">
+		{#if user.exists && user.image}
+			<!-- Decorative: the name/email text next to it carries the accessible name -->
+			<Avatar.Image src={user.image} alt="" referrerpolicy="no-referrer" />
+		{/if}
+		<Avatar.Fallback class="text-xs">{initials}</Avatar.Fallback>
+	</Avatar.Root>
+	<div class="min-w-0">
+		{#if user.exists}
+			<div class="truncate font-medium">{user.name ?? user.email ?? user.id}</div>
+			{#if user.name && user.email}
+				<div class="truncate text-xs text-muted-foreground">{user.email}</div>
+			{/if}
+		{:else}
+			<div class="truncate font-mono text-xs text-muted-foreground">{user.id}</div>
+			<div class="text-xs text-muted-foreground italic">
+				<T keyName="admin.audit_log.deleted_user" />
+			</div>
 		{/if}
 	</div>
-{:else}
-	<div class="min-w-0" data-testid={testId}>
-		<div class="truncate font-mono text-xs text-muted-foreground">{user.id}</div>
-		<div class="text-xs text-muted-foreground italic">
-			<T keyName="admin.audit_log.deleted_user" />
-		</div>
-	</div>
-{/if}
+</div>


### PR DESCRIPTION
The audit log admin and target columns rendered plain text while the users table renders each person with a size-8 avatar. On top of that every audit log cell was pinned with align-top, so the single-line Time and Action cells sat at the top of a tall two-line row and the whole table read misaligned next to the rest of the admin panel.

The audit log user ref now carries an optional image, resolved from the same Better Auth user record as name and email, and the admin/target cells render the same avatar-plus-name layout as the users table (initials fallback, "?" for a deleted user). The forced align-top is gone, so rows center vertically again, and the loading skeleton mirrors the new layout with a matching avatar circle so it lines up pixel-for-pixel with a real row.

Verified against the local backend with real ban, unban, and set-role entries: real rows and skeleton rows both measure 53px with vertically centered cells and a 32px avatar, in light and dark mode. cd saas-starter && bun run test:e2e -- admin-audit-log passes (2 tests). Static checks pass.

Regression guard: not warranted, one-off visual parity change with no recurring bug class.