### PR TITLE
fix(security): Close scheme-reparse open redirect in safeRedirectPath

### DIFF
--- a/src/lib/utils/__tests__/url.test.ts
+++ b/src/lib/utils/__tests__/url.test.ts
@@ -14,6 +14,10 @@ describe('safeRedirectPath', () => {
 		expect(safeRedirectPath('/app?foo=bar', '/')).toBe('/app?foo=bar');
 	});
 
+	it('preserves a same-origin query and hash', () => {
+		expect(safeRedirectPath('/de/app?tab=one#profile', '/')).toBe('/de/app?tab=one#profile');
+	});
+
 	it('rejects a protocol-relative URL', () => {
 		expect(safeRedirectPath('//evil.com', '/')).toBe('/');
 	});
@@ -22,18 +26,61 @@ describe('safeRedirectPath', () => {
 		expect(safeRedirectPath('http://evil.com', '/')).toBe('/');
 	});
 
+	it('rejects backslash and encoded network-path variants', () => {
+		expect(safeRedirectPath('/\\evil.com', '/')).toBe('/');
+		expect(safeRedirectPath('/%2f%2fevil.com', '/')).toBe('/');
+		expect(safeRedirectPath('/%5c%5cevil.com', '/')).toBe('/');
+	});
+
+	it('rejects control characters and malformed escapes', () => {
+		expect(safeRedirectPath('/de/app\nLocation: https://evil.test', '/')).toBe('/');
+		expect(safeRedirectPath('/de/%zz', '/')).toBe('/');
+	});
+
+	it('rejects percent-encoded control characters', () => {
+		expect(safeRedirectPath('/de/app%0d%0aLocation:%20https://evil.test', '/')).toBe('/');
+		expect(safeRedirectPath('/app%09/next', '/')).toBe('/');
+	});
+
+	it('rejects encoded control chars regardless of case or position', () => {
+		expect(safeRedirectPath('/app%00', '/')).toBe('/');
+		expect(safeRedirectPath('/app%0D%0A', '/')).toBe('/');
+		expect(safeRedirectPath('/app?x=%0a', '/')).toBe('/');
+		expect(safeRedirectPath('/app#%0d', '/')).toBe('/');
+	});
+
+	it('decodes only once, leaving double-encoded sequences literal', () => {
+		// %25%30%64 decodes once to the literal text "%0d", not a CR; the value
+		// is a same-origin path and is preserved verbatim (the consumer never
+		// decodes a second time).
+		expect(safeRedirectPath('/x%25%30%64', '/')).toBe('/x%25%30%64');
+	});
+
+	it('rejects scheme-relative targets that resolve cross-origin', () => {
+		// A leading scheme with no authority slashes slips a naive `//` check yet
+		// navigates to http://evil.com/ from an https origin.
+		expect(safeRedirectPath('http:evil.com', '/')).toBe('/');
+		expect(safeRedirectPath('http:/evil.com', '/')).toBe('/');
+		expect(safeRedirectPath('http:\\evil.com', '/')).toBe('/');
+	});
+
+	it('rejects an absolute URL whose host matches the sentinel origin', () => {
+		expect(safeRedirectPath('http://redirect.invalid/x', '/')).toBe('/');
+	});
+
+	it('rejects embedded credentials in the authority', () => {
+		expect(safeRedirectPath('//user:pass@redirect.invalid/x', '/')).toBe('/');
+	});
+
+	it('canonicalizes the accepted path so check and use agree', () => {
+		expect(safeRedirectPath('/a/../b', '/')).toBe('/b');
+		expect(safeRedirectPath('/café?q=hello world#x y', '/')).toBe(
+			'/caf%C3%A9?q=hello%20world#x%20y'
+		);
+	});
+
 	it('rejects a javascript: URI', () => {
 		expect(safeRedirectPath('javascript:alert(1)', '/')).toBe('/');
-	});
-
-	it('rejects the backslash authority bypass (/\\evil.com resolves cross-origin)', () => {
-		// A leading slash-backslash forms an authority in the URL parser, so it
-		// slips a naive `//` prefix check yet resolves to https://evil.com.
-		expect(safeRedirectPath('/\\evil.com', '/')).toBe('/');
-	});
-
-	it('rejects a mixed slash-backslash bypass', () => {
-		expect(safeRedirectPath('/\\/evil.com', '/')).toBe('/');
 	});
 
 	it('rejects an empty string', () => {

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -1,20 +1,38 @@
 /**
- * Whitelist-validates a redirect URL: only same-origin relative paths are
- * allowed. Everything else returns the fallback.
+ * Whitelist-validates a redirect URL: only same-origin root-relative paths
+ * (starting with a single /) are allowed. Everything else returns the fallback,
+ * and the accepted value is re-emitted in canonical form so the string that
+ * passed validation is the string that gets navigated.
  *
- * Resolves the candidate against a sentinel origin and keeps it only if the
- * origin did not change. A prefix check ("starts with / but not //") is not
- * enough: browsers and the WHATWG URL parser treat a backslash as a path
- * separator, so `/\evil.com` slips past a `//` check yet resolves to
- * `https://evil.com`. Resolving catches that, protocol-relative `//host`,
- * absolute URLs, and `javascript:` URIs in one test.
+ * Prevents open redirect attacks by rejecting absolute and scheme-relative URLs
+ * (`//evil.com`, `http:evil.com`), backslash-authority variants (`/\evil.com`),
+ * embedded credentials, and control characters — both raw and once-decoded, so
+ * a later decode layer cannot resurrect a rejected vector.
  */
 export function safeRedirectPath(url: string, fallback: string): string {
-	if (!url) return fallback;
+	if (!url || !url.startsWith('/') || hasUnsafeUrlCharacters(url)) return fallback;
+
 	try {
-		const resolved = new URL(url, 'http://redirect.invalid');
-		return resolved.origin === 'http://redirect.invalid' ? url : fallback;
+		const decoded = decodeURIComponent(url);
+		if (decoded.startsWith('//') || decoded.startsWith('/\\') || hasControlCharacters(decoded))
+			return fallback;
+
+		const base = new URL('https://redirect.invalid');
+		const parsed = new URL(url, base);
+		if (parsed.origin !== base.origin || parsed.username || parsed.password) return fallback;
+		return `${parsed.pathname}${parsed.search}${parsed.hash}`;
 	} catch {
 		return fallback;
 	}
+}
+
+function hasUnsafeUrlCharacters(value: string): boolean {
+	return value.includes('\\') || hasControlCharacters(value);
+}
+
+function hasControlCharacters(value: string): boolean {
+	return [...value].some((character) => {
+		const code = character.charCodeAt(0);
+		return code <= 31 || code === 127;
+	});
 }


### PR DESCRIPTION
The origin-resolution introduced in #641 correctly kills the backslash-authority bypass, but `safeRedirectPath` still returns the **raw input** when the resolved origin matches the sentinel. Because the sentinel base is `http:`, a candidate is validated under `http:` yet navigated at the app's real `https` origin, and a scheme-relative target slips through:

```
safeRedirectPath('http:evil.com', '/')   // → 'http:evil.com'
new URL('http:evil.com', 'https://app.example').href   // → 'http://evil.com/'
```

`http:evil.com` and `http:/evil.com` are live open redirects. Absolute targets whose host equals the sentinel (`http://redirect.invalid/x`) and authorities carrying credentials (`//user:pass@redirect.invalid/x`) are echoed back unchanged too.

This resolves it by validating a strict root-relative allow-list and re-emitting the accepted value in canonical form: require a leading `/`, reject backslashes and control characters both raw and once-decoded (so a later decode layer can't resurrect a CR/LF/tab/null), reject embedded credentials, and return `pathname + search + hash` so the string that passed validation is the string that gets navigated. The guard decodes exactly once, matching how the value is consumed, so legitimate double-encoded segments stay literal.

Behaviour is unchanged for the existing callers (they all pass root-relative `redirectTo` values); the one visible change is that accepted paths are canonicalised (`/a/../b` → `/b`, spaces/unicode percent-encoded) rather than echoed verbatim — worth calling out for anyone relying on exact-string echo.

Regression guard: added src/lib/utils/__tests__/url.test.ts (safeRedirectPath scheme-reparse, encoded-control, single-decode-boundary, credential and canonicalisation cases)
All existing tests still pass and the new cases fail against the pre-fix implementation.

Opened as a draft since it changes the accepted-value form; happy to adjust if you'd prefer to keep raw echo and only add the leading-slash + decoded-control guards.
