### PR TITLE
docs(autumn): note that coupons live Stripe-side, not in this config

### DIFF
--- a/autumn.config.ts
+++ b/autumn.config.ts
@@ -1,5 +1,9 @@
 import { feature, item, plan } from 'atmn';
 
+// Coupons and promotion codes are NOT defined here. Autumn manages them as
+// Stripe-side rewards through the dashboard; `atmn push` neither creates nor
+// reads them, so a live discount never shows up in this config.
+
 /**
  * Community chat messages - metered per month.
  */


### PR DESCRIPTION
Coupons and promotion codes are not defined in `autumn.config.ts`. Autumn manages them as Stripe-side rewards through the dashboard, and `atmn push` neither creates nor reads them, so a live discount never appears in this file. Without the note, grepping the config for one comes up empty and reads as "there is no coupon", which is wrong.

Docs only.