### PR TITLE
fix(auth): send Cache-Control on auth-group HTML

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -261,6 +261,21 @@ const handleCacheControl: Handle = async function handleCacheControl({ event, re
 		// this is safe only because every route reaching this branch is non-prerendered
 		// and the markdown variant is private (kept out of shared caches).
 		response.headers.set('Vary', 'Accept');
+	} else if (
+		response.status === 200 &&
+		!event.locals.token &&
+		event.route.id?.includes('/(auth)/')
+	) {
+		// Auth-group HTML shells (signin, signup, forgot-password, ...) reference the
+		// same content-hashed chunks as the marketing shells but fell through the
+		// marketing matcher and shipped with no Cache-Control at all, leaving
+		// freshness to cache heuristics. Any reuse must revalidate so a shell never
+		// outlives its chunk set. Unlike the marketing branch there is no s-maxage:
+		// auth shells are not edge-cached, so the zone Browser Cache TTL floor
+		// documented above does not apply. No Vary: Accept either, these routes have
+		// no markdown variant. Matching on the route group keeps new auth pages
+		// covered automatically.
+		response.headers.set('Cache-Control', 'public, no-cache');
 	}
 
 	return response;


### PR DESCRIPTION
Closes #677

The cache-control hook piggybacks on the public-marketing route matcher, which covers only home, contact, privacy, terms and impressum. Every page in the (auth) route group returned its HTML with no Cache-Control header at all, leaving freshness to cache heuristics even though these shells reference the same content-hashed chunks whose post-deploy staleness is the bug class behind #651.

The hook now applies "public, no-cache" to 200 responses for unauthenticated requests on any /(auth)/ route id, so a cached shell must revalidate before reuse. Unlike the marketing branch there is no s-maxage (auth shells are not edge-cached, so the zone Browser Cache TTL floor does not apply) and no "Vary: Accept" (auth routes have no markdown variant). Matching on the route group covers future auth pages automatically.

Regression guard: not warranted, single hook branch; the header is trivially observable and a deploy-shaped staleness scenario is not reproducible in unit scope.
Verified in the downstream fork on a CF preview: /en/signin returns "public, no-cache" and the marketing pages keep their existing header and Vary.
