### PR TITLE
fix(ui): Repair mobile and verification flows

### DIFF
--- a/e2e/signup.spec.ts
+++ b/e2e/signup.spec.ts
@@ -60,6 +60,12 @@ test.describe('Signup form', () => {
 		await expect(page.getByTestId('signup-verification-step')).toBeVisible({ timeout: 15000 });
 		await expect(page.getByTestId('auth-error')).toHaveCount(0);
 
+		// The account now exists, so the verification step returns to sign in rather
+		// than reopening a signup form that can only fail with a duplicate account.
+		await page.getByRole('link', { name: 'Back to login' }).click();
+		await expect(page).toHaveURL(/\/en\/signin$/);
+		await expect(page.getByTestId('email-input')).toHaveValue(signupEmail);
+
 		// Verify the email out of band (the real flow clicks a link in the verification email)
 		const result = await client.mutation(api.tests.verifyTestUserEmail, {
 			email: signupEmail,
@@ -68,11 +74,8 @@ test.describe('Signup form', () => {
 		expect(result.success).toBe(true);
 
 		// The account created through the form can sign in through the form
-		await page.goto('/signin');
-		await expect(page.getByTestId('email-input')).toBeEnabled({ timeout: 30000 });
 		await expect(page.getByTestId('signin-button')).toBeEnabled({ timeout: 30000 });
 
-		await page.getByTestId('email-input').fill(signupEmail);
 		await page.getByTestId('password-input').fill(TEST_PASSWORD);
 		await page.getByTestId('signin-button').click();
 

--- a/src/lib/components/ui/item/item-description.svelte
+++ b/src/lib/components/ui/item/item-description.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="item-description"
 	class={cn(
-		'line-clamp-2 text-left text-sm leading-normal font-normal text-muted-foreground group-data-[size=xs]/item:text-xs [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary',
+		'text-left text-sm leading-normal font-normal text-muted-foreground group-data-[size=xs]/item:text-xs [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/item/item-description.test.ts
+++ b/src/lib/components/ui/item/item-description.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve('src/lib/components/ui/item/item-description.svelte'), 'utf8');
+
+describe('Item.Description', () => {
+	it('does not hide overflowing copy by default', () => {
+		// Info cards are not interactive, so truncated copy has no way to be revealed.
+		expect(source).not.toMatch(/\b(?:line-clamp-\S+|truncate|overflow-hidden)\b/);
+	});
+});

--- a/src/lib/components/ui/item/item.svelte
+++ b/src/lib/components/ui/item/item.svelte
@@ -7,7 +7,7 @@
 			variant: {
 				default: 'border-transparent',
 				outline: 'border-border',
-				muted: 'bg-muted/50 border-transparent'
+				muted: 'bg-muted/50 border-transparent max-sm:flex-col max-sm:items-stretch'
 			},
 			size: {
 				default: 'gap-3.5 px-4 py-3.5',

--- a/src/lib/components/ui/item/item.test.ts
+++ b/src/lib/components/ui/item/item.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve('src/lib/components/ui/item/item.svelte'), 'utf8');
+
+describe('Item.Root', () => {
+	it('stacks muted information cards on narrow screens', () => {
+		const mutedVariant = source.match(/muted:\s*'([^']+)'/)?.[1];
+
+		expect(mutedVariant).toContain('max-sm:flex-col');
+		expect(mutedVariant).toContain('max-sm:items-stretch');
+	});
+});

--- a/src/routes/[[lang]]/(auth)/signin/VerificationStep.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/VerificationStep.svelte
@@ -8,10 +8,10 @@
 	type Props = {
 		email: string;
 		formError: string;
-		onBack: () => void;
+		backHref: string;
 	};
 
-	let { email, formError, onBack }: Props = $props();
+	let { email, formError, backHref }: Props = $props();
 
 	const { t } = getTranslate();
 </script>
@@ -44,7 +44,7 @@
 				</Field.Field>
 			{/if}
 			<Field.Field>
-				<Button type="button" variant="ghost" class="w-full" onclick={onBack}>
+				<Button href={backHref} variant="ghost" class="w-full">
 					<T keyName="auth.verification.button_back" />
 				</Button>
 			</Field.Field>

--- a/src/routes/[[lang]]/(auth)/signup/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signup/+page.svelte
@@ -43,6 +43,10 @@
 	const hasOAuthAuth = $derived(
 		Boolean(oauthProviders.data?.google || oauthProviders.data?.github)
 	);
+	const signinLinkSearch = $derived(
+		params.redirectTo ? `?redirectTo=${encodeURIComponent(params.redirectTo)}` : ''
+	);
+	const signinHref = $derived(resolve(localizedHref('/signin') + signinLinkSearch));
 
 	let isLoading = $state(false);
 	let formError = $state('');
@@ -178,11 +182,6 @@
 		}
 	}
 
-	function cancelVerification() {
-		verificationStep = null;
-		formError = '';
-	}
-
 	async function handleOAuth(provider: PendingOAuthProvider) {
 		haptic.trigger('light');
 		isLoading = true;
@@ -221,11 +220,7 @@
 		<Card.Root class="overflow-hidden p-0 [view-transition-name:auth-card]">
 			<Card.Content class="grid p-0 md:grid-cols-2">
 				{#if verificationStep}
-					<VerificationStep
-						email={verificationStep.email}
-						{formError}
-						onBack={cancelVerification}
-					/>
+					<VerificationStep email={verificationStep.email} {formError} backHref={signinHref} />
 				{:else}
 					<SignUpForm
 						{id}

--- a/src/routes/[[lang]]/app/settings/+page.svelte
+++ b/src/routes/[[lang]]/app/settings/+page.svelte
@@ -40,6 +40,17 @@
 		else url.searchParams.set('tab', value);
 		goto(resolve(url.pathname + url.search), { keepFocus: true, noScroll: true });
 	}
+
+	// The tab bar can overflow its column on narrow viewports, so keep the active
+	// trigger in view on mount and whenever the URL-driven tab changes.
+	let tabsScroller = $state<HTMLElement | null>(null);
+	$effect(() => {
+		// Read activeTab so this re-runs on tab change (and on mount).
+		if (!tabsScroller || !activeTab) return;
+		tabsScroller
+			.querySelector<HTMLElement>('[data-state="active"]')
+			?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+	});
 </script>
 
 <SEOHead
@@ -62,20 +73,27 @@
 		<Separator />
 
 		<Tabs.Root value={activeTab} onValueChange={updateTab} class="space-y-6">
-			<Tabs.List>
-				<Tabs.Trigger value="account">
-					<T keyName="settings.tabs.account" />
-				</Tabs.Trigger>
-				<Tabs.Trigger value="password">
-					<T keyName="settings.tabs.password" />
-				</Tabs.Trigger>
-				<Tabs.Trigger value="email">
-					<T keyName="settings.tabs.email" />
-				</Tabs.Trigger>
-				<Tabs.Trigger value="security">
-					<T keyName="settings.tabs.security" />
-				</Tabs.Trigger>
-			</Tabs.List>
+			<!-- Bleed to the screen edge on mobile so the w-fit pill can scroll; align
+			     flush with the max-w-3xl column on lg (page wrapper has px-4 lg:px-6). -->
+			<div
+				bind:this={tabsScroller}
+				class="-mx-4 no-scrollbar scroll-px-4 overflow-x-auto px-4 lg:mx-0 lg:px-0"
+			>
+				<Tabs.List>
+					<Tabs.Trigger value="account">
+						<T keyName="settings.tabs.account" />
+					</Tabs.Trigger>
+					<Tabs.Trigger value="password">
+						<T keyName="settings.tabs.password" />
+					</Tabs.Trigger>
+					<Tabs.Trigger value="email">
+						<T keyName="settings.tabs.email" />
+					</Tabs.Trigger>
+					<Tabs.Trigger value="security">
+						<T keyName="settings.tabs.security" />
+					</Tabs.Trigger>
+				</Tabs.List>
+			</div>
 
 			<Tabs.Content value="account" class="space-y-6">
 				{#if user}


### PR DESCRIPTION
Closes #717
Closes #718
Closes #719
Closes #720

Fork feedback exposed four inherited UX defects: item descriptions hid non-interactive help copy, muted info cards wasted mobile width, translated settings tabs became unreachable, and completed signup verification returned to an unusable signup form.

Item descriptions now remain complete, muted cards stack below the small breakpoint, the settings tab strip scrolls its active tab into view, and verification links back to sign-in while preserving redirect state and the entered email.

<!-- pr-media:start -->
| Mobile info card | Spanish mobile tabs |
| --- | --- |
| <img width="900" alt="Mobile info card" src="https://github.com/user-attachments/assets/0c1fce9a-fd03-46bb-8394-339dfe76b449" /> | <img width="900" alt="Spanish mobile tabs" src="https://github.com/user-attachments/assets/e207cabe-4b64-4621-aa07-8cecb8859262" /> |
<!-- pr-media:end -->

Regression guard: added Item overflow and responsive-layout invariants plus signup return-path E2E coverage; the settings scroller is a one-off route correction.

Verified with targeted static checks, focused Vitest coverage, the signup Playwright flow, full type checks, and live browser checks at 320 px in English and Spanish.
