### PR TITLE
chore(deps): Update @types/node to v26

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
         "@tailwindcss/vite": "4.3.2",
         "@tanstack/table-core": "8.21.3",
         "@tolgee/cli": "2.20.0",
-        "@types/node": "25.9.4",
+        "@types/node": "26.1.0",
         "@typescript-eslint/eslint-plugin": "8.62.1",
         "@typescript-eslint/parser": "8.62.1",
         "bits-ui": "2.18.1",
@@ -1350,7 +1350,7 @@
 
     "@types/mysql": ["@types/mysql@2.15.27", "", { "dependencies": { "@types/node": "*" } }, "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA=="],
 
-    "@types/node": ["@types/node@25.9.4", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g=="],
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "@types/pg": ["@types/pg@8.15.6", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
 
@@ -2812,7 +2812,7 @@
 
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"@tailwindcss/vite": "4.3.2",
 		"@tanstack/table-core": "8.21.3",
 		"@tolgee/cli": "2.20.0",
-		"@types/node": "25.9.4",
+		"@types/node": "26.1.0",
 		"@typescript-eslint/eslint-plugin": "8.62.1",
 		"@typescript-eslint/parser": "8.62.1",
 		"bits-ui": "2.18.1",


### PR DESCRIPTION
Split from the grouped major PR #355 so each major lands reviewable on its own.

Type definitions only, pinned 25.9.4 to 26.1.0 matching the Node 26 LTS line. No runtime surface; `bun run check:convex` and the type check cover it.

See also: #355