### PR TITLE
feat(admin): Record impersonation duration in audit log

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -28,6 +28,7 @@
 			},
 			"deleted_user": "Gelöschter Benutzer",
 			"details": {
+				"impersonation_duration": "Dauer {duration}",
 				"role_change": "{previousRole} → {newRole}"
 			},
 			"empty": "Noch keine Audit-Log-Einträge.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -28,6 +28,7 @@
 			},
 			"deleted_user": "Deleted user",
 			"details": {
+				"impersonation_duration": "Lasted {duration}",
 				"role_change": "{previousRole} → {newRole}"
 			},
 			"empty": "No audit log entries yet.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -28,6 +28,7 @@
 			},
 			"deleted_user": "Usuario eliminado",
 			"details": {
+				"impersonation_duration": "Duró {duration}",
 				"role_change": "{previousRole} → {newRole}"
 			},
 			"empty": "Aún no hay entradas en el registro de auditoría.",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -28,6 +28,7 @@
 			},
 			"deleted_user": "Utilisateur supprimé",
 			"details": {
+				"impersonation_duration": "A duré {duration}",
 				"role_change": "{previousRole} → {newRole}"
 			},
 			"empty": "Aucune entrée dans le journal d'audit pour le moment.",

--- a/src/lib/convex/admin/auditLog/queries.test.ts
+++ b/src/lib/convex/admin/auditLog/queries.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import schema from '../../schema';
+import { auditLogMetadataValidator } from './queries';
+
+/**
+ * Regression guard: the adminAuditLogs.metadata union is declared twice — once
+ * in schema.ts (the table definition, what the writer stores) and once as
+ * auditLogMetadataValidator in queries.ts (what the reader returns and the
+ * frontend renders). A variant added to one but not the other would let a
+ * writer persist a shape the reader can't type. This test compares the
+ * structural JSON of both, order-independent, so they can never silently drift.
+ */
+function normalizeUnion(validator: { isOptional: string }): {
+	optional: boolean;
+	members: string[];
+} {
+	// `.json` is a runtime getter on every validator but is intentionally absent
+	// from the public TS type, so read it through a narrow cast.
+	const json = (validator as unknown as { json: { type: string; value?: unknown[] } }).json;
+	const members =
+		json.type === 'union' && Array.isArray(json.value)
+			? json.value.map((member) => JSON.stringify(member)).sort()
+			: [JSON.stringify(json)];
+	return { optional: validator.isOptional === 'optional', members };
+}
+
+describe('adminAuditLogs.metadata union', () => {
+	it('stays structurally in sync between schema.ts and queries.ts', () => {
+		const schemaMetadata = schema.tables.adminAuditLogs.validator.fields.metadata;
+		expect(normalizeUnion(schemaMetadata)).toEqual(normalizeUnion(auditLogMetadataValidator));
+	});
+});

--- a/src/lib/convex/admin/auditLog/queries.ts
+++ b/src/lib/convex/admin/auditLog/queries.ts
@@ -20,12 +20,15 @@ export const auditLogActionValidator = v.union(
 
 /**
  * Typed metadata per action, mirroring the schema's optional metadata union.
+ * Exported so `queries.test.ts` can assert it stays structurally in sync with
+ * the same union declared in schema.ts (the two must never drift apart).
  */
-const auditLogMetadataValidator = v.optional(
+export const auditLogMetadataValidator = v.optional(
 	v.union(
 		v.object({ reason: v.string() }), // ban_user, unban_user
 		v.object({ newRole: v.string(), previousRole: v.string() }), // set_role
-		v.object({}) // impersonate, stop_impersonation, revoke_sessions
+		v.object({ durationMs: v.number() }), // stop_impersonation
+		v.object({}) // impersonate, revoke_sessions
 	)
 );
 

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -306,6 +306,9 @@ export const authComponent = createClient<DataModel, typeof authSchema>(componen
 			 */
 			onCreate: async (ctx, session) => {
 				if (session.impersonatedBy) {
+					// The start row carries no duration on purpose: the impersonate
+					// and stop_impersonation rows read as a pair, where the start
+					// shows the time column and the stop shows the elapsed duration.
 					await ctx.db.insert('adminAuditLogs', {
 						adminUserId: session.impersonatedBy,
 						action: 'impersonate',
@@ -319,11 +322,15 @@ export const authComponent = createClient<DataModel, typeof authSchema>(componen
 			// impersonation session; both mean the impersonation ended.
 			onDelete: async (ctx, session) => {
 				if (session.impersonatedBy) {
+					// createdAt is typed as a number but can arrive as a Date from
+					// the adapter; new Date(...) normalizes both. Math.max guards
+					// against clock skew producing a negative duration.
+					const startedAt = new Date(session.createdAt).getTime();
 					await ctx.db.insert('adminAuditLogs', {
 						adminUserId: session.impersonatedBy,
 						action: 'stop_impersonation',
 						targetUserId: session.userId,
-						metadata: {},
+						metadata: { durationMs: Math.max(0, Date.now() - startedAt) },
 						timestamp: Date.now()
 					});
 				}

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -41,7 +41,8 @@ export default defineSchema({
 			v.union(
 				v.object({ reason: v.string() }), // ban_user, unban_user
 				v.object({ newRole: v.string(), previousRole: v.string() }), // set_role
-				v.object({}) // impersonate, stop_impersonation, revoke_sessions
+				v.object({ durationMs: v.number() }), // stop_impersonation
+				v.object({}) // impersonate, revoke_sessions
 			)
 		),
 		timestamp: v.number()

--- a/src/lib/utils/format-duration.test.ts
+++ b/src/lib/utils/format-duration.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration } from './format-duration';
+
+// Rebuild the expected string via the same Intl config so the assertions check
+// unit selection and rounding, not ICU's exact abbreviation across Node versions.
+function expected(value: number, unit: 'second' | 'minute' | 'hour', lang = 'en'): string {
+	return new Intl.NumberFormat(lang, { style: 'unit', unit, unitDisplay: 'short' }).format(value);
+}
+
+describe('formatDuration', () => {
+	it('renders sub-minute durations in seconds', () => {
+		expect(formatDuration(0, 'en')).toBe(expected(0, 'second'));
+		expect(formatDuration(45_000, 'en')).toBe(expected(45, 'second'));
+	});
+
+	it('renders sub-hour durations in minutes', () => {
+		expect(formatDuration(5 * 60_000, 'en')).toBe(expected(5, 'minute'));
+	});
+
+	it('renders hour-plus durations in hours', () => {
+		expect(formatDuration(3 * 3_600_000, 'en')).toBe(expected(3, 'hour'));
+	});
+
+	it('rounds to the nearest whole unit', () => {
+		// 90s -> 1.5 min -> rounds to 2 min
+		expect(formatDuration(90_000, 'en')).toBe(expected(2, 'minute'));
+	});
+
+	it('localizes the unit for non-English locales', () => {
+		expect(formatDuration(45_000, 'de')).toBe(expected(45, 'second', 'de'));
+		expect(formatDuration(45_000, 'de')).toContain('45');
+	});
+});

--- a/src/lib/utils/format-duration.ts
+++ b/src/lib/utils/format-duration.ts
@@ -1,0 +1,30 @@
+/**
+ * Format an elapsed duration (in milliseconds) into a localized, human-readable
+ * string like "45 sec", "5 min", or "3 hr". Picks the largest unit that keeps
+ * the number readable: seconds under a minute, minutes under an hour, else
+ * hours, and rounds to a whole unit. Intl.NumberFormat localizes the unit
+ * itself, so no translation keys are needed. A falsy `lang` falls back to the
+ * runtime default locale.
+ */
+export function formatDuration(ms: number, lang: string): string {
+	const seconds = ms / 1000;
+	let value: number;
+	let unit: 'second' | 'minute' | 'hour';
+
+	if (seconds < 60) {
+		value = Math.round(seconds);
+		unit = 'second';
+	} else if (seconds < 3600) {
+		value = Math.round(seconds / 60);
+		unit = 'minute';
+	} else {
+		value = Math.round(seconds / 3600);
+		unit = 'hour';
+	}
+
+	return new Intl.NumberFormat(lang || undefined, {
+		style: 'unit',
+		unit,
+		unitDisplay: 'short'
+	}).format(value);
+}

--- a/src/routes/[[lang]]/admin/audit-log/columns.ts
+++ b/src/routes/[[lang]]/admin/audit-log/columns.ts
@@ -101,6 +101,7 @@ export function createColumns(
 			cell: ({ row }) =>
 				renderComponent(DetailsCell, {
 					metadata: row.original.metadata,
+					lang,
 					testId: 'audit-log-details-cell'
 				})
 		}

--- a/src/routes/[[lang]]/admin/audit-log/details-cell.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/details-cell.svelte
@@ -1,19 +1,24 @@
 <script lang="ts">
 	import { T } from '@tolgee/svelte';
 	import type { AuditLogItem } from '$lib/convex/admin/auditLog/queries';
+	import { formatDuration } from '$lib/utils/format-duration';
 
 	interface Props {
 		metadata: AuditLogItem['metadata'];
+		lang: string;
 		testId?: string;
 	}
 
-	let { metadata, testId }: Props = $props();
+	let { metadata, lang, testId }: Props = $props();
 
 	const reason = $derived(metadata && 'reason' in metadata ? metadata.reason : undefined);
 	const roleChange = $derived(
 		metadata && 'newRole' in metadata
 			? { previousRole: metadata.previousRole, newRole: metadata.newRole }
 			: undefined
+	);
+	const duration = $derived(
+		metadata && 'durationMs' in metadata ? formatDuration(metadata.durationMs, lang) : undefined
 	);
 </script>
 
@@ -26,6 +31,10 @@
 				keyName="admin.audit_log.details.role_change"
 				params={{ previousRole: roleChange.previousRole, newRole: roleChange.newRole }}
 			/>
+		</span>
+	{:else if duration}
+		<span class="text-muted-foreground">
+			<T keyName="admin.audit_log.details.impersonation_duration" params={{ duration }} />
 		</span>
 	{:else}
 		<span class="text-muted-foreground/50">-</span>


### PR DESCRIPTION
Impersonation rows in the audit log showed nothing in the details column, so an admin reviewing the log could see that an impersonation happened but never how long it lasted.

The Better Auth session onDelete trigger now writes `durationMs` into the stop_impersonation event, computed from the deleted session's createdAt with normalization for Date-or-number values and a guard against negative clock skew. The start row intentionally stays empty: the pair reads as start time (time column) plus elapsed duration (stop row). The details cell renders the value through a new localized key with the duration formatted via Intl.NumberFormat unit style, so the unit itself needs no translation keys. Old rows with empty metadata stay valid, no migration.

A new unit test asserts the two copies of the audit metadata union (schema.ts and the query validator) stay structurally identical, guarding the class of drift this dual definition invites, plus edge-case tests for the duration formatter.

Regression guard: added union-sync test in src/lib/convex/admin/auditLog/queries.test.ts

`bun run check:convex`, static checks, and `bun run test:unit` (772 tests) pass. The Tolgee push of the new key is pending, the translation server is currently unreachable; all four locale files are complete in this PR.