### PR TITLE
perf(app): Defer eager shell work

### DIFF
--- a/e2e/ai-chat.spec.ts
+++ b/e2e/ai-chat.spec.ts
@@ -5,8 +5,8 @@ import { waitForAuthenticated } from './utils/auth';
 // src/hooks.server.ts based on Accept-Language (see the precedent in
 // e2e/upgrade-checkout-failure.spec.ts), which would break selectors on
 // non-English runners.
-test.describe('AI Chat - Warm Thread', () => {
-	test('navigating to AI Chat loads instantly with a thread param', async ({ page }) => {
+test.describe('AI Chat - Lazy Warm Thread', () => {
+	test('navigating to AI Chat resolves a thread on the chat route', async ({ page }) => {
 		await page.goto('/en/app');
 		await waitForAuthenticated(page);
 
@@ -15,21 +15,20 @@ test.describe('AI Chat - Warm Thread', () => {
 		await expect(aiChatLink).toBeVisible();
 		await aiChatLink.click();
 
-		// Should navigate to /ai-chat with a ?thread= param (the pre-warmed thread)
+		// The chat route creates or reuses a warm thread, then canonicalizes the URL.
 		await page.waitForURL(/\/app\/ai-chat\?thread=/, { timeout: 10000 });
 
 		// The chat textarea should be visible (no loading screen)
 		await expect(page.locator('textarea')).toBeVisible({ timeout: 10000 });
 	});
 
-	test('sidebar AI Chat href includes thread param from pre-warm', async ({ page }) => {
+	test('sidebar AI Chat href points directly to the chat route', async ({ page }) => {
 		await page.goto('/en/app');
 		await waitForAuthenticated(page);
 
-		// The AI Chat link renders as an <a> carrying the testid
 		const aiChatAnchor = page.getByTestId('sidebar-nav-ai-chat');
 		await expect(aiChatAnchor).toBeVisible();
-		await expect(aiChatAnchor).toHaveAttribute('href', /ai-chat\?thread=/, { timeout: 10000 });
+		await expect(aiChatAnchor).toHaveAttribute('href', '/en/app/ai-chat');
 	});
 
 	test('direct navigation to /ai-chat without thread param redirects to warm thread', async ({
@@ -45,25 +44,28 @@ test.describe('AI Chat - Warm Thread', () => {
 		await expect(page.locator('textarea')).toBeVisible({ timeout: 10000 });
 	});
 
-	test('clicking AI Chat when already on warm thread does not navigate away', async ({ page }) => {
+	test('returning to AI Chat reuses the same warm thread', async ({ page }) => {
 		await page.goto('/en/app');
 		await waitForAuthenticated(page);
 
-		// Navigate to AI Chat
 		const aiChatLink = page.getByTestId('sidebar-nav-ai-chat');
 		await aiChatLink.click();
 		await page.waitForURL(/\/app\/ai-chat\?thread=/, { timeout: 10000 });
+		const firstThreadId = new URL(page.url()).searchParams.get('thread');
+		expect(firstThreadId).toBeTruthy();
 
-		// Capture current URL
-		const firstUrl = page.url();
+		// Leave the chat route entirely so the return click is a genuine navigation
+		// off a URL without a thread param — otherwise waitForURL below would match
+		// the still-canonical URL before the second resolution even runs.
+		await page.goto('/en/app');
+		await waitForAuthenticated(page);
+		await expect(aiChatLink).toBeVisible();
 
-		// Click AI Chat again - should stay on the same URL (disableNav)
 		await aiChatLink.click();
+		await page.waitForURL(/\/app\/ai-chat\?thread=/, { timeout: 10000 });
+		const secondThreadId = new URL(page.url()).searchParams.get('thread');
 
-		// Race a bounded waitForURL against the expected no-nav: if a slow
-		// navigation does happen it resolves early and the assertion below
-		// fails; if nothing happens it times out harmlessly.
-		await page.waitForURL((url) => url.href !== firstUrl, { timeout: 2000 }).catch(() => {});
-		expect(page.url()).toBe(firstUrl);
+		// The unused warm thread is reused, not replaced.
+		expect(secondThreadId).toBe(firstThreadId);
 	});
 });

--- a/scripts/app-shell-performance.test.ts
+++ b/scripts/app-shell-performance.test.ts
@@ -1,0 +1,48 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const appLayoutPath = path.resolve('src/routes/[[lang]]/app/+layout.svelte');
+const sidebarConfigPath = path.resolve(
+	'src/lib/components/authenticated/configs/app-sidebar-config.ts'
+);
+const posthogPath = path.resolve('src/lib/analytics/posthog.ts');
+const threadListPath = path.resolve('src/lib/components/authenticated/sidebar-thread-list.svelte');
+
+describe('app shell performance invariants', () => {
+	it('loads only the initially visible AI chat threads', () => {
+		const source = fs.readFileSync(appLayoutPath, 'utf8');
+
+		expect(source).toContain('api.aiChat.threads.listThreads');
+		// Initial page of 10, growable via the query so "Show more" reflects the
+		// real backend count instead of a client-only slice.
+		expect(source).toContain('let threadListLimit = $state(10)');
+		expect(source).toMatch(/listThreads,[\s\S]*limit:\s*threadListLimit/);
+		expect(source).not.toMatch(/listThreads,[\s\S]*limit:\s*50/);
+		expect(source).toContain('threadsQuery.data?.hasMore');
+	});
+
+	it('drives the sidebar Show more from the backend hasMore, not a client slice', () => {
+		const source = fs.readFileSync(threadListPath, 'utf8');
+
+		expect(source).not.toContain('displayLimit');
+		expect(source).toContain('let { items, hasMore, onShowMore }');
+	});
+
+	it('defers warm-thread lookup and creation to the AI chat route', () => {
+		const layout = fs.readFileSync(appLayoutPath, 'utf8');
+		const sidebar = fs.readFileSync(sidebarConfigPath, 'utf8');
+
+		expect(layout).not.toContain('getWarmThread');
+		expect(layout).not.toContain('getOrCreateWarmThread');
+		expect(layout).toContain("Digit2: localizedHref('/app/ai-chat')");
+		expect(sidebar).toContain("url: localizedHref('/app/ai-chat')");
+		expect(sidebar).not.toContain('warmThreadId');
+	});
+
+	it('disables unused PostHog survey code', () => {
+		const source = fs.readFileSync(posthogPath, 'utf8');
+
+		expect(source).toMatch(/posthog\.init\([\s\S]*disable_surveys:\s*true/);
+	});
+});

--- a/src/lib/analytics/posthog.ts
+++ b/src/lib/analytics/posthog.ts
@@ -65,6 +65,7 @@ export async function initPosthog(): Promise<PostHogClient | null> {
 			posthog.init(PUBLIC_POSTHOG_API_KEY, {
 				api_host: apiHost,
 				ui_host: 'https://eu.posthog.com',
+				disable_surveys: true,
 				person_profiles: 'identified_only',
 				// Cookieless: store nothing in cookies/localStorage so the privacy
 				// policy's "essential cookies only, no consent banner" claim holds

--- a/src/lib/components/authenticated/authenticated-layout.svelte
+++ b/src/lib/components/authenticated/authenticated-layout.svelte
@@ -18,6 +18,10 @@
 		fullControl?: boolean;
 		/** Thread sub-items passed separately to preserve DOM nodes in autoAnimate */
 		threadSubItems?: NavSubItem[];
+		/** Whether more threads exist beyond the currently loaded threadSubItems */
+		threadsHasMore?: boolean;
+		/** Requests a bigger thread page from the owning query */
+		onLoadMoreThreads?: () => void;
 		/** Persisted sidebar open/collapsed state, read server-side for a flash-free first paint */
 		sidebarOpen?: boolean;
 	}
@@ -30,6 +34,8 @@
 		rootLabel,
 		fullControl = false,
 		threadSubItems,
+		threadsHasMore = false,
+		onLoadMoreThreads,
 		sidebarOpen
 	}: Props = $props();
 
@@ -57,7 +63,14 @@
 		style="--sidebar-width: calc(var(--spacing) * 72); --header-height: calc(var(--spacing) * 12);"
 		class="h-svh overflow-hidden"
 	>
-		<AuthenticatedSidebar variant="inset" config={sidebarConfig} {user} {threadSubItems} />
+		<AuthenticatedSidebar
+			variant="inset"
+			config={sidebarConfig}
+			{user}
+			{threadSubItems}
+			{threadsHasMore}
+			{onLoadMoreThreads}
+		/>
 		<Sidebar.Inset id="main-content" class={fullControl ? 'flex flex-col overflow-hidden' : ''}>
 			<AuthenticatedHeader {routePrefix} {rootLabel} />
 

--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -19,9 +19,20 @@
 		user?: User;
 		/** Thread sub-items passed separately to avoid snippet re-render destroying DOM nodes */
 		threadSubItems?: NavSubItem[];
+		/** Whether more threads exist beyond the currently loaded threadSubItems */
+		threadsHasMore?: boolean;
+		/** Requests a bigger thread page from the owning query */
+		onLoadMoreThreads?: () => void;
 	}
 
-	let { config, user, threadSubItems, ...restProps }: Props = $props();
+	let {
+		config,
+		user,
+		threadSubItems,
+		threadsHasMore = false,
+		onLoadMoreThreads,
+		...restProps
+	}: Props = $props();
 
 	const aiChatOpen = new PersistedState('ai-chat-threads-open', true);
 </script>
@@ -197,11 +208,15 @@
 					{/each}
 				</Sidebar.Menu>
 			</Sidebar.GroupContent>
-			<!-- Thread list with client-side display limit (t3code pattern).
-				 "Show more" only changes local state inside SidebarThreadList,
-				 so no parent re-render and autoAnimate works correctly. -->
+			<!-- Thread list only renders the currently loaded page; hasMore/onLoadMoreThreads
+				 come from the owning listThreads query so "Show more" reflects the real
+				 backend count instead of a client-only slice. -->
 			{#if aiChatOpen.current}
-				<SidebarThreadList items={threadSubItems ?? []} />
+				<SidebarThreadList
+					items={threadSubItems ?? []}
+					hasMore={threadsHasMore}
+					onShowMore={onLoadMoreThreads ?? (() => {})}
+				/>
 			{/if}
 		</Sidebar.Group>
 	</Sidebar.Content>

--- a/src/lib/components/authenticated/configs/app-sidebar-config.ts
+++ b/src/lib/components/authenticated/configs/app-sidebar-config.ts
@@ -25,7 +25,6 @@ export function getAppSidebarConfig(
 	pageState: PageState,
 	userRole?: string,
 	aiChatThreads?: AiChatThread[],
-	warmThreadId?: string | null,
 	newConversationLabel?: string
 ): SidebarConfig {
 	const { pathname, search, lang } = pageState;
@@ -41,11 +40,6 @@ export function getAppSidebarConfig(
 		isActive: activeThreadId === thread._id,
 		timestamp: thread.lastMessageAt
 	}));
-
-	// Point "AI Chat" to the pre-warmed thread when available
-	const aiChatUrl = warmThreadId
-		? localizedHref(`/app/ai-chat?thread=${warmThreadId}`)
-		: localizedHref('/app/ai-chat');
 
 	return {
 		header: {
@@ -64,14 +58,12 @@ export function getAppSidebarConfig(
 			},
 			{
 				translationKey: 'app.sidebar.ai_chat',
-				url: aiChatUrl,
+				url: localizedHref('/app/ai-chat'),
 				icon: BotMessageSquareIcon,
 				isActive: pathname.startsWith(`/${lang}/app/ai-chat`),
 				collapsible: true,
 				subItems: aiChatSubItems,
 				kbd: [ctrlSymbol, '⇧', '2'],
-				// Disable nav when already on the warm thread (already "new chat")
-				disableNav: !!activeThreadId && activeThreadId === warmThreadId,
 				testId: 'sidebar-nav-ai-chat'
 			}
 		],

--- a/src/lib/components/authenticated/sidebar-thread-list.svelte
+++ b/src/lib/components/authenticated/sidebar-thread-list.svelte
@@ -10,14 +10,15 @@
 
 	const { t } = getTranslate();
 
-	const THREAD_PREVIEW_LIMIT = 10;
-	const THREAD_LOAD_MORE_STEP = 5;
-
 	interface Props {
 		items: NavSubItem[];
+		/** Whether more threads exist server-side beyond the currently loaded items */
+		hasMore: boolean;
+		/** Requests a bigger thread page from the owning query */
+		onShowMore: () => void;
 	}
 
-	let { items }: Props = $props();
+	let { items, hasMore, onShowMore }: Props = $props();
 
 	// Locale-aware compact timestamp ("05/30, 02:35 PM" / "30.05., 14:35"),
 	// revealed on row hover. Reactive on the route language so switching locales
@@ -30,13 +31,6 @@
 			minute: '2-digit'
 		})
 	);
-
-	// Client-side display limit (same pattern as t3code's THREAD_PREVIEW_LIMIT).
-	// "Show more" only changes this local state — no server re-fetch, no parent
-	// re-render, so autoAnimate sees only newly appended DOM nodes.
-	let displayLimit = $state(THREAD_PREVIEW_LIMIT);
-	const visibleItems: NavSubItem[] = $derived(items.slice(0, displayLimit));
-	const hasMore = $derived(items.length > displayLimit);
 
 	let listRef = $state<HTMLElement | null>(null);
 	const animatedNodes = new WeakSet<HTMLElement>();
@@ -55,7 +49,7 @@
 		data-tolgee-restricted
 		class="no-scrollbar max-h-[calc(100svh-18rem)] overflow-y-auto"
 	>
-		{#each visibleItems as sub (sub.id)}
+		{#each items as sub (sub.id)}
 			<Sidebar.MenuSubItem>
 				<Sidebar.MenuSubButton isActive={sub.isActive} onclick={() => haptic.trigger('light')}>
 					{#snippet child({ props })}
@@ -86,7 +80,7 @@
 					class="w-full px-2 py-1 text-left text-xs text-muted-foreground hover:text-foreground active:translate-y-px"
 					onclick={() => {
 						haptic.trigger('light');
-						displayLimit += THREAD_LOAD_MORE_STEP;
+						onShowMore();
 					}}
 				>
 					{$t('app.sidebar.show_more')}

--- a/src/routes/[[lang]]/app/+layout.svelte
+++ b/src/routes/[[lang]]/app/+layout.svelte
@@ -6,11 +6,10 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { tick, onDestroy } from 'svelte';
+	import { tick } from 'svelte';
 	import { localizedHref } from '$lib/utils/i18n';
-	import { useQuery, useConvexClient } from 'convex-svelte';
+	import { useQuery } from 'convex-svelte';
 	import { api } from '$lib/convex/_generated/api';
-	import { ConvexError } from 'convex/values';
 	import { getTranslate } from '@tolgee/svelte';
 	import type { LayoutData } from './$types';
 	import type { Snippet } from 'svelte';
@@ -24,50 +23,21 @@
 
 	let { children, data }: Props = $props();
 
-	const client = useConvexClient();
 	const viewer = $derived(data.viewer as typeof data.viewer & { role?: string });
 
-	// AI chat threads for sidebar.
-	// Load a generous batch upfront; display limit is managed client-side
-	// inside SidebarThreadList (same pattern as t3code) so "Show more"
-	// never triggers a server re-fetch or parent re-render.
-	const threadsQuery = useQuery(api.aiChat.threads.listThreads, () => ({ limit: 50 }));
+	// Match the sidebar's initial display count; "Show more" bumps this limit,
+	// which reactively re-runs the query for the rest. The chat route creates a
+	// warm thread only when the user opens AI Chat without a thread id.
+	const THREAD_LOAD_MORE_STEP = 5;
+	let threadListLimit = $state(10);
+	const threadsQuery = useQuery(api.aiChat.threads.listThreads, () => ({
+		limit: threadListLimit
+	}));
 	const aiChatThreads = $derived(threadsQuery.data?.threads ?? []);
-
-	// Pre-warm thread: always keep one empty thread ready for instant "new chat"
-	const warmThreadQuery = useQuery(api.aiChat.threads.getWarmThread, {});
-	const warmThreadId = $derived(warmThreadQuery.data?.threadId ?? null);
-
-	let ensureWarmInFlight = $state(false);
-	let ensureWarmBlocked = $state(false);
-	let ensureWarmUnblockTimer: ReturnType<typeof setTimeout> | undefined;
-
-	$effect(() => {
-		if (warmThreadQuery.data === null && !ensureWarmInFlight && !ensureWarmBlocked && viewer) {
-			ensureWarmInFlight = true;
-			client
-				.mutation(api.aiChat.threads.getOrCreateWarmThread, {})
-				.catch((error) => {
-					// Back off instead of retrying at network pace: the effect re-runs
-					// when ensureWarmInFlight resets while data is still null, so a
-					// deterministic failure (e.g. thread-create rate limit) would loop.
-					console.error('[app] Failed to ensure warm thread:', error);
-					ensureWarmBlocked = true;
-					const retryAfter =
-						error instanceof ConvexError
-							? ((error.data as { retryAfter?: number })?.retryAfter ?? 60000)
-							: 60000;
-					ensureWarmUnblockTimer = setTimeout(() => {
-						ensureWarmBlocked = false;
-					}, retryAfter);
-				})
-				.finally(() => {
-					ensureWarmInFlight = false;
-				});
-		}
-	});
-
-	onDestroy(() => clearTimeout(ensureWarmUnblockTimer));
+	const aiChatThreadsHasMore = $derived(threadsQuery.data?.hasMore ?? false);
+	function loadMoreThreads(): void {
+		threadListLimit += THREAD_LOAD_MORE_STEP;
+	}
 
 	// Chat pages need fullControl (manage own scroll containers)
 	const fullControl = $derived(
@@ -85,7 +55,7 @@
 		if (e.ctrlKey && e.shiftKey && !e.altKey && !e.metaKey) {
 			const shiftRoutes: Record<string, string> = {
 				Digit1: localizedHref('/app/community-chat'),
-				Digit2: localizedHref(warmThreadId ? `/app/ai-chat?thread=${warmThreadId}` : '/app/ai-chat')
+				Digit2: localizedHref('/app/ai-chat')
 			};
 			url = shiftRoutes[e.code];
 		} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
@@ -110,7 +80,6 @@
 			{ pathname: page.url.pathname, search: page.url.search, lang: page.params.lang },
 			viewer?.role,
 			aiChatThreads,
-			warmThreadId,
 			$t('ai_chat.thread.no_messages')
 		)
 	);
@@ -141,6 +110,8 @@
 	rootLabel="App"
 	{fullControl}
 	{threadSubItems}
+	threadsHasMore={aiChatThreadsHasMore}
+	onLoadMoreThreads={loadMoreThreads}
 	sidebarOpen={data.sidebarOpen}
 >
 	{@render children?.()}

--- a/src/routes/[[lang]]/app/ai-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/+page.svelte
@@ -12,6 +12,7 @@
 	import { toast } from 'svelte-sonner';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import ThreadChat from './thread-chat.svelte';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 
 	const { t } = getTranslate();
 
@@ -40,23 +41,33 @@
 	// Thread from URL param
 	const threadId = $derived(page.url.searchParams.get('thread') ?? '');
 
-	// Fallback: if navigated to /ai-chat without ?thread= (e.g. direct URL), get warm thread.
-	// The common path (sidebar click) already includes ?thread=warmId, so this rarely fires.
+	// Fallback: if navigated to /ai-chat without ?thread= (e.g. direct URL, or the
+	// sidebar's unconditional link before a thread exists), get a warm thread.
+	// ThreadChat stays unmounted below while this is in flight, since ChatInput
+	// has no createThread configured and would otherwise let the user send before
+	// there is a thread to send into.
 	let resolvingThread = $state(false);
 	let resolveThreadBlocked = $state(false);
 	let resolveThreadUnblockTimer: ReturnType<typeof setTimeout> | undefined;
+	// Bumped on every resolution attempt so a stale .then/.catch from an attempt
+	// the user has since navigated away from (e.g. picked an existing thread from
+	// the sidebar while this was pending) cannot overwrite the newer thread param.
+	let resolveGeneration = 0;
 
 	$effect(() => {
 		if (!threadId && !resolvingThread && !resolveThreadBlocked && viewer.data) {
 			resolvingThread = true;
+			const generation = ++resolveGeneration;
 			client
 				.mutation(api.aiChat.threads.getOrCreateWarmThread, {})
 				.then((result) => {
+					if (generation !== resolveGeneration || threadId) return;
 					const url = new URL(page.url);
 					url.searchParams.set('thread', result.threadId);
 					goto(resolve(url.pathname + url.search), { noScroll: true, replaceState: true });
 				})
 				.catch((err) => {
+					if (generation !== resolveGeneration) return;
 					// Back off instead of retrying at network pace: the effect re-runs
 					// when resolvingThread resets while threadId is still empty, so a
 					// deterministic failure (e.g. thread-create rate limit) would loop.
@@ -71,7 +82,7 @@
 					}, retryAfter);
 				})
 				.finally(() => {
-					resolvingThread = false;
+					if (generation === resolveGeneration) resolvingThread = false;
 				});
 		}
 	});
@@ -105,15 +116,25 @@
 
 {#if viewer.data}
 	<div class="flex h-full flex-col">
-		<ThreadChat
-			{threadId}
-			{isPro}
-			{hasMessagesAvailable}
-			{remainingMessages}
-			{totalMessages}
-			onUpgrade={handleUpgrade}
-			isUpgrading={upgradeOperation.isLoading}
-			onMessageSent={() => autumn.refetch()}
-		/>
+		{#if threadId}
+			<ThreadChat
+				{threadId}
+				{isPro}
+				{hasMessagesAvailable}
+				{remainingMessages}
+				{totalMessages}
+				onUpgrade={handleUpgrade}
+				isUpgrading={upgradeOperation.isLoading}
+				onMessageSent={() => autumn.refetch()}
+			/>
+		{:else}
+			<!-- Direct navigation without ?thread=: resolving a warm thread above.
+			     ChatInput has no createThread configured, so it must not mount (and
+			     accept a send) until threadId exists. -->
+			<div class="flex h-full items-center justify-center" role="status">
+				<LoaderCircleIcon class="size-5 text-muted-foreground motion-safe:animate-spin" />
+				<span class="sr-only">{$t('aria.loading')}</span>
+			</div>
+		{/if}
 	</div>
 {/if}


### PR DESCRIPTION
Closes #731

The shared app shell did work on every `/app` route that only the chat surface needs. The root layout subscribed to 50 AI chat threads although the sidebar renders ten, and a warm thread was created eagerly on every visit. PostHog also loaded optional survey code the template does not use.

This trims the thread subscription to ten and wires the backend `hasMore` through to a real "Show more" that grows the query, so older threads stay reachable. Warm-thread creation moves to the chat route, which now resolves on demand behind a generation guard so a stale resolution can't overwrite a thread the user has since selected, and keeps the chat input unmounted until a thread id exists so a fast send can't fire without a thread. Unused PostHog surveys are disabled at init.

Verified with targeted static checks, whole-project type and Convex checks, focused Vitest coverage, and a production build.
