### PR TITLE
feat(support): runtime prompt override store

### DIFF
--- a/docs/recipes/optimize-support-prompt.md
+++ b/docs/recipes/optimize-support-prompt.md
@@ -85,19 +85,41 @@ app.
 
 ## The override seam: where the optimized prompt lands
 
-The support agent reads its instructions from a named export, `SUPPORT_AGENT_INSTRUCTIONS`,
-instead of an inline literal. That export is the seam this recipe plugs into. Two ways to use
-it:
+The support agent reads its instructions from a named export, `SUPPORT_AGENT_INSTRUCTIONS`
+(`src/lib/convex/support/agent.ts`), instead of an inline literal, and at runtime
+`support/messages.ts` prefers a stored override over that seed. There are two ways to plug an
+optimized prompt in:
 
 - **Static**: have the optimizer print the winning prompt, then paste it in as the new value
-  of `SUPPORT_AGENT_INSTRUCTIONS` and ship it. Simplest, fully reviewable in a diff, no schema
-  change.
-- **Dynamic**: store the optimized prompt in a small table (one active row, plus history),
-  have the agent read the stored override and fall back to `SUPPORT_AGENT_INSTRUCTIONS` when
-  none is set, and let the action write a new row at the end of a run. This lets you re-tune
-  on a schedule as more tickets close, without a deploy.
+  of `SUPPORT_AGENT_INSTRUCTIONS` and ship it. Simplest, fully reviewable in a diff, no
+  database write.
+- **Dynamic**: write the prompt into the `supportAgentPrompts` table through
+  `support/promptStore`. `getActive` resolves the active row before every streamed reply and
+  passes it as the per-turn system override; when no row is active the agent falls back to
+  `SUPPORT_AGENT_INSTRUCTIONS`. This lets you re-tune as more tickets close, without a deploy.
 
-Start static. Move to dynamic only once you are re-running the optimization regularly.
+The dynamic seam already ships in the template, so you do not build the storage or the runtime
+lookup yourself. To hot-swap the prompt by hand, or from the end of an optimization run:
+
+```sh
+# Activate a new prompt (deactivates the previous active row for its locale)
+bunx convex run support/promptStore:savePrompt '{"systemPrompt": "You are ...", "note": "2026-07 optimization run"}'
+
+# Scope an override to one locale (getActive serves the locale-less default elsewhere)
+bunx convex run support/promptStore:savePrompt '{"systemPrompt": "Du bist ...", "locale": "de"}'
+
+# Roll back to the seed prompt without a deploy (deactivate the live row by id)
+bunx convex run support/promptStore:setActive '{"id": "<rowId>", "active": false}'
+```
+
+An optimization pipeline writes into this same seam. It builds a gold corpus from resolved
+tickets, scores candidate replies with the closeness-to-gold judge, runs an optimizer such as
+GEPA to rewrite the prompt, and calls `savePrompt` as its last step. Guard that step with the
+floor from earlier: never persist a prompt whose judged score is below the current seed, so a
+bad or empty run leaves the live prompt untouched and the seed stays the fallback. The
+template ships the seam, not the engine, so this stays a recipe you grow into.
+
+Start static. Move to dynamic once you are re-running the optimization regularly.
 
 ## Reference implementation
 
@@ -114,4 +136,6 @@ optimizer:
 
 Take the structure and the env-resolution wholesale. Swap the spot-the-AI jury for the
 closeness-to-gold judge described above, point the corpus at done `supportThreads` instead of
-LinkedIn turns, and write the result through `SUPPORT_AGENT_INSTRUCTIONS`.
+LinkedIn turns, and write the result through the override seam above: paste it into
+`SUPPORT_AGENT_INSTRUCTIONS` for the static path, or call `support/promptStore:savePrompt` for
+the dynamic one.

--- a/src/lib/convex/_generated/api.d.ts
+++ b/src/lib/convex/_generated/api.d.ts
@@ -78,6 +78,7 @@ import type * as support_messageListing from "../support/messageListing.js";
 import type * as support_messages from "../support/messages.js";
 import type * as support_migration from "../support/migration.js";
 import type * as support_ownership from "../support/ownership.js";
+import type * as support_promptStore from "../support/promptStore.js";
 import type * as support_rateLimit from "../support/rateLimit.js";
 import type * as support_supportThreadFields from "../support/supportThreadFields.js";
 import type * as support_threads from "../support/threads.js";
@@ -165,6 +166,7 @@ declare const fullApi: ApiFromModules<{
   "support/messages": typeof support_messages;
   "support/migration": typeof support_migration;
   "support/ownership": typeof support_ownership;
+  "support/promptStore": typeof support_promptStore;
   "support/rateLimit": typeof support_rateLimit;
   "support/supportThreadFields": typeof support_supportThreadFields;
   "support/threads": typeof support_threads;

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -81,6 +81,20 @@ export default defineSchema({
 			filterFields: ['status', 'assignedTo', 'isHandedOff', 'awaitingAdminResponse']
 		}),
 
+	// Stored overrides for the support agent's system prompt. support/promptStore
+	// serves the active row at runtime (support/messages.ts) in place of the seed
+	// prompt in agent.ts (SUPPORT_AGENT_INSTRUCTIONS), which stays the fallback
+	// when no row is active. Lets you hot-swap the prompt from the database, or
+	// from a prompt-optimization run, without a deploy. At most one active row
+	// per locale (the by_active index keeps getActive off a full-table scan).
+	supportAgentPrompts: defineTable({
+		systemPrompt: v.string(), // Full prompt served in place of the seed
+		locale: v.optional(v.string()), // Scopes the override to one locale; absent = default for all
+		note: v.optional(v.string()), // Freeform: why this override exists / where it came from
+		active: v.boolean(), // Whether getActive may serve this row
+		createdAt: v.number()
+	}).index('by_active', ['active']),
+
 	// Admin settings - key-value store for app configuration
 	adminSettings: defineTable({
 		key: v.string(), // Setting key (e.g., 'defaultSupportEmail')

--- a/src/lib/convex/support/__tests__/messages.test.ts
+++ b/src/lib/convex/support/__tests__/messages.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// createAIResponse pulls in the whole support module graph at import. Stub the
+// heavy or env-dependent siblings so this stays a handler-level unit test that
+// only exercises the prompt-override wiring into streamText.
+vi.mock('../agent', () => ({
+	supportAgent: {
+		streamText: vi.fn(),
+		saveMessage: vi.fn()
+	}
+}));
+
+vi.mock('../rateLimit', () => ({
+	supportRateLimiter: {
+		limit: vi.fn().mockResolvedValue({ ok: true, retryAfter: 0 })
+	}
+}));
+
+vi.mock('../types', () => ({
+	createRateLimitError: vi.fn(() => new Error('rate limited'))
+}));
+
+vi.mock('../../i18n/translations', () => ({
+	t: vi.fn(() => 'translated'),
+	extractLocaleFromUrl: vi.fn(() => 'en')
+}));
+
+vi.mock('../ownership', () => ({
+	requireSupportThreadAccess: vi.fn()
+}));
+
+vi.mock('../messageListing', () => ({
+	listMessagesForThread: vi.fn()
+}));
+
+vi.mock('../threads', () => ({
+	syncSupportLastMessage: vi.fn()
+}));
+
+vi.mock('../../files/metadata', () => ({
+	getFileMetadataByUrls: vi.fn()
+}));
+
+vi.mock('../../aiUsage/agentUsage', () => ({
+	makeAgentUsageSink: vi.fn(() => ({ usageHandler: vi.fn(), collect: () => [] }))
+}));
+
+vi.mock('../../aiUsage/record', () => ({
+	recordAiUsage: vi.fn()
+}));
+
+vi.mock('../../constants', () => ({ MAX_MESSAGE_LENGTH: 4000 }));
+
+vi.mock('@convex-dev/agent', () => ({ getFile: vi.fn() }));
+
+vi.mock('@convex-dev/agent/validators', async () => {
+	const { v } = await import('convex/values');
+	return { vStreamArgs: v.optional(v.any()) };
+});
+
+// Ref strings are inlined here because vi.mock factories are hoisted above any
+// module-scope const. The same literals are re-declared below for the assertions.
+vi.mock('../../_generated/api', () => ({
+	components: {},
+	internal: {
+		support: {
+			promptStore: { getActive: 'internal.support.promptStore.getActive' },
+			threads: { updateLastMessage: 'internal.support.threads.updateLastMessage' }
+		}
+	}
+}));
+
+const GET_ACTIVE_REF = 'internal.support.promptStore.getActive';
+
+import { supportAgent } from '../agent';
+import { createAIResponse } from '../messages';
+
+const streamTextMock = supportAgent.streamText as unknown as ReturnType<typeof vi.fn>;
+
+type Fn<A, R> = { _handler: (ctx: unknown, args: A) => Promise<R> };
+const handler = createAIResponse as unknown as Fn<
+	{ threadId: string; promptMessageId: string; userId?: string },
+	null
+>;
+
+const args = { threadId: 'thread_1', promptMessageId: 'prompt_1', userId: 'user_1' };
+
+function makeCtx(override: string | null) {
+	return {
+		runQuery: vi.fn(async (ref: string) => (ref === GET_ACTIVE_REF ? override : undefined)),
+		runMutation: vi.fn().mockResolvedValue(null)
+	};
+}
+
+describe('createAIResponse prompt override wiring', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		streamTextMock.mockResolvedValue({
+			consumeStream: vi.fn().mockResolvedValue(undefined)
+		});
+	});
+
+	it('passes the active stored prompt to streamText as the system override', async () => {
+		const ctx = makeCtx('stored override prompt');
+
+		await handler._handler(ctx, args);
+
+		expect(ctx.runQuery).toHaveBeenCalledWith(GET_ACTIVE_REF, {});
+		expect(streamTextMock).toHaveBeenCalledTimes(1);
+		expect(streamTextMock.mock.calls[0][2]).toEqual({
+			promptMessageId: 'prompt_1',
+			system: 'stored override prompt'
+		});
+	});
+
+	it('leaves system undefined so the seed prompt stands when none is active', async () => {
+		const ctx = makeCtx(null);
+
+		await handler._handler(ctx, args);
+
+		expect(streamTextMock.mock.calls[0][2]).toEqual({
+			promptMessageId: 'prompt_1',
+			system: undefined
+		});
+	});
+});

--- a/src/lib/convex/support/__tests__/promptStore.test.ts
+++ b/src/lib/convex/support/__tests__/promptStore.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { getActive, savePrompt, setActive } from '../promptStore';
+
+/**
+ * Handler-level unit tests (the codebase idiom): each Convex fn exposes its
+ * handler under `_handler`, driven here against a tiny in-memory db so the
+ * activation lifecycle (one active row per locale, exact-locale wins) is
+ * exercised end-to-end rather than asserted on mock call counts.
+ */
+
+type Row = {
+	_id: string;
+	systemPrompt: string;
+	locale?: string;
+	note?: string;
+	active: boolean;
+	createdAt: number;
+};
+
+// Minimal Convex db double: just enough of query/withIndex/collect/insert/patch/get
+// for promptStore. withIndex applies the recorded eq() constraints against the rows.
+function makeDb() {
+	const rows: Row[] = [];
+	let counter = 0;
+	const db = {
+		rows,
+		query: (_table: string) => ({
+			withIndex: (
+				_index: string,
+				cb: (q: { eq: (field: string, value: unknown) => unknown }) => unknown
+			) => {
+				const filters: Array<[string, unknown]> = [];
+				const q = {
+					eq: (field: string, value: unknown) => {
+						filters.push([field, value]);
+						return q;
+					}
+				};
+				cb(q);
+				return {
+					collect: async () =>
+						rows.filter((row) =>
+							filters.every(([field, value]) => (row as Record<string, unknown>)[field] === value)
+						)
+				};
+			}
+		}),
+		insert: async (_table: string, doc: Omit<Row, '_id'>) => {
+			const _id = `prompt_${++counter}`;
+			rows.push({ _id, ...doc });
+			return _id;
+		},
+		patch: async (id: string, patch: Partial<Row>) => {
+			const row = rows.find((r) => r._id === id);
+			if (row) Object.assign(row, patch);
+		},
+		get: async (id: string) => rows.find((r) => r._id === id) ?? null
+	};
+	return db;
+}
+
+type Fn<A, R> = { _handler: (ctx: unknown, args: A) => Promise<R> };
+const getActiveH = getActive as unknown as Fn<{ locale?: string }, string | null>;
+const savePromptH = savePrompt as unknown as Fn<
+	{ systemPrompt: string; locale?: string; note?: string },
+	string
+>;
+const setActiveH = setActive as unknown as Fn<{ id: string; active: boolean }, null>;
+
+const activeRows = (db: ReturnType<typeof makeDb>) => db.rows.filter((r) => r.active);
+
+describe('support promptStore', () => {
+	it('returns null when no prompt is active (falls back to the seed)', async () => {
+		const db = makeDb();
+		expect(await getActiveH._handler({ db }, {})).toBeNull();
+	});
+
+	it('serves a saved prompt and marks it active', async () => {
+		const db = makeDb();
+		await savePromptH._handler({ db }, { systemPrompt: 'v1' });
+
+		expect(db.rows).toHaveLength(1);
+		expect(db.rows[0].active).toBe(true);
+		expect(await getActiveH._handler({ db }, {})).toBe('v1');
+	});
+
+	it('persists an optional note without affecting resolution', async () => {
+		const db = makeDb();
+		await savePromptH._handler(
+			{ db },
+			{ systemPrompt: 'v1', note: 'from 2026-07 optimization run' }
+		);
+
+		expect(db.rows[0].note).toBe('from 2026-07 optimization run');
+		expect(await getActiveH._handler({ db }, {})).toBe('v1');
+	});
+
+	it('activating a new prompt deactivates the previous one for the same locale', async () => {
+		const db = makeDb();
+		await savePromptH._handler({ db }, { systemPrompt: 'v1' });
+		await savePromptH._handler({ db }, { systemPrompt: 'v2' });
+
+		expect(activeRows(db)).toHaveLength(1);
+		expect(activeRows(db)[0].systemPrompt).toBe('v2');
+		expect(await getActiveH._handler({ db }, {})).toBe('v2');
+	});
+
+	it('prefers an exact-locale prompt over the locale-less default', async () => {
+		const db = makeDb();
+		await savePromptH._handler({ db }, { systemPrompt: 'global' });
+		await savePromptH._handler({ db }, { systemPrompt: 'german', locale: 'de' });
+
+		// Different locales, so both stay active.
+		expect(activeRows(db)).toHaveLength(2);
+		expect(await getActiveH._handler({ db }, { locale: 'de' })).toBe('german');
+		// An unmatched locale falls back to the locale-less default.
+		expect(await getActiveH._handler({ db }, { locale: 'fr' })).toBe('global');
+		// No locale requested serves the locale-less default.
+		expect(await getActiveH._handler({ db }, {})).toBe('global');
+	});
+
+	it('scopes savePrompt deactivation to the same locale', async () => {
+		const db = makeDb();
+		await savePromptH._handler({ db }, { systemPrompt: 'global' });
+		await savePromptH._handler({ db }, { systemPrompt: 'de-v1', locale: 'de' });
+		// Re-saving the de override deactivates only the prior de row, not global.
+		await savePromptH._handler({ db }, { systemPrompt: 'de-v2', locale: 'de' });
+
+		expect(
+			activeRows(db)
+				.map((r) => r.systemPrompt)
+				.sort()
+		).toEqual(['de-v2', 'global']);
+		expect(await getActiveH._handler({ db }, {})).toBe('global');
+		expect(await getActiveH._handler({ db }, { locale: 'de' })).toBe('de-v2');
+	});
+
+	it('setActive deactivates same-locale siblings when activating a row', async () => {
+		const db = makeDb();
+		const id1 = await savePromptH._handler({ db }, { systemPrompt: 'v1' });
+		await savePromptH._handler({ db }, { systemPrompt: 'v2' });
+		// v2 is now active, v1 is not. Roll back to v1.
+		await setActiveH._handler({ db }, { id: id1, active: true });
+
+		expect(activeRows(db)).toHaveLength(1);
+		expect(activeRows(db)[0]._id).toBe(id1);
+		expect(await getActiveH._handler({ db }, {})).toBe('v1');
+	});
+
+	it('setActive leaves other locales active when activating one locale', async () => {
+		const db = makeDb();
+		await savePromptH._handler({ db }, { systemPrompt: 'global' });
+		const deId1 = await savePromptH._handler({ db }, { systemPrompt: 'de-v1', locale: 'de' });
+		await savePromptH._handler({ db }, { systemPrompt: 'de-v2', locale: 'de' });
+		// global + de-v2 active. Re-activate de-v1; global must stay untouched.
+		await setActiveH._handler({ db }, { id: deId1, active: true });
+
+		expect(
+			activeRows(db)
+				.map((r) => r.systemPrompt)
+				.sort()
+		).toEqual(['de-v1', 'global']);
+		expect(await getActiveH._handler({ db }, {})).toBe('global');
+		expect(await getActiveH._handler({ db }, { locale: 'de' })).toBe('de-v1');
+	});
+
+	it('deactivating the live row rolls back to the seed fallback', async () => {
+		const db = makeDb();
+		const id = await savePromptH._handler({ db }, { systemPrompt: 'v1' });
+		await setActiveH._handler({ db }, { id, active: false });
+
+		expect(activeRows(db)).toHaveLength(0);
+		expect(await getActiveH._handler({ db }, {})).toBeNull();
+	});
+});

--- a/src/lib/convex/support/agent.ts
+++ b/src/lib/convex/support/agent.ts
@@ -6,10 +6,13 @@ import { LEGAL_CONFIG } from '../../config/legal';
 import { requestHandoff } from './tools/handoff';
 
 /**
- * System instructions for the support agent.
+ * System instructions for the support agent — the seed prompt.
  *
- * Exported separately so prompt-optimization tooling can override the prompt
- * without touching the Agent wiring.
+ * This is the fallback served when no stored override is active. At runtime
+ * support/messages.ts reads support/promptStore.getActive and, when a row is
+ * active, passes it as the per-turn system override in place of this text.
+ * Prompt-optimization tooling writes its result through that store, so it can
+ * ship a new prompt without editing this file.
  */
 export const SUPPORT_AGENT_INSTRUCTIONS = `You are a helpful customer support agent for ${LEGAL_CONFIG.brandName}, a modern SaaS application template built with SvelteKit, Convex, and Tailwind CSS. Your answers are brief and in WhatsApp style.
 

--- a/src/lib/convex/support/messages.ts
+++ b/src/lib/convex/support/messages.ts
@@ -201,13 +201,21 @@ export const createAIResponse = internalAction({
 		const sink = makeAgentUsageSink();
 
 		try {
+			// Load the active support prompt override, if any. null falls back to the
+			// agent's built-in SUPPORT_AGENT_INSTRUCTIONS (agent.ts). The seam already
+			// accepts a locale; we pass none here and serve the global default.
+			const systemOverride = await ctx.runQuery(internal.support.promptStore.getActive, {});
+
 			// Stream the AI response with tool execution support
 			// maxSteps is configured at the agent level (agent.ts) for multi-step tool execution
 			const result = await supportAgent.streamText(
 				ctx,
 				{ threadId: args.threadId, userId: args.userId },
 				{
-					promptMessageId: args.promptMessageId
+					promptMessageId: args.promptMessageId,
+					// AgentPrompt.system overrides the agent's instructions for this turn;
+					// undefined leaves SUPPORT_AGENT_INSTRUCTIONS in place.
+					system: systemOverride ?? undefined
 				},
 				{
 					usageHandler: sink.usageHandler,

--- a/src/lib/convex/support/promptStore.ts
+++ b/src/lib/convex/support/promptStore.ts
@@ -1,0 +1,108 @@
+import { v } from 'convex/values';
+import { internalMutation, internalQuery } from '../_generated/server';
+
+/**
+ * Runtime override store for the support agent's system prompt.
+ *
+ * Lets you hot-swap Kai's system prompt straight from the database, with no
+ * deploy: support/messages.ts reads the active row before every streamed reply
+ * and passes it as the per-turn system override. When no row is active the agent
+ * falls back to the seed prompt in code (SUPPORT_AGENT_INSTRUCTIONS in agent.ts),
+ * so the source stays the safety net. A prompt-optimization pipeline can write
+ * its winning prompt here via savePrompt to ship it without editing source.
+ *
+ * At most one row is active per locale. getActive prefers an exact-locale row
+ * over a locale-less one, so a global default and a locale-specific override can
+ * coexist.
+ */
+
+/**
+ * Resolve the active support system prompt for a request. Returns the active
+ * prompt's systemPrompt, or null when none is active (the caller then falls back
+ * to SUPPORT_AGENT_INSTRUCTIONS). Read on the hot path by support/messages.ts
+ * before every streamed reply.
+ */
+export const getActive = internalQuery({
+	args: { locale: v.optional(v.string()) },
+	returns: v.union(v.string(), v.null()),
+	handler: async (ctx, { locale }) => {
+		// Bounded: at most one active row per locale. The by_active index keeps
+		// this off a full-table scan.
+		const active = await ctx.db
+			.query('supportAgentPrompts')
+			.withIndex('by_active', (q) => q.eq('active', true))
+			.collect();
+		if (active.length === 0) return null;
+		// Prefer a prompt scoped to the request's locale; otherwise serve the
+		// locale-less default (a global override), then any active row as a last
+		// resort.
+		const exact = locale ? active.find((row) => row.locale === locale) : undefined;
+		const fallback = active.find((row) => row.locale === undefined);
+		const chosen = exact ?? fallback ?? active[0];
+		return chosen?.systemPrompt ?? null;
+	}
+});
+
+/**
+ * Persist a new support prompt and make it the one served for its locale.
+ * Deactivates the locale's currently-active row first, so getActive only ever
+ * resolves one prompt per locale. Returns the new row's id.
+ */
+export const savePrompt = internalMutation({
+	args: {
+		systemPrompt: v.string(),
+		locale: v.optional(v.string()),
+		note: v.optional(v.string())
+	},
+	returns: v.id('supportAgentPrompts'),
+	handler: async (ctx, { systemPrompt, locale, note }) => {
+		// Bounded: at most one active row per locale; the by_active index keeps
+		// this off a full scan.
+		const active = await ctx.db
+			.query('supportAgentPrompts')
+			.withIndex('by_active', (q) => q.eq('active', true))
+			.collect();
+		for (const row of active) {
+			// Sequential patches over a tiny active set (one row per locale).
+			if (row.locale === locale) {
+				await ctx.db.patch(row._id, { active: false });
+			}
+		}
+		return await ctx.db.insert('supportAgentPrompts', {
+			systemPrompt,
+			...(locale !== undefined ? { locale } : {}),
+			...(note !== undefined ? { note } : {}),
+			active: true,
+			createdAt: Date.now()
+		});
+	}
+});
+
+/**
+ * Operator lever: flip a stored prompt's active flag. Activating a row
+ * deactivates the other active rows of its locale first, so getActive still
+ * resolves a single prompt per locale. Deactivating the live row rolls the
+ * support agent back to the SUPPORT_AGENT_INSTRUCTIONS fallback without a new
+ * savePrompt.
+ */
+export const setActive = internalMutation({
+	args: { id: v.id('supportAgentPrompts'), active: v.boolean() },
+	returns: v.null(),
+	handler: async (ctx, { id, active }) => {
+		if (active) {
+			const target = await ctx.db.get(id);
+			if (target === null) return null;
+			const siblings = await ctx.db
+				.query('supportAgentPrompts')
+				.withIndex('by_active', (q) => q.eq('active', true))
+				.collect();
+			for (const row of siblings) {
+				if (row._id !== id && row.locale === target.locale) {
+					await ctx.db.patch(row._id, { active: false });
+				}
+			}
+		}
+		await ctx.db.patch(id, { active });
+		return null;
+	}
+});


### PR DESCRIPTION
The support agent's system prompt is compiled into the deploy: changing a single sentence means editing source and redeploying, and although `SUPPORT_AGENT_INSTRUCTIONS` is exported "so prompt-optimization tooling can override the prompt", nothing actually consumed that seam.

This adds the missing runtime half. A new `supportAgentPrompts` table stores prompt overrides (`systemPrompt`, optional `locale`, optional `note`, `active`, `createdAt`), and `support/promptStore.ts` manages them: `savePrompt` inserts and activates a row while deactivating the previous one for its locale, `setActive` toggles a row (deactivating rolls the agent back to the seed instantly), and `getActive` resolves the prompt for a request, preferring an exact-locale row over the locale-less default. `support/messages.ts` reads the active row before every streamed reply and passes it as the per-turn `system` override to `supportAgent.streamText`; when no row is active the built-in instructions stand, so the code seed stays the safety net. The existing `docs/recipes/optimize-support-prompt.md` recipe now documents the shipped seam: the `bunx convex run support/promptStore:savePrompt` hot-swap commands and the shape of an optimization pipeline (gold corpus, judges, a floor guard against shipping below the seed) that would write into it.

`bun run test:unit` (801 tests), `bun run check`, `bun run check:convex`, and `bun run lint` all pass.
