### PR TITLE
fix(files): keep chat attachments from being vacuumed

### DIFF
--- a/src/lib/convex/admin/support/__tests__/mutations.test.ts
+++ b/src/lib/convex/admin/support/__tests__/mutations.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// sendAdminReply is an adminMutation, so its _handler first runs the customCtx
+// that calls authComponent.getAuthUser. Mock auth to hand back an admin user and
+// keep the rest of the module graph light.
+vi.mock('../../../auth', () => ({
+	authComponent: {
+		getAuthUser: vi.fn(),
+		safeGetAuthUser: vi.fn()
+	}
+}));
+
+vi.mock('@convex-dev/agent', () => ({
+	saveMessage: vi.fn(),
+	getFile: vi.fn()
+}));
+
+vi.mock('../../../support/threads', () => ({
+	shouldSendNotification: vi.fn(() => false),
+	syncSupportLastMessage: vi.fn()
+}));
+
+vi.mock('../../../constants', () => ({ MAX_MESSAGE_LENGTH: 4000 }));
+
+vi.mock('../../../i18n/translations', () => ({
+	t: vi.fn(() => 'translated')
+}));
+
+vi.mock('../../../_generated/api', () => ({
+	components: { agent: {} },
+	internal: {
+		admin: {
+			support: {
+				notifications: {
+					cancelPendingNotification:
+						'internal.admin.support.notifications.cancelPendingNotification'
+				}
+			}
+		},
+		emails: {
+			send: { sendAdminReplyNotification: 'internal.emails.send.sendAdminReplyNotification' }
+		}
+	}
+}));
+
+import { saveMessage, getFile } from '@convex-dev/agent';
+import { authComponent } from '../../../auth';
+import { sendAdminReply } from '../mutations';
+
+const saveMessageMock = saveMessage as unknown as ReturnType<typeof vi.fn>;
+const getFileMock = getFile as unknown as ReturnType<typeof vi.fn>;
+const getAuthUserMock = authComponent.getAuthUser as unknown as ReturnType<typeof vi.fn>;
+
+type RegisteredFunction<TArgs, TResult> = {
+	_handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const replyHandler = sendAdminReply as unknown as RegisteredFunction<
+	{ threadId: string; prompt: string; fileIds?: string[] },
+	null
+>;
+
+function makeCtx() {
+	return {
+		db: {
+			query: vi.fn(() => ({
+				withIndex: vi.fn(() => ({
+					first: vi.fn().mockResolvedValue({
+						_id: 'st_1',
+						threadId: 't1',
+						assignedTo: undefined,
+						notificationEmail: undefined,
+						notificationSentAt: undefined
+					})
+				}))
+			})),
+			patch: vi.fn()
+		},
+		scheduler: { runAfter: vi.fn() }
+	};
+}
+
+// An admin reply persists human-provenance metadata (provider + adminUserId) that
+// the UI relies on to distinguish it from an AI answer. Forwarding attachment
+// fileIds must add to that metadata, never replace the provider fields, and a
+// text-only reply must not gain a fileIds key.
+describe('sendAdminReply attachment refcount metadata', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getAuthUserMock.mockResolvedValue({
+			_id: 'admin_1',
+			role: 'admin',
+			name: 'Admin User',
+			email: 'admin@example.com'
+		});
+		saveMessageMock.mockResolvedValue({ messageId: 'm1' });
+		getFileMock.mockResolvedValue({
+			filePart: {
+				type: 'file',
+				data: new URL('https://files/f1'),
+				mediaType: 'image/png',
+				filename: 'f1.png'
+			}
+		});
+	});
+
+	it('merges fileIds into the human metadata without dropping provider fields', async () => {
+		const ctx = makeCtx();
+
+		await replyHandler._handler(ctx, { threadId: 't1', prompt: 'hi', fileIds: ['file_1'] });
+
+		// Standalone saveMessage(ctx, components.agent, args) -> args is index [2].
+		const metadata = saveMessageMock.mock.calls[0][2].metadata;
+		expect(metadata.provider).toBe('human');
+		expect(metadata.providerMetadata.admin).toMatchObject({
+			isAdminMessage: true,
+			adminUserId: 'admin_1'
+		});
+		expect(metadata.fileIds).toEqual(['file_1']);
+	});
+
+	it('omits fileIds for a text-only reply', async () => {
+		const ctx = makeCtx();
+
+		await replyHandler._handler(ctx, { threadId: 't1', prompt: 'hi' });
+
+		const metadata = saveMessageMock.mock.calls[0][2].metadata;
+		expect(metadata.provider).toBe('human');
+		expect(metadata.providerMetadata.admin.isAdminMessage).toBe(true);
+		expect('fileIds' in metadata).toBe(false);
+	});
+});

--- a/src/lib/convex/admin/support/mutations.ts
+++ b/src/lib/convex/admin/support/mutations.ts
@@ -217,7 +217,8 @@ export const sendAdminReply = adminMutation({
 						adminName,
 						adminEmail: ctx.user.email
 					}
-				}
+				},
+				...(args.fileIds?.length ? { fileIds: args.fileIds } : {})
 			}
 		});
 

--- a/src/lib/convex/aiChat/messages.ts
+++ b/src/lib/convex/aiChat/messages.ts
@@ -83,6 +83,7 @@ export const sendMessage = authedMutation({
 			const result = await aiChatAgent.saveMessage(ctx, {
 				threadId: args.threadId,
 				message: { role: 'user', content },
+				metadata: { fileIds: args.fileIds },
 				skipEmbeddings: true
 			});
 			messageId = result.messageId;

--- a/src/lib/convex/support/__tests__/messages.test.ts
+++ b/src/lib/convex/support/__tests__/messages.test.ts
@@ -65,15 +65,26 @@ vi.mock('../../_generated/api', () => ({
 	internal: {
 		support: {
 			promptStore: { getActive: 'internal.support.promptStore.getActive' },
-			threads: { updateLastMessage: 'internal.support.threads.updateLastMessage' }
+			threads: { updateLastMessage: 'internal.support.threads.updateLastMessage' },
+			messages: { createAIResponse: 'internal.support.messages.createAIResponse' }
+		},
+		admin: {
+			support: {
+				notifications: {
+					scheduleAdminNotification:
+						'internal.admin.support.notifications.scheduleAdminNotification'
+				}
+			}
 		}
 	}
 }));
 
 const GET_ACTIVE_REF = 'internal.support.promptStore.getActive';
 
+import { getFile } from '@convex-dev/agent';
 import { supportAgent } from '../agent';
-import { createAIResponse } from '../messages';
+import { requireSupportThreadAccess } from '../ownership';
+import { createAIResponse, sendMessage } from '../messages';
 
 const streamTextMock = supportAgent.streamText as unknown as ReturnType<typeof vi.fn>;
 
@@ -122,5 +133,68 @@ describe('createAIResponse prompt override wiring', () => {
 			promptMessageId: 'prompt_1',
 			system: undefined
 		});
+	});
+});
+
+// The component keeps a file alive only while a stored message references it via
+// message.fileIds; the vacuum deletes any file whose refcount is 0. sendMessage
+// therefore has to forward the attached fileIds as saveMessage metadata, and only
+// for the multimodal branch — a plain text message must not carry a fileIds key.
+describe('sendMessage attachment refcount metadata', () => {
+	const requireAccessMock = requireSupportThreadAccess as unknown as ReturnType<typeof vi.fn>;
+	const saveMessageMock = supportAgent.saveMessage as unknown as ReturnType<typeof vi.fn>;
+	const getFileMock = getFile as unknown as ReturnType<typeof vi.fn>;
+
+	const sendHandler = sendMessage as unknown as Fn<
+		{ threadId: string; prompt: string; fileIds?: string[] },
+		{ messageId: string }
+	>;
+
+	function makeSendCtx() {
+		return {
+			db: { patch: vi.fn() },
+			scheduler: { runAfter: vi.fn() }
+		};
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		requireAccessMock.mockResolvedValue({
+			owner: { ownerId: 'user_1', isAnonymous: false },
+			supportThread: {
+				_id: 'st_1',
+				status: 'open',
+				isWarm: false,
+				isHandedOff: false,
+				pageUrl: ''
+			}
+		});
+		saveMessageMock.mockResolvedValue({ messageId: 'm1' });
+		getFileMock.mockResolvedValue({
+			filePart: {
+				type: 'file',
+				data: new URL('https://files/f1'),
+				mediaType: 'image/png',
+				filename: 'f1.png'
+			}
+		});
+	});
+
+	it('forwards fileIds as saveMessage metadata for a multimodal message', async () => {
+		const ctx = makeSendCtx();
+
+		await sendHandler._handler(ctx, { threadId: 't1', prompt: 'hi', fileIds: ['file_1'] });
+
+		// Agent instance method signature is saveMessage(ctx, args), so the args
+		// object is the second positional argument.
+		expect(saveMessageMock.mock.calls[0][1].metadata).toEqual({ fileIds: ['file_1'] });
+	});
+
+	it('does not attach metadata for a text-only message', async () => {
+		const ctx = makeSendCtx();
+
+		await sendHandler._handler(ctx, { threadId: 't1', prompt: 'hi' });
+
+		expect(saveMessageMock.mock.calls[0][1].metadata).toBeUndefined();
 	});
 });

--- a/src/lib/convex/support/messages.ts
+++ b/src/lib/convex/support/messages.ts
@@ -99,6 +99,7 @@ export const sendMessage = mutation({
 					role: 'user',
 					content
 				},
+				metadata: { fileIds: args.fileIds },
 				skipEmbeddings: true
 			});
 


### PR DESCRIPTION
Chat attachments were being deleted about 24 hours after upload. The hourly file vacuum removes any file whose refcount in the @convex-dev/agent component is zero, and the three places that save a message with attachments never incremented that refcount. They build the message content from `getFile(...)` file parts, whose data is a stored-file URL, and `serializeContent` only auto-extracts a fileId when a part carries an inline buffer larger than 64KB, never for an already-stored URL part. So the saved message carried no fileIds, `changeRefcount` never ran, and the file sat at refcount zero until the vacuum reclaimed it.

The fix passes `metadata: { fileIds }` to `saveMessage` at the three attachment save sites, which is the documented channel the component reads to refcount referenced files. The support chat and aiChat multimodal branches add `metadata: { fileIds: args.fileIds }`; the admin reply merges a guarded `fileIds` spread into its existing metadata so provider and providerMetadata stay intact and text-only replies keep byte-identical metadata. The vacuum itself is unchanged: it already trusts the component refcount through two guards, and re-scanning messages for URLs would only duplicate and fight that authority.

Handler-level unit tests pin the contract: the multimodal branch must pass `metadata.fileIds`, and the text-only branch must not, so the fix cannot regress or over-broaden. Reverting any one of the three edits fails its test.

Regression guard: added tests in support/__tests__/messages.test.ts and admin/support/__tests__/mutations.test.ts

`bun run check:convex` and `bun run test:unit` pass.
