### PR TITLE
fix(files): make avatar delivery fast and cacheable

### DIFF
--- a/scripts/avatar-inline-route.test.ts
+++ b/scripts/avatar-inline-route.test.ts
@@ -1,0 +1,30 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Regression guard for slow, uncacheable avatar delivery.
+//
+// updateProfileImage must never hand out the files-control component's
+// /files/download URLs for avatars: that route forces `Cache-Control:
+// no-store` + `Content-Disposition: attachment` and proxy-streams the file
+// body through the httpAction (measured 4-16s for a 310KB avatar), so every
+// avatar render re-downloaded the file and lost the race against UI entrance
+// animations (support-widget greeting). Avatars go through the app's
+// /files/inline redirect route instead, which 302s to the browser-cacheable
+// storage URL.
+//
+// This guards the "two separate data sources must agree" class: the URL
+// storage.ts builds and the route http.ts registers.
+describe('avatar inline route agreement', () => {
+	const storageSrc = fs.readFileSync(path.resolve('src/lib/convex/storage.ts'), 'utf-8');
+	const httpSrc = fs.readFileSync(path.resolve('src/lib/convex/http.ts'), 'utf-8');
+
+	it('storage.ts builds /files/inline URLs, not component download URLs', () => {
+		expect(storageSrc).toContain('/files/inline?token=');
+		expect(storageSrc).not.toContain('buildDownloadUrl');
+	});
+
+	it('http.ts registers the /files/inline route those URLs point at', () => {
+		expect(httpSrc).toContain("path: '/files/inline'");
+	});
+});

--- a/src/lib/convex/http.ts
+++ b/src/lib/convex/http.ts
@@ -19,6 +19,54 @@ registerFilesControlRoutes(http, components.convexFilesControl, {
 	enableUploadRoute: false
 });
 
+// Inline variant of the download route (/files/inline?token=...), used for
+// avatar images. The component's /files/download hardcodes
+// `Cache-Control: no-store` + `Content-Disposition: attachment` and proxy-
+// streams the file body through the httpAction (measured 4-16s for a 310KB
+// avatar), so every avatar render re-downloaded the file and lost the race
+// against UI entrance animations (support-widget greeting). This route
+// resolves the same download grant but 302-redirects to the underlying
+// storage URL: no body proxying, and the storage response itself is
+// browser-cacheable (private, max-age=30d). The redirect is cacheable for a
+// day; a new avatar upload mints a new grant token (= a new URL), so redirect
+// staleness only matters for provider transfers, where the old blob keeps
+// serving until deleted.
+http.route({
+	path: '/files/inline',
+	method: 'GET',
+	handler: httpAction(async (ctx, request) => {
+		const token = new URL(request.url).searchParams.get('token');
+		if (!token) {
+			return Response.json({ error: "Missing 'token' query parameter" }, { status: 400 });
+		}
+		const result = await ctx.runMutation(
+			components.convexFilesControl.download.consumeDownloadGrantForUrl,
+			{ downloadToken: token }
+		);
+		if (result.status !== 'ok' || !result.downloadUrl) {
+			// Status mapping mirrors the component's own download route.
+			const status =
+				result.status === 'expired' ||
+				result.status === 'exhausted' ||
+				result.status === 'file_expired'
+					? 410
+					: result.status === 'password_required'
+						? 401
+						: result.status === 'access_denied' || result.status === 'invalid_password'
+							? 403
+							: 404;
+			return Response.json({ error: 'Download unavailable' }, { status });
+		}
+		return new Response(null, {
+			status: 302,
+			headers: {
+				Location: result.downloadUrl,
+				'Cache-Control': 'public, max-age=86400'
+			}
+		});
+	})
+});
+
 // Resend webhook endpoint
 // Configure this URL in your Resend dashboard: https://your-deployment.convex.site/resend-webhook
 // This endpoint receives email events (delivered, bounced, complained, opened, clicked)

--- a/src/lib/convex/storage.ts
+++ b/src/lib/convex/storage.ts
@@ -1,5 +1,4 @@
 import { v, ConvexError } from 'convex/values';
-import { buildDownloadUrl } from '@gilhrpenner/convex-files-control';
 import { PROFILE_IMAGE_ALLOWED_TYPES, PROFILE_IMAGE_MAX_SIZE } from './constants';
 import { authedMutation } from './functions';
 import { components } from './_generated/api';
@@ -43,8 +42,11 @@ export const generateUploadUrl = authedMutation({
  * against the profile image requirements (allowed MIME types and size limit),
  * deleting rejected files via the component.
  *
- * Returns a permanent shareable download-grant URL served by the component's
- * `/files/download` HTTP route (registered in `http.ts`). The URL is
+ * Returns a permanent shareable download-grant URL served by the
+ * `/files/inline` HTTP route (registered in `http.ts`), which 302-redirects
+ * to the storage URL so avatars render inline and browser-cacheable — the
+ * component's own `/files/download` route forces `no-store` + `attachment`
+ * and proxy-streams the body, which made every avatar render slow. The URL is
  * provider-agnostic: transferring the file to another storage provider
  * rewrites the grant's storageId, so stored avatar URLs keep working.
  *
@@ -123,9 +125,6 @@ export const updateProfileImage = authedMutation({
 			throw new ConvexError('File storage is not configured.');
 		}
 
-		return buildDownloadUrl({
-			baseUrl: siteUrl,
-			downloadToken: grant.downloadToken
-		});
+		return `${siteUrl}/files/inline?token=${grant.downloadToken}`;
 	}
 });

--- a/src/lib/utils/downscale-image.ts
+++ b/src/lib/utils/downscale-image.ts
@@ -1,0 +1,40 @@
+/**
+ * Downscale an image file client-side before upload.
+ *
+ * Avatars render at 48px or smaller, so uploading a full-size photo (e.g. a
+ * 310KB camera PNG) only slows every later avatar load. Decodes via
+ * `createImageBitmap` (respects EXIF orientation), draws onto a canvas capped
+ * at `maxDim`, and re-encodes as WebP.
+ *
+ * Conservative by design: animated GIFs are passed through untouched (a canvas
+ * draw would freeze the first frame), the re-encode is only used when it is
+ * actually smaller than the original, and any decode/encode failure falls back
+ * to the original file.
+ */
+export async function downscaleImage(file: File, maxDim = 512): Promise<Blob> {
+	if (file.type === 'image/gif') return file;
+	try {
+		const bitmap = await createImageBitmap(file);
+		try {
+			const scale = Math.min(1, maxDim / Math.max(bitmap.width, bitmap.height));
+			const width = Math.max(1, Math.round(bitmap.width * scale));
+			const height = Math.max(1, Math.round(bitmap.height * scale));
+			const canvas = document.createElement('canvas');
+			canvas.width = width;
+			canvas.height = height;
+			const ctx = canvas.getContext('2d');
+			if (!ctx) return file;
+			ctx.drawImage(bitmap, 0, 0, width, height);
+			const blob = await new Promise<Blob | null>((resolve) =>
+				canvas.toBlob(resolve, 'image/webp', 0.85)
+			);
+			// An already-optimized small file can beat the WebP re-encode; keep
+			// whichever is smaller.
+			return blob && blob.size < file.size ? blob : file;
+		} finally {
+			bitmap.close();
+		}
+	} catch {
+		return file;
+	}
+}

--- a/src/routes/[[lang]]/app/settings/account-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/account-settings.svelte
@@ -15,6 +15,7 @@
 	import { api } from '$lib/convex/_generated/api.js';
 	import { ConvexError } from 'convex/values';
 	import { PROFILE_IMAGE_MAX_SIZE, PROFILE_IMAGE_MAX_SIZE_LABEL } from '$lib/convex/constants.js';
+	import { downscaleImage } from '$lib/utils/downscale-image.js';
 	import { translateValidationErrors } from '$lib/utils/validation-i18n.js';
 
 	const { t } = getTranslate();
@@ -77,9 +78,14 @@
 				{}
 			);
 
+			// Avatars render at ≤48px; shrink oversized photos before upload so
+			// every later avatar load stays small (falls back to the original
+			// file on any decode/encode failure).
+			const upload = await downscaleImage(file);
+
 			// XHR transport for progress events, so the avatar shows live
 			// upload feedback instead of a silently disabled input.
-			const storageId = await uploadToStorage(uploadUrl, file, (progress) => {
+			const storageId = await uploadToStorage(uploadUrl, upload, (progress) => {
 				uploadProgress = progress;
 			});
 


### PR DESCRIPTION
Closes #664

The files-control /files/download route hardcodes Cache-Control: no-store and Content-Disposition: attachment, and proxy-streams the file body through the httpAction. A 310KB avatar took 4-16s to load, measured against a production deployment, and could never be cached by the browser. The visible symptom: the support widget's greeting entrance has a 3s image-load timeout (#247), which always fired first, so the animation played with the letter fallback instead of the admin avatar.

A new /files/inline route resolves the same download grant but 302-redirects to the underlying storage URL, which is browser-cacheable (private, max-age 30d); the redirect itself is cacheable for a day. updateProfileImage returns these URLs now. Existing stored avatar URLs keep working through the unchanged /files/download route until re-minted. The uploader also downscales images client-side before upload (512px cap, WebP re-encode, GIF passthrough, fallback to the original on any failure), closing the profile-image gap left by #348.

Regression guard: added scripts/avatar-inline-route.test.ts (pins the storage.ts URL format to the http.ts route).

`bun run check:convex` passes. `bun run test:unit` passes. The same change is verified in a production deployment: redirect answers 302 with the storage URL, avatars load with correct sizes and cache headers.