### PR TITLE
feat(admin): Combine audit log action and user filters

### DIFF
--- a/e2e/admin-audit-log.spec.ts
+++ b/e2e/admin-audit-log.spec.ts
@@ -263,4 +263,55 @@ test.describe('Admin Audit Log', () => {
 		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
 		await expect(page.getByTestId('audit-log-row').first()).toBeVisible({ timeout: 10000 });
 	});
+
+	test('combines the action filter with a target user filter', async ({ page }) => {
+		// Guarantee genuine ban_user / unban_user entries for our target.
+		await banAndUnbanTarget(page, targetEmail);
+
+		await page.goto('/en/admin/audit-log');
+		await page.waitForLoadState('domcontentloaded');
+		await waitForAuditLogReady(page);
+
+		// Pin the action filter to ban_user first.
+		await selectActionFilter(page, 'ban_user');
+		await expect.poll(() => new URL(page.url()).searchParams.get('action')).toBe('ban_user');
+
+		// Then layer a target filter on top by clicking our target's cell. The action
+		// filter must stay in place (compound by_target_action), not get cleared.
+		await page
+			.getByTestId('audit-log-target-cell')
+			.filter({ hasText: targetEmail })
+			.first()
+			.click();
+
+		// The URL now carries BOTH the action and target params.
+		await expect.poll(() => new URL(page.url()).searchParams.get('action')).toBe('ban_user');
+		await expect.poll(() => new URL(page.url()).searchParams.get('target')).not.toBeNull();
+		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+
+		// The chip resolves and every visible row is a ban against our target.
+		await expect(page.getByTestId('audit-log-user-filter-chip')).toBeVisible();
+		await expect(page.getByTestId('audit-log-row').first()).toBeVisible({ timeout: 10000 });
+
+		const badges = (await page.getByTestId('audit-log-action-badge').allTextContents()).map(
+			(value) => value.trim()
+		);
+		expect(badges.length).toBeGreaterThan(0);
+		expect(badges.every((label) => label === 'Ban user')).toBe(true);
+
+		const targetCells = page.getByTestId('audit-log-target-cell');
+		const count = await targetCells.count();
+		expect(count).toBeGreaterThan(0);
+		for (let i = 0; i < count; i++) {
+			await expect(targetCells.nth(i)).toContainText(targetEmail);
+		}
+
+		// Removing the chip drops only the target param; the action filter stays.
+		await page.getByTestId('audit-log-user-filter-chip-remove').click();
+		await expect.poll(() => new URL(page.url()).searchParams.get('target')).toBeNull();
+		await expect.poll(() => new URL(page.url()).searchParams.get('action')).toBe('ban_user');
+		await expect(page.getByTestId('audit-log-user-filter-chip')).toHaveCount(0);
+		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+		await expect(page.getByTestId('audit-log-row').first()).toBeVisible({ timeout: 10000 });
+	});
 });

--- a/src/lib/convex/admin/auditLog/queries.ts
+++ b/src/lib/convex/admin/auditLog/queries.ts
@@ -59,8 +59,9 @@ export const auditLogItemValidator = v.object({
 export type AuditLogItem = Infer<typeof auditLogItemValidator>;
 
 /**
- * Shared filter args. The UI sends at most one filter at a time; see
- * {@link queryAuditLogs} for how a single index is chosen from them.
+ * Shared filter args. The action filter combines with one user filter (admin or
+ * target); the two user filters stay mutually exclusive. See {@link queryAuditLogs}
+ * for how an index is chosen from them.
  */
 const auditLogFilterArgs = {
 	actionFilter: v.optional(auditLogActionValidator),
@@ -87,22 +88,44 @@ export const auditLogSortByValidator = v.object({
 type AuditLogDirection = 'asc' | 'desc';
 
 /**
- * Pick the single most selective index for the given filter and return the
- * query ordered by `direction` (defaults to newest-first).
+ * Pick the most selective index for the given filter and return the query
+ * ordered by `direction` (defaults to newest-first).
  *
- * Filters are treated as mutually exclusive: the UI sends at most one of
- * actionFilter, adminUserId, or targetUserId, so we choose exactly one index
- * and do NOT apply the remaining filters as extra conditions (v1). Priority if
- * several are somehow set: action -> admin -> target -> unfiltered
- * (by_timestamp). For the single-value index branches, ordering by the index
- * resolves to `_creationTime` within the pinned value, which matches the
- * `timestamp` insertion order used by the writers in admin/mutations.ts.
+ * The action filter combines with one user filter: actionFilter can be paired
+ * with either adminUserId or targetUserId, served by the compound indexes
+ * by_admin_action / by_target_action. The two user filters stay mutually
+ * exclusive (the UI never sets both). Priority: admin+action -> target+action
+ * -> action -> admin -> target -> unfiltered (by_timestamp).
+ *
+ * The single-filter indexes by_admin / by_target must NOT be dropped in favor
+ * of the compound ones: with only one equality field pinned, a compound index
+ * orders by (action, _creationTime) instead of purely by time, so the log rows
+ * would sort by action first rather than newest-first. Within each branch,
+ * ordering by the chosen index resolves to `_creationTime` after the pinned
+ * fields, which matches the `timestamp` insertion order used by the writers in
+ * admin/mutations.ts.
  */
 function queryAuditLogs(
 	ctx: QueryCtx,
 	filters: AuditLogFilters,
 	direction: AuditLogDirection = 'desc'
 ) {
+	if (filters.adminUserId !== undefined && filters.actionFilter !== undefined) {
+		const adminUserId = filters.adminUserId;
+		const action = filters.actionFilter;
+		return ctx.db
+			.query('adminAuditLogs')
+			.withIndex('by_admin_action', (q) => q.eq('adminUserId', adminUserId).eq('action', action))
+			.order(direction);
+	}
+	if (filters.targetUserId !== undefined && filters.actionFilter !== undefined) {
+		const targetUserId = filters.targetUserId;
+		const action = filters.actionFilter;
+		return ctx.db
+			.query('adminAuditLogs')
+			.withIndex('by_target_action', (q) => q.eq('targetUserId', targetUserId).eq('action', action))
+			.order(direction);
+	}
 	if (filters.actionFilter !== undefined) {
 		const action = filters.actionFilter;
 		return ctx.db
@@ -229,8 +252,8 @@ export const resolveAuditLogUser = adminQuery({
 });
 
 /**
- * Count audit log entries matching the same (mutually exclusive) filter as
- * {@link listAuditLogs}. Count half of the table-kit contract.
+ * Count audit log entries matching the same filter as {@link listAuditLogs}.
+ * Count half of the table-kit contract.
  *
  * Capped at 5001 via .take() — this is a template-scale table, so we avoid an
  * unbounded .collect(). A returned 5001 means "5000+"; the UI can render a
@@ -248,8 +271,8 @@ export const getAuditLogCount = adminQuery({
 /**
  * Resolve the last page for the audit log table in one server call, so the
  * table-kit "jump to last page" action does not have to walk cursors from the
- * client. Same mutually-exclusive filter semantics as {@link listAuditLogs}
- * (reuses {@link queryAuditLogs}).
+ * client. Same filter semantics as {@link listAuditLogs} (reuses
+ * {@link queryAuditLogs}).
  *
  * Returns the 1-indexed last page and the cursor that fetches it (null for a
  * single-page result), matching the { page, cursor } contract of

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -49,6 +49,8 @@ export default defineSchema({
 		.index('by_admin', ['adminUserId'])
 		.index('by_target', ['targetUserId'])
 		.index('by_action', ['action'])
+		.index('by_admin_action', ['adminUserId', 'action'])
+		.index('by_target_action', ['targetUserId', 'action'])
 		.index('by_timestamp', ['timestamp']),
 
 	// Internal notes for users - visible only to admins, not to users

--- a/src/routes/[[lang]]/admin/audit-log/+page.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/+page.svelte
@@ -139,24 +139,22 @@
 		}
 	});
 
-	// The action, admin, and target filters are mutually exclusive: the backend
-	// applies a single index (action > admin > target), so setting one clears the
-	// others. This delivers issue #659's "all actions by/against user X" and keeps
-	// the chip honest instead of showing a user whose filter the backend dropped.
+	// The action filter combines with one user filter, served by the compound
+	// indexes by_admin_action / by_target_action. Setting an action leaves the
+	// active user filter in place; picking a user only clears the other user
+	// filter (admin and target stay mutually exclusive) while keeping the action.
+	// This delivers issue #659's "action X by/against user Y" without dropping a
+	// filter the user still expects to be applied.
 	function handleFilterChange(action: AuditLogAction | undefined) {
-		auditTable.setFilter('admin', '');
-		auditTable.setFilter('target', '');
 		auditTable.setFilter('action', action ?? 'all');
 	}
 
 	function filterByAdmin(userId: string) {
-		auditTable.setFilter('action', 'all');
 		auditTable.setFilter('target', '');
 		auditTable.setFilter('admin', userId);
 	}
 
 	function filterByTarget(userId: string) {
-		auditTable.setFilter('action', 'all');
 		auditTable.setFilter('admin', '');
 		auditTable.setFilter('target', userId);
 	}


### PR DESCRIPTION
The audit log filters shipped in #662 were mutually exclusive: the backend applied a single index per query, so picking an action cleared an active user filter and vice versa. Questions like "all bans by admin X" needed two visits.

Two compound indexes (`by_admin_action`, `by_target_action`) now serve the combined case, with the routing priority admin+action, target+action, action, admin, target, unfiltered. The single-filter indexes stay: with only one equality field pinned, a compound index would order rows by action before time and break the newest-first sort, which the query doc comment now spells out. The frontend filter handlers stop clearing each other; only the two user filters remain mutually exclusive. No query argument shapes changed, so count and last-page resolution combine for free.

`bun run check:convex` and static checks pass, and `e2e/admin-audit-log.spec.ts` passes locally with a new case asserting the combined state: both URL params active, every row matching both filters, and chip removal keeping the action filter.