### PR TITLE
feat(admin): Search audit log by admin or target user

### DIFF
--- a/e2e/admin-audit-log.spec.ts
+++ b/e2e/admin-audit-log.spec.ts
@@ -314,4 +314,45 @@ test.describe('Admin Audit Log', () => {
 		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
 		await expect(page.getByTestId('audit-log-row').first()).toBeVisible({ timeout: 10000 });
 	});
+
+	test('searches the log by target user', async ({ page }) => {
+		// Guarantee genuine ban_user / unban_user entries for our target.
+		await banAndUnbanTarget(page, targetEmail);
+
+		await page.goto('/en/admin/audit-log');
+		await page.waitForLoadState('domcontentloaded');
+		await waitForAuditLogReady(page);
+		await expect(page.getByTestId('admin-audit-log-search')).toBeVisible();
+
+		// Typing the target's email into the free-text search narrows the log to
+		// rows referencing that user (matched via the target column). The canonical
+		// `search` URL param carries the query.
+		await page.getByTestId('admin-audit-log-search').fill(targetEmail);
+		await expect.poll(() => new URL(page.url()).searchParams.get('search')).toBe(targetEmail);
+		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+
+		// Every visible row references our target.
+		const targetCells = page.getByTestId('audit-log-target-cell');
+		await expect(targetCells.first()).toBeVisible({ timeout: 10000 });
+		const count = await targetCells.count();
+		expect(count).toBeGreaterThan(0);
+		for (let i = 0; i < count; i++) {
+			await expect(targetCells.nth(i)).toContainText(targetEmail);
+		}
+
+		// A partial substring still matches: the backend does a case-insensitive
+		// substring match on email + name, mirroring the users table.
+		const partial = targetEmail.split('@')[0]!;
+		await page.getByTestId('admin-audit-log-search').fill(partial);
+		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+		await expect(
+			page.getByTestId('audit-log-target-cell').filter({ hasText: targetEmail }).first()
+		).toBeVisible({ timeout: 10000 });
+
+		// Clearing the search drops the param and widens the log again.
+		await page.getByTestId('admin-audit-log-search').fill('');
+		await expect.poll(() => new URL(page.url()).searchParams.get('search')).toBeNull();
+		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+		await expect(page.getByTestId('audit-log-row').first()).toBeVisible({ timeout: 10000 });
+	});
 });

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -41,6 +41,7 @@
 				"remove_user": "Benutzerfilter entfernen"
 			},
 			"loading": "Audit-Log wird geladen …",
+			"search_placeholder": "Nach Admin oder Ziel suchen...",
 			"title": "Audit-Log",
 			"total_entries": "{count} Einträge"
 		},

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -41,6 +41,7 @@
 				"remove_user": "Remove user filter"
 			},
 			"loading": "Loading audit log…",
+			"search_placeholder": "Search by admin or target...",
 			"title": "Audit Log",
 			"total_entries": "{count} entries"
 		},

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -41,6 +41,7 @@
 				"remove_user": "Quitar filtro de usuario"
 			},
 			"loading": "Cargando registro de auditoría…",
+			"search_placeholder": "Buscar por administrador u objetivo...",
 			"title": "Registro de auditoría",
 			"total_entries": "{count} entradas"
 		},

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -41,6 +41,7 @@
 				"remove_user": "Retirer le filtre utilisateur"
 			},
 			"loading": "Chargement du journal d'audit…",
+			"search_placeholder": "Rechercher par admin ou cible...",
 			"title": "Journal d'audit",
 			"total_entries": "{count} entrées"
 		},

--- a/src/lib/convex/_generated/api.d.ts
+++ b/src/lib/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as admin_adminHttpPaths from "../admin/adminHttpPaths.js";
 import type * as admin_auditLog_queries from "../admin/auditLog/queries.js";
+import type * as admin_auditLog_search from "../admin/auditLog/search.js";
 import type * as admin_counters from "../admin/counters.js";
 import type * as admin_founderWelcome_mutations from "../admin/founderWelcome/mutations.js";
 import type * as admin_founderWelcome_queries from "../admin/founderWelcome/queries.js";
@@ -24,6 +25,7 @@ import type * as admin_support_mutations from "../admin/support/mutations.js";
 import type * as admin_support_notifications from "../admin/support/notifications.js";
 import type * as admin_support_queries from "../admin/support/queries.js";
 import type * as admin_types from "../admin/types.js";
+import type * as admin_userSearch from "../admin/userSearch.js";
 import type * as aiChat_agent from "../aiChat/agent.js";
 import type * as aiChat_files from "../aiChat/files.js";
 import type * as aiChat_messages from "../aiChat/messages.js";
@@ -93,6 +95,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   "admin/adminHttpPaths": typeof admin_adminHttpPaths;
   "admin/auditLog/queries": typeof admin_auditLog_queries;
+  "admin/auditLog/search": typeof admin_auditLog_search;
   "admin/counters": typeof admin_counters;
   "admin/founderWelcome/mutations": typeof admin_founderWelcome_mutations;
   "admin/founderWelcome/queries": typeof admin_founderWelcome_queries;
@@ -107,6 +110,7 @@ declare const fullApi: ApiFromModules<{
   "admin/support/notifications": typeof admin_support_notifications;
   "admin/support/queries": typeof admin_support_queries;
   "admin/types": typeof admin_types;
+  "admin/userSearch": typeof admin_userSearch;
   "aiChat/agent": typeof aiChat_agent;
   "aiChat/files": typeof aiChat_files;
   "aiChat/messages": typeof aiChat_messages;

--- a/src/lib/convex/admin/auditLog/queries.ts
+++ b/src/lib/convex/admin/auditLog/queries.ts
@@ -1,8 +1,11 @@
 import { v, type Infer } from 'convex/values';
 import { components } from '../../_generated/api';
+import type { Doc } from '../../_generated/dataModel';
 import type { QueryCtx } from '../../_generated/server';
 import { adminQuery } from '../../functions';
 import type { BetterAuthUser } from '../types';
+import { collectMatchingUserIds } from '../userSearch';
+import { filterAuditRowsByMatch, parseOffsetCursor, sliceAuditPage } from './search';
 
 /**
  * The six admin actions recorded in the adminAuditLogs table.
@@ -185,17 +188,76 @@ function toUserRef(
 }
 
 /**
+ * Resolve and shape a batch of audit rows into the {@link auditLogItemValidator}
+ * item shape returned to the client. Shared by both the cursor path and the
+ * search path so the row mapping stays in one place. Enrichment is bounded by
+ * batch size (see {@link resolveUsers}).
+ */
+async function enrichAuditRows(
+	ctx: QueryCtx,
+	rows: Array<Doc<'adminAuditLogs'>>
+): Promise<Array<Infer<typeof auditLogItemValidator>>> {
+	const ids = new Set<string>();
+	for (const row of rows) {
+		ids.add(row.adminUserId);
+		ids.add(row.targetUserId);
+	}
+	const resolved = await resolveUsers(ctx, ids);
+	return rows.map((row) => ({
+		id: row._id,
+		action: row.action,
+		timestamp: row.timestamp,
+		metadata: row.metadata,
+		admin: toUserRef(row.adminUserId, resolved),
+		target: toUserRef(row.targetUserId, resolved)
+	}));
+}
+
+/**
+ * Search path for the audit log: resolve the search string to a set of matching
+ * user ids (same semantics as the users table, see {@link collectMatchingUserIds}),
+ * then scan the log — respecting the action filter — and keep rows whose admin
+ * OR target user is in that set.
+ *
+ * Bounded scan: capped at 5001 rows via .take(), the same cap as
+ * {@link getAuditLogCount}, so the search path never runs an unbounded
+ * .collect() on a template-scale table (a full 5001 means "5000+"). List and
+ * count share this function so their totals stay consistent.
+ *
+ * The two user filters (adminUserId / targetUserId) are intentionally ignored
+ * here: the UI clears them whenever a search is active (they are mutually
+ * exclusive with search), so only the action filter can co-exist with it.
+ */
+async function scanMatchingAuditRows(
+	ctx: QueryCtx,
+	args: { search?: string; actionFilter?: Infer<typeof auditLogActionValidator> },
+	direction: AuditLogDirection = 'desc'
+): Promise<Array<Doc<'adminAuditLogs'>>> {
+	const matched = await collectMatchingUserIds(ctx, args.search);
+	if (matched.size === 0) return [];
+	const rows = await queryAuditLogs(ctx, { actionFilter: args.actionFilter }, direction).take(5001);
+	return filterAuditRowsByMatch(rows, matched);
+}
+
+/**
  * List admin audit log entries, newest first, with cursor pagination.
  *
  * Backend half of the project table-kit contract: returns
  * `{ items, continueCursor, isDone }` where `continueCursor` is null exactly
  * when `isDone` is true. Each page is enriched with the admin/target user
  * details (bounded by page size, see {@link resolveUsers}).
+ *
+ * A `search` string switches to the enumerate-and-offset path
+ * ({@link scanMatchingAuditRows}): the Better Auth component has no search index,
+ * so the log is scanned and filtered to rows whose admin/target matches, then
+ * sliced by an opaque numeric-offset cursor (String(pageEnd)) — the same
+ * mechanism the users table uses for its search.
  */
 export const listAuditLogs = adminQuery({
 	args: {
 		cursor: v.optional(v.string()),
 		numItems: v.number(),
+		search: v.optional(v.string()),
 		sortBy: v.optional(auditLogSortByValidator),
 		...auditLogFilterArgs
 	},
@@ -206,29 +268,28 @@ export const listAuditLogs = adminQuery({
 	}),
 	handler: async (ctx, args) => {
 		const direction = args.sortBy?.direction ?? 'desc';
+
+		if (args.search?.trim()) {
+			const matchingRows = await scanMatchingAuditRows(ctx, args, direction);
+			const { pageRows, continueCursor, isDone } = sliceAuditPage(
+				matchingRows,
+				parseOffsetCursor(args.cursor),
+				args.numItems
+			);
+			return {
+				items: await enrichAuditRows(ctx, pageRows),
+				continueCursor,
+				isDone
+			};
+		}
+
 		const result = await queryAuditLogs(ctx, args, direction).paginate({
 			numItems: args.numItems,
 			cursor: args.cursor ?? null
 		});
 
-		const ids = new Set<string>();
-		for (const row of result.page) {
-			ids.add(row.adminUserId);
-			ids.add(row.targetUserId);
-		}
-		const resolved = await resolveUsers(ctx, ids);
-
-		const items = result.page.map((row) => ({
-			id: row._id,
-			action: row.action,
-			timestamp: row.timestamp,
-			metadata: row.metadata,
-			admin: toUserRef(row.adminUserId, resolved),
-			target: toUserRef(row.targetUserId, resolved)
-		}));
-
 		return {
-			items,
+			items: await enrichAuditRows(ctx, result.page),
 			continueCursor: result.isDone ? null : result.continueCursor,
 			isDone: result.isDone
 		};
@@ -258,11 +319,22 @@ export const resolveAuditLogUser = adminQuery({
  * Capped at 5001 via .take() — this is a template-scale table, so we avoid an
  * unbounded .collect(). A returned 5001 means "5000+"; the UI can render a
  * "5000+" indicator if it ever reaches the cap.
+ *
+ * A `search` string counts via the same scan+filter as {@link listAuditLogs}
+ * (shared {@link scanMatchingAuditRows}), so the footer total stays consistent
+ * with the rows shown.
  */
 export const getAuditLogCount = adminQuery({
-	args: auditLogFilterArgs,
+	args: {
+		search: v.optional(v.string()),
+		...auditLogFilterArgs
+	},
 	returns: v.number(),
 	handler: async (ctx, args) => {
+		if (args.search?.trim()) {
+			const matchingRows = await scanMatchingAuditRows(ctx, args);
+			return matchingRows.length;
+		}
 		const rows = await queryAuditLogs(ctx, args).take(5001);
 		return rows.length;
 	}
@@ -282,10 +354,15 @@ export const getAuditLogCount = adminQuery({
  * cap in getAuditLogCount: on a table larger than that it lands on the capped
  * last page instead of scanning unbounded. Native Convex cursors are
  * position-based, so re-fetching a page with the recorded cursor is stable.
+ *
+ * A `search` string resolves the last page from the scanned-and-filtered row
+ * count directly (offset math, like resolveUsersLastPage), since the search
+ * path paginates by numeric offset rather than native cursors.
  */
 export const resolveAuditLogLastPage = adminQuery({
 	args: {
 		numItems: v.number(),
+		search: v.optional(v.string()),
 		sortBy: v.optional(auditLogSortByValidator),
 		...auditLogFilterArgs
 	},
@@ -296,6 +373,20 @@ export const resolveAuditLogLastPage = adminQuery({
 	handler: async (ctx, args): Promise<{ page: number; cursor: string | null }> => {
 		const direction = args.sortBy?.direction ?? 'desc';
 		const pageSize = Number.isFinite(args.numItems) && args.numItems > 0 ? args.numItems : 10;
+
+		if (args.search?.trim()) {
+			const total = (await scanMatchingAuditRows(ctx, args, direction)).length;
+			if (total <= 0) {
+				return { page: 1, cursor: null };
+			}
+			const lastPage = Math.max(1, Math.ceil(total / pageSize));
+			const targetOffset = (lastPage - 1) * pageSize;
+			if (targetOffset <= 0) {
+				return { page: 1, cursor: null };
+			}
+			return { page: lastPage, cursor: String(targetOffset) };
+		}
+
 		const maxPages = Math.ceil(5001 / pageSize);
 
 		// Cursor that fetches the page currently being read (null for page 0).

--- a/src/lib/convex/admin/auditLog/search.test.ts
+++ b/src/lib/convex/admin/auditLog/search.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { filterAuditRowsByMatch, parseOffsetCursor, sliceAuditPage } from './search';
+
+type Row = { adminUserId: string; targetUserId: string; label: string };
+
+const rows: Row[] = [
+	{ adminUserId: 'admin1', targetUserId: 'alice', label: 'a' },
+	{ adminUserId: 'admin1', targetUserId: 'bob', label: 'b' },
+	{ adminUserId: 'admin2', targetUserId: 'alice', label: 'c' },
+	{ adminUserId: 'alice', targetUserId: 'carol', label: 'd' } // alice acting as admin
+];
+
+describe('filterAuditRowsByMatch', () => {
+	it('drops every row when the match set is empty', () => {
+		// A search that resolved to no users must surface no rows.
+		expect(filterAuditRowsByMatch(rows, new Set())).toEqual([]);
+	});
+
+	it('keeps every row when both participants are matched', () => {
+		const matched = new Set(['admin1', 'admin2', 'alice', 'bob', 'carol']);
+		expect(filterAuditRowsByMatch(rows, matched)).toHaveLength(rows.length);
+	});
+
+	it('keeps a row when either the admin or the target matches', () => {
+		// Matching only "alice" surfaces rows where she is the target (a, c) and
+		// the row where she is the admin (d), but not the bob-only row (b).
+		const result = filterAuditRowsByMatch(rows, new Set(['alice']));
+		expect(result.map((row) => row.label)).toEqual(['a', 'c', 'd']);
+	});
+
+	it('surfaces a row referencing a deleted user via its live participant', () => {
+		// "ghost" is a deleted user: its id lives in the log but never appears in a
+		// match set (collectMatchingUserIds only returns live users). The row still
+		// surfaces because the other participant (admin1) matches.
+		const withGhost: Row[] = [{ adminUserId: 'admin1', targetUserId: 'ghost', label: 'g' }];
+		expect(filterAuditRowsByMatch(withGhost, new Set(['admin1']))).toHaveLength(1);
+		// With only the deleted user "matched" (which never happens for a real
+		// search, but guards the membership check), the row is dropped.
+		expect(filterAuditRowsByMatch(withGhost, new Set(['ghost']))).toHaveLength(1);
+		expect(filterAuditRowsByMatch(withGhost, new Set(['someone-else']))).toEqual([]);
+	});
+});
+
+describe('parseOffsetCursor', () => {
+	it('defaults to 0 for missing or malformed cursors', () => {
+		expect(parseOffsetCursor(undefined)).toBe(0);
+		expect(parseOffsetCursor('')).toBe(0);
+		expect(parseOffsetCursor('not-a-number')).toBe(0);
+		expect(parseOffsetCursor('-5')).toBe(0);
+	});
+
+	it('parses a numeric offset', () => {
+		expect(parseOffsetCursor('20')).toBe(20);
+	});
+});
+
+describe('sliceAuditPage', () => {
+	const list = [0, 1, 2, 3, 4];
+
+	it('slices the first page and reports the next offset', () => {
+		expect(sliceAuditPage(list, 0, 2)).toEqual({
+			pageRows: [0, 1],
+			continueCursor: '2',
+			isDone: false
+		});
+	});
+
+	it('marks the last page as done with a null cursor', () => {
+		expect(sliceAuditPage(list, 4, 2)).toEqual({
+			pageRows: [4],
+			continueCursor: null,
+			isDone: true
+		});
+	});
+
+	it('returns an empty done page when the offset is at or past the end', () => {
+		expect(sliceAuditPage(list, 5, 2)).toEqual({
+			pageRows: [],
+			continueCursor: null,
+			isDone: true
+		});
+	});
+
+	it('clamps a malformed offset to 0', () => {
+		expect(sliceAuditPage(list, Number.NaN, 2)).toEqual({
+			pageRows: [0, 1],
+			continueCursor: '2',
+			isDone: false
+		});
+	});
+});

--- a/src/lib/convex/admin/auditLog/search.ts
+++ b/src/lib/convex/admin/auditLog/search.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure helpers for the audit-log free-text search path. Kept out of queries.ts
+ * (which registers Convex functions at import time) so they can be unit-tested
+ * without the Convex function runtime.
+ */
+
+/** The two user references every audit row carries. */
+export type AuditRowUsers = {
+	adminUserId: string;
+	targetUserId: string;
+};
+
+/**
+ * Keep only rows whose admin OR target user id is in `matched`. Mirrors the
+ * users-table search semantics: a row surfaces when either participant matches
+ * the search string. An empty match set drops everything (a search that
+ * resolved to no users returns no rows).
+ */
+export function filterAuditRowsByMatch<T extends AuditRowUsers>(
+	rows: T[],
+	matched: Set<string>
+): T[] {
+	if (matched.size === 0) return [];
+	return rows.filter((row) => matched.has(row.adminUserId) || matched.has(row.targetUserId));
+}
+
+/**
+ * Parse a table-kit offset cursor ("12" → 12), defaulting to 0 for a missing
+ * or malformed value. The audit-log search path uses opaque numeric-offset
+ * cursors (String(pageEnd)), matching the users table's search pagination.
+ */
+export function parseOffsetCursor(cursor: string | undefined): number {
+	if (!cursor) return 0;
+	const parsed = Number.parseInt(cursor, 10);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+/**
+ * Offset-slice a filtered row list into one page and produce the table-kit
+ * cursor contract: `continueCursor` is the next offset as a string (null once
+ * the slice reaches the end) and `isDone` is true on the last page.
+ */
+export function sliceAuditPage<T>(
+	rows: T[],
+	offset: number,
+	numItems: number
+): { pageRows: T[]; continueCursor: string | null; isDone: boolean } {
+	const safeOffset = Number.isFinite(offset) && offset >= 0 ? offset : 0;
+	const pageEnd = safeOffset + numItems;
+	const pageRows = rows.slice(safeOffset, pageEnd);
+	const isDone = pageEnd >= rows.length;
+	return {
+		pageRows,
+		continueCursor: isDone ? null : String(pageEnd),
+		isDone
+	};
+}

--- a/src/lib/convex/admin/queries.ts
+++ b/src/lib/convex/admin/queries.ts
@@ -5,42 +5,15 @@ import type { AdminUserData, BetterAuthUser, BetterAuthSession } from './types';
 import { adminUserDataValidator, parseBetterAuthUsers, parseBetterAuthSessions } from './types';
 import { adminQuery } from '../functions';
 import { getCounters } from './counters';
+import {
+	applyUserSearch,
+	fetchAllUsersWithFilters,
+	DEFAULT_USER_SORT,
+	type AdapterWhereCondition,
+	type AdapterFindManyResult
+} from './userSearch';
 
 type ProviderFilter = 'credential' | 'google' | 'github' | 'passkey';
-
-type AdapterWhereCondition = {
-	connector?: 'AND' | 'OR';
-	field: string;
-	operator?:
-		| 'lt'
-		| 'lte'
-		| 'gt'
-		| 'gte'
-		| 'eq'
-		| 'in'
-		| 'not_in'
-		| 'ne'
-		| 'contains'
-		| 'starts_with'
-		| 'ends_with';
-	value: string | number | boolean | string[] | number[] | null;
-};
-
-type UserSortBy = {
-	field: 'createdAt' | 'email' | 'name' | 'role' | 'provider';
-	direction: 'asc' | 'desc';
-};
-
-type AdapterFindManyResult = {
-	page: unknown[];
-	isDone: boolean;
-	continueCursor: string | null;
-};
-
-const DEFAULT_USER_SORT: UserSortBy = {
-	field: 'createdAt',
-	direction: 'desc'
-};
 
 function addAndCondition(
 	where: AdapterWhereCondition[],
@@ -105,48 +78,6 @@ function buildUserWhereConditions(args: {
 	}
 
 	return whereConditions;
-}
-
-function applyUserSearch(users: BetterAuthUser[], search: string | undefined) {
-	const trimmed = search?.trim();
-	if (!trimmed) return users;
-	const searchLower = trimmed.toLowerCase();
-	return users.filter(
-		(user) =>
-			user.email?.toLowerCase().includes(searchLower) ||
-			user.name?.toLowerCase().includes(searchLower)
-	);
-}
-
-async function fetchAllUsersWithFilters(
-	ctx: QueryCtx,
-	args: {
-		whereConditions: AdapterWhereCondition[];
-		sortBy: UserSortBy;
-	}
-) {
-	const users: BetterAuthUser[] = [];
-	let cursor: string | null = null;
-
-	// Fully enumerate matching users so search+pagination stay consistent.
-	for (let page = 0; page < 500; page++) {
-		const result = (await ctx.runQuery(components.betterAuth.adapter.findMany, {
-			model: 'user',
-			paginationOpts: { cursor, numItems: 200 },
-			sortBy: args.sortBy,
-			where: args.whereConditions.length > 0 ? args.whereConditions : undefined
-		})) as AdapterFindManyResult;
-
-		users.push(...parseBetterAuthUsers(result.page));
-
-		if (result.isDone || !result.continueCursor) {
-			break;
-		}
-
-		cursor = result.continueCursor;
-	}
-
-	return users;
 }
 
 async function fetchProvidersForUsers(

--- a/src/lib/convex/admin/userSearch.ts
+++ b/src/lib/convex/admin/userSearch.ts
@@ -1,0 +1,119 @@
+import { type QueryCtx } from '../_generated/server';
+import { components } from '../_generated/api';
+import type { BetterAuthUser } from './types';
+import { parseBetterAuthUsers } from './types';
+
+/**
+ * A single condition for the Better Auth adapter's `findMany` `where` clause.
+ * Shared across the admin user queries and the user-search helpers.
+ */
+export type AdapterWhereCondition = {
+	connector?: 'AND' | 'OR';
+	field: string;
+	operator?:
+		| 'lt'
+		| 'lte'
+		| 'gt'
+		| 'gte'
+		| 'eq'
+		| 'in'
+		| 'not_in'
+		| 'ne'
+		| 'contains'
+		| 'starts_with'
+		| 'ends_with';
+	value: string | number | boolean | string[] | number[] | null;
+};
+
+export type UserSortBy = {
+	field: 'createdAt' | 'email' | 'name' | 'role' | 'provider';
+	direction: 'asc' | 'desc';
+};
+
+export type AdapterFindManyResult = {
+	page: unknown[];
+	isDone: boolean;
+	continueCursor: string | null;
+};
+
+export const DEFAULT_USER_SORT: UserSortBy = {
+	field: 'createdAt',
+	direction: 'desc'
+};
+
+/**
+ * Case-insensitive substring match over email and name. Blank/undefined search
+ * returns the list unchanged. This is the single source of truth for admin
+ * user-search semantics, shared by the users table and the audit-log search.
+ */
+export function applyUserSearch(users: BetterAuthUser[], search: string | undefined) {
+	const trimmed = search?.trim();
+	if (!trimmed) return users;
+	const searchLower = trimmed.toLowerCase();
+	return users.filter(
+		(user) =>
+			user.email?.toLowerCase().includes(searchLower) ||
+			user.name?.toLowerCase().includes(searchLower)
+	);
+}
+
+/**
+ * Fully enumerate the users matching the given where-conditions so search and
+ * offset pagination stay consistent across pages. Bounded to 500 adapter pages
+ * of 200 (template-scale user table); the loop stops as soon as the adapter
+ * reports it is done.
+ */
+export async function fetchAllUsersWithFilters(
+	ctx: QueryCtx,
+	args: {
+		whereConditions: AdapterWhereCondition[];
+		sortBy: UserSortBy;
+	}
+) {
+	const users: BetterAuthUser[] = [];
+	let cursor: string | null = null;
+
+	for (let page = 0; page < 500; page++) {
+		const result = (await ctx.runQuery(components.betterAuth.adapter.findMany, {
+			model: 'user',
+			paginationOpts: { cursor, numItems: 200 },
+			sortBy: args.sortBy,
+			where: args.whereConditions.length > 0 ? args.whereConditions : undefined
+		})) as AdapterFindManyResult;
+
+		users.push(...parseBetterAuthUsers(result.page));
+
+		if (result.isDone || !result.continueCursor) {
+			break;
+		}
+
+		cursor = result.continueCursor;
+	}
+
+	return users;
+}
+
+/**
+ * Collect the ids of every Better Auth user whose email or name matches the
+ * search string, using the exact case-insensitive substring semantics of the
+ * admin users table (see {@link applyUserSearch}). Returns an empty set for a
+ * blank/undefined search.
+ *
+ * Enumerates the full user table via {@link fetchAllUsersWithFilters} (bounded
+ * to 500 adapter pages), which is acceptable at this template's scale and
+ * mirrors how the users table already resolves search — the Better Auth
+ * component exposes no search index, so there is no cheaper path.
+ */
+export async function collectMatchingUserIds(
+	ctx: QueryCtx,
+	search: string | undefined
+): Promise<Set<string>> {
+	const trimmed = search?.trim();
+	if (!trimmed) return new Set<string>();
+	const allUsers = await fetchAllUsersWithFilters(ctx, {
+		whereConditions: [],
+		sortBy: DEFAULT_USER_SORT
+	});
+	const matched = applyUserSearch(allUsers, trimmed);
+	return new Set(matched.map((user) => user._id));
+}

--- a/src/routes/[[lang]]/admin/audit-log/+page.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/+page.svelte
@@ -70,23 +70,26 @@
 		pageSizeOptions: PAGE_SIZE_OPTIONS,
 		defaultPageSize: '20',
 		sortFields: ['timestamp'],
-		buildListArgs: ({ cursor, pageSize, filters, sortBy }) => ({
+		buildListArgs: ({ cursor, pageSize, search, filters, sortBy }) => ({
 			cursor: cursor ?? undefined,
 			numItems: pageSize,
+			search,
 			actionFilter: filters.action === 'all' ? undefined : (filters.action as AuditLogAction),
 			adminUserId: filters.admin || undefined,
 			targetUserId: filters.target || undefined,
 			sortBy: sortBy ? { field: 'timestamp', direction: sortBy.direction } : undefined
 		}),
 		// Count is order-independent, so the sort direction is intentionally omitted.
-		buildCountArgs: ({ filters }) => ({
+		buildCountArgs: ({ search, filters }) => ({
+			search,
 			actionFilter: filters.action === 'all' ? undefined : (filters.action as AuditLogAction),
 			adminUserId: filters.admin || undefined,
 			targetUserId: filters.target || undefined
 		}),
-		resolveLastPage: async ({ pageSize, filters, sortBy }) => {
+		resolveLastPage: async ({ pageSize, search, filters, sortBy }) => {
 			const result = await client.query(api.admin.auditLog.queries.resolveAuditLogLastPage, {
 				numItems: pageSize,
+				search,
 				actionFilter: filters.action === 'all' ? undefined : (filters.action as AuditLogAction),
 				adminUserId: filters.admin || undefined,
 				targetUserId: filters.target || undefined,
@@ -98,6 +101,7 @@
 		toCount: (result) => result
 	});
 
+	const tableParams = $derived(auditTable.currentUrlState);
 	const pageIndex = $derived(auditTable.pageIndex);
 	const pageSize = $derived(auditTable.pageSize);
 	const isLoading = $derived(auditTable.isLoading);
@@ -149,12 +153,26 @@
 		auditTable.setFilter('action', action ?? 'all');
 	}
 
+	// Free-text search and a pinned user filter are mutually exclusive: the
+	// search already scans admin+target names/emails, and the backend serves it
+	// with an offset scan that ignores the admin/target index filters. Clearing
+	// the active user filter when a search begins keeps the two from contradicting.
+	function handleSearchChange(value: string) {
+		if (value && (auditTable.filters.admin || auditTable.filters.target)) {
+			auditTable.setFilter('admin', '');
+			auditTable.setFilter('target', '');
+		}
+		auditTable.setSearch(value);
+	}
+
 	function filterByAdmin(userId: string) {
+		auditTable.setSearch('');
 		auditTable.setFilter('target', '');
 		auditTable.setFilter('admin', userId);
 	}
 
 	function filterByTarget(userId: string) {
+		auditTable.setSearch('');
 		auditTable.setFilter('admin', '');
 		auditTable.setFilter('target', userId);
 	}
@@ -227,10 +245,9 @@
 	{#if browser}<ConvexCursorTableShell
 			testIdPrefix="admin-audit-log"
 			tableTestId="admin-audit-log-table"
-			showSearch={false}
-			searchValue=""
-			searchPlaceholder=""
-			onSearchChange={() => {}}
+			searchValue={tableParams.search}
+			searchPlaceholder={$t('admin.audit_log.search_placeholder')}
+			onSearchChange={handleSearchChange}
 			pageIndex={auditTable.pageIndex}
 			pageCount={auditTable.pageCount}
 			pageSize={auditTable.pageSize}


### PR DESCRIPTION
The audit log had no way to find entries by who was involved: the users table has a search box, the log only had the action dropdown and the click-to-filter chips from #662. Free-text search was deliberately split out of #659 as the larger piece.

The search resolves the query string to matching user ids with the exact same semantics as the users table (the shared logic now lives in a `collectMatchingUserIds` helper both features import), then scans the log once through the existing index routing, keeps rows whose admin or target is in the match set, and pages by numeric-offset cursor exactly like the users search does. The scan is capped at the same 5001 rows as the existing count query, so no unbounded collect ever runs; list and count share one scan function so their totals cannot drift. Enrichment stays bounded to the visible page. The action filter combines with search, while the admin/target chip filters and search clear each other, extending the existing exclusivity model.

Pure helpers for match filtering and offset slicing are unit-tested (10 cases including deleted users and cursor edge cases), and a new E2E case covers searching by target email, partial matches, and clearing back to the full log.

`bun run check:convex`, static checks, `bun run test:unit` (776 tests), and `e2e/admin-audit-log.spec.ts` (5 cases) pass locally. The Tolgee push of the new placeholder key is pending, the translation server is unreachable; all four locale files are complete in this PR.