### PR TITLE
fix(cache): Stop caching marketing HTML shells

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,18 +534,18 @@ Request-time values needed for an SSR render that shares a layout with prerender
 
 #### Cache-control for marketing pages
 
-Marketing HTML gets the same `Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400` policy through two different edge-cache paths, because prerendered and SSR routes are served differently on CF:
+Marketing HTML gets `Cache-Control: public, no-cache` so browsers and shared caches revalidate the shell before every reuse. HTML references content-hashed JS chunks; a stale shell that outlives a deploy points at chunks that no longer exist and fails before Svelte hydrates. `no-cache` also keeps the response non-edge-cacheable, which matters on Cloudflare: a fixed zone Browser Cache TTL (default 4h) rewrites the browser-facing `max-age` of any edge-cacheable response back up to its floor, so a `max-age=0` + `s-maxage` combination does not survive to the browser.
 
 - **Non-prerendered routes (e.g. `/pricing`)** go through `server.respond()`, so the `handleCacheControl` hook in `hooks.server.ts` sets the header.
   - Condition: unauthenticated + matches `matchPublicMarketingRoute()`
   - Placed AFTER `handleMarketingMarkdown` in `sequence()` to preserve markdown's own TTL
-- **Prerendered routes (home, about, privacy, terms, impressum)** are served as static assets and bypass SvelteKit hooks, so they ship with no Cache-Control. The worker postbuild patch (`scripts/patch-cf-worker.ts`) injects the same header right after the `ASSETS.fetch` call, gated on `!__wantsMarkdown` + `prerendered.has(pathname)` + a marketing-route regex (`pricing` is intentionally excluded — it is SSR, not prerendered).
+- **Prerendered routes (home, about, privacy, terms, impressum)** are served as static assets and bypass SvelteKit hooks. The worker postbuild patch (`scripts/patch-cf-worker.ts`) bypasses worktop's Cache API lookup for these shells, fetches them from `ASSETS` with `cache-control: no-cache`, and sets the same `Cache-Control: public, no-cache` response header (`pricing` is intentionally excluded from the patch's route regex — it is SSR, not prerendered).
 
 Markdown responses on the same URLs use `Cache-Control: private` to stay out of shared caches: CF Edge ignores `Vary: Accept`, so any edge-cacheable markdown would poison subsequent HTML requests on the same URL. The worker patch leaves the markdown variant private by reusing the same `__wantsMarkdown` negotiation check.
 
 #### Cache purging (production)
 
-`scripts/cf-prod-deploy.ts` is the production deploy command: it runs `wrangler deploy` and then purges the edge cache, so a new deploy is served immediately instead of stale cached HTML. The purge is a no-op unless both `CF_PURGE_TOKEN` and `CF_ZONE_ID` are set, so forks without a custom domain keep plain `wrangler deploy` behavior.
+`scripts/cf-prod-deploy.ts` is the production deploy command: it runs `wrangler deploy` and then purges the edge cache. Current marketing HTML shells are `public, no-cache`, but the purge clears legacy cached shell entries from older deploys. The purge is a no-op unless both `CF_PURGE_TOKEN` and `CF_ZONE_ID` are set, so forks without a custom domain keep plain `wrangler deploy` behavior.
 
 - CF API: `POST /zones/{zone_id}/purge_cache` with `{ "purge_everything": true }`
 - Docs: https://developers.cloudflare.com/api/resources/cache/methods/purge/
@@ -555,7 +555,7 @@ Markdown responses on the same URLs use `Cache-Control: private` to stay out of 
 ### Cloudflare Platform Gotchas
 
 - **CF Cache API ignores `Vary`.** Never rely on `Vary`-based content negotiation inside the worker. Bypass the worktop cache before it runs for any header-dependent response. See `scripts/patch-cf-worker.ts`.
-- **Prerendered pages bypass SvelteKit hooks.** Patch the worker to fall through to `server.respond()` for any hook-dependent behavior on prerendered routes. The same patch also injects the marketing edge-cache header (`Cache-Control: public, s-maxage=3600, ...`) onto prerendered marketing HTML, since the `handleCacheControl` hook never runs for them. See `scripts/patch-cf-worker.ts`.
+- **Prerendered pages bypass SvelteKit hooks.** Patch the worker to fall through to `server.respond()` for hook-dependent behavior such as markdown negotiation. For prerendered marketing HTML, the same patch bypasses the worker cache and sets `Cache-Control: public, no-cache`, since the `handleCacheControl` hook never runs for those static shells. See `scripts/patch-cf-worker.ts`.
 
 ### Regression Guard Decision Tree
 

--- a/README.md
+++ b/README.md
@@ -229,18 +229,14 @@ The build command intentionally reuses `scripts/deploy.ts` so production stays a
 
 ### Custom domain (Cloudflare)
 
-When you serve the app from a custom domain on a Cloudflare zone (not the default `*.workers.dev`), set the zone's **Browser Cache TTL** to **Respect Existing Headers** (Caching > Configuration), or add a Cache Rule on the marketing HTML paths that does the same.
-
-The app sends `Cache-Control: public, max-age=0, must-revalidate, ...` on the HTML shell so a returning visitor always revalidates and never boots a stale shell that points at chunk hashes a new deploy has replaced (which would render a blank page until a hard refresh). Cloudflare's default Browser Cache TTL (4 hours) overrides a lower origin `max-age`, so without this change the shell is force-cached for 4 hours and the recovery cannot run.
+No zone cache tuning is needed. HTML shells ship `Cache-Control: public, no-cache`, so a returning visitor always revalidates and never boots a stale shell that points at chunk hashes a new deploy has replaced (which would render a blank page until a hard refresh). Because `no-cache` also keeps the shell out of the edge cache, the zone's Browser Cache TTL setting (which rewrites the browser-facing `max-age` of edge-cacheable responses up to its floor, 4 hours by default) never applies to it.
 
 After deploying, verify the live header carries no injected `max-age`:
 
 ```bash
 curl -sI https://your-domain.example/en | grep -i cache-control
-# expect: public, max-age=0, must-revalidate, s-maxage=3600, stale-while-revalidate=86400
+# expect: public, no-cache
 ```
-
-`*.workers.dev` deployments are unaffected: the Browser Cache TTL setting applies only to zones you control, and workers.dev passes the origin header through unchanged.
 
 ### First Admin
 

--- a/e2e/public-agent-surface.spec.ts
+++ b/e2e/public-agent-surface.spec.ts
@@ -58,7 +58,7 @@ test.describe('public agent surface', () => {
 		}
 	});
 
-	test('prerendered marketing HTML is edge-cacheable, markdown variant is not', async ({
+	test('prerendered marketing HTML revalidates, markdown variant stays private', async ({
 		request
 	}) => {
 		test.skip(!isCloudflarePreview, 'worker patch is CF-only; not present in local test stack');
@@ -66,8 +66,13 @@ test.describe('public agent surface', () => {
 			headers: { Accept: 'text/html' }
 		});
 		expect(html.status()).toBe(200);
+		// public, no-cache: shells must never outlive their deploy's chunk set,
+		// and staying non-edge-cacheable keeps a fixed zone Browser Cache TTL
+		// from rewriting the browser-facing max-age back up, which let stale
+		// shells 404 their chunk imports on client navigation after a deploy.
 		expect(html.headers()['cache-control']).toContain('public');
-		expect(html.headers()['cache-control']).toContain('s-maxage=3600');
+		expect(html.headers()['cache-control']).toContain('no-cache');
+		expect(html.headers()['cache-control']).not.toContain('s-maxage');
 
 		const md = await request.get(`/en/about?cb=${Date.now()}`, {
 			headers: { Accept: 'text/markdown' }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,16 +52,16 @@ export default defineConfig({
 		/* Collect trace when retrying the failed test */
 		trace: 'on-first-retry',
 		/* Preview bypass headers for protected deployments, plus a cache bypass:
-		 * the CF worker's worktop cache layer serves prerendered marketing HTML
-		 * per colo for up to s-maxage=3600. The branch alias URL is stable across
-		 * pushes, so after a re-deploy a colo can keep serving the PREVIOUS
-		 * build's HTML whose immutable chunk hashes now 404 — the page never
-		 * hydrates and auth-dependent UI (e.g. marketing-nav-dashboard in
-		 * prerender-auth-navigation.spec.ts) never appears, failing all retries
-		 * identically. A `cache-control: no-cache` REQUEST header takes worktop's
-		 * built-in lookup bypass, so E2E always tests the freshly deployed build.
-		 * Response headers are untouched (public-agent-surface.spec.ts asserts
-		 * them), and the response is still saved to the cache afterwards. */
+		 * marketing HTML shells bypass the CF worker's worktop cache server-side
+		 * (public, no-cache), but other cacheable responses still enter it, keyed
+		 * per colo on the stable branch alias URL. After a re-deploy a colo could
+		 * keep serving a PREVIOUS build's cached response whose immutable chunk
+		 * hashes now 404 — the page never hydrates and auth-dependent UI (e.g.
+		 * marketing-nav-dashboard in prerender-auth-navigation.spec.ts) never
+		 * appears, failing all retries identically. A `cache-control: no-cache`
+		 * REQUEST header takes worktop's built-in lookup bypass, so E2E always
+		 * tests the freshly deployed build. Response headers are untouched
+		 * (public-agent-surface.spec.ts asserts them). */
 		extraHTTPHeaders: {
 			...bypass.headers,
 			'cache-control': 'no-cache'

--- a/scripts/cf-prod-deploy.ts
+++ b/scripts/cf-prod-deploy.ts
@@ -2,11 +2,12 @@
  * CF Workers production deploy command — wraps `wrangler deploy`, then purges the
  * Cloudflare edge cache.
  *
- * Marketing routes that aren't prerendered are edge-cached by the handleCacheControl
- * hook (`Cache-Control: public, s-maxage=3600, ...`). A plain `wrangler deploy` uploads
- * the new version but never invalidates that cache, so visitors keep getting the old HTML
- * until the TTL expires. Purging after a successful deploy makes the new version live
- * immediately.
+ * Older deploys allowed marketing HTML shells into the Cloudflare edge cache.
+ * A plain `wrangler deploy` uploads the new version but never invalidates those
+ * existing entries, so visitors could keep getting old HTML until the TTL expired.
+ * Purging after a successful deploy clears those legacy entries; current HTML
+ * responses are `Cache-Control: public, no-cache` so new shells do not persist
+ * across deploys.
  *
  * Set as the production deploy command in CF Workers Builds dashboard.
  * The purge is a no-op unless both CF_PURGE_TOKEN and CF_ZONE_ID are set, so forks
@@ -34,10 +35,10 @@ if (!token || !zoneId) {
 
 // The worker is already published at this point, so the purge is fail-open: any failure
 // (HTTP error or a network-level throw like DNS/connection refused/timeout) only means the
-// edge serves stale HTML until the TTL expires (the pre-existing behavior). Log loudly but
-// exit 0 so the build doesn't fail and trigger a confusing retry of an already-live deploy.
-// purge_everything is intentional: the zone only caches non-prerendered marketing HTML, so a
-// full purge is the simplest correct invalidation; a tag/prefix purge could miss stale paths.
+// edge may serve a legacy stale HTML entry until its TTL expires. Log loudly but exit 0
+// so the build doesn't fail and trigger a confusing retry of an already-live deploy.
+// purge_everything is intentional: a tag/prefix purge could miss stale paths, and the
+// app's immutable assets are content-hashed, so purging them costs one revalidation.
 try {
 	const res = await fetch(`https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`, {
 		method: 'POST',

--- a/scripts/patch-cf-worker.test.ts
+++ b/scripts/patch-cf-worker.test.ts
@@ -60,7 +60,7 @@ describe('patch-cf-worker', () => {
 		expect(result).toContain('__wantsMarkdown');
 	});
 
-	it('skips worktop cache for markdown requests', () => {
+	it('skips worktop cache for markdown requests and marketing shells', () => {
 		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
 
 		// __wantsMarkdown detection should appear before the cache lookup
@@ -68,8 +68,11 @@ describe('patch-cf-worker', () => {
 		const cacheIndex = result.indexOf('await r2(req)');
 		expect(mdIndex).toBeLessThan(cacheIndex);
 
-		// Cache lookup should be gated: !__wantsMarkdown && !pragma... && await r2(req)
-		expect(result).toContain('!__wantsMarkdown && !pragma.includes("no-cache") && await r2(req)');
+		// Cache lookup should be gated on both bypasses, so markdown requests and
+		// legacy marketing shell entries from older deploys are never served
+		expect(result).toContain(
+			'!__wantsMarkdown && !__isPublicMarketingHtml && !pragma.includes("no-cache") && await r2(req)'
+		);
 	});
 
 	it('wraps ALL static-serving disjuncts without extra parens', () => {
@@ -117,37 +120,55 @@ describe('patch-cf-worker', () => {
 		);
 	});
 
-	it('adds s-maxage edge cache to prerendered marketing HTML', () => {
+	it('forces no-cache revalidation for prerendered marketing HTML', () => {
 		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
-		expect(result).toContain('s-maxage=3600, stale-while-revalidate=86400');
-		expect(result).toMatch(/!__wantsMarkdown && prerendered\.has\(pathname\)/);
-		expect(result).toContain('res = new Response(res.body, res)');
-		expect(result.match(/s-maxage=3600/g)?.length).toBe(1);
-		expect(result.match(/const __wantsMarkdown =/g)?.length).toBe(1);
-	});
-
-	it('forces browser revalidation of prerendered marketing HTML', () => {
-		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
-		// Browser must revalidate the shell so it never boots a stale version
-		// referencing deleted chunk hashes after a deploy.
+		// The asset fetch itself must revalidate, and the response must carry
+		// no-cache so worktop's save helper refuses to store it: marketing shells
+		// can never outlive the asset deployment they came from.
+		expect(result).toContain('__assetHeaders.set("cache-control", "no-cache")');
 		expect(result).toContain(
-			'public, max-age=0, must-revalidate, s-maxage=3600, stale-while-revalidate=86400'
+			'res = await env2.ASSETS.fetch(new Request(req, { headers: __assetHeaders }))'
 		);
+		expect(result).toContain('res = await env2.ASSETS.fetch(req)');
+		expect(result).not.toContain('$1.ASSETS');
+		expect(result).toMatch(/__isPublicMarketingHtml && prerendered\.has\(pathname\)/);
+		expect(result).toContain('res = new Response(res.body, res)');
+		expect(result).toContain('res.headers.set("Cache-Control", "public, no-cache")');
+		expect(result).not.toContain('s-maxage');
+		expect(result.match(/const __wantsMarkdown =/g)?.length).toBe(1);
+		expect(result.match(/const __isPublicMarketingHtml =/g)?.length).toBe(1);
 	});
 
 	it('does not add a public cache header to the server.respond branch', () => {
 		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
 		const elseIdx = result.indexOf('res = await server.respond(req');
-		expect(result.slice(elseIdx)).not.toContain('s-maxage');
+		expect(result.slice(elseIdx)).not.toContain('res.headers.set("Cache-Control"');
 	});
 
-	it('injects the marketing edge-cache on the no-cache fallback path', () => {
+	it('injects the marketing no-cache handling on the no-cache fallback path', () => {
 		const result = applyMarkdownPatch(WORKER_FIXTURE_NO_CACHE)!;
-		expect(result).toContain(
-			'public, max-age=0, must-revalidate, s-maxage=3600, stale-while-revalidate=86400'
-		);
+		expect(result).toContain('__assetHeaders.set("cache-control", "no-cache")');
+		expect(result).toContain('res.headers.set("Cache-Control", "public, no-cache")');
 		expect(result).toContain('res = new Response(res.body, res)');
-		expect(result.match(/s-maxage=3600/g)?.length).toBe(1);
+		expect(result).not.toContain('$1.ASSETS');
+	});
+
+	it('stays in sync with the handleCacheControl header in hooks.server.ts', () => {
+		// The injected worker header and the SSR hook header are the same policy
+		// declared in two places; if they drift, prerendered and SSR marketing
+		// pages silently diverge in cache behavior.
+		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
+		const injected = result.match(/res\.headers\.set\("Cache-Control", "([^"]+)"\)/)?.[1];
+		expect(injected).toBeTruthy();
+
+		const hooksSource = fs.readFileSync(path.resolve('src/hooks.server.ts'), 'utf-8');
+		// Isolate the marketing branch (matchPublicMarketingRoute up to its Vary
+		// header) so the auth-group branch cannot mask a drifted marketing value.
+		const marketingBranch = hooksSource.slice(
+			hooksSource.indexOf('matchPublicMarketingRoute(event.url.pathname)'),
+			hooksSource.indexOf("response.headers.set('Vary', 'Accept')")
+		);
+		expect(marketingBranch).toContain(`'Cache-Control', '${injected}'`);
 	});
 });
 
@@ -191,7 +212,7 @@ describe('applyVersionedCacheKeyPatch', () => {
 		const result = applyVersionedCacheKeyPatch(md, 'abc123')!;
 
 		expect(result).toContain(
-			'!__wantsMarkdown && !pragma.includes("no-cache") && await r2(__cacheKey)'
+			'!__wantsMarkdown && !__isPublicMarketingHtml && !pragma.includes("no-cache") && await r2(__cacheKey)'
 		);
 		expect(result).toContain('? c(__cacheKey, res, ctx) : res;');
 		expect(result.match(/const __cacheKey =/g)?.length).toBe(1);

--- a/scripts/patch-cf-worker.ts
+++ b/scripts/patch-cf-worker.ts
@@ -14,10 +14,13 @@
  * a) Detect markdown requests early (before cache lookup)
  * b) Skip the worktop cache for markdown requests
  * c) Skip static asset serving for markdown requests
- * d) Inject an s-maxage edge-cache header for prerendered marketing HTML.
+ * d) Force prerendered marketing HTML to revalidate instead of entering the
+ *    worker cache.
  *    Those pages are served as static assets and bypass SvelteKit hooks, so
- *    they ship with no Cache-Control. This mirrors the handleCacheControl hook
- *    that caches the SSR /pricing route, leaving the markdown variant private.
+ *    they ship with no Cache-Control. HTML shells reference content-hashed JS
+ *    chunks; caching them across deploys can leave the browser booting a shell
+ *    whose chunks no longer exist. This mirrors the handleCacheControl hook
+ *    for SSR marketing HTML, leaving the markdown variant private.
  *
  * Runs as postbuild for all builds. Skips gracefully when no worker file exists
  * (e.g., Vercel via adapter-auto where server.respond() always runs).
@@ -36,36 +39,41 @@ export const STATIC_SERVING_PATTERN = /(if\s*\()(is_static_asset\b.+?\.startsWit
 const WORKTOP_LOOKUP_CORE = /!pragma\.includes\("no-cache"\) && await /.source;
 
 // Match the worktop cache lookup: `let res = !pragma.includes("no-cache") && await r2(req);`
-// We inject the __wantsMarkdown check here so markdown requests bypass the cache entirely.
-// CF Cache API ignores Vary headers, so cached HTML would be served for markdown requests.
+// We inject cache-bypass checks here so markdown requests and marketing HTML shells
+// bypass the worker cache entirely. CF Cache API ignores Vary headers, and cached
+// HTML shells can reference chunk hashes removed by a later deploy.
 export const CACHE_LOOKUP_PATTERN = new RegExp(`(let res = )(${WORKTOP_LOOKUP_CORE}\\w+\\(req\\))`);
 
 // Match the static-asset serving call: `res = await env2.ASSETS.fetch(req);`
-// We append the marketing edge-cache injection right after it, capturing the
-// minified env binding (e.g. `env2`) so the replacement references the real name.
+// We replace it with a marketing-HTML-aware fetch, capturing the minified env
+// binding (e.g. `env2`) so the replacement references the real name.
 export const ASSET_SERVE_PATTERN = /res = await (\w+)\.ASSETS\.fetch\(req\);?/;
 
-// Injection appended after the ASSETS.fetch call. `$1` is replaced with the
-// captured env binding. Double-gated on the same __wantsMarkdown const used by
-// the markdown passthrough so the markdown variant stays private, plus the
-// prerendered set and a marketing-route regex (pricing is intentionally absent,
-// it is SSR via handleCacheControl, not prerendered).
-const MARKETING_HTML_CACHE_INJECTION = `res = await $1.ASSETS.fetch(req);
-        if (!__wantsMarkdown && prerendered.has(pathname) && /^\\/[a-z]{2}(\\/(about|privacy|terms|impressum))?$/.test(pathname)) {
-          // Prerendered marketing HTML bypasses SvelteKit hooks on CF, so it ships
-          // with no Cache-Control. Apply the same policy handleCacheControl gives the
-          // SSR /pricing route. ASSETS responses have immutable headers, so
-          // reconstruct to mutate. max-age=0, must-revalidate asks the browser to
-          // revalidate the shell so the location.href recovery in the root layout
-          // fetches a fresh one instead of a stale shell with dead chunk hashes.
-          // Necessary but not sufficient: a fixed zone Browser Cache TTL (default 4h)
-          // is a floor that CF uses to rewrite the browser-facing max-age back up to
-          // 14400 while the response stays edge-cacheable. The zone must set Browser
-          // Cache TTL to "Respect Existing Headers" (or a Cache Rule on the marketing
-          // HTML paths) for max-age=0 to survive. This string must stay identical to
-          // handleCacheControl in src/hooks.server.ts.
+// Marketing pathname predicate injected into the worker, shared by the cache
+// bypass and the ASSETS.fetch replacement so the two can never drift. The
+// homepage (/en) matches via the absent optional group; pricing is
+// intentionally absent, it is SSR via handleCacheControl, not prerendered.
+const MARKETING_ROUTE_PREDICATE = `const __isPublicMarketingHtml = /^\\/[a-z]{2}(\\/(about|privacy|terms|impressum))?\\/?$/.test(new URL(req.url).pathname);`;
+
+// Replacement for the ASSETS.fetch call. `$1` is replaced with the captured env
+// binding. Prerendered marketing HTML bypasses SvelteKit hooks, so force a
+// no-cache asset fetch and mark the response no-cache before the generated
+// worker decides whether to store it in the worktop cache (worktop's save
+// helper refuses responses carrying no-cache).
+const MARKETING_HTML_CACHE_INJECTION = `if (__isPublicMarketingHtml && prerendered.has(pathname)) {
+          const __assetHeaders = new Headers(req.headers);
+          __assetHeaders.set("cache-control", "no-cache");
+          res = await $1.ASSETS.fetch(new Request(req, { headers: __assetHeaders }));
+          // HTML shells reference immutable chunk hashes. A cached entry that
+          // survives a deploy points at chunks the new asset set no longer serves,
+          // preventing Svelte from hydrating and arming the client-side recovery
+          // backstop. Keep HTML revalidated; immutable assets remain long-cacheable.
+          // ASSETS responses have immutable headers, so reconstruct to mutate. This
+          // string must stay identical to handleCacheControl in src/hooks.server.ts.
           res = new Response(res.body, res);
-          res.headers.set("Cache-Control", "public, max-age=0, must-revalidate, s-maxage=3600, stale-while-revalidate=86400");
+          res.headers.set("Cache-Control", "public, no-cache");
+        } else {
+          res = await $1.ASSETS.fetch(req);
         }`;
 
 /**
@@ -79,13 +87,15 @@ export function applyMarkdownPatch(source: string): string | null {
 		return null;
 	}
 
-	// Step 1: Inject __wantsMarkdown detection before the cache lookup and skip cache
+	// Step 1: Inject __wantsMarkdown detection before the cache lookup, then skip
+	// the cache for markdown requests AND marketing HTML shells. The shell bypass
+	// also stops legacy cache entries from older deploys from ever being served.
 	let patched = source;
 
 	if (CACHE_LOOKUP_PATTERN.test(patched)) {
 		patched = patched.replace(
 			CACHE_LOOKUP_PATTERN,
-			`const __wantsMarkdown = /\\btext\\/markdown\\b/i.test(req.headers.get("accept") || "");\n$1!__wantsMarkdown && $2`
+			`const __wantsMarkdown = /\\btext\\/markdown\\b/i.test(req.headers.get("accept") || "");\n    ${MARKETING_ROUTE_PREDICATE}\n$1!__wantsMarkdown && !__isPublicMarketingHtml && $2`
 		);
 		// Step 2: Also skip static asset serving for markdown requests
 		patched = patched.replace(STATIC_SERVING_PATTERN, `$1!__wantsMarkdown && ($2))`);
@@ -104,21 +114,22 @@ export function applyMarkdownPatch(source: string): string | null {
 		// Fallback: inject before static serving (prerendered pages still fixed, no cache layer to bypass)
 		patched = patched.replace(
 			STATIC_SERVING_PATTERN,
-			`const __wantsMarkdown = /\\btext\\/markdown\\b/i.test(req.headers.get("accept") || "");\n$1!__wantsMarkdown && ($2))`
+			`const __wantsMarkdown = /\\btext\\/markdown\\b/i.test(req.headers.get("accept") || "");\n${MARKETING_ROUTE_PREDICATE}\n$1!__wantsMarkdown && ($2))`
 		);
 	}
 
-	// Step 3: Inject an s-maxage edge-cache header for prerendered marketing HTML.
+	// Step 3: Inject no-cache headers for prerendered marketing HTML.
 	// Runs in both the cache and no-cache paths (single tail return). Reuses the
-	// same __wantsMarkdown const so the markdown variant stays private.
+	// same marketing predicate that skips the worker cache above, and the same
+	// __wantsMarkdown const so the markdown variant stays private.
 	if (ASSET_SERVE_PATTERN.test(patched)) {
 		const before = patched;
 		patched = patched.replace(ASSET_SERVE_PATTERN, (_m, envName) =>
-			MARKETING_HTML_CACHE_INJECTION.replace('$1', envName)
+			MARKETING_HTML_CACHE_INJECTION.replaceAll('$1', envName)
 		);
 		if (patched === before) {
 			throw new Error(
-				'ASSET_SERVE_PATTERN matched but the marketing edge-cache injection did not apply.'
+				'ASSET_SERVE_PATTERN matched but the marketing no-cache injection did not apply.'
 			);
 		}
 	}
@@ -129,8 +140,9 @@ export function applyMarkdownPatch(source: string): string | null {
 // Match the worktop cache lookup call so its `req` argument can be swapped for
 // a versioned cache key. Anchored on the `!pragma.includes("no-cache") &&`
 // prefix so `env2.ASSETS.fetch(req)` and `server.respond(req, ...)` can never
-// match. Tolerates the `!__wantsMarkdown && ` prefix applyMarkdownPatch
-// prepends. Order matters: run applyMarkdownPatch FIRST (as the CLI does).
+// match. Tolerates the `!__wantsMarkdown && !__isPublicMarketingHtml && `
+// prefix applyMarkdownPatch prepends. Order matters: run applyMarkdownPatch
+// FIRST (as the CLI does).
 // Reversed, its patterns expect the bare `(req)` argument, miss the salted
 // call, and silently skip the markdown cache bypass.
 export const CACHE_KEY_LOOKUP_PATTERN = new RegExp(`(${WORKTOP_LOOKUP_CORE})(\\w+)\\(req\\)`);
@@ -143,11 +155,13 @@ export const CACHE_KEY_SAVE_PATTERN = /(\? )(\w+)\(req, (res, ctx\))/;
  *
  * The worktop layer caches responses per colo keyed on the bare URL. Branch
  * alias and workers.dev URLs stay constant across deploys, so after a push a
- * colo keeps serving the previous build's marketing HTML for up to
- * s-maxage=3600 while its immutable chunk hashes 404 on the new deployment:
- * the page never hydrates. workers.dev cannot purge, so the stale copy can
- * only age out. Keying lookup AND save on `?__v=<version>` gives every deploy
- * a cold cache namespace; old entries expire unreferenced.
+ * colo could keep serving a previous build's HTML while its immutable chunk
+ * hashes 404 on the new deployment: the page never hydrates. workers.dev
+ * cannot purge, so a stale copy can only age out. Marketing shells now bypass
+ * this cache entirely (public, no-cache via applyMarkdownPatch), but any
+ * other response shipping cacheable headers is still stored; keying lookup
+ * AND save on `?__v=<version>` gives every deploy a cold cache namespace,
+ * and old entries expire unreferenced.
  *
  * Returns the patched source, null when the worker has no worktop cache layer
  * (nothing to salt), and throws when only one of the two call sites matches:

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -223,7 +223,7 @@ const authFirstPattern: Handle = async function authFirstPattern({ event, resolv
 };
 
 /**
- * Set edge cache headers for unauthenticated marketing pages.
+ * Set revalidation cache headers for unauthenticated marketing pages.
  * Placed AFTER handleMarketingMarkdown — markdown requests return early
  * (no resolve() call) so this hook is skipped for them, preserving
  * the existing markdown 5-minute TTL.
@@ -236,27 +236,18 @@ const handleCacheControl: Handle = async function handleCacheControl({ event, re
 		!event.locals.token &&
 		matchPublicMarketingRoute(event.url.pathname)
 	) {
-		// max-age=0, must-revalidate asks the browser to revalidate the HTML shell on
-		// every navigation (a 304 keeps it cheap) so the location.href recovery in the
-		// root layout fetches a fresh shell instead of re-reading a stale one that
-		// references deleted chunk hashes. s-maxage keeps the shared edge cache.
-		//
-		// Necessary but not sufficient on Cloudflare. A fixed zone Browser Cache TTL
-		// (default 4h) acts as a floor: CF rewrites the browser-facing max-age back up
-		// to 14400 whenever the origin value is lower, and this response stays
-		// edge-cacheable (public + s-maxage), so max-age=0 is overridden until the zone
-		// is reconfigured. See developers.cloudflare.com/cache/how-to/edge-browser-cache-ttl/.
-		// Required CF change (zone-level, not expressible from origin headers): set
-		// Browser Cache TTL to "Respect Existing Headers", or add a Cache Rule scoped to
-		// the marketing HTML paths that does the same. Verify after deploy: the live
-		// Cache-Control on /en must NOT carry an injected max-age=14400.
-		//
-		// This string must stay in sync with the prerendered marketing HTML header in
-		// scripts/patch-cf-worker.ts.
-		response.headers.set(
-			'Cache-Control',
-			'public, max-age=0, must-revalidate, s-maxage=3600, stale-while-revalidate=86400'
-		);
+		// Marketing HTML shells reference content-hashed JS chunks. A cached shell
+		// that survives a deploy points at chunks the new asset set no longer
+		// serves, preventing hydration and arming the client-side recovery
+		// backstop. no-cache keeps every reuse conditional (a 304 keeps
+		// revalidation cheap) and, unlike the previous max-age=0 + s-maxage combo,
+		// leaves the response non-edge-cacheable — so a fixed zone Browser Cache
+		// TTL (default 4h) cannot rewrite the browser-facing max-age back up to
+		// 14400, which it does to any edge-cacheable response and which let stale
+		// shells sit in browsers for hours after a deploy. Immutable assets remain
+		// long-cacheable. This string must stay in sync with the prerendered
+		// marketing HTML header in scripts/patch-cf-worker.ts.
+		response.headers.set('Cache-Control', 'public, no-cache');
 		// These URLs also serve markdown via Accept header. CF edge ignores Vary, so
 		// this is safe only because every route reaching this branch is non-prerendered
 		// and the markdown variant is private (kept out of shared caches).
@@ -269,12 +260,10 @@ const handleCacheControl: Handle = async function handleCacheControl({ event, re
 		// Auth-group HTML shells (signin, signup, forgot-password, ...) reference the
 		// same content-hashed chunks as the marketing shells but fell through the
 		// marketing matcher and shipped with no Cache-Control at all, leaving
-		// freshness to cache heuristics. Any reuse must revalidate so a shell never
-		// outlives its chunk set. Unlike the marketing branch there is no s-maxage:
-		// auth shells are not edge-cached, so the zone Browser Cache TTL floor
-		// documented above does not apply. No Vary: Accept either, these routes have
-		// no markdown variant. Matching on the route group keeps new auth pages
-		// covered automatically.
+		// freshness to cache heuristics. Same policy as the marketing branch: any
+		// reuse must revalidate so a shell never outlives its chunk set. No
+		// Vary: Accept though, these routes have no markdown variant. Matching on
+		// the route group keeps new auth pages covered automatically.
 		response.headers.set('Cache-Control', 'public, no-cache');
 	}
 


### PR DESCRIPTION
Production showed a client-side navigation 404ing on `/_app/immutable/nodes/12.Cadvcu9C.js` right after a deploy, forcing the preload-error backstop to reload the page and costing the user a click. The marketing HTML shell was served with `public, max-age=0, must-revalidate, s-maxage=3600, stale-while-revalidate=86400`, which keeps it edge-cacheable, and Cloudflare rewrites the browser-facing `max-age` of edge-cacheable responses up to the zone Browser Cache TTL floor (4h by default). The live header on `/en` carried the injected `max-age=14400`, so browsers kept a stale shell for up to 4 hours across deploys, pointing at chunk hashes the new asset set no longer serves. The remedy documented in the old hooks comment (zone-level Respect Existing Headers) was never applied and is not template-safe anyway, since forks deploy onto arbitrary zones with default settings.

Marketing HTML now ships `Cache-Control: public, no-cache` on both serving paths: `handleCacheControl` for SSR routes like `/en/pricing`, and the worker postbuild patch for prerendered shells. `no-cache` keeps every reuse conditional (304s stay cheap) and leaves the response non-edge-cacheable, so the zone TTL floor cannot apply and no zone configuration is needed; the Browser Cache TTL setup step is removed from the README. The worker patch additionally skips the worktop cache lookup for marketing shells, so legacy entries from older deploys can never be served, and marks the response `no-cache` before the generated save helper runs, which refuses to store `no-cache` responses (verified against the bundled adapter template). The versioned cache key from #654 stays as defense in depth for other cacheable responses. The E2E cache assertion and the docs were updated to the new policy.

Regression guard: added a sync test in `scripts/patch-cf-worker.test.ts` asserting the injected worker header equals the `handleCacheControl` marketing header in `src/hooks.server.ts`.
`bunx vitest run scripts/patch-cf-worker.test.ts scripts/version-config.test.ts` passes, including patching the real adapter worker template. `bun scripts/static-checks.ts` on the changed files passes.