### PR TITLE
fix(template): Repair inherited failure states

### DIFF
--- a/.github/workflows/e2e-fork-preview.yml
+++ b/.github/workflows/e2e-fork-preview.yml
@@ -125,15 +125,27 @@ jobs:
       - name: Wait for Convex backend readiness
         run: |
           echo "Waiting for Convex backend at: ${PUBLIC_CONVEX_URL}"
+          missing=0
           for i in $(seq 1 12); do
-            if curl -sf --connect-timeout 5 --max-time 10 "${PUBLIC_CONVEX_URL}" > /dev/null; then
+            code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 10 "${PUBLIC_CONVEX_URL}" || true)
+            if [ "$code" = "200" ]; then
               echo "Convex backend is ready (attempt $i)"
               exit 0
             fi
-            echo "Not ready yet (attempt $i/12), waiting 5s..."
+            if [ "$code" = "404" ]; then
+              missing=$((missing + 1))
+              if [ "$missing" -ge 2 ]; then
+                echo "::error::Convex preview backend is gone (HTTP 404 at ${PUBLIC_CONVEX_URL})."
+                echo "::error::Recreate it by rerunning the preview deployment for this commit or pushing an empty commit."
+                exit 1
+              fi
+            else
+              missing=0
+            fi
+            echo "Not ready yet (attempt $i/12, http=$code), waiting 5s..."
             [ "$i" -lt 12 ] && sleep 5
           done
-          echo "::error::Convex backend not ready after 60s: ${PUBLIC_CONVEX_URL}"
+          echo "::error::Convex backend not ready after 60s (last http=$code): ${PUBLIC_CONVEX_URL}"
           exit 1
 
       - name: Run E2E tests

--- a/.github/workflows/e2e-preview-cf.yml
+++ b/.github/workflows/e2e-preview-cf.yml
@@ -129,15 +129,27 @@ jobs:
       - name: Wait for Convex backend readiness
         run: |
           echo "Waiting for Convex backend at: ${PUBLIC_CONVEX_URL}"
+          missing=0
           for i in $(seq 1 12); do
-            if curl -sf --connect-timeout 5 --max-time 10 "${PUBLIC_CONVEX_URL}" > /dev/null; then
+            code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 10 "${PUBLIC_CONVEX_URL}" || true)
+            if [ "$code" = "200" ]; then
               echo "Convex backend is ready (attempt $i)"
               exit 0
             fi
-            echo "Not ready yet (attempt $i/12), waiting 5s..."
+            if [ "$code" = "404" ]; then
+              missing=$((missing + 1))
+              if [ "$missing" -ge 2 ]; then
+                echo "::error::Convex preview backend is gone (HTTP 404 at ${PUBLIC_CONVEX_URL})."
+                echo "::error::Recreate it by rerunning the Cloudflare Workers check for this commit or pushing an empty commit."
+                exit 1
+              fi
+            else
+              missing=0
+            fi
+            echo "Not ready yet (attempt $i/12, http=$code), waiting 5s..."
             [ "$i" -lt 12 ] && sleep 5
           done
-          echo "::error::Convex backend not ready after 60s: ${PUBLIC_CONVEX_URL}"
+          echo "::error::Convex backend not ready after 60s (last http=$code): ${PUBLIC_CONVEX_URL}"
           exit 1
 
       - name: Log test configuration

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -517,6 +517,9 @@
 			"rate_limited": "Sie senden zu schnell Nachrichten. Versuchen Sie es in {seconds}s erneut.",
 			"send_failed": "Nachricht konnte nicht gesendet werden"
 		},
+		"notices": {
+			"limit_reached": "Du hast dein Nachrichtenlimit erreicht, deshalb konnte diese Antwort nicht erstellt werden."
+		},
 		"reasoning": {
 			"connecting": "Verbinde...",
 			"thinking": "Denke nach...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -517,6 +517,9 @@
 			"rate_limited": "You're sending messages too fast. Try again in {seconds}s.",
 			"send_failed": "Failed to send message"
 		},
+		"notices": {
+			"limit_reached": "You've reached your message limit, so this reply couldn't be generated."
+		},
 		"reasoning": {
 			"connecting": "Connecting...",
 			"thinking": "Thinking...",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -517,6 +517,9 @@
 			"rate_limited": "Estás enviando mensajes demasiado rápido. Vuelve a intentarlo en {seconds}s.",
 			"send_failed": "Error al enviar mensaje"
 		},
+		"notices": {
+			"limit_reached": "Has alcanzado tu límite de mensajes, así que no se pudo generar esta respuesta."
+		},
 		"reasoning": {
 			"connecting": "Conectando...",
 			"thinking": "Pensando...",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -517,6 +517,9 @@
 			"rate_limited": "Vous envoyez des messages trop vite. Réessayez dans {seconds}s.",
 			"send_failed": "Échec de l'envoi du message"
 		},
+		"notices": {
+			"limit_reached": "Tu as atteint ta limite de messages, cette réponse n'a donc pas pu être générée."
+		},
 		"reasoning": {
 			"connecting": "Connexion...",
 			"thinking": "Réflexion...",

--- a/src/lib/chat/ui/ChatMessage.svelte
+++ b/src/lib/chat/ui/ChatMessage.svelte
@@ -9,6 +9,9 @@
 	import { getChatUIContext } from './chat-context.svelte.js';
 	import { deriveOrderedParts, LEADING_REASONING_KEY, type OrderedPart } from './ordered-parts.js';
 	import { type DisplayMessage, type Attachment } from '../core/types.js';
+	import { AI_CHAT_LIMIT_NOTICE } from '$lib/convex/constants';
+	import { T } from '@tolgee/svelte';
+	import LockIcon from '@lucide/svelte/icons/lock';
 
 	let {
 		message,
@@ -51,6 +54,10 @@
 	);
 	const usesFilledBubble = $derived(isUser || isAdminMessage);
 	const align = $derived(ctx.getAlignment(message.role));
+	const isLimitNotice = $derived(
+		(message.metadata?.providerMetadata as { system?: { notice?: string } })?.system?.notice ===
+			AI_CHAT_LIMIT_NOTICE
+	);
 	function handleReasoningOpenChange(stateKey: string, open: boolean) {
 		ctx.setReasoningOpen(stateKey, open);
 		ctx.markUserToggled(stateKey);
@@ -130,6 +137,13 @@
 		{#if usesFilledBubble}
 			<MessageBubble {align} variant="filled" hasTopAttachment={attachments.length > 0}>
 				{message.displayText}
+			</MessageBubble>
+		{:else if isLimitNotice}
+			<MessageBubble {align} variant="ghost">
+				<div class="flex items-center gap-2 text-sm text-muted-foreground">
+					<LockIcon class="size-4 shrink-0" aria-hidden="true" />
+					<span><T keyName="chat.notices.limit_reached" /></span>
+				</div>
 			</MessageBubble>
 		{:else}
 			<!-- AI messages: ghost/prose style with interleaved reasoning/tools/text -->

--- a/src/lib/chat/ui/ChatRoot.svelte
+++ b/src/lib/chat/ui/ChatRoot.svelte
@@ -18,7 +18,7 @@
 		getListStreamMessages,
 		getNormalizedMessages,
 		getStreamDeltas,
-		hasStreamingAssistantMessage,
+		hasAssistantResponseStarted,
 		type MessagesQueryResponse
 	} from './streaming-display.js';
 	import { syncReasoningAccordionState } from './reasoning-accordion-sync.js';
@@ -223,10 +223,11 @@
 		uiContext.setMessagesReady(messagesReady);
 	});
 
-	// Clear awaiting state when NEW streaming assistant message appears
-	// (not based on hasActiveStreams which includes old finished streams)
+	// Clear awaiting state once an assistant response becomes visible. The usual
+	// reply starts a stream, while terminal system notices arrive without one.
 	$effect(() => {
-		if (hasStreamingAssistantMessage(renderDisplayMessages) && core.isAwaitingStream) {
+		if (!core.isAwaitingStream) return;
+		if (hasAssistantResponseStarted(renderDisplayMessages)) {
 			core.setAwaitingStream(false);
 		}
 	});

--- a/src/lib/chat/ui/streaming-display.test.ts
+++ b/src/lib/chat/ui/streaming-display.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { UIMessage } from '@convex-dev/agent';
 import type { StreamMessage } from '@convex-dev/agent/validators';
-import type { ChatMessage } from '../core/types.js';
+import type { ChatMessage, DisplayMessage } from '../core/types.js';
 import {
 	buildDisplayMessages,
 	buildTransformContext,
 	getActiveStreamIds,
+	hasAssistantResponseStarted,
 	hasStreamingAssistantMessage
 } from './streaming-display.js';
 import type { StreamCacheManager } from '../core/stream-cache.js';
@@ -30,6 +31,17 @@ function createAssistantMessage(overrides: Partial<ChatMessage> = {}): ChatMessa
 		status: 'success',
 		order: 1,
 		text: 'Persisted response',
+		...overrides
+	};
+}
+
+function createDisplayMessage(overrides: Partial<DisplayMessage> = {}): DisplayMessage {
+	return {
+		...createAssistantMessage(),
+		displayText: 'Persisted response',
+		displayReasoning: '',
+		isStreaming: false,
+		hasReasoningStream: false,
 		...overrides
 	};
 }
@@ -267,5 +279,15 @@ describe('hasStreamingAssistantMessage', () => {
 				typeof buildDisplayMessages
 			>)
 		).toBe(false);
+	});
+});
+
+describe('hasAssistantResponseStarted', () => {
+	it('accepts a terminal assistant notice without mistaking an older reply for the current turn', () => {
+		const assistant = createDisplayMessage({ status: 'success' });
+		const user = { ...assistant, id: 'user-1', role: 'user' as const };
+
+		expect(hasAssistantResponseStarted([assistant])).toBe(true);
+		expect(hasAssistantResponseStarted([assistant, user])).toBe(false);
 	});
 });

--- a/src/lib/chat/ui/streaming-display.ts
+++ b/src/lib/chat/ui/streaming-display.ts
@@ -147,3 +147,7 @@ export function hasStreamingAssistantMessage(messages: DisplayMessage[]): boolea
 			(message.status === 'pending' || message.status === 'streaming')
 	);
 }
+
+export function hasAssistantResponseStarted(messages: DisplayMessage[]): boolean {
+	return hasStreamingAssistantMessage(messages) || messages.at(-1)?.role === 'assistant';
+}

--- a/src/lib/convex/aiChat/__tests__/createAIResponse.test.ts
+++ b/src/lib/convex/aiChat/__tests__/createAIResponse.test.ts
@@ -33,7 +33,8 @@ vi.mock('../../support/messageListing', () => ({
 }));
 
 vi.mock('@convex-dev/agent', () => ({
-	getFile: vi.fn()
+	getFile: vi.fn(),
+	saveMessage: vi.fn().mockResolvedValue({ messageId: 'notice_1' })
 }));
 
 vi.mock('@convex-dev/agent/validators', async () => {
@@ -42,7 +43,7 @@ vi.mock('@convex-dev/agent/validators', async () => {
 });
 
 vi.mock('../../_generated/api', () => ({
-	components: {},
+	components: { agent: {} },
 	internal: {
 		aiChat: {
 			threads: {
@@ -56,11 +57,13 @@ vi.mock('../../_generated/api', () => ({
 }));
 
 import { checkAndCountUsage, refundUsage } from '../../autumn';
+import { saveMessage } from '@convex-dev/agent';
 import { aiChatAgent } from '../agent';
 import { createAIResponse } from '../messages';
 
 const checkAndCountUsageMock = checkAndCountUsage as unknown as ReturnType<typeof vi.fn>;
 const refundUsageMock = refundUsage as unknown as ReturnType<typeof vi.fn>;
+const saveMessageMock = saveMessage as unknown as ReturnType<typeof vi.fn>;
 const streamTextMock = aiChatAgent.streamText as unknown as ReturnType<typeof vi.fn>;
 
 type RegisteredFunction<TArgs> = {
@@ -86,6 +89,7 @@ describe('createAIResponse', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		refundUsageMock.mockResolvedValue(undefined);
+		saveMessageMock.mockResolvedValue({ messageId: 'notice_1' });
 		runMutation = vi.fn().mockResolvedValue(null);
 		ctx = { runMutation };
 		streamTextMock.mockResolvedValue({
@@ -94,7 +98,7 @@ describe('createAIResponse', () => {
 		});
 	});
 
-	it('skips generation entirely when the quota is denied', async () => {
+	it('persists a terminal notice when the quota is denied', async () => {
 		checkAndCountUsageMock.mockResolvedValue('denied');
 		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -102,6 +106,15 @@ describe('createAIResponse', () => {
 
 		expect(streamTextMock).not.toHaveBeenCalled();
 		expect(refundUsageMock).not.toHaveBeenCalled();
+		expect(saveMessageMock).toHaveBeenCalledTimes(1);
+		expect(saveMessageMock.mock.calls[0][2]).toMatchObject({
+			threadId: 'thread_1',
+			message: { role: 'assistant' },
+			metadata: {
+				provider: 'system',
+				providerMetadata: { system: { notice: 'ai_chat_limit_reached' } }
+			}
+		});
 		warn.mockRestore();
 	});
 

--- a/src/lib/convex/aiChat/messages.ts
+++ b/src/lib/convex/aiChat/messages.ts
@@ -3,7 +3,7 @@ import { v, ConvexError } from 'convex/values';
 import { internal } from '../_generated/api';
 import { aiChatAgent } from './agent';
 import { paginationOptsValidator } from 'convex/server';
-import { getFile } from '@convex-dev/agent';
+import { getFile, saveMessage } from '@convex-dev/agent';
 import { vStreamArgs } from '@convex-dev/agent/validators';
 import { components } from '../_generated/api';
 import type { UserContent } from 'ai';
@@ -14,7 +14,7 @@ import { getFileMetadataByUrls } from '../files/metadata';
 import { checkAndCountUsage, refundUsage } from '../autumn';
 import { requireAiChatThreadRecord } from './ownership';
 import { t } from '../i18n/translations';
-import { MAX_MESSAGE_LENGTH } from '../constants';
+import { AI_CHAT_LIMIT_NOTICE, MAX_MESSAGE_LENGTH } from '../constants';
 import { makeAgentUsageSink } from '../aiUsage/agentUsage';
 import { recordAiUsage } from '../aiUsage/record';
 
@@ -155,6 +155,23 @@ export const createAIResponse = internalAction({
 			});
 			if (outcome === 'denied') {
 				console.warn(`[createAIResponse] AI chat limit reached for user ${args.userId}`);
+				// Returning without an assistant message strands the client in its
+				// awaiting-stream state. Persist a terminal notice so the turn resolves;
+				// providerMetadata lets the UI replace this fallback with localized copy.
+				await saveMessage(ctx, components.agent, {
+					threadId: args.threadId,
+					userId: args.userId,
+					message: {
+						role: 'assistant',
+						content: "You've reached your message limit, so this reply couldn't be generated."
+					},
+					metadata: {
+						provider: 'system',
+						providerMetadata: {
+							system: { notice: AI_CHAT_LIMIT_NOTICE }
+						}
+					}
+				});
 				return null;
 			}
 			// 'unavailable' fails open: generate uncounted rather than blocking

--- a/src/lib/convex/constants.ts
+++ b/src/lib/convex/constants.ts
@@ -7,3 +7,8 @@ export const PROFILE_IMAGE_ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gi
 // Mirrors the client-side MAX_MESSAGE_LENGTH in src/lib/chat/core/types.ts;
 // Convex code cannot import client chat modules, so it is duplicated here.
 export const MAX_MESSAGE_LENGTH = 2000;
+
+// Sentinel stored under providerMetadata.system.notice when the AI chat
+// usage gate denies a turn. The UI maps it to localized copy instead of
+// rendering the English fallback stored with the message.
+export const AI_CHAT_LIMIT_NOTICE = 'ai_chat_limit_reached';


### PR DESCRIPTION
Closes #722
Closes #723

Two failure paths inherited by template forks were hard to diagnose: concurrent AI quota races could leave the composer spinning forever, and missing Convex preview deployments looked like generic readiness timeouts.

Denied AI turns now persist a localized terminal assistant notice and clear the awaiting state without requiring a stream. Both preview E2E workflows now identify consecutive 404 responses and explain how to recreate the deployment.

<!-- pr-media:start -->
| Concurrent quota race |
| --- |
| <img width="1800" alt="Concurrent quota race" src="https://github.com/user-attachments/assets/68db4035-d815-4bb6-b40e-4597da487c78" /> |
<!-- pr-media:end -->

Regression guard: added denied-turn action and terminal-response unit coverage.

Verified with the full static/type/Convex checks, all 846 unit tests, and a two-tab browser quota race.