### PR TITLE
chore(mcp): Wire the official PostHog MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,15 @@
 		},
 		"chrome-devtools": {
 			"command": "bunx",
-			"args": ["-y", "chrome-devtools-mcp@latest", "--no-usage-statistics"]
+			"args": [
+				"-y",
+				"chrome-devtools-mcp@latest",
+				"--no-usage-statistics"
+			]
+		},
+		"posthog": {
+			"type": "http",
+			"url": "https://mcp.posthog.com/mcp"
 		}
 	}
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,11 +6,7 @@
 		},
 		"chrome-devtools": {
 			"command": "bunx",
-			"args": [
-				"-y",
-				"chrome-devtools-mcp@latest",
-				"--no-usage-statistics"
-			]
+			"args": ["-y", "chrome-devtools-mcp@latest", "--no-usage-statistics"]
 		},
 		"posthog": {
 			"type": "http",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,8 @@ There is currently no query over `emailEvents`; inspect events via the Convex da
 
 This project uses **PostHog** for product analytics with an optional **Cloudflare Worker proxy** to bypass ad blockers while minimizing costs.
 
+The official PostHog MCP is wired in `.mcp.json` (OAuth on first use, auto-routes to the account's US/EU region) — use it to inspect live insights, dashboards, and events, e.g. to verify a funnel still matches the event properties after renaming or removing one.
+
 ## Testing Guidelines
 
 ### E2E Playwright Tests


### PR DESCRIPTION
Adds the remote PostHog MCP (https://mcp.posthog.com/mcp) to the project MCP config. It authenticates via OAuth on first use and routes automatically to the account's US/EU region, so no secret lands in the repo, matching the existing svelte MCP entry. Forks inherit the wiring with zero setup; AGENTS.md's analytics section points agents at it for verifying insights and funnels against the event inventory.

Config only, no code paths affected.