### PR TITLE
fix(support): Paint capturing state before screenshot freeze

### DIFF
--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotEditor.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotEditor.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import { lockscroll } from '@svelte-put/lockscroll';
 	import { snapdom } from '@zumer/snapdom';
-	import { getTranslate } from '@tolgee/svelte';
+	import { getTranslate, T } from '@tolgee/svelte';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import { getSnapDOMConfig } from '$lib/utils/snapdom-config';
 	import { processImage } from '$lib/media/process-image';
 	import {
@@ -40,10 +42,16 @@
 
 	// Capture screenshot and pass to callback
 	async function handleSave() {
+		if (editorContext.isSaving) return; // re-entrancy guard for the pre-paint window
 		haptic.trigger('medium');
+		editorContext.isSaving = true;
+		await tick(); // flush the saving state into the DOM
+		// Double rAF guarantees the browser composites the capturing overlay before
+		// the synchronous snapdom clone below freezes the main thread.
+		await new Promise((resolve) =>
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined)))
+		);
 		try {
-			editorContext.isSaving = true;
-
 			const dpr = window.devicePixelRatio || 1;
 			const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 
@@ -159,6 +167,22 @@
 >
 	<ScreenshotToolbar />
 	<ScreenshotCanvas />
+
+	{#if editorContext.isSaving}
+		<!-- Capturing feedback. Kept inside [data-screenshot-editor] so snapdom's
+		     excludeMode:'remove' strips it from the capture with the rest of the
+		     editor chrome. z-index sits above the toolbar (z-[110]) and canvas. -->
+		<div
+			class="fixed inset-0 z-[120] flex items-center justify-center bg-background/95 backdrop-blur-sm"
+		>
+			<div
+				class="flex items-center gap-3 rounded-xl bg-background px-5 py-3 shadow-lg ring-1 ring-foreground/10"
+			>
+				<LoaderCircleIcon class="size-5 text-muted-foreground motion-safe:animate-spin" />
+				<span class="text-sm font-medium"><T keyName="support.screenshot.capturing" /></span>
+			</div>
+		</div>
+	{/if}
 
 	<!-- Instructions overlay (bottom center)
 	<div

--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotToolbar.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotToolbar.svelte
@@ -9,6 +9,7 @@
 	import CircleIcon from '@lucide/svelte/icons/circle';
 	import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
 	import CheckIcon from '@lucide/svelte/icons/check';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import { screenshotEditorContext } from './screenshot-editor-context.svelte';
 	import { DEFAULT_COLORS } from './types';
 	import { getTranslate } from '@tolgee/svelte';
@@ -134,10 +135,16 @@
 			class="size-9 sm:hidden"
 			onclick={editor.handleSave}
 			disabled={editor.isSaving || !editor.hasShapes}
-			title={$t('support.screenshot.next')}
-			aria-label={$t('support.screenshot.next')}
+			title={editor.isSaving ? $t('support.screenshot.capturing') : $t('support.screenshot.next')}
+			aria-label={editor.isSaving
+				? $t('support.screenshot.capturing')
+				: $t('support.screenshot.next')}
 		>
-			<CheckIcon class="size-4" />
+			{#if editor.isSaving}
+				<LoaderCircleIcon class="size-4 motion-safe:animate-spin" />
+			{:else}
+				<CheckIcon class="size-4" />
+			{/if}
 		</Button>
 
 		<!-- Next Button - Desktop: Text -->


### PR DESCRIPTION
Confirming a marked bug in the screenshot editor kicks off snapdom's synchronous full-page DOM clone on the main thread. The saving state was set in the same frame, so the browser never painted it: the user clicked, the UI froze for seconds with zero feedback, and extra clicks piled up. Reproduced on the marketing page, where the freeze was long enough to twice disconnect a CDP automation session.

The state now flushes with tick() plus a double requestAnimationFrame before the clone starts, guaranteeing the browser composites the feedback first. A centered capturing overlay with a spinner shows during the freeze and lives inside the editor container, so snapdom's excludeMode strips it from the capture itself. The mobile confirm button gets the same spinner and localized capturing label the desktop button already had, and a re-entrancy guard drops clicks landing in the pre-paint window. The clone itself stays synchronous; this fixes the perceived freeze, and reuses the existing capturing key in all four locales.

Regression guard: not warranted, singular UX timing fix with no lintable invariant; verified manually with CPU throttling.

`bun scripts/static-checks.ts` on both files passes and the svelte-autofixer reports no issues. Manual verification on the preview deploy follows in this PR.