### PR TITLE
fix(build): Strip sensitive values from serialized env manifest

### DIFF
--- a/scripts/strip-varlock-secrets.test.ts
+++ b/scripts/strip-varlock-secrets.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { stripSensitiveManifestValues } from './strip-varlock-secrets';
+
+function fixture() {
+	return {
+		settings: { redactLogs: true },
+		config: {
+			PUBLIC_CONVEX_URL: { value: 'https://example.convex.cloud', isSensitive: false },
+			CONVEX_DEPLOY_KEY: { value: 'prod:secret-deploy-key', isSensitive: true },
+			CONVEX_MANAGEMENT_TOKEN: { value: 'mgmt-token', isSensitive: true },
+			CONVEX_INTERNAL_URL: { value: 'http://convex:3210', isSensitive: true },
+			// Already-unset sensitive var: no value key at all
+			SENTRY_AUTH_TOKEN: { isSensitive: true },
+			VARLOCK_ENV: { value: 'production', isSensitive: false }
+		}
+	};
+}
+
+describe('stripSensitiveManifestValues', () => {
+	it('drops the value of every @sensitive entry', () => {
+		const stripped = stripSensitiveManifestValues(fixture());
+		for (const key of ['CONVEX_DEPLOY_KEY', 'CONVEX_MANAGEMENT_TOKEN', 'CONVEX_INTERNAL_URL']) {
+			expect(stripped.config[key], key).not.toHaveProperty('value');
+		}
+	});
+
+	it('keeps the value of non-sensitive entries intact', () => {
+		const stripped = stripSensitiveManifestValues(fixture());
+		expect(stripped.config.PUBLIC_CONVEX_URL.value).toBe('https://example.convex.cloud');
+		expect(stripped.config.VARLOCK_ENV.value).toBe('production');
+	});
+
+	it('preserves every key and its isSensitive flag (structure stays intact)', () => {
+		const original = fixture();
+		const stripped = stripSensitiveManifestValues(fixture());
+		expect(Object.keys(stripped.config)).toEqual(Object.keys(original.config));
+		for (const key of Object.keys(original.config)) {
+			expect(stripped.config[key].isSensitive, key).toBe(original.config[key].isSensitive);
+		}
+	});
+
+	it('produces the same shape for a stripped var as an already-unset sensitive var', () => {
+		const stripped = stripSensitiveManifestValues(fixture());
+		// SENTRY_AUTH_TOKEN was already valueless; CONVEX_DEPLOY_KEY had a value that got dropped
+		expect(stripped.config.CONVEX_DEPLOY_KEY).toEqual(stripped.config.SENTRY_AUTH_TOKEN);
+	});
+
+	it('mutates in place and returns the same reference', () => {
+		const manifest = fixture();
+		expect(stripSensitiveManifestValues(manifest)).toBe(manifest);
+	});
+
+	it('tolerates a missing or empty manifest', () => {
+		expect(stripSensitiveManifestValues(undefined)).toBeUndefined();
+		expect(stripSensitiveManifestValues(null)).toBeNull();
+		expect(stripSensitiveManifestValues({})).toEqual({});
+	});
+});

--- a/scripts/strip-varlock-secrets.ts
+++ b/scripts/strip-varlock-secrets.ts
@@ -1,0 +1,27 @@
+/**
+ * Strip resolved values of sensitive env vars out of a varlock manifest.
+ *
+ * `@varlock/vite-integration`'s `resolved-env` SSR inject mode serializes the whole
+ * resolved manifest into the server bundle (`globalThis.__varlockLoadedEnv = {...}`),
+ * including the plaintext `value` of every var marked `@sensitive`. That bundle ships
+ * to the edge and is readable from the deployed artifact, so any write-only platform
+ * secret present at build time (Convex deploy keys, management token, build-time-only
+ * API keys) is exposed there even though nothing at runtime reads it.
+ *
+ * Dropping the `value` keeps the entry and its `isSensitive` flag, so the runtime
+ * `initVarlockEnv()` still registers the key (as `undefined`) — byte-for-byte the same
+ * shape a var that is simply unset already serializes to. No runtime read depends on a
+ * sensitive value from this manifest: SvelteKit server code reads private vars via
+ * `$env/dynamic/private` (the platform's own `process.env`), and the sensitive vars in
+ * this schema are either build/deploy-only or consumed by the separate Convex backend.
+ */
+type ManifestItem = { value?: unknown; isSensitive?: boolean };
+type EnvManifest = { config?: Record<string, ManifestItem> } | undefined | null;
+
+export function stripSensitiveManifestValues<T extends EnvManifest>(manifest: T): T {
+	if (!manifest?.config) return manifest;
+	for (const item of Object.values(manifest.config)) {
+		if (item?.isSensitive) delete item.value;
+	}
+	return manifest;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ import { resetRedactionMap } from 'varlock/env';
 import { DEV_FEATURES, type DevFeature } from './src/lib/dev/features';
 import { findAvailablePort, portlessOwnsPort } from './scripts/dev-ports';
 import { TEST_ONLY_ENV_PLACEHOLDERS } from './scripts/local-convex-env';
+import { stripSensitiveManifestValues } from './scripts/strip-varlock-secrets';
 import { sentrySvelteKit } from '@sentry/sveltekit';
 import devtoolsJson from 'vite-plugin-devtools-json';
 import tailwindcss from '@tailwindcss/vite';
@@ -387,6 +388,20 @@ export default defineConfig(async ({ mode }) => {
 	}
 
 	plugins.push(
+		// Drop plaintext values of @sensitive vars from varlock's resolved-env manifest
+		// before varlockVitePlugin serializes it into the SSR bundle. Write-only platform
+		// secrets (Convex deploy/preview keys, management token) are otherwise readable in
+		// the deployed edge artifact even though nothing at runtime reads them. buildStart
+		// runs after varlock's config reload and before the manifest is serialized, and
+		// mutates the same live binding varlockVitePlugin serializes, so this is
+		// adapter-agnostic (Cloudflare, Vercel, adapter-node). See scripts/strip-varlock-secrets.ts.
+		{
+			name: 'strip-varlock-sensitive-manifest-values',
+			apply: 'build',
+			buildStart() {
+				if (mode === 'production') stripSensitiveManifestValues(varlockLoadedEnv);
+			}
+		},
 		varlockVitePlugin(mode === 'production' ? { ssrInjectMode: 'resolved-env' } : {}),
 		tailwindcss(),
 		sveltekit(),


### PR DESCRIPTION
varlock's resolved-env SSR inject mode serializes the entire resolved env manifest into the server bundle, including the plaintext value of every var marked sensitive in the schema. Any write-only platform secret present in the build environment ends up readable inside the deployed server artifact, even though nothing at runtime reads it: the deploy keys are consumed by scripts/deploy.ts in CI via process.env, SvelteKit server code reads private vars through $env/dynamic/private, and the remaining sensitive vars live in the separate Convex backend. Upgrading @varlock/vite-integration does not change this default, the current release only adds an opt-in encryption mode that would still ship the values.

A small build plugin now drops the value of every sensitive entry from the shared manifest binding before varlock serializes it, at buildStart in production builds only. The key and its sensitivity flag stay, which is byte-for-byte the shape an unset optional var already produces, so initVarlockEnv and non-sensitive values are unaffected and dev behavior (including log redaction) is unchanged. Because the mutation happens before serialization rather than in a post-build patch, it covers every deploy adapter.

Verified with sentinel values in the sensitive vars: without the plugin they appear in the SSR output, with it the build output contains zero occurrences while non-sensitive values stay intact.

Regression guard: added scripts/strip-varlock-secrets.test.ts

`bun run test:unit` passes (788 tests including the six new ones), static checks pass, and a production build completes with the stripped manifest.