### PR TITLE
perf(support): Remove thread query fanout

### DIFF
--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -159,7 +159,7 @@
 				}
 			}
 		}
-		return urls;
+		return [...new Set(urls)].slice(0, 100);
 	});
 
 	// Query file metadata for dimensions by URL (extracts storageId server-side)

--- a/src/lib/convex/admin/support/queries.ts
+++ b/src/lib/convex/admin/support/queries.ts
@@ -9,6 +9,7 @@ import { isAnonymousUser } from '../../utils/anonymousUser';
 import { vStreamArgs } from '@convex-dev/agent/validators';
 import { listMessagesForThread } from '../../support/messageListing';
 import { supportThreadFields } from '../../support/supportThreadFields';
+import { toAgentThreadStatus } from '../../support/denormalization';
 
 /** Return validator for supportThreads documents (schema fields + system fields). */
 const vSupportMetadata = v.object({
@@ -100,98 +101,67 @@ export const listThreadsForAdmin = adminQuery({
 			// NON-SEARCH PATH: Only show threads that have been handed off to human support
 			// All paths filter by isHandedOff === true
 			if (statusFilter && (isUnassigned || assignedToFilter)) {
-				// Combined: status + assignment (use compound index + filter for isHandedOff)
+				// Combined: status + assignment, ordered by recent activity.
 				supportThreads = await ctx.db
 					.query('supportThreads')
-					.withIndex('by_status_and_assigned', (q) =>
+					.withIndex('by_handed_off_status_assigned_updated', (q) =>
 						q
+							.eq('isHandedOff', true)
 							.eq('status', statusFilter)
 							.eq('assignedTo', isUnassigned ? undefined : assignedToFilter)
 					)
-					// Intentional: indexed prefix above; adding isHandedOff to every compound index would bloat schema
-					// eslint-disable-next-line @convex-dev/no-filter-in-query
-					.filter((q) => q.eq(q.field('isHandedOff'), true))
 					.order('desc')
 					.paginate(paginationOpts);
 			} else if (statusFilter) {
-				// Status only - use new compound index
+				// Status only.
 				supportThreads = await ctx.db
 					.query('supportThreads')
-					.withIndex('by_handed_off_and_status', (q) =>
+					.withIndex('by_handed_off_status_updated', (q) =>
 						q.eq('isHandedOff', true).eq('status', statusFilter)
 					)
 					.order('desc')
 					.paginate(paginationOpts);
 			} else if (isUnassigned) {
-				// Unassigned only (no status filter)
+				// Unassigned only (no status filter).
 				supportThreads = await ctx.db
 					.query('supportThreads')
-					.withIndex('by_assigned', (q) => q.eq('assignedTo', undefined))
-					// Intentional: indexed prefix above; adding isHandedOff to every compound index would bloat schema
-					// eslint-disable-next-line @convex-dev/no-filter-in-query
-					.filter((q) => q.eq(q.field('isHandedOff'), true))
+					.withIndex('by_handed_off_assigned_updated', (q) =>
+						q.eq('isHandedOff', true).eq('assignedTo', undefined)
+					)
 					.order('desc')
 					.paginate(paginationOpts);
 			} else if (assignedToFilter) {
-				// Specific admin only (no status filter)
+				// Specific admin only (no status filter).
 				supportThreads = await ctx.db
 					.query('supportThreads')
-					.withIndex('by_assigned', (q) => q.eq('assignedTo', assignedToFilter))
-					// Intentional: indexed prefix above; adding isHandedOff to every compound index would bloat schema
-					// eslint-disable-next-line @convex-dev/no-filter-in-query
-					.filter((q) => q.eq(q.field('isHandedOff'), true))
+					.withIndex('by_handed_off_assigned_updated', (q) =>
+						q.eq('isHandedOff', true).eq('assignedTo', assignedToFilter)
+					)
 					.order('desc')
 					.paginate(paginationOpts);
 			} else {
-				// No filters - use new index for isHandedOff only
+				// No filters.
 				supportThreads = await ctx.db
 					.query('supportThreads')
-					.withIndex('by_handed_off_and_status', (q) => q.eq('isHandedOff', true))
+					.withIndex('by_handed_off_updated', (q) => q.eq('isHandedOff', true))
 					.order('desc')
 					.paginate(paginationOpts);
 			}
 		}
 
-		// =========================================================================
-		// ENRICHMENT: Read generic agent-thread metadata after support registry selection
-		// =========================================================================
-		const threadsWithDetails = await Promise.all(
-			supportThreads.page.map(async (supportThread) => {
-				try {
-					const agentThread = await ctx.runQuery(components.agent.threads.getThread, {
-						threadId: supportThread.threadId
-					});
-
-					if (!agentThread) {
-						// Thread was deleted but supportThread still exists - skip it
-						return null;
-					}
-
-					return {
-						_id: supportThread.threadId,
-						_creationTime: supportThread.createdAt,
-						userId: supportThread.userId,
-						title: supportThread.title,
-						summary: supportThread.summary,
-						status: agentThread.status,
-						supportMetadata: supportThread,
-						lastMessage: supportThread.lastMessage,
-						lastMessageAt: supportThread.lastMessageAt,
-						userName: supportThread.userName,
-						userEmail: supportThread.userEmail
-					};
-				} catch (error) {
-					console.error(
-						`[listThreadsForAdmin] ❌ ERROR enriching thread ${supportThread.threadId}:`,
-						error
-					);
-					return null;
-				}
-			})
-		);
-
-		// Filter out null entries (deleted threads)
-		const validThreads = threadsWithDetails.filter((t): t is NonNullable<typeof t> => t !== null);
+		const validThreads = supportThreads.page.map((supportThread) => ({
+			_id: supportThread.threadId,
+			_creationTime: supportThread.createdAt,
+			userId: supportThread.userId,
+			title: supportThread.title,
+			summary: supportThread.summary,
+			status: toAgentThreadStatus(supportThread.status),
+			supportMetadata: supportThread,
+			lastMessage: supportThread.lastMessage,
+			lastMessageAt: supportThread.lastMessageAt,
+			userName: supportThread.userName,
+			userEmail: supportThread.userEmail
+		}));
 
 		// =========================================================================
 		// ENRICHMENT: Batch fetch user images from Better Auth
@@ -207,20 +177,21 @@ export const listThreadsForAdmin = adminQuery({
 		if (userIds.length > 0) {
 			// Fetch each user individually by ID to avoid fetching arbitrary first-N users
 			const userResults = await Promise.all(
-				userIds.map((userId) =>
-					ctx.runQuery(components.betterAuth.adapter.findOne, {
+				userIds.map(async (userId) => ({
+					userId,
+					user: (await ctx.runQuery(components.betterAuth.adapter.findOne, {
 						model: 'user',
-						where: [{ field: '_id', operator: 'eq', value: userId }]
-					})
-				)
+						where: [{ field: '_id', operator: 'eq', value: userId }],
+						select: ['image']
+					})) as { image?: string | null } | null
+				}))
 			);
 
 			// Build lookup map for user images
-			for (const user of userResults) {
+			for (const { userId, user } of userResults) {
 				if (!user) continue;
-				const parsed = val.safeParse(betterAuthUserSchema, user);
-				if (parsed.success && parsed.output.image) {
-					userImageMap.set(parsed.output._id, parsed.output.image);
+				if (user.image) {
+					userImageMap.set(userId, user.image);
 				}
 			}
 		}
@@ -280,21 +251,14 @@ export const getThreadForAdmin = adminQuery({
 			throw new Error(`Support thread not found for threadId: ${args.threadId}`);
 		}
 
-		const agentThread = await ctx.runQuery(components.agent.threads.getThread, {
-			threadId: args.threadId
-		});
-
-		if (!agentThread) {
-			throw new Error(`Agent thread not found for threadId: ${args.threadId}`);
-		}
-
 		// 4. Get assigned admin details
 		let assignedAdmin;
 		if (supportThread.assignedTo) {
-			const admin = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+			const admin = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
 				model: 'user',
-				where: [{ field: '_id', operator: 'eq', value: supportThread.assignedTo }]
-			});
+				where: [{ field: '_id', operator: 'eq', value: supportThread.assignedTo }],
+				select: ['id', 'name', 'email', 'image']
+			})) as { _id: string; name?: string; email?: string; image?: string | null } | null;
 			if (admin) {
 				assignedAdmin = {
 					id: admin._id,
@@ -311,10 +275,11 @@ export const getThreadForAdmin = adminQuery({
 			if (!isAnonymousUser(supportThread.userId)) {
 				// Registered user - lookup in user table
 				try {
-					const userData = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+					const userData = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
 						model: 'user',
-						where: [{ field: '_id', operator: 'eq', value: supportThread.userId }]
-					});
+						where: [{ field: '_id', operator: 'eq', value: supportThread.userId }],
+						select: ['id', 'name', 'email', 'image']
+					})) as { _id: string; name?: string; email?: string; image?: string | null } | null;
 					if (userData) {
 						user = {
 							id: userData._id,
@@ -337,7 +302,7 @@ export const getThreadForAdmin = adminQuery({
 			userId: supportThread.userId,
 			title: supportThread.title,
 			summary: supportThread.summary,
-			status: agentThread.status,
+			status: toAgentThreadStatus(supportThread.status),
 			supportMetadata: supportThread,
 			assignedAdmin,
 			user

--- a/src/lib/convex/files/metadata.test.ts
+++ b/src/lib/convex/files/metadata.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { QueryCtx } from '../_generated/server';
+import { getFileMetadataByUrls } from './metadata';
+
+describe('getFileMetadataByUrls', () => {
+	it('deduplicates URLs before querying metadata', async () => {
+		const first = vi.fn().mockResolvedValue({ width: 640, height: 480 });
+		const withIndex = vi.fn(() => ({ first }));
+		const query = vi.fn(() => ({ withIndex }));
+		const ctx = { db: { query } } as unknown as QueryCtx;
+
+		await expect(
+			getFileMetadataByUrls(ctx, ['https://example.com/image.png', 'https://example.com/image.png'])
+		).resolves.toEqual({
+			'https://example.com/image.png': { width: 640, height: 480 }
+		});
+		expect(query).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects oversized batches before reading the database', async () => {
+		const query = vi.fn();
+		const ctx = { db: { query } } as unknown as QueryCtx;
+		const urls = Array.from({ length: 101 }, (_, index) => `https://example.com/${index}.png`);
+
+		await expect(getFileMetadataByUrls(ctx, urls)).rejects.toThrow('Too many file metadata URLs.');
+		expect(query).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/convex/files/metadata.ts
+++ b/src/lib/convex/files/metadata.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 import { internalMutation } from '../_generated/server';
 import type { QueryCtx } from '../_generated/server';
 
@@ -20,10 +20,15 @@ export async function getFileMetadataByUrls(
 	ctx: QueryCtx,
 	urls: string[]
 ): Promise<Record<string, { width?: number; height?: number }>> {
+	const uniqueUrls = [...new Set(urls)];
+	if (uniqueUrls.length > 100) {
+		throw new ConvexError('Too many file metadata URLs.');
+	}
+
 	const results: Record<string, { width?: number; height?: number }> = {};
 
 	await Promise.all(
-		urls.map(async (url) => {
+		uniqueUrls.map(async (url) => {
 			const meta = await ctx.db
 				.query('fileMetadata')
 				.withIndex('by_url', (q) => q.eq('url', url))

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -72,9 +72,15 @@ export default defineSchema({
 		.index('by_user', ['userId'])
 		.index('by_user_warm', ['userId', 'isWarm'])
 		.index('by_user_and_updated', ['userId', 'updatedAt'])
-		.index('by_assigned', ['assignedTo'])
-		.index('by_status_and_assigned', ['status', 'assignedTo'])
-		.index('by_handed_off_and_status', ['isHandedOff', 'status'])
+		.index('by_handed_off_updated', ['isHandedOff', 'updatedAt'])
+		.index('by_handed_off_assigned_updated', ['isHandedOff', 'assignedTo', 'updatedAt'])
+		.index('by_handed_off_status_updated', ['isHandedOff', 'status', 'updatedAt'])
+		.index('by_handed_off_status_assigned_updated', [
+			'isHandedOff',
+			'status',
+			'assignedTo',
+			'updatedAt'
+		])
 		.index('by_needs_response', ['isHandedOff', 'status', 'awaitingAdminResponse'])
 		.searchIndex('search_all', {
 			searchField: 'searchText',

--- a/src/lib/convex/support/__tests__/denormalization.test.ts
+++ b/src/lib/convex/support/__tests__/denormalization.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { buildSupportMessageDenormalization, buildSupportSearchText } from '../denormalization';
+import {
+	buildSupportMessageDenormalization,
+	buildSupportSearchText,
+	toAgentThreadStatus
+} from '../denormalization';
 
 describe('support denormalization helpers', () => {
+	it('maps canonical support status to the agent UI status', () => {
+		expect(toAgentThreadStatus('open')).toBe('active');
+		expect(toAgentThreadStatus('done')).toBe('archived');
+	});
+
 	it('builds support search text from the available denormalized fields', () => {
 		expect(
 			buildSupportSearchText({

--- a/src/lib/convex/support/__tests__/maintenance.test.ts
+++ b/src/lib/convex/support/__tests__/maintenance.test.ts
@@ -148,7 +148,8 @@ describe('support maintenance helpers', () => {
 		expect(profileLookups).toHaveLength(1);
 		expect(profileLookups[0][1]).toEqual({
 			model: 'user',
-			where: [{ field: '_id', operator: 'eq', value: 'user_1' }]
+			where: [{ field: '_id', operator: 'eq', value: 'user_1' }],
+			select: ['name', 'email']
 		});
 	});
 

--- a/src/lib/convex/support/denormalization.ts
+++ b/src/lib/convex/support/denormalization.ts
@@ -17,6 +17,10 @@ export type SupportLatestThreadMessage = {
 	};
 };
 
+export function toAgentThreadStatus(status: 'open' | 'done'): 'active' | 'archived' {
+	return status === 'done' ? 'archived' : 'active';
+}
+
 /**
  * supportThreads is the feature registry for support access, search, and list rendering.
  * agent:messages provides the generic latest message, which we denormalize into supportThreads.

--- a/src/lib/convex/support/threadLifecycle.ts
+++ b/src/lib/convex/support/threadLifecycle.ts
@@ -52,7 +52,8 @@ export async function getSupportOwnerProfile(
 	try {
 		const user = await ctx.runQuery(components.betterAuth.adapter.findOne, {
 			model: 'user',
-			where: [{ field: '_id', operator: 'eq', value: resolvedUserId }]
+			where: [{ field: '_id', operator: 'eq', value: resolvedUserId }],
+			select: ['name', 'email']
 		});
 		if (user) {
 			return { userName: user.name, userEmail: user.email };

--- a/src/lib/convex/support/threads.ts
+++ b/src/lib/convex/support/threads.ts
@@ -23,6 +23,7 @@ import {
 	updateThreadMetadata as updateSupportThreadMetadata
 } from './threadMaintenance';
 import { normalizeNotificationEmail } from './notificationPreferences';
+import { toAgentThreadStatus } from './denormalization';
 
 export { shouldSendNotification } from './notificationPreferences';
 export { syncSupportLastMessage } from './threadLifecycle';
@@ -169,6 +170,7 @@ export const listThreads = query({
 			.withIndex('by_user_and_updated', (q) => q.eq('userId', owner.ownerId))
 			.order('desc')
 			.paginate(args.paginationOpts ?? { numItems: 20, cursor: null });
+		// Bounded: each owner has at most one pre-warmed thread.
 		const supportThreads = supportThreadsPage.page.filter((supportThread) => !supportThread.isWarm);
 
 		// Collect unique admin IDs and fetch their info
@@ -181,10 +183,11 @@ export const listThreads = query({
 		await Promise.all(
 			[...adminIds].map(async (adminId) => {
 				try {
-					const admin = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+					const admin = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
 						model: 'user',
-						where: [{ field: '_id', operator: 'eq', value: adminId }]
-					});
+						where: [{ field: '_id', operator: 'eq', value: adminId }],
+						select: ['name', 'image']
+					})) as { name?: string; image?: string | null } | null;
 					if (admin) {
 						adminMap.set(adminId, { name: admin.name, image: admin.image ?? null });
 					}
@@ -194,56 +197,33 @@ export const listThreads = query({
 			})
 		);
 
-		// For each thread, get the last message and combine with support data
-		const threadsWithLastMessage = await Promise.all(
-			supportThreads.map(async (supportThread) => {
-				let thread;
-				try {
-					thread = await ctx.runQuery(components.agent.threads.getThread, {
-						threadId: supportThread.threadId
-					});
-				} catch (error) {
-					console.log(
-						`[listThreads] Failed to fetch agent thread ${supportThread.threadId}:`,
-						error
-					);
-					return null;
-				}
+		const threadsWithLastMessage = supportThreads.map((supportThread) => {
+			const assignedAdmin = supportThread.assignedTo
+				? adminMap.get(supportThread.assignedTo)
+				: undefined;
 
-				if (!thread) {
-					return null;
-				}
-
-				const assignedAdmin = supportThread.assignedTo
-					? adminMap.get(supportThread.assignedTo)
-					: undefined;
-
-				return {
-					_id: supportThread.threadId,
-					_creationTime: supportThread.createdAt,
-					userId: supportThread.userId,
-					title: supportThread.title,
-					summary: supportThread.summary,
-					status: thread.status,
-					lastAgentName: supportThread.lastAgentName,
-					lastMessageRole: supportThread.lastMessageRole,
-					lastMessage: supportThread.lastMessage,
-					lastMessageAt: supportThread.lastMessageAt,
-					isHandedOff: supportThread.isHandedOff ?? false,
-					notificationEmail: supportThread.notificationEmail,
-					assignedAdmin
-				};
-			})
-		);
+			return {
+				_id: supportThread.threadId,
+				_creationTime: supportThread.createdAt,
+				userId: supportThread.userId,
+				title: supportThread.title,
+				summary: supportThread.summary,
+				status: toAgentThreadStatus(supportThread.status),
+				lastAgentName: supportThread.lastAgentName,
+				lastMessageRole: supportThread.lastMessageRole,
+				lastMessage: supportThread.lastMessage,
+				lastMessageAt: supportThread.lastMessageAt,
+				isHandedOff: supportThread.isHandedOff ?? false,
+				notificationEmail: supportThread.notificationEmail,
+				assignedAdmin
+			};
+		});
 
 		// Sort by lastMessageAt in descending order (most recent first)
-		const validThreads = threadsWithLastMessage.filter(
-			(thread): thread is NonNullable<(typeof threadsWithLastMessage)[number]> => thread !== null
-		);
-		validThreads.sort((a, b) => (b.lastMessageAt ?? 0) - (a.lastMessageAt ?? 0));
+		threadsWithLastMessage.sort((a, b) => (b.lastMessageAt ?? 0) - (a.lastMessageAt ?? 0));
 
 		return {
-			page: validThreads,
+			page: threadsWithLastMessage,
 			isDone: supportThreadsPage.isDone,
 			continueCursor: supportThreadsPage.continueCursor
 		};
@@ -290,10 +270,11 @@ export const getThread = query({
 		let assignedAdmin: { name?: string; image: string | null } | undefined;
 		if (supportThread?.assignedTo) {
 			try {
-				const admin = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+				const admin = (await ctx.runQuery(components.betterAuth.adapter.findOne, {
 					model: 'user',
-					where: [{ field: '_id', operator: 'eq', value: supportThread.assignedTo }]
-				});
+					where: [{ field: '_id', operator: 'eq', value: supportThread.assignedTo }],
+					select: ['name', 'image']
+				})) as { name?: string; image?: string | null } | null;
 				if (admin) {
 					assignedAdmin = {
 						name: admin.name,
@@ -307,6 +288,7 @@ export const getThread = query({
 
 		return {
 			...thread,
+			status: toAgentThreadStatus(supportThread.status),
 			isHandedOff: supportThread?.isHandedOff ?? false,
 			notificationEmail: supportThread?.notificationEmail,
 			assignedAdmin
@@ -430,7 +412,8 @@ export const getAdminAvatars = query({
 		const result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
 			model: 'user',
 			paginationOpts: { cursor: null, numItems: 100 },
-			where: [{ field: 'role', operator: 'eq', value: 'admin' }]
+			where: [{ field: 'role', operator: 'eq', value: 'admin' }],
+			select: ['name', 'image']
 		});
 
 		const admins = result.page as Array<{


### PR DESCRIPTION
Support list queries currently call the agent component once per row for status already stored in the support registry, while admin filters paginate through post-filtered indexes. File metadata lookup also accepts duplicate and unbounded URL batches.

Use handed-off/status/assignment indexes ordered by activity, derive agent UI status from the canonical support status, project only required Better Auth fields, and deduplicate and cap metadata requests at both client and server boundaries.

Regression guard: added support status mapping and file metadata batch tests.

Full static checks, Convex type checking, all 843 unit tests, and the production build pass.