### PR TITLE
fix(ui): pin tool-chip header radius to container token

### DIFF
--- a/src/lib/components/prompt-kit/tool/ToolHeader.svelte
+++ b/src/lib/components/prompt-kit/tool/ToolHeader.svelte
@@ -57,7 +57,11 @@
 			{...props}
 			variant="ghost"
 			class={cn(
-				'h-auto w-full justify-between rounded-b-none bg-background px-3 py-2 font-normal',
+				// Pin the top corners to the container token (Tool.svelte is rounded-lg):
+				// the Button primitive's base radius is theme-owned, so a re-themed fork
+				// (e.g. a pill-shaped Button base) would otherwise curve far inside the
+				// clipped container.
+				'h-auto w-full justify-between rounded-t-lg rounded-b-none bg-background px-3 py-2 font-normal',
 				className
 			)}
 		>


### PR DESCRIPTION
The tool-call chip header is a ghost Button inside the rounded-lg, overflow-hidden Tool container, and it inherits its top radius from the Button primitive. With the default theme this happens to nest cleanly because the Button base (rounded-md) is smaller than the container radius. Any fork that re-themes the Button primitive (a pill-shaped base, for example) gets a header that curves far inside the clipped container, which reads as broken corners in the chat.

The header now pins its top corners to the container's own token with an explicit rounded-t-lg next to the existing rounded-b-none, so the chip nests cleanly regardless of the Button theme. No visual change with the default theme.

Regression guard: not warranted, one-line CSS class pin with no behavior change

`bun run check` is clean (0 errors).
