### PR TITLE
chore(renovate): Hold autumn-js major until convex support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,7 @@
 			"matchPackageNames": [
 				"!better-auth",
 				"!ai",
+				"!autumn-js",
 				"!eslint",
 				"!@eslint/compat",
 				"!@eslint/js",
@@ -94,6 +95,12 @@
 				"/^@convex-dev/agent$/",
 				"/^@openrouter/ai-sdk-provider$/"
 			]
+		},
+		{
+			"description": "Disable autumn-js major updates until @useautumn/convex ships an autumn-js 1.x compatible release (#666)",
+			"matchUpdateTypes": ["major"],
+			"enabled": false,
+			"matchPackageNames": ["autumn-js"]
 		},
 		{
 			"description": "Group ESLint non-major updates for manual review",


### PR DESCRIPTION
The grouped major PR #355 kept failing partly because it bundled the autumn-js 0.1 to 1.x bump, which is not actionable on our side: @useautumn/convex 0.0.23 (npm latest) peer-depends on autumn-js ^0.1.24, its client sends snake_case args that 1.x rejects, and the 26.5 MB 1.x SDK pushed into the Convex functions bundle exceeds the 64 MB isolate limit during deploy. Details and the migration plan live in #666.

This excludes autumn-js from the grouped major updates and disables its major PRs, following the existing Better Auth, AI, and ESLint hold patterns. Minor and patch updates of autumn-js 0.1.x keep flowing through the non-major group. The hold gets lifted with #666 once @useautumn/convex ships a 1.x compatible release.

`bunx prettier --check renovate.json` passes.