### PR TITLE
fix(chat): opt tool cards out of prose styling

### DIFF
--- a/src/lib/components/prompt-kit/tool/Tool.svelte
+++ b/src/lib/components/prompt-kit/tool/Tool.svelte
@@ -21,7 +21,7 @@
 
 <Collapsible
 	bind:open
-	class={cn('mb-4 overflow-hidden rounded-lg border border-border', className)}
+	class={cn('not-prose mb-4 overflow-hidden rounded-lg border border-border', className)}
 >
 	{@render children(toolPart)}
 </Collapsible>


### PR DESCRIPTION
The expanded tool-call view rendered its output box dark navy on the light chat card. Tool calls render inside the AI message bubble, which carries the `prose` class, so `@tailwindcss/typography` styled the output `<pre>` with `--tw-prose-pre-bg`, a dark slate that ships even in light mode. The `<pre>` has no background of its own, so it inherited that dark box while its wrapper stayed on the light `bg-background`.

Adding `not-prose` to the tool wrapper takes the whole tool card out of the prose scope, so the output box falls back to its own theme-aware `bg-background`. This mirrors the reasoning component, which already opts out with `not-prose` for the same reason. The tool details use explicit utility classes throughout, so nothing relied on prose styling.

Regression guard: not warranted, one-class prose opt-out matching the sibling reasoning component

`bun run check` passes in CI.
