### PR TITLE
fix(admin): Redirect impersonation instead of reload prompt

### DIFF
--- a/e2e/admin-impersonation.spec.ts
+++ b/e2e/admin-impersonation.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect, type Page } from '@playwright/test';
+import 'varlock/auto-load';
+import { ConvexHttpClient } from 'convex/browser';
+import { api } from '../src/lib/convex/_generated/api';
+import { resolveConvexUrl } from './utils/convex-url';
+import { resolveSiteUrl } from './utils/site-url';
+import { getPreviewBypass } from './utils/preview-bypass';
+import { waitForAuthenticated } from './utils/auth';
+
+const SITE_URL = resolveSiteUrl();
+const TEST_PASSWORD = 'TestPassword123!';
+const bypass = getPreviewBypass();
+
+function getRequestHeaders(): Record<string, string> {
+	return {
+		'Content-Type': 'application/json',
+		Origin: SITE_URL,
+		...bypass.headers
+	};
+}
+
+async function createAuthUser(email: string, name: string) {
+	const response = await fetch(`${SITE_URL}/api/auth/sign-up/email`, {
+		method: 'POST',
+		headers: getRequestHeaders(),
+		body: JSON.stringify({ email, password: TEST_PASSWORD, name })
+	});
+
+	if (!response.ok) {
+		const errorBody = await response.text().catch(() => 'unknown error');
+		throw new Error(`Failed to create seed user ${email}: ${response.status} ${errorBody}`);
+	}
+}
+
+async function waitForAuditLogReady(page: Page) {
+	await expect(page.getByTestId('admin-audit-log-page')).toBeVisible();
+	await expect(page.getByTestId('admin-audit-log-table')).toBeVisible();
+	await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+}
+
+async function selectActionFilter(page: Page, action: string) {
+	await page.getByTestId('admin-audit-log-action-filter').click();
+	await page.getByTestId(`admin-audit-log-action-filter-${action}`).click();
+	await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+}
+
+test.describe('Admin Impersonation', () => {
+	test.describe.configure({ mode: 'serial', timeout: 180000 });
+
+	const testSecret = process.env.AUTH_E2E_TEST_SECRET;
+	const convexUrl = resolveConvexUrl();
+
+	let client: ConvexHttpClient;
+	let targetEmail = '';
+	const createdEmails: string[] = [];
+	let uncaughtPageErrors: string[] = [];
+
+	test.beforeAll(async () => {
+		test.setTimeout(180000);
+
+		if (!testSecret) {
+			throw new Error('AUTH_E2E_TEST_SECRET is required in .env.test');
+		}
+		if (!convexUrl) {
+			throw new Error(
+				'Convex URL not configured (set PUBLIC_CONVEX_URL or start local dev server)'
+			);
+		}
+
+		client = new ConvexHttpClient(convexUrl);
+		targetEmail = `impersonation-target-${Date.now()}@e2e.example.com`;
+
+		await createAuthUser(targetEmail, 'Impersonation Target');
+		createdEmails.push(targetEmail);
+		await client.mutation(api.tests.verifyTestUserEmail, {
+			email: targetEmail,
+			secret: testSecret
+		});
+	});
+
+	test.afterAll(async () => {
+		if (!testSecret || !client) return;
+
+		for (const email of createdEmails) {
+			try {
+				await client.mutation(api.tests.deleteTestUser, { email, secret: testSecret });
+			} catch (error) {
+				console.warn(`[admin-impersonation] cleanup failed for ${email}:`, error);
+			}
+		}
+	});
+
+	test.beforeEach(async ({ page }) => {
+		uncaughtPageErrors = [];
+		page.on('pageerror', (error) => {
+			uncaughtPageErrors.push(error.message);
+		});
+	});
+
+	test.afterEach(() => {
+		expect(
+			uncaughtPageErrors,
+			`Uncaught browser runtime errors:\n${uncaughtPageErrors.join('\n')}`
+		).toEqual([]);
+	});
+
+	test('impersonates a user, redirects into the app, stops, and records the audit trail', async ({
+		page
+	}) => {
+		// Find the target user in the admin table and start impersonation.
+		await page.goto('/en/admin/users');
+		await page.waitForLoadState('domcontentloaded');
+		await expect(page.getByTestId('admin-users-page')).toBeVisible();
+		await expect(page.getByTestId('admin-users-search')).toBeVisible({ timeout: 30000 });
+
+		await page.getByTestId('admin-users-search').fill(targetEmail);
+		await expect(
+			page.getByTestId('admin-users-email-cell').filter({ hasText: targetEmail })
+		).toHaveCount(1, { timeout: 10000 });
+		await expect(page.getByTestId('admin-users-row-actions')).toHaveCount(1);
+
+		await page.getByTestId('admin-users-row-actions').click();
+		await page.getByTestId('admin-users-action-impersonate').click();
+
+		// The UX fix: impersonation triggers a full navigation into the app (no
+		// reload-prompt dialog), then the app boots as the impersonated identity.
+		await page.waitForURL(/\/en\/app/, { timeout: 30000 });
+		await waitForAuthenticated(page);
+
+		// The impersonation banner is visible and the user menu now shows the
+		// impersonated user, proving the app runs under the swapped session.
+		await expect(page.getByTestId('impersonation-banner')).toBeVisible({ timeout: 15000 });
+		await expect(page.locator('#user-menu-trigger')).toContainText(targetEmail);
+
+		// Stop impersonating from the user menu. This restores the admin session and
+		// navigates back to the users table.
+		await page.locator('#user-menu-trigger').click();
+		await page.getByTestId('app-user-menu-stop-impersonating').click();
+
+		await page.waitForURL(/\/en\/admin\/users/, { timeout: 30000 });
+		await page.waitForLoadState('domcontentloaded');
+		await expect(page.getByTestId('admin-users-page')).toBeVisible();
+		await expect.poll(async () => page.getByTestId('impersonation-banner').count()).toBe(0);
+
+		// The audit log records the stop with the elapsed duration. Search narrows the
+		// log to our target, the action filter isolates the stop_impersonation entry.
+		await page.goto('/en/admin/audit-log');
+		await page.waitForLoadState('domcontentloaded');
+		await waitForAuditLogReady(page);
+		await expect(page.getByTestId('admin-audit-log-search')).toBeVisible();
+
+		await page.getByTestId('admin-audit-log-search').fill(targetEmail);
+		await expect.poll(() => new URL(page.url()).searchParams.get('search')).toBe(targetEmail);
+		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
+
+		await selectActionFilter(page, 'stop_impersonation');
+		await expect
+			.poll(() => new URL(page.url()).searchParams.get('action'))
+			.toBe('stop_impersonation');
+
+		// Every remaining row is a stop against our target, and the details cell
+		// reports the impersonation duration ("Lasted ...", possibly 0 sec).
+		const badges = (await page.getByTestId('audit-log-action-badge').allTextContents()).map(
+			(value) => value.trim()
+		);
+		expect(badges.length).toBeGreaterThan(0);
+		expect(badges.every((label) => label === 'Stop impersonation')).toBe(true);
+
+		await expect(
+			page.getByTestId('audit-log-target-cell').filter({ hasText: targetEmail })
+		).toHaveCount(1, { timeout: 10000 });
+		await expect(page.getByTestId('audit-log-details-cell').first()).toContainText(/Lasted/, {
+			timeout: 10000
+		});
+	});
+});

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -57,8 +57,6 @@
 			"ban_reason_label": "Sperrgrund",
 			"ban_reason_placeholder": "Sperrgrund (optional)",
 			"ban_title": "Benutzer sperren",
-			"impersonation_active_description": "Bitte laden Sie die Seite neu, um als der andere Benutzer angemeldet zu werden.",
-			"impersonation_active_title": "Identitätswechsel aktiv",
 			"revoke_description": "Möchten Sie wirklich alle Sitzungen für {email} widerrufen? Die Person wird überall abgemeldet.",
 			"revoke_title": "Sitzungen widerrufen",
 			"set_role_description": "Möchten Sie die Rolle von {email} wirklich auf {role} ändern?",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -57,8 +57,6 @@
 			"ban_reason_label": "Ban reason",
 			"ban_reason_placeholder": "Ban reason (optional)",
 			"ban_title": "Ban User",
-			"impersonation_active_description": "Please reload the page to be logged in as the impersonated user.",
-			"impersonation_active_title": "Impersonation Active",
 			"revoke_description": "Are you sure you want to revoke all sessions for {email}? They will be logged out everywhere.",
 			"revoke_title": "Revoke Sessions",
 			"set_role_description": "Are you sure you want to change the role of {email} to {role}?",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -57,8 +57,6 @@
 			"ban_reason_label": "Motivo del bloqueo",
 			"ban_reason_placeholder": "Motivo del bloqueo (opcional)",
 			"ban_title": "Bloquear Usuario",
-			"impersonation_active_description": "Por favor, recarga la página para iniciar sesión como el usuario suplantado.",
-			"impersonation_active_title": "Suplantación activa",
 			"revoke_description": "¿Estás seguro de que quieres revocar todas las sesiones de {email}? Se cerrará sesión en todos los dispositivos.",
 			"revoke_title": "Revocar Sesiones",
 			"set_role_description": "¿Estás seguro de que quieres cambiar el rol de {email} a {role}?",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -57,8 +57,6 @@
 			"ban_reason_label": "Motif du bannissement",
 			"ban_reason_placeholder": "Motif du bannissement (optionnel)",
 			"ban_title": "Bannir l'Utilisateur",
-			"impersonation_active_description": "Veuillez recharger la page pour vous connecter en tant qu'utilisateur usurpé.",
-			"impersonation_active_title": "Usurpation active",
 			"revoke_description": "Êtes-vous sûr de vouloir révoquer toutes les sessions de {email} ? La déconnexion sera effectuée partout.",
 			"revoke_title": "Révoquer les Sessions",
 			"set_role_description": "Êtes-vous sûr de vouloir changer le rôle de {email} en {role} ?",

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -26,11 +26,20 @@
 
 	interface Props {
 		user: { name: string; email: string; avatar: string };
-		isImpersonating?: boolean;
 	}
 
-	let { user, isImpersonating = false }: Props = $props();
+	let { user }: Props = $props();
 	const sidebar = useSidebar();
+
+	// Impersonation state comes from the live session, not a parent prop: while an
+	// admin impersonates a user the session carries impersonatedBy, so the app
+	// shell reads it directly to show the banner and the Stop control.
+	let isImpersonating = $state(false);
+	$effect(() => {
+		return authClient.useSession().subscribe((s) => {
+			isImpersonating = !!s.data?.session?.impersonatedBy;
+		});
+	});
 
 	// Autumn subscription state
 	const autumn = useCustomer();
@@ -97,7 +106,14 @@
 				return;
 			}
 			toast.success($t('app.user_menu.impersonation_stopped'));
-			goto(resolve(localizedHref('/admin/users')));
+			// Stopping restored the admin session cookie, but Better Auth's convex
+			// plugin does not re-mint the SSR JWT cookie on stop. Force a session read
+			// so the server issues a fresh convex_jwt for the admin before we navigate,
+			// otherwise SSR resolves the still-alive impersonated token.
+			await authClient.getSession({ query: { disableCookieCache: true } });
+			// Full document navigation, not a client-side goto: the app must boot with
+			// the fresh JWT and new Convex subscriptions bound to the admin identity.
+			window.location.assign(localizedHref('/admin/users'));
 		} catch {
 			toast.error($t('app.user_menu.impersonation_stop_failed'));
 		}
@@ -107,6 +123,7 @@
 {#if isImpersonating}
 	<div
 		class="mb-2 rounded-md border border-warning/20 bg-warning/10 px-3 py-2 text-xs font-medium text-warning"
+		data-testid="impersonation-banner"
 	>
 		<T keyName="app.user_menu.impersonating_banner" />
 	</div>
@@ -194,7 +211,11 @@
 				</DropdownMenu.Group>
 				{#if isImpersonating}
 					<DropdownMenu.Separator />
-					<DropdownMenu.Item onclick={() => stopImpersonating()} class="text-warning">
+					<DropdownMenu.Item
+						onclick={() => stopImpersonating()}
+						class="text-warning"
+						data-testid="app-user-menu-stop-impersonating"
+					>
 						<UserXIcon />
 						<T keyName="app.user_menu.stop_impersonating" />
 					</DropdownMenu.Item>

--- a/src/routes/[[lang]]/admin/users/+page.svelte
+++ b/src/routes/[[lang]]/admin/users/+page.svelte
@@ -2,6 +2,7 @@
 	import SEOHead from '$lib/components/SEOHead.svelte';
 	import * as v from 'valibot';
 	import { clamp } from '$lib/utils/math';
+	import { localizedHref } from '$lib/utils/i18n';
 	import {
 		type RowSelectionState,
 		type SortingState,
@@ -208,7 +209,6 @@
 	let dialogOpen = $state(false);
 	let roleDialogOpen = $state(false);
 	let selectedRole = $state<UserRole>('user');
-	let impersonationDialogOpen = $state(false);
 	let isActionLoading = $state(false);
 
 	// Provide context for action component (currentUserId is set by admin layout)
@@ -350,7 +350,17 @@
 				return;
 			}
 
-			impersonationDialogOpen = true;
+			// Impersonation swapped the session cookie, but Better Auth's convex
+			// plugin only re-mints the SSR JWT cookie on sign-in/get-session, not on
+			// impersonate. Force a session read so the server issues a fresh convex_jwt
+			// for the impersonated identity before we navigate, otherwise SSR resolves
+			// the still-alive admin token and the app boots as the admin.
+			await authClient.getSession({ query: { disableCookieCache: true } });
+
+			// Full document navigation, not a client-side goto: the app must boot with
+			// the fresh JWT and new Convex subscriptions bound to the impersonated
+			// identity.
+			window.location.assign(localizedHref('/app'));
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
 			toast.error($t('admin.users.toast.impersonate_failed', { message }));
@@ -709,23 +719,6 @@
 			>
 				<T keyName="common.confirm" />
 			</Button>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
-
-<!-- Impersonation Active Dialog -->
-<Dialog.Root bind:open={impersonationDialogOpen}>
-	<Dialog.Content>
-		<Dialog.Header>
-			<Dialog.Title>
-				<T keyName="admin.dialog.impersonation_active_title" />
-			</Dialog.Title>
-			<Dialog.Description>
-				<T keyName="admin.dialog.impersonation_active_description" />
-			</Dialog.Description>
-		</Dialog.Header>
-		<Dialog.Footer>
-			<Button onclick={() => (impersonationDialogOpen = false)}>OK</Button>
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>


### PR DESCRIPTION
Impersonating a user from the admin panel showed a dialog telling the admin to reload the page manually. After reloading you were still on the admin route, which the impersonated user cannot access, so every impersonation ended in a manual trip to the dashboard. The stop control had it worse: the banner and menu item hung off an `isImpersonating` prop no parent ever passed, so the entire stop UI was unreachable, and its handler used a client-side goto that would have kept stale Convex subscriptions alive.

Impersonation now navigates straight to the app with a full document load, and stopping returns to the admin users page the same way, since the session cookie swap needs a fresh JWT and new Convex subscriptions. Testing surfaced a second, load-bearing gap: Better Auth's convex plugin only re-mints the SSR JWT cookie on sign-in and get-session, not on impersonate or stop, so the still-alive old token kept SSR resolving the previous identity. Both paths force a session read with the cookie cache disabled before navigating, which issues a fresh JWT for the new identity; without it the app booted with the impersonated banner but admin data. The banner now derives its state from the live session via the established useSession subscription pattern, the reload dialog and its translation keys are gone from all four locales, and banner plus stop control carry test ids.

Regression guard: added e2e/admin-impersonation.spec.ts

The new spec covers the full flow end to end: impersonate from the users table, land on /app without a dialog, banner and target identity visible, stop from the menu, return to admin users, and the audit log showing the stop_impersonation entry with its duration. `bun scripts/static-checks.ts` on the changed files passes, the new spec passes locally, and `e2e/admin-audit-log.spec.ts` passes as a regression check on a fresh backend. The Tolgee sync of the removed keys is pending, the translation server is unreachable.