### PR TITLE
fix(chat): show email prompt on tool-call handoff

### DIFF
--- a/src/lib/chat/ui/ChatMessages.svelte
+++ b/src/lib/chat/ui/ChatMessages.svelte
@@ -12,6 +12,7 @@
 	import { ScrollButton } from '$lib/components/prompt-kit/scroll-button';
 	import ProgressiveBlur from '$blocks/magic/ProgressiveBlur.svelte';
 	import { getChatUIContext } from './chat-context.svelte.js';
+	import { isHandoffAnchor } from './handoff-anchor.js';
 	import ChatMessage from './ChatMessage.svelte';
 	import type { DisplayMessage, Attachment } from '../core/types.js';
 	import { mode } from 'mode-watcher';
@@ -208,7 +209,7 @@
 								{message}
 								attachments={getAttachments(message)}
 								isFirstInGroup={isFirstInGroup(index, ctx.displayMessages)}
-								isHandoffMessage={message.displayText?.startsWith(HANDOFF_MESSAGE)}
+								isHandoffMessage={isHandoffAnchor(message, HANDOFF_MESSAGE)}
 								{showEmailPrompt}
 								{currentEmail}
 								{isEmailPending}

--- a/src/lib/chat/ui/handoff-anchor.test.ts
+++ b/src/lib/chat/ui/handoff-anchor.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { isHandoffAnchor } from './handoff-anchor';
+import type { MessagePart } from '../core/types.js';
+
+const CANNED = 'Thanks for reaching out.';
+
+function msg(displayText: string, parts?: MessagePart[]) {
+	return { displayText, parts };
+}
+
+describe('isHandoffAnchor', () => {
+	it('detects the canned handoff response from the widget button flow', () => {
+		expect(isHandoffAnchor(msg(`${CANNED} The team will reply here.`), CANNED)).toBe(true);
+	});
+
+	it('detects a request_handoff tool call from the agent flow', () => {
+		const parts = [
+			{ type: 'text', text: "I've noted that bug. The team is on it." },
+			{ type: 'tool-request_handoff', state: 'output-available' }
+		] as unknown as MessagePart[];
+		expect(isHandoffAnchor(msg("I've noted that bug. The team is on it.", parts), CANNED)).toBe(
+			true
+		);
+	});
+
+	it('ignores ordinary assistant messages and unrelated tool calls', () => {
+		expect(isHandoffAnchor(msg('The trial runs 14 days.'), CANNED)).toBe(false);
+		const parts = [
+			{ type: 'tool-someOtherTool', state: 'output-available' }
+		] as unknown as MessagePart[];
+		expect(isHandoffAnchor(msg('Done.', parts), CANNED)).toBe(false);
+	});
+
+	it('never matches everything when the canned text resolves empty', () => {
+		expect(isHandoffAnchor(msg('Any message at all.'), '')).toBe(false);
+	});
+});

--- a/src/lib/chat/ui/handoff-anchor.ts
+++ b/src/lib/chat/ui/handoff-anchor.ts
@@ -1,0 +1,19 @@
+import type { DisplayMessage } from '../core/types.js';
+
+/**
+ * Whether a message anchors the inline email prompt in a handed-off thread.
+ *
+ * Two handoff flows produce different message shapes: the widget button saves a
+ * canned handoff response (detected by its localized opening sentence), while
+ * Kai's request_handoff tool call leaves a normal assistant message whose parts
+ * carry the tool invocation (tool parts are typed "tool-{toolName}"). Text
+ * sniffing alone misses the tool flow, so the email field would never render
+ * even though the thread is handed off and Kai points the user to it.
+ */
+export function isHandoffAnchor(
+	message: Pick<DisplayMessage, 'displayText' | 'parts'>,
+	handoffMessage: string
+): boolean {
+	if (handoffMessage && message.displayText?.startsWith(handoffMessage)) return true;
+	return (message.parts ?? []).some((p) => p.type === 'tool-request_handoff');
+}


### PR DESCRIPTION
When the support agent hands a conversation to the team via its request_handoff tool, the widget header flips to the handed-off state and the agent points the user to the email field below the conversation, but no such field renders. The inline email prompt only anchored to the canned handoff response message that the "Talk to support" button saves (matched by its localized opening sentence), and the tool flow saves no canned message, so the prompt never appeared.

Anchor detection now lives in handoff-anchor.ts and matches either shape: the canned response text, or a message whose parts carry the request_handoff tool invocation (tool parts are typed "tool-{toolName}"). As a side hardening, an empty canned string no longer anchors every message, since startsWith("") is true for any text.

Regression guard: added handoff-anchor.test.ts

`bunx vitest run src/lib/chat/ui/handoff-anchor.test.ts` passes (4 tests), `bun run check` is clean (0 errors).
