### PR TITLE
chore(renovate): Suppress mode-watcher abandonment warning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -116,8 +116,8 @@
 			"enabled": false
 		},
 		{
-			"description": "Suppress abandonment warnings for packages we keep intentionally. clsx and husky are stable/feature-complete, date-fns still ships fixes (last commits 2025-09), vaul-svelte is stuck on 1.0.0-next.7 but has no viable Svelte 5 alternative.",
-			"matchPackageNames": ["clsx", "date-fns", "husky", "vaul-svelte"],
+			"description": "Suppress abandonment warnings for packages we keep intentionally. clsx and husky are stable/feature-complete, date-fns still ships fixes (last commits 2025-09), vaul-svelte is stuck on 1.0.0-next.7 but has no viable Svelte 5 alternative, mode-watcher is dormant (last release 2025-06) but shallowly integrated with no active replacement; on the next Svelte major bump watch for the render_fn error (svecosystem/mode-watcher#161) and fall back to a ~50-line self-roll if it bites.",
+			"matchPackageNames": ["clsx", "date-fns", "husky", "mode-watcher", "vaul-svelte"],
 			"abandonmentThreshold": "10 years"
 		}
 	]


### PR DESCRIPTION
The dependency dashboard flags mode-watcher as abandoned (last release 2025-06-28). Assessment: the package is dormant rather than broken, our integration is shallow (one ModeWatcher mount, one toggleMode call site, six mode reads), none of the open upstream bugs touch our usage, and no actively maintained replacement exists; a self-rolled fallback would be roughly 50 lines on top of the head-script pattern the layout already uses.

This adds mode-watcher to the existing abandonment suppression rule with that rationale, including a watch note: on the next Svelte major bump check for the render_fn error tracked upstream in svecosystem/mode-watcher#161 and switch to the self-roll if it materializes.

`bunx prettier --check renovate.json` passes.