### PR TITLE
fix(i18n): Ship static translations only in production builds

### DIFF
--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -54,7 +54,17 @@ const CONFIG = {
 		 * Scope: this scanner only covers .svelte/.ts files under src/ (full runs glob
 		 * that set; --staged/file-args runs filter the given files down to it).
 		 */
-		execSync: /\bexecSync\s*\(/
+		execSync: /\bexecSync\s*\(/,
+		/**
+		 * Ungated Tolgee apiKey in the root layout. Passing the key straight to
+		 * tolgeeBuilder.init leaves it in place through DCE, so Vite inlines it into
+		 * the deployed client bundle and production/preview builds fetch translations
+		 * from the Tolgee server at runtime. Gate it behind import.meta.env.DEV (see
+		 * src/routes/+layout.svelte) so the key and its value are dead-code-eliminated
+		 * from non-dev builds. The gated form reads `import.meta.env.DEV ?` right after
+		 * the colon, so this pattern only matches the unguarded assignment.
+		 */
+		ungatedTolgeeApiKey: /apiKey:\s*import\.meta\.env\.VITE_TOLGEE_API_KEY/
 	}
 };
 
@@ -245,7 +255,7 @@ async function main(): Promise<void> {
 		}
 		console.log('\n');
 
-		// Banned patterns (deprecated tokens, bare animate-spin, static Sentry imports, execSync)
+		// Banned patterns (deprecated tokens, bare animate-spin, static Sentry imports, execSync, ungated Tolgee apiKey)
 		printHeader(step++, 'Banned patterns');
 		{
 			const filesToScan = scopedMode
@@ -278,6 +288,11 @@ async function main(): Promise<void> {
 					if (CONFIG.bannedPatterns.execSync.test(line)) {
 						violations.push(
 							`${file}:${i + 1}: execSync (use spawn-style argument arrays, see runCommandCapture in scripts/deploy/utils.ts): ${line.trim()}`
+						);
+					}
+					if (CONFIG.bannedPatterns.ungatedTolgeeApiKey.test(line)) {
+						violations.push(
+							`${file}:${i + 1}: ungated Tolgee apiKey (gate behind import.meta.env.DEV so it is stripped from production/preview bundles): ${line.trim()}`
 						);
 					}
 				}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -107,8 +107,12 @@
 		defaultLanguage: 'en',
 		fallbackLanguage: 'en',
 
-		apiUrl: import.meta.env.VITE_TOLGEE_API_URL,
-		apiKey: import.meta.env.VITE_TOLGEE_API_KEY
+		// Live Tolgee (in-context editing) is dev-only. Production and preview
+		// builds fold import.meta.env.DEV to false, so apiUrl/apiKey and their
+		// inlined values are dead-code-eliminated: the shipped bundle runs purely
+		// from staticData and never talks to the Tolgee server.
+		apiUrl: import.meta.env.DEV ? import.meta.env.VITE_TOLGEE_API_URL : undefined,
+		apiKey: import.meta.env.DEV ? import.meta.env.VITE_TOLGEE_API_KEY : undefined
 	});
 
 	if (browser) {


### PR DESCRIPTION
The root layout passed VITE_TOLGEE_API_URL and VITE_TOLGEE_API_KEY to Tolgee.init unconditionally. Vite inlines VITE_ values statically, so any build that knows these vars ships the API key and server URL in the client bundle, and Tolgee treats the instance as a dev instance that prefers fetching live translation records over the bundled staticData. Deployed environments were one plugin registration away from depending on the translation server at runtime, which spent 14 hours unreachable this week.

Both fields are now gated behind import.meta.env.DEV, matching the existing DevTools gate. Build-time constant folding dead-code-eliminates the values from production and preview bundles: deployed runtimes run purely from staticData and never talk to the Tolgee server, while local dev keeps live translations and in-context editing unchanged.

Verified with a sentinel value in VITE_TOLGEE_API_KEY: the gated build has zero occurrences in the client output, the ungated form reproduces the leak into a client chunk. A banned-pattern check in static-checks.ts now flags the ungated apiKey assignment, written so the gated form does not match.

Regression guard: added ungatedTolgeeApiKey banned pattern in scripts/static-checks.ts

`bun scripts/static-checks.ts` on the changed files passes and `bun run test:unit` passes (782 tests).