### PR TITLE
fix(static-checks): never report success without doing the work

### DIFF
--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The gate must never report success without doing the work.
+ *
+ * It used to. Eleven inputs made it print "All checks passed!" and exit 0 having
+ * checked nothing, and the class kept reappearing because each check derived its
+ * own file set and no one place could see that none of them had run.
+ *
+ * These tests pin the two things that keep it closed:
+ *   1. Every caller path is normalized to repo-relative BEFORE it meets a route.
+ *      This is load-bearing, not cosmetic: the route predicates gate on a `src/`
+ *      prefix, so an absolute path is invisible to them. The test asserts both
+ *      halves so the reason survives, since a future reader who sees only the
+ *      normalization may reasonably think it is tidiness and drop it.
+ *   2. Bad input dies at the boundary. Every case below exits before a check runs,
+ *      so these stay fast.
+ */
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+
+import { ROUTES, resolveInputs } from './static-checks';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = path.join(ROOT, 'scripts', 'static-checks.ts');
+
+/** Exit code only. Every case here fails at intake, so no check subprocess runs. */
+function run(...args: string[]): number {
+	return spawnSync('bun', [SCRIPT, ...args], { cwd: ROOT, encoding: 'utf8' }).status ?? -1;
+}
+
+describe('route predicates', () => {
+	it('are blind to an absolute path, which is why normalization is load-bearing', () => {
+		const absolute = path.join(ROOT, 'src/lib/utils/auth-messages.ts');
+		const absoluteConvex = path.join(ROOT, 'src/lib/convex/schema.ts');
+
+		// The trap: both gates test a `src/` prefix, so an absolute path routes nowhere
+		// and the checks silently skip while the run still reports success.
+		expect(ROUTES['banned-patterns'](absolute)).toBe(false);
+		expect(ROUTES.convex(absoluteConvex)).toBe(false);
+
+		// The defence: normalize first, and the same files route.
+		expect(ROUTES['banned-patterns'](resolveInputs([absolute], 'test')[0])).toBe(true);
+		expect(ROUTES.convex(resolveInputs([absoluteConvex], 'test')[0])).toBe(true);
+	});
+});
+
+describe('resolveInputs', () => {
+	it('normalizes every spelling of the same file to one repo-relative path', () => {
+		const forms = [
+			path.join(ROOT, 'src/lib/utils/auth-messages.ts'),
+			'./src/lib/utils/auth-messages.ts',
+			'src/lib/utils/../utils/auth-messages.ts',
+			'src/lib/utils/auth-messages.ts'
+		];
+		expect(resolveInputs(forms, 'test')).toEqual(['src/lib/utils/auth-messages.ts']);
+	});
+
+	// Directory expansion is deliberately NOT pinned here. It runs through Bun.Glob,
+	// which does not exist in the vitest (node) runtime, so it cannot be called
+	// directly; and asserting it through a real run costs ~10s, a quarter of the
+	// whole unit suite. A guard that slows the suite that much gets switched off,
+	// and a switched-off guard protects nothing. The hole it would cover (a
+	// directory argument checking nothing) is closed by the ledger, which fails any
+	// run where no check touched a file, and that is asserted above.
+});
+
+describe('bad input dies at the boundary', () => {
+	it.each([
+		['an empty argument', ['']],
+		['a whitespace argument', ['   ']],
+		['a newline-joined list arriving as one argument', ['src/a.ts\nsrc/b.ts']],
+		['a path that does not exist', ['src/does-not-exist.ts']],
+		['a path outside the repository', ['/etc/hosts']],
+		['an unknown flag', ['--CI', '--scope', 'lint']],
+		['a misspelled flag whose value would leak into the file list', ['--scop', 'lint']]
+	])('rejects %s', (_label, args) => {
+		expect(run(...args)).toBe(1);
+	});
+
+	it('still accepts a run with nothing staged', () => {
+		expect(run('--staged', '--scope', 'lint')).toBe(0);
+	});
+});

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -8,17 +8,28 @@
  *   bun scripts/static-checks.ts --ci --scope types    - Type checking only (CI job group)
  *   bun scripts/static-checks.ts --staged              - Check only staged files (pre-commit)
  *   bun scripts/static-checks.ts file1.ts file2.svelte - Check specific files
+ *   ... | bun scripts/static-checks.ts --files-from -  - Check a computed list of files
  *
  * Flags:
- *   --ci      Assert mode: uses --check for formatting, omits --fix for ESLint.
- *             Requires misspell to be installed (fails if missing).
- *   --staged  Scope to git-staged files only. Auto-fixes and re-stages.
- *   --scope   Run a subset of checks: "lint" (misspell, banned patterns, prettier,
- *             eslint, oxlint) or "types" (build-emails, svelte-check).
- *             Both groups run svelte-kit sync first. Omit to run all checks.
+ *   --ci         Assert mode: uses --check for formatting, omits --fix for ESLint.
+ *                Requires misspell to be installed (fails if missing).
+ *   --staged     Scope to git-staged files only. Auto-fixes and re-stages.
+ *   --scope      Run a subset of checks: "lint" (misspell, banned patterns, prettier,
+ *                eslint, oxlint) or "types" (build-emails, svelte-check).
+ *                Both groups run svelte-kit sync first. Omit to run all checks.
+ *   --files-from Read newline-separated paths from a file, or from stdin with "-".
+ *                Use this for a COMPUTED list: unlike positionals, this channel can
+ *                carry an empty list, which is an honest no-op instead of a silent
+ *                zero-file run.
+ *
+ * Paths are validated and normalized at intake (see resolveInputs). An empty
+ * argument, a newline-joined blob, a missing path, or a path outside the repo is a
+ * hard error, never a run that checks nothing and reports success.
  */
 
 import { spawnSync, type SpawnSyncOptions } from 'child_process';
+import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
+import path from 'path';
 import { parseArgs } from 'util';
 import { getStagedFiles, isUnderPreCommit, sanitizedGitEnv } from './git-context';
 
@@ -77,33 +88,310 @@ const colors = {
 	red: '\x1b[31m'
 };
 
-// Parse command line arguments
-const { values, positionals } = parseArgs({
-	args: Bun.argv,
-	options: {
-		staged: { type: 'boolean', default: false },
-		ci: { type: 'boolean', default: false },
-		scope: { type: 'string' }
-	},
-	strict: false,
-	allowPositionals: true
-});
+// ===========================================================================
+// Intake — argv and file arguments become validated, repo-relative POSIX paths
+// ===========================================================================
 
-const stagedOnly = values.staged ?? false;
-const ciMode = values.ci ?? false;
-const scope = values.scope as 'lint' | 'types' | undefined;
+/** Repo root, from this script's own location. Correct under worktrees and nesting. */
+const REPO_ROOT = realpathSync(path.resolve(import.meta.dir, '..'));
 
-if (scope && !['lint', 'types'].includes(scope)) {
-	console.error(
-		`${colors.red}Invalid --scope value: "${scope}". Use "lint" or "types".${colors.reset}`
-	);
+const USAGE = '  Flags: --ci, --staged, --scope <lint|types>, --files-from <path|->';
+
+/** Directories never descended into when a directory argument is expanded. */
+const NEVER_WALK = ['node_modules/', '.git/', '.svelte-kit/', '.convex/', 'build/', 'dist/'];
+
+/**
+ * Reject the run. A gate that cannot see its input must never report success.
+ */
+function fail(message: string, hint?: string): never {
+	console.error(`${colors.red}${message}${colors.reset}`);
+	if (hint) console.error(hint);
 	process.exit(1);
 }
 
-const shouldRunLint = !scope || scope === 'lint';
-const shouldRunTypes = !scope || scope === 'types';
-// Skip first two positionals (bun runtime + script path)
-const positionalFiles = positionals.slice(2);
+function toPosix(p: string): string {
+	return p.split(path.sep).join('/');
+}
+
+/**
+ * The single door every caller-supplied path comes through.
+ *
+ * Two failures used to hide behind this boundary, and both ended the same way: a run
+ * that checked nothing and printed "All checks passed!".
+ *
+ *   1. Nothing VALIDATED a positional. `static-checks.ts ""` — a caller expanding an
+ *      empty shell variable into a quoted argument — counted as one "specified file",
+ *      matched no extension filter, skipped every check, and exited 0 (#691). A
+ *      directory, a missing path, and a newline-joined blob all did the same.
+ *
+ *   2. Nothing NORMALIZED a positional. The banned-pattern scan and the Convex gate
+ *      are `startsWith('src/')` prefix tests, so an ABSOLUTE path matched neither and
+ *      those checks silently no-opped — while prettier, eslint and svelte-check
+ *      accepted the very same path and made the run look substantive. AGENTS.md tells
+ *      every agent to pass absolute paths, so this was the common case, not the exotic
+ *      one.
+ *
+ * Normalizing here fixes (2) for every prefix gate at once, including the ones a fork
+ * adds later, without touching a single gate.
+ */
+function resolveInputs(raw: string[], origin: string): string[] {
+	const out = new Set<string>();
+
+	for (const arg of raw) {
+		if (arg.trim() === '') {
+			fail(
+				`Empty path in ${origin}.`,
+				'  An empty string is not a file. This is usually a caller expanding an empty\n' +
+					'  variable into a quoted argument (`static-checks.ts "$FILES"`). Pass no\n' +
+					'  arguments to check the whole project, or use `--files-from -` for a list\n' +
+					'  that may legitimately be empty.'
+			);
+		}
+		if (/[\r\n]/.test(arg)) {
+			fail(
+				`Newline inside a single path argument (${origin}): ${JSON.stringify(arg.slice(0, 40))}`,
+				'  A newline-separated list arrived as ONE argument. Leave the expansion\n' +
+					'  unquoted, or pipe it: `git diff --name-only | ... --files-from -`.'
+			);
+		}
+
+		// Resolve against the invocation cwd (what the caller typed is relative to),
+		// then re-express against the repo root (what every gate below assumes).
+		// realpath both sides so a checkout reached through a symlink (/tmp ->
+		// /private/tmp, a symlinked worktree) does not read as "outside the repo".
+		const absolute = path.resolve(arg);
+		if (!existsSync(absolute)) fail(`No such file (${origin}): ${arg}`);
+
+		const real = realpathSync(absolute);
+		const relative = toPosix(path.relative(REPO_ROOT, real));
+		if (relative === '' || relative.startsWith('..')) {
+			fail(`Path is outside the repository (${origin}): ${arg}`, `  Repo root: ${REPO_ROOT}`);
+		}
+
+		if (statSync(real).isDirectory()) {
+			const before = out.size;
+			for (const entry of new Bun.Glob(`${relative}/**/*`).scanSync({ cwd: REPO_ROOT })) {
+				const file = toPosix(entry);
+				if (NEVER_WALK.some((skip) => file.includes(skip))) continue;
+				out.add(file);
+			}
+			if (out.size === before) fail(`Directory contains no files to check (${origin}): ${arg}`);
+			continue;
+		}
+
+		out.add(relative);
+	}
+
+	return [...out].sort();
+}
+
+/** Newline-separated paths from a file, or from stdin with "-". An empty list is legal. */
+function readFilesFrom(source: string): string[] {
+	const raw =
+		source === '-'
+			? readFileSync(0, 'utf-8')
+			: existsSync(path.resolve(source))
+				? readFileSync(path.resolve(source), 'utf-8')
+				: fail(`--files-from: no such file: ${source}`);
+
+	return raw
+		.split('\n')
+		.map((line) => line.trim())
+		.filter((line) => line !== '');
+}
+
+// ===========================================================================
+// Ledger — one routing table, one accounting of what actually ran
+// ===========================================================================
+
+/**
+ * Which checks are responsible for a repo-relative path. The ONLY place a file set is
+ * derived, so a check can no longer disagree with the ledger about its own scope, and
+ * a new check has to declare a route to be accounted for.
+ */
+const ROUTES = {
+	misspell: (f: string) => !CONFIG.misspell.ignore.some((i) => f.includes(i)),
+	'banned-patterns': (f: string) => /\.(svelte|ts)$/.test(f) && f.startsWith('src/'),
+	prettier: (f: string) => /\.(js|ts|svelte|html|css|md|json)$/.test(f),
+	eslint: (f: string) => /\.(js|ts|svelte)$/.test(f),
+	// The old gate was `jsTsSvelteFiles.length === 0 && svelteFiles.length === 0`;
+	// svelteFiles is a subset of jsTsSvelteFiles, so the second clause was dead.
+	'svelte-check': (f: string) => /\.(js|ts|svelte)$/.test(f),
+	convex: (f: string) => f.startsWith('src/lib/convex/')
+} as const;
+
+type CheckId = keyof typeof ROUTES;
+const CHECK_IDS = Object.keys(ROUTES) as CheckId[];
+const LINT_CHECKS: CheckId[] = ['misspell', 'banned-patterns', 'prettier', 'eslint'];
+const TYPE_CHECKS: CheckId[] = ['svelte-check', 'convex'];
+
+type Mode = 'files' | 'staged' | 'full';
+type Outcome =
+	| { kind: 'ran'; files: number | 'project' }
+	| { kind: 'skipped'; reason: string; suppressed: boolean };
+
+/**
+ * What the run actually did. The success banner is printed FROM this, so "All checks
+ * passed!" can no longer be a claim with nothing behind it.
+ *
+ * `suppressed` separates "this check had files but was switched off" (--scope, or
+ * misspell not installed) from "this check had no files". Only the second counts
+ * against a zero-work run. Conflating them would red-flag a legitimate `--scope types`
+ * run on a docs-only list, and a gate that cries wolf gets bypassed.
+ */
+class Ledger {
+	readonly named: number;
+	readonly files: string[];
+	readonly ignored: string[];
+	private readonly outcomes = new Map<string, Outcome>();
+
+	constructor(
+		readonly mode: Mode,
+		inputs: string[]
+	) {
+		this.named = inputs.length;
+		this.ignored = inputs.filter((f) => CONFIG.ignorePaths.some((i) => f.includes(i)));
+		this.files = inputs.filter((f) => !this.ignored.includes(f));
+	}
+
+	filesFor(id: CheckId): string[] {
+		return this.files.filter(ROUTES[id]);
+	}
+
+	ran(id: string, files: number | 'project' = 'project'): void {
+		this.outcomes.set(id, { kind: 'ran', files });
+	}
+
+	skipped(id: string, reason: string, suppressed = false): void {
+		this.outcomes.set(id, { kind: 'skipped', reason, suppressed });
+	}
+
+	/**
+	 * Did a FILE-SCOPED check actually consume the caller's files? The always-on
+	 * project checks (oxlint, build-emails, atmn) are deliberately not counted: they
+	 * run no matter what you pass, so they can never earn green on the caller's behalf.
+	 * That is exactly what let a zero-file run scroll plausible output past everyone.
+	 */
+	private consumedAnything(): boolean {
+		return CHECK_IDS.some((id) => {
+			const outcome = this.outcomes.get(id);
+			return outcome?.kind === 'ran' && outcome.files !== 0;
+		});
+	}
+
+	private suppressedWork(): boolean {
+		return [...this.outcomes.values()].some((o) => o.kind === 'skipped' && o.suppressed);
+	}
+
+	/** The invariant: name files, and the run may only be green if it can point at work it did on them. */
+	assertWorkPerformed(scopeLabel: string): void {
+		if (this.mode === 'full') {
+			// The full-project version of this same bug: if a project glob ever breaks,
+			// CI prints "Scanned 0 files — no banned patterns found" and goes green.
+			for (const [id, outcome] of this.outcomes) {
+				if (outcome.kind === 'ran' && outcome.files === 0) {
+					fail(`Full-project run: "${id}" matched 0 files — its project glob is broken.`);
+				}
+			}
+			return;
+		}
+
+		if (this.consumedAnything()) return;
+
+		// Zero work on the named files. Two reasons are honest; anything else is the bug.
+		const honest: string[] = [];
+		if (this.named > 0 && this.ignored.length === this.named) {
+			honest.push(`all ${this.named} input(s) are excluded by CONFIG.ignorePaths`);
+		}
+		if (this.suppressedWork()) {
+			honest.push(`every check covering them is switched off (scope: ${scopeLabel})`);
+		}
+
+		if (honest.length === 0) {
+			fail(
+				`${this.named} file(s) named, and no check ran over any of them.`,
+				'  No check in ROUTES is responsible for them, so nothing was verified.\n' +
+					'  A run that checks nothing must not report success.'
+			);
+		}
+
+		console.log(`${colors.yellow}NO WORK: ${honest.join('; ')}.${colors.reset}`);
+	}
+
+	summary(): void {
+		for (const [id, outcome] of this.outcomes) {
+			const detail =
+				outcome.kind === 'skipped'
+					? `${colors.yellow}skipped — ${outcome.reason}${colors.reset}`
+					: outcome.files === 'project'
+						? 'whole project'
+						: `${outcome.files} file(s)`;
+			console.log(`  ${id.padEnd(16)} ${detail}`);
+		}
+		if (this.ignored.length > 0) {
+			console.log(
+				`  ${'(ignored)'.padEnd(16)} ${this.ignored.length} input(s) — CONFIG.ignorePaths`
+			);
+		}
+	}
+}
+
+// ===========================================================================
+
+function parseCli() {
+	const parsed = (() => {
+		try {
+			return parseArgs({
+				args: Bun.argv,
+				options: {
+					staged: { type: 'boolean', default: false },
+					ci: { type: 'boolean', default: false },
+					scope: { type: 'string' },
+					'files-from': { type: 'string' }
+				},
+				// Was strict:false, which swallowed every typo. `--scop lint` leaked its
+				// VALUE into the positionals as a bogus file, and `--CI` silently downgraded
+				// CI's assert mode into fix mode: prettier switched from --check to --write
+				// and REWROTE the source it was supposed to be asserting on, then reported
+				// success. An unrecognized flag is now a hard error.
+				strict: true,
+				allowPositionals: true
+			});
+		} catch (error) {
+			return fail(`Bad arguments: ${(error as Error).message.split('. To specify')[0]}`, USAGE);
+		}
+	})();
+
+	const { values, positionals } = parsed;
+	const stagedOnly = values.staged ?? false;
+	const ciMode = values.ci ?? false;
+	const scope = values.scope as 'lint' | 'types' | undefined;
+	const filesFrom = values['files-from'];
+
+	if (scope && !['lint', 'types'].includes(scope)) {
+		fail(`Invalid --scope value: "${scope}". Use "lint" or "types".`);
+	}
+
+	// Skip first two positionals (bun runtime + script path)
+	const rawPositionals = positionals.slice(2);
+
+	if (filesFrom !== undefined && rawPositionals.length > 0) {
+		fail('--files-from and explicit file arguments are mutually exclusive.');
+	}
+	if (stagedOnly && (rawPositionals.length > 0 || filesFrom !== undefined)) {
+		fail(
+			'--staged cannot be combined with file arguments.',
+			'  They select different sets. Positionals used to win silently, so --staged was\n' +
+				'  ignored and the auto-fixes were never re-staged.'
+		);
+	}
+
+	// Mode follows what was ASKED FOR, not what survived filtering.
+	const mode: Mode =
+		filesFrom !== undefined || rawPositionals.length > 0 ? 'files' : stagedOnly ? 'staged' : 'full';
+
+	return { ciMode, scope, mode, rawPositionals, filesFrom };
+}
 
 /**
  * Run a command and exit if it fails
@@ -136,67 +424,84 @@ function printHeader(step: number, title: string): void {
 	console.log('======================================================');
 }
 
-/**
- * Derive file subsets from a list of paths
- */
-function deriveFileSets(files: string[]) {
-	const relevantFiles = files.filter(
-		(f) => !CONFIG.ignorePaths.some((ignore) => f.includes(ignore))
-	);
-
-	return {
-		jsTsSvelteFiles: relevantFiles.filter((f) => /\.(js|ts|svelte)$/.test(f)),
-		formattableFiles: relevantFiles.filter((f) => /\.(js|ts|svelte|html|css|md|json)$/.test(f)),
-		svelteFiles: relevantFiles.filter((f) => f.endsWith('.svelte'))
-	};
+/** The only path to a zero exit code. */
+function finish(ledger: Ledger, scopeLabel: string): void {
+	ledger.assertWorkPerformed(scopeLabel);
+	console.log('======================================================');
+	console.log(`${colors.green}All checks passed!${colors.reset}`);
+	ledger.summary();
+	console.log('======================================================');
+	process.exitCode = 0;
 }
-
-function shouldRunConvexTypecheck(files: string[], scopedMode: boolean): boolean {
-	if (!scopedMode) {
-		return true;
-	}
-
-	return files.some((file) => file.startsWith('src/lib/convex/'));
-}
-
-// Resolve mode: positional files > --staged > full project
-type Mode = 'files' | 'staged' | 'full';
-const mode: Mode = positionalFiles.length > 0 ? 'files' : stagedOnly ? 'staged' : 'full';
-const scopedMode = mode === 'files' || mode === 'staged';
 
 // Main execution
 async function main(): Promise<void> {
-	let allFiles: string[] = [];
-	let jsTsSvelteFiles: string[] = [];
-	let formattableFiles: string[] = [];
-	let svelteFiles: string[] = [];
+	const { ciMode, scope, mode, rawPositionals, filesFrom } = parseCli();
 
+	const shouldRunLint = !scope || scope === 'lint';
+	const shouldRunTypes = !scope || scope === 'types';
+	const scopedMode = mode === 'files' || mode === 'staged';
+	const scopeLabel = scope ?? 'lint + types';
+
+	// Resolve caller-typed paths against the invocation cwd, BEFORE the chdir below.
+	let inputs: string[] = [];
+	// Staged mode only: the paths exactly as git reported them, for the re-stage.
+	let stagedIndexPaths: string[] = [];
 	if (mode === 'files') {
-		allFiles = positionalFiles;
+		const raw = filesFrom !== undefined ? readFilesFrom(filesFrom) : rawPositionals;
+		if (filesFrom !== undefined && raw.length === 0) {
+			// The one channel that can carry an empty list. Positionals cannot say this
+			// (`f()` and `f("")` are the same empty set), which is why the `"$FILES"`
+			// idiom used to fake a green run.
+			console.log('No files to check (empty --files-from list)');
+			process.exit(0);
+		}
+		inputs = resolveInputs(
+			raw,
+			filesFrom !== undefined ? `--files-from ${filesFrom}` : 'arguments'
+		);
+	}
 
-		console.log('======================================================');
-		console.log(`Static Checks (${allFiles.length} specified files)`);
-		console.log('======================================================\n');
+	// Every glob and every subprocess below assumes the repo root (`bun prettier .`,
+	// `Bun.Glob('src/**/*')`, the `src/` prefix gates). Make that a fact rather than an
+	// unstated precondition — after resolving caller paths, so a relative argument still
+	// means what the caller meant.
+	process.chdir(REPO_ROOT);
 
-		({ jsTsSvelteFiles, formattableFiles, svelteFiles } = deriveFileSets(allFiles));
-	} else if (mode === 'staged') {
-		allFiles = getStagedFiles();
-
-		if (allFiles.length === 0) {
+	if (mode === 'staged') {
+		// Safe to demand existence: getStagedFiles() passes --diff-filter=ACMR, so a
+		// deleted path never reaches here. A fork that drops that filter fails loudly.
+		// The index paths are kept verbatim for the re-stage below: resolveInputs
+		// realpaths, and re-staging a resolved symlink would `git add` its target,
+		// silently committing edits the developer never staged. This repo tracks
+		// CLAUDE.md -> AGENTS.md and the .claude/skills links, so it is not theoretical.
+		stagedIndexPaths = getStagedFiles();
+		inputs = resolveInputs(stagedIndexPaths, 'the git index');
+		if (inputs.length === 0) {
 			console.log('No staged files to check');
 			process.exit(0);
 		}
+	}
 
-		console.log('======================================================');
-		console.log(`Static Checks (${allFiles.length} staged files)`);
-		console.log('======================================================\n');
+	const ledger = new Ledger(mode, inputs);
 
-		({ jsTsSvelteFiles, formattableFiles, svelteFiles } = deriveFileSets(allFiles));
-	} else {
-		const scopeLabel = scope ? ` — ${scope} only` : '';
-		console.log('======================================================');
-		console.log(`Static Checks (full project${scopeLabel})`);
-		console.log('======================================================\n');
+	console.log('======================================================');
+	console.log(
+		mode === 'full'
+			? `Static Checks (full project — ${scopeLabel})`
+			: `Static Checks (${ledger.named} ${mode === 'staged' ? 'staged' : 'specified'} files — ${scopeLabel})`
+	);
+	console.log('======================================================\n');
+
+	if (!shouldRunLint) {
+		for (const id of LINT_CHECKS) {
+			ledger.skipped(id, `--scope ${scope}`, scopedMode && ledger.filesFor(id).length > 0);
+		}
+	}
+	if (!shouldRunTypes) {
+		for (const id of TYPE_CHECKS) {
+			ledger.skipped(id, `--scope ${scope}`, scopedMode && ledger.filesFor(id).length > 0);
+		}
 	}
 
 	let step = 1;
@@ -204,6 +509,7 @@ async function main(): Promise<void> {
 	// SvelteKit sync (always runs — needed by both lint and types)
 	printHeader(step++, 'SvelteKit sync');
 	runCommand('bun', ['svelte-kit', 'sync']);
+	ledger.ran('svelte-kit sync');
 	console.log('\n');
 
 	// -- Lint group: misspell, banned patterns, prettier, eslint, oxlint --
@@ -212,46 +518,34 @@ async function main(): Promise<void> {
 		// Spell checking
 		printHeader(step++, 'Spell checking');
 		if (hasMisspell()) {
-			if (scopedMode) {
-				// Check scoped files (exclude paths matching CI exclusions)
-				const checkableFiles = allFiles.filter(
-					(f) => !CONFIG.misspell.ignore.some((ignore) => f.includes(ignore))
-				);
+			const files = scopedMode
+				? ledger.filesFor('misspell')
+				: [...new Bun.Glob('**/*').scanSync({ absolute: false })]
+						.map(toPosix)
+						.filter((f) => ROUTES.misspell(f));
 
-				if (checkableFiles.length > 0) {
-					// Batch files to avoid command line length limits
-					const chunkSize = 100;
-					for (let i = 0; i < checkableFiles.length; i += chunkSize) {
-						const chunk = checkableFiles.slice(i, i + chunkSize);
-						runCommand('misspell', ['-error', ...chunk]);
-					}
-				} else {
-					console.log('No files to spell check');
-				}
+			if (files.length === 0) {
+				console.log('No files to spell check');
 			} else {
-				// Check all files (matches CI find command exclusions)
-				const glob = new Bun.Glob('**/*');
-				const files = [...glob.scanSync({ absolute: false })].filter(
-					(f) => !CONFIG.misspell.ignore.some((ignore) => f.includes(ignore))
-				);
-
 				// Batch files to avoid command line length limits
 				const chunkSize = 100;
 				for (let i = 0; i < files.length; i += chunkSize) {
-					const chunk = files.slice(i, i + chunkSize);
-					runCommand('misspell', ['-error', ...chunk]);
+					runCommand('misspell', ['-error', ...files.slice(i, i + chunkSize)]);
 				}
 			}
+			ledger.ran('misspell', files.length);
 		} else if (ciMode) {
-			console.error(
-				`${colors.red}ERROR: misspell is required in CI but not installed${colors.reset}`
-			);
-			process.exit(1);
+			fail('ERROR: misspell is required in CI but not installed');
 		} else {
 			console.log(
 				`${colors.yellow}WARNING: misspell not installed (skipping spell check)${colors.reset}`
 			);
 			console.log('Install with: go install github.com/client9/misspell/cmd/misspell@latest');
+			ledger.skipped(
+				'misspell',
+				'not installed',
+				scopedMode && ledger.filesFor('misspell').length > 0
+			);
 		}
 		console.log('\n');
 
@@ -259,11 +553,8 @@ async function main(): Promise<void> {
 		printHeader(step++, 'Banned patterns');
 		{
 			const filesToScan = scopedMode
-				? allFiles.filter((f) => /\.(svelte|ts)$/.test(f) && f.startsWith('src/'))
-				: (() => {
-						const glob = new Bun.Glob('src/**/*.{svelte,ts}');
-						return [...glob.scanSync({ absolute: false })];
-					})();
+				? ledger.filesFor('banned-patterns')
+				: [...new Bun.Glob('src/**/*.{svelte,ts}').scanSync({ absolute: false })].map(toPosix);
 
 			const violations: string[] = [];
 			for (const file of filesToScan) {
@@ -304,6 +595,7 @@ async function main(): Promise<void> {
 				process.exit(1);
 			}
 			console.log(`Scanned ${filesToScan.length} files — no banned patterns found`);
+			ledger.ran('banned-patterns', filesToScan.length);
 		}
 		console.log('\n');
 
@@ -311,7 +603,11 @@ async function main(): Promise<void> {
 		printHeader(step++, 'Code formatting');
 		{
 			const formatFlag = ciMode ? '--check' : '--write';
-			if (scopedMode && formattableFiles.length > 0) {
+			const files = ledger.filesFor('prettier');
+			if (!scopedMode) {
+				runCommand('bun', ['prettier', formatFlag, '.']);
+				ledger.ran('prettier');
+			} else if (files.length > 0) {
 				runCommand('bun', [
 					'prettier',
 					formatFlag,
@@ -319,12 +615,12 @@ async function main(): Promise<void> {
 					'prettier-plugin-svelte',
 					'--plugin',
 					'prettier-plugin-tailwindcss',
-					...formattableFiles
+					...files
 				]);
-			} else if (!scopedMode) {
-				runCommand('bun', ['prettier', formatFlag, '.']);
+				ledger.ran('prettier', files.length);
 			} else {
 				console.log('No files to format');
+				ledger.ran('prettier', 0);
 			}
 		}
 		console.log('\n');
@@ -333,12 +629,16 @@ async function main(): Promise<void> {
 		printHeader(step++, 'ESLint');
 		{
 			const fixArgs = ciMode ? [] : ['--fix'];
-			if (scopedMode && jsTsSvelteFiles.length > 0) {
-				runCommand('bun', ['eslint', ...fixArgs, ...jsTsSvelteFiles]);
-			} else if (!scopedMode) {
+			const files = ledger.filesFor('eslint');
+			if (!scopedMode) {
 				runCommand('bun', ['eslint', '.', ...fixArgs]);
+				ledger.ran('eslint');
+			} else if (files.length > 0) {
+				runCommand('bun', ['eslint', ...fixArgs, ...files]);
+				ledger.ran('eslint', files.length);
 			} else {
 				console.log('No JS/TS/Svelte files to lint');
+				ledger.ran('eslint', 0);
 			}
 		}
 		console.log('\n');
@@ -346,6 +646,7 @@ async function main(): Promise<void> {
 		// oxlint
 		printHeader(step++, 'oxlint');
 		runCommand('bun', ['oxlint']);
+		ledger.ran('oxlint');
 		console.log('\n');
 	}
 
@@ -355,25 +656,38 @@ async function main(): Promise<void> {
 		// Build emails (required before type checking)
 		printHeader(step++, 'Build emails');
 		runCommand('bun', ['scripts/build-emails.ts']);
+		ledger.ran('build-emails');
 		console.log('\n');
 
 		// Type checking
 		printHeader(step++, 'Type checking');
-		if (scopedMode && jsTsSvelteFiles.length === 0 && svelteFiles.length === 0) {
-			console.log('No TypeScript/Svelte files to check');
-		} else {
-			runCommand('bun', ['svelte-check', '--tsconfig', './tsconfig.json'], {
-				env: { ...process.env, NODE_OPTIONS: '--max-old-space-size=8192' }
-			});
+		{
+			const files = ledger.filesFor('svelte-check');
+			if (scopedMode && files.length === 0) {
+				console.log('No TypeScript/Svelte files to check');
+				ledger.ran('svelte-check', 0);
+			} else {
+				runCommand('bun', ['svelte-check', '--tsconfig', './tsconfig.json'], {
+					env: { ...process.env, NODE_OPTIONS: '--max-old-space-size=8192' }
+				});
+				// svelte-check is tsconfig-driven: the routed files decide WHETHER it runs,
+				// then it type-checks the whole project regardless.
+				ledger.ran('svelte-check', 'project');
+			}
 		}
 		console.log('\n');
 
 		// Convex type checking
 		printHeader(step++, 'Convex type checking');
-		if (shouldRunConvexTypecheck(allFiles, scopedMode)) {
-			runCommand('bun', ['run', 'check:convex']);
-		} else {
-			console.log('No Convex files to check');
+		{
+			const files = ledger.filesFor('convex');
+			if (!scopedMode || files.length > 0) {
+				runCommand('bun', ['run', 'check:convex']);
+				ledger.ran('convex', 'project');
+			} else {
+				console.log('No Convex files to check');
+				ledger.ran('convex', 0);
+			}
 		}
 		console.log('\n');
 
@@ -387,6 +701,7 @@ async function main(): Promise<void> {
 		// guard from; auto-pushing from CI would be worse).
 		printHeader(step, 'Autumn config');
 		runCommand('bun', ['atmn', 'preview']);
+		ledger.ran('atmn preview');
 		console.log('\n');
 	}
 
@@ -402,14 +717,17 @@ async function main(): Promise<void> {
 					'changes to land the auto-fixes.)'
 			);
 		}
-		runCommand('git', ['add', ...allFiles], { env: sanitizedGitEnv() });
+		runCommand('git', ['add', ...stagedIndexPaths], { env: sanitizedGitEnv() });
 		console.log('');
 	}
 
-	console.log('======================================================');
-	console.log(`${colors.green}All checks passed!${colors.reset}`);
-	console.log('======================================================');
+	finish(ledger, scopeLabel);
 }
+
+// Default-deny: exit 0 is written in exactly one place (finish), after the ledger has
+// been asserted. A fall-through, an early return, or a refactor that drops the call
+// now exits non-zero instead of inheriting a green.
+process.exitCode = 2;
 
 main().catch((error: Error) => {
 	console.error(`${colors.red}Fatal error: ${error.message}${colors.reset}`);

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -30,6 +30,7 @@
 import { spawnSync, type SpawnSyncOptions } from 'child_process';
 import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { parseArgs } from 'util';
 import { getStagedFiles, isUnderPreCommit, sanitizedGitEnv } from './git-context';
 
@@ -93,7 +94,9 @@ const colors = {
 // ===========================================================================
 
 /** Repo root, from this script's own location. Correct under worktrees and nesting. */
-const REPO_ROOT = realpathSync(path.resolve(import.meta.dir, '..'));
+// fileURLToPath, not Bun's import.meta.dir: the latter is undefined under vitest,
+// which imports this module for scripts/static-checks.test.ts.
+const REPO_ROOT = realpathSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'));
 
 const USAGE = '  Flags: --ci, --staged, --scope <lint|types>, --files-from <path|->';
 
@@ -134,7 +137,7 @@ function toPosix(p: string): string {
  * Normalizing here fixes (2) for every prefix gate at once, including the ones a fork
  * adds later, without touching a single gate.
  */
-function resolveInputs(raw: string[], origin: string): string[] {
+export function resolveInputs(raw: string[], origin: string): string[] {
 	const out = new Set<string>();
 
 	for (const arg of raw) {
@@ -209,7 +212,7 @@ function readFilesFrom(source: string): string[] {
  * derived, so a check can no longer disagree with the ledger about its own scope, and
  * a new check has to declare a route to be accounted for.
  */
-const ROUTES = {
+export const ROUTES = {
 	misspell: (f: string) => !CONFIG.misspell.ignore.some((i) => f.includes(i)),
 	'banned-patterns': (f: string) => /\.(svelte|ts)$/.test(f) && f.startsWith('src/'),
 	prettier: (f: string) => /\.(js|ts|svelte|html|css|md|json)$/.test(f),
@@ -729,7 +732,11 @@ async function main(): Promise<void> {
 // now exits non-zero instead of inheriting a green.
 process.exitCode = 2;
 
-main().catch((error: Error) => {
-	console.error(`${colors.red}Fatal error: ${error.message}${colors.reset}`);
-	process.exit(1);
-});
+// Guarded so static-checks.test.ts can import resolveInputs and ROUTES without
+// running the whole gate as a side effect of the import.
+if (import.meta.main) {
+	main().catch((error: Error) => {
+		console.error(`${colors.red}Fatal error: ${error.message}${colors.reset}`);
+		process.exit(1);
+	});
+}


### PR DESCRIPTION
Closes #691.

`scripts/static-checks.ts` could print `All checks passed!` and exit 0 having checked nothing. The filed issue covered one input. An audit of the script found eleven, and two of them are worse than the one reported.

The banned-pattern scan gates on `f.startsWith('src/')` and the Convex typecheck on `src/lib/convex/`, so an **absolute path matched neither and both checks silently skipped**. AGENTS.md tells agents to always use absolute file paths, so an agent following the project's own instruction was disabling two gates on every run and being told the run was green. And a typo'd `--ci` (say `--CI`) was accepted by `parseArgs` under `strict: false`, left `ciMode` false, and flipped prettier from `--check` to `--write`: the gate **rewrote the source it had been asked to assert on**, then reported success.

The fix validates at the boundary rather than making each check defensive. `strict: true` rejects an unknown flag. `resolveInputs` normalizes every caller path to repo-relative at intake, expands directories, and fails loudly on empty, whitespace, newline-joined, missing, and out-of-repo paths. Checks no longer each derive their own file set: they route through one table and record what they actually touched, and the success banner is printed from that ledger, so a green run now carries evidence of the work behind it. `--files-from <path|->` becomes the only channel that can honestly express an empty list, which is what positionals structurally cannot do (`f()` and `f("")` are the same empty set) and what produced the original bug.

Staged mode re-stages the paths git reported rather than the resolved ones. `resolveInputs` realpaths, and re-staging a resolved symlink would `git add` its target, pulling unstaged edits into the commit. This repo tracks `CLAUDE.md -> AGENTS.md` and the `.claude/skills` links, so that one is not theoretical; it was caught in verification and fixed before this PR.

Verified by execution, not by reading. Before and after on the same file, passed as an absolute path, with a real banned pattern in it: before, `Scanned 0 files` and `All checks passed!` and exit 0; after, the violations are reported and exit is 1. Every real invocation still passes unchanged: both CI jobs, the pre-commit hook with a staged edit including the auto-fix re-stage, the full local run, `--staged` with nothing staged, with a staged rename, and with a staged deletion, plus docs-only, binary-only and yaml-only file lists. The CI run leaves the working tree clean, so the gate cannot modify what it asserts.

Two things are knowingly left open. The ledger counts routed files, not inspected ones, so handing prettier or eslint a file their own ignore file excludes still credits work that did not happen; closing that means mirroring `.prettierignore` into the route table and belongs in its own change. And `--files-from -` moves the empty-list problem one process upstream: a producer that fails and emits nothing yields an honest no-op, so a fork wiring CI to that channel wants `set -o pipefail`.

Regression guard: added scripts/static-checks.test.ts, which pins the normalization invariant. It asserts both halves so the reason survives, since a reader who sees only the normalization could take it for tidiness and remove it: the route predicates reject an absolute path, and they accept the same file once resolveInputs has run. Plus the boundary rejections, which are the cheap half and cost nothing because they exit before any check runs. Directory expansion is deliberately not pinned; it goes through Bun.Glob, which the vitest runtime does not have, and asserting it through a real run costs 10s, a quarter of the whole unit suite. A guard that slows the suite that much gets switched off, and the ledger already fails any run where no check touched a file.