### PR TITLE
feat(security): Add script-src CSP in report-only mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -642,10 +642,19 @@ Examples: URL parsing, stream processing, optimistic updates.
 
 #### "This security header / policy must be present"
 
-Examples: HSTS, X-Frame-Options on all responses including static assets (no CSP is currently set).
+Examples: HSTS, X-Frame-Options on all responses including static assets.
 
 → **`_headers` file** (project root) for static assets + **server hook** for SSR responses.
 Both are needed — static assets bypass hooks.
+
+The Content-Security-Policy is split by what a `<meta>` tag can carry. `object-src`/`base-uri`
+live in `kit.csp` (`svelte.config.js`): SvelteKit embeds them as a `<meta>` on prerendered
+pages and as a header on SSR pages. `frame-ancestors` cannot ride a `<meta>`, so it is a
+header set in three synced places (`hooks.server.ts`, `_headers`, `vercel.json`); the hook
+appends it to SvelteKit's header rather than overwriting. `script-src` runs in report-only
+mode (`kit.csp.reportOnly`), wired to Sentry only when `PUBLIC_SENTRY_DSN` is set at build
+time; two static hashes cover the inline scripts SvelteKit does not tag (see
+`src/lib/security/csp.js`). Enforcement of `script-src` is a later deliberate flip.
 
 #### "This export is intentionally unused (template knob for forks)"
 

--- a/_headers
+++ b/_headers
@@ -5,7 +5,10 @@
   Permissions-Policy: camera=(), microphone=(), geolocation=(), browsing-topics=(), payment=(), usb=(), serial=()
   X-DNS-Prefetch-Control: off
   Strict-Transport-Security: max-age=63072000; includeSubDomains
-  Content-Security-Policy: object-src 'none'; base-uri 'self'; frame-ancestors 'none'
+  # script-src/object-src/base-uri live in kit.csp (svelte.config.js): prerendered
+  # pages carry them in a <meta> tag. Only frame-ancestors, which a <meta> cannot
+  # express, is set here for static assets. Kept in sync with hooks.server.ts / vercel.json.
+  Content-Security-Policy: frame-ancestors 'none'
   Cross-Origin-Opener-Policy: same-origin-allow-popups
   Cross-Origin-Resource-Policy: same-origin
 

--- a/scripts/security-headers-sync.test.ts
+++ b/scripts/security-headers-sync.test.ts
@@ -10,6 +10,12 @@ import { describe, expect, it } from 'vitest';
  *    file is CF/Netlify-only, so without this Vercel static assets get none)
  *
  * If one is updated without the others, some responses will be missing headers.
+ *
+ * Content-Security-Policy is the one header not fully expressed here: script-src/
+ * object-src/base-uri live in kit.csp (svelte.config.js), so all three sources
+ * below carry only the header-only frame-ancestors directive. On SSR the hook
+ * appends it to the CSP header SvelteKit already set (a merge, not an overwrite),
+ * so it is matched via its fallback literal rather than a plain set().
  */
 
 function parseHeadersFile(filePath: string): Map<string, string> {
@@ -55,6 +61,17 @@ function parseHooksHeaders(filePath: string): Map<string, string> {
 		headers.set(name, value);
 	}
 
+	// CSP is set via a merge (frame-ancestors is appended to the header SvelteKit
+	// already set from kit.csp) rather than a plain literal, so the generic pattern
+	// above does not catch it. Match its fallback value — the same frame-ancestors
+	// directive it appends and guarantees on every response.
+	// The fallback is written as a double-quoted JS string because its value
+	// contains single quotes (frame-ancestors 'none').
+	const csp = content.match(
+		/headers\.set\(\s*['"]Content-Security-Policy['"]\s*,[\s\S]*?:\s*"([^"]+)"\s*\)/
+	);
+	if (csp) headers.set('content-security-policy', csp[1]!);
+
 	return headers;
 }
 
@@ -89,7 +106,7 @@ describe('security headers sync', () => {
 		],
 		['x-dns-prefetch-control', 'off'],
 		['strict-transport-security', 'max-age=63072000; includeSubDomains'],
-		['content-security-policy', "object-src 'none'; base-uri 'self'; frame-ancestors 'none'"],
+		['content-security-policy', "frame-ancestors 'none'"],
 		['cross-origin-opener-policy', 'same-origin-allow-popups'],
 		['cross-origin-resource-policy', 'same-origin']
 	]);

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -318,9 +318,16 @@ const handleSecurityHeaders: Handle = async function handleSecurityHeaders({ eve
 	);
 	response.headers.set('X-DNS-Prefetch-Control', 'off');
 	response.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains');
+	// script-src/object-src/base-uri now live in kit.csp (svelte.config.js): on SSR
+	// pages SvelteKit sets the Content-Security-Policy header, on prerendered pages a
+	// <meta>. frame-ancestors cannot ride a <meta> and SvelteKit can't set headers on
+	// prerendered static pages, so it stays a header here (SSR) and in _headers /
+	// vercel.json (prerendered). Append rather than overwrite: a plain headers.set
+	// would clobber the object-src/base-uri header SvelteKit already set on SSR pages.
+	const kitCsp = response.headers.get('Content-Security-Policy');
 	response.headers.set(
 		'Content-Security-Policy',
-		"object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+		kitCsp ? `${kitCsp}; frame-ancestors 'none'` : "frame-ancestors 'none'"
 	);
 	response.headers.set('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
 	response.headers.set('Cross-Origin-Resource-Policy', 'same-origin');

--- a/src/lib/security/csp.js
+++ b/src/lib/security/csp.js
@@ -1,0 +1,106 @@
+/**
+ * Content-Security-Policy building blocks shared between the SvelteKit config
+ * (svelte.config.js) and the hash regression guard (csp.test.ts).
+ *
+ * Enforced everywhere today: object-src 'none' and base-uri 'self' (via kit.csp
+ * below) plus frame-ancestors 'none' (header-only, set in hooks.server.ts and
+ * mirrored in _headers / vercel.json because it cannot ride a <meta> tag).
+ *
+ * script-src runs in REPORT-ONLY: it does not block anything yet, it only
+ * collects violation reports so the policy can be validated before a later
+ * enforcement flip. Report-only is emitted only when a Sentry DSN is configured
+ * (see buildContentSecurityPolicy).
+ */
+
+// sha256 of the two inline <script> blocks that SvelteKit does not hash itself:
+//  - APP_HTML: the vite:preloadError + __deployReloadArmed bootstrap in src/app.html
+//  - MODE_WATCHER: the FOUC-prevention head script mode-watcher injects via {@html}
+// Both are byte-identical across every rendered page. Regenerate after editing
+// app.html or bumping mode-watcher: run `bun run build`, then read the sha256 of
+// each inline block from a prerendered page (csp.test.ts documents the exact
+// command). The mode-watcher block is the production bundler's reformatted output,
+// so its hash can only be regenerated from a real build, not from source text.
+export const APP_HTML_SCRIPT_HASH = 'sha256-Ml0GII2JIRPFSoeoBdrueYbrawv5r1xJB41NAsxXDxw=';
+export const MODE_WATCHER_SCRIPT_HASH = 'sha256-Cr3r+iKjDTUxJaxM3r/Iq0ow6clOB9AqoT6j0wMFMIM=';
+
+// Fingerprint of mode-watcher's setInitialMode source (node_modules/mode-watcher/
+// dist/mode.js), NOT the deployed hash. A change here means the FOUC script moved
+// and MODE_WATCHER_SCRIPT_HASH must be regenerated from a build. Lets the guard
+// fail loudly on a mode-watcher bump without running the production bundler.
+export const MODE_WATCHER_SOURCE_FINGERPRINT =
+	'sha256-NNW8Woh/BBAB32UgnIohmp5dmS5tYyx630lkf4nITzY=';
+
+/**
+ * Derive a Sentry CSP report endpoint from a Sentry DSN.
+ *   DSN:      https://<publicKey>@<host>/<projectId>
+ *   Endpoint: https://<host>/api/<projectId>/security/?sentry_key=<publicKey>
+ * Returns null for an empty or malformed DSN.
+ * @param {string | undefined | null} dsn
+ * @returns {string | null}
+ */
+export function deriveSentryReportUri(dsn) {
+	if (!dsn) return null;
+	try {
+		const url = new URL(dsn);
+		const publicKey = url.username;
+		const projectId = url.pathname.replace(/^\/+/, '');
+		if (!publicKey || !projectId) return null;
+		return `${url.protocol}//${url.host}/api/${projectId}/security/?sentry_key=${publicKey}`;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Shape of the object handed to `kit.csp`. Declared locally rather than reusing
+ * SvelteKit's `CspDirectives` type, which is not publicly exported and breaks
+ * declaration emit for this module. Structurally compatible with `kit.csp`.
+ * @typedef {object} KitCspConfig
+ * @property {'auto'} mode
+ * @property {{ 'object-src': string[], 'base-uri': string[] }} directives
+ * @property {Record<string, string[]>} [reportOnly]
+ */
+
+/**
+ * Build the kit.csp config object.
+ *
+ * Enforced `directives` hold object-src/base-uri (unchanged strictness).
+ * `reportOnly` carries the script-src policy and is only added when a Sentry DSN
+ * is present: SvelteKit throws at build time if a report-only policy has no
+ * report-uri/report-to, and a report-only policy with nowhere to report is a
+ * no-op. Forks without Sentry therefore ship the enforced base policy only.
+ *
+ * @param {{ sentryDsn?: string | null }} [opts]
+ * @returns {KitCspConfig}
+ */
+export function buildContentSecurityPolicy({ sentryDsn } = {}) {
+	/** @type {KitCspConfig} */
+	const csp = {
+		mode: 'auto',
+		directives: {
+			'object-src': ['none'],
+			'base-uri': ['self']
+		}
+	};
+
+	const reportUri = deriveSentryReportUri(sentryDsn);
+	if (reportUri) {
+		csp.reportOnly = {
+			// strict-dynamic trusts scripts loaded by an already-trusted script
+			// (kit's nonce/hash-tagged bootstrap); the two static hashes cover the
+			// inline blocks kit does not tag; wasm-unsafe-eval is for the Rive canvas.
+			'script-src': [
+				'self',
+				'strict-dynamic',
+				'wasm-unsafe-eval',
+				APP_HTML_SCRIPT_HASH,
+				MODE_WATCHER_SCRIPT_HASH
+			],
+			'object-src': ['none'],
+			'base-uri': ['self'],
+			'report-uri': [reportUri]
+		};
+	}
+
+	return csp;
+}

--- a/src/lib/security/csp.test.ts
+++ b/src/lib/security/csp.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+	APP_HTML_SCRIPT_HASH,
+	MODE_WATCHER_SCRIPT_HASH,
+	MODE_WATCHER_SOURCE_FINGERPRINT,
+	buildContentSecurityPolicy,
+	deriveSentryReportUri
+} from './csp.js';
+
+const sha256 = (content: string) =>
+	'sha256-' + createHash('sha256').update(content, 'utf8').digest('base64');
+
+// Content of an attribute-less inline <script> ... </script> block.
+function firstInlineScript(html: string): string {
+	const content = html.match(/<script>([\s\S]*?)<\/script>/)?.[1];
+	if (content == null) throw new Error('no inline <script> block found');
+	return content;
+}
+
+describe('CSP script-src hashes', () => {
+	it('APP_HTML_SCRIPT_HASH matches the current src/app.html inline script', () => {
+		// app.html is copied into every page verbatim, so hashing the source block
+		// reproduces the deployed hash exactly. If this fails, the bootstrap script
+		// changed: update APP_HTML_SCRIPT_HASH in src/lib/security/csp.js.
+		const appHtml = readFileSync(path.resolve('src/app.html'), 'utf8');
+		expect(sha256(firstInlineScript(appHtml))).toBe(APP_HTML_SCRIPT_HASH);
+	});
+
+	it('mode-watcher setInitialMode source is unchanged (proxy for the deployed hash)', () => {
+		// MODE_WATCHER_SCRIPT_HASH is the production bundler's reformatted output of
+		// mode-watcher's FOUC script, so it cannot be recomputed without a full build.
+		// Instead fingerprint the setInitialMode SOURCE: a mode-watcher bump that
+		// touches it fails here, signalling that MODE_WATCHER_SCRIPT_HASH must be
+		// regenerated from a fresh `bun run build` (see the regeneration note below).
+		const modeSource = readFileSync(path.resolve('node_modules/mode-watcher/dist/mode.js'), 'utf8');
+		const fn = modeSource.match(/function setInitialMode[\s\S]*?\n\}/);
+		expect(fn, 'setInitialMode not found in mode-watcher/dist/mode.js').not.toBeNull();
+		expect(
+			sha256(fn![0]),
+			'mode-watcher FOUC script changed — rebuild and regenerate MODE_WATCHER_SCRIPT_HASH'
+		).toBe(MODE_WATCHER_SOURCE_FINGERPRINT);
+	});
+
+	it('both hashes are well-formed sha256 CSP source expressions', () => {
+		const format = /^sha256-[A-Za-z0-9+/]{43}=$/;
+		expect(APP_HTML_SCRIPT_HASH).toMatch(format);
+		expect(MODE_WATCHER_SCRIPT_HASH).toMatch(format);
+	});
+});
+
+describe('deriveSentryReportUri', () => {
+	it('builds a Sentry security endpoint from a DSN', () => {
+		expect(deriveSentryReportUri('https://abc123@o123456.ingest.sentry.io/7890')).toBe(
+			'https://o123456.ingest.sentry.io/api/7890/security/?sentry_key=abc123'
+		);
+	});
+
+	it('returns null for missing or malformed DSNs', () => {
+		expect(deriveSentryReportUri(undefined)).toBeNull();
+		expect(deriveSentryReportUri('')).toBeNull();
+		expect(deriveSentryReportUri('not-a-url')).toBeNull();
+		// No public key / no project id
+		expect(deriveSentryReportUri('https://o123456.ingest.sentry.io/7890')).toBeNull();
+		expect(deriveSentryReportUri('https://abc123@o123456.ingest.sentry.io/')).toBeNull();
+	});
+});
+
+describe('buildContentSecurityPolicy', () => {
+	it('enforces object-src/base-uri and omits report-only without a Sentry DSN', () => {
+		const csp = buildContentSecurityPolicy({});
+		expect(csp.mode).toBe('auto');
+		expect(csp.directives).toEqual({ 'object-src': ['none'], 'base-uri': ['self'] });
+		// SvelteKit throws at build time on a report-only policy without report-uri,
+		// so forks without Sentry must get no reportOnly block at all.
+		expect(csp.reportOnly).toBeUndefined();
+	});
+
+	it('adds a report-only script-src with both hashes and the report-uri when Sentry is set', () => {
+		const csp = buildContentSecurityPolicy({
+			sentryDsn: 'https://abc123@o123456.ingest.sentry.io/7890'
+		});
+		const scriptSrc = csp.reportOnly?.['script-src'] ?? [];
+		expect(scriptSrc).toContain(APP_HTML_SCRIPT_HASH);
+		expect(scriptSrc).toContain(MODE_WATCHER_SCRIPT_HASH);
+		expect(scriptSrc).toContain('strict-dynamic');
+		expect(scriptSrc).toContain('wasm-unsafe-eval');
+		expect(csp.reportOnly?.['report-uri']).toEqual([
+			'https://o123456.ingest.sentry.io/api/7890/security/?sentry_key=abc123'
+		]);
+	});
+});

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,6 +3,7 @@ import auto from '@sveltejs/adapter-auto';
 import cloudflare from '@sveltejs/adapter-cloudflare';
 import node from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { buildContentSecurityPolicy } from './src/lib/security/csp.js';
 
 // Workers Builds sets WORKERS_CI but adapter-auto only checks CF_PAGES.
 // Use adapter-cloudflare explicitly when WORKERS_CI is detected.
@@ -49,6 +50,12 @@ const config = {
 			$blocks: 'src/blocks',
 			$static: 'static'
 		},
+		// object-src/base-uri stay enforced (embedded as <meta> on prerendered
+		// pages, as a header on SSR pages). script-src runs report-only and is
+		// wired to Sentry only when PUBLIC_SENTRY_DSN is set at build time.
+		// frame-ancestors is not here — it cannot ride a <meta> tag, so it lives
+		// in hooks.server.ts / _headers / vercel.json. See src/lib/security/csp.js.
+		csp: buildContentSecurityPolicy({ sentryDsn: process.env.PUBLIC_SENTRY_DSN }),
 		experimental: {
 			remoteFunctions: true
 		},

--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,7 @@
 				{ "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains" },
 				{
 					"key": "Content-Security-Policy",
-					"value": "object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+					"value": "frame-ancestors 'none'"
 				},
 				{ "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" },
 				{ "key": "Cross-Origin-Resource-Policy", "value": "same-origin" }


### PR DESCRIPTION
The app shipped a CSP with object-src, base-uri, and frame-ancestors but no script-src, so an injected script had nothing stopping it from running. This adds a script-src policy in report-only mode, the second XSS defense, without changing what the enforced policy blocks today.

object-src and base-uri move into kit.csp, embedded as a meta tag on prerendered pages and as a header on SSR pages via auto mode. frame-ancestors cannot ride a meta tag and SvelteKit cannot set headers on prerendered static pages, so it stays a header in hooks.server.ts, _headers, and vercel.json. The hook now appends frame-ancestors to the header SvelteKit already set rather than overwriting it, since a plain set would have clobbered object-src and base-uri on every SSR page.

script-src runs report-only: self plus strict-dynamic so trust flows transitively to bundled integrations without host allowlists, wasm-unsafe-eval for the Rive canvas, and two static hashes for the inline scripts SvelteKit does not tag itself (the app.html bootstrap and the mode-watcher FOUC script). SvelteKit rejects a report-only policy without a report endpoint, so the report-only block is only emitted when PUBLIC_SENTRY_DSN is set at build time and derives a Sentry CSP report URI from it; forks without Sentry ship the enforced base policy only. Enforcing script-src is a deliberate later flip once reports come back clean.

A regression guard recomputes the app.html hash from source and fingerprints the mode-watcher source so a bump fails loudly with instructions to regenerate the deployed hash from a build. The existing three-way security-header sync test now accounts for frame-ancestors living across the hook, _headers, and vercel.json.

Also corrects the AGENTS.md note that claimed no CSP was set.

Regression guard: added csp hash sync test in src/lib/security/csp.test.ts

`bun run build` produces the CSP meta on prerendered pages, `bun run test:unit` passes (789 tests), and static checks pass. Enforced blocking is unchanged: with no Sentry DSN the report-only block is not emitted, so this ships object-src/base-uri/frame-ancestors exactly as before plus report-only telemetry where Sentry is configured.