### PR TITLE
fix(ai-chat): Prewarm new threads

### DIFF
--- a/e2e/ai-chat.spec.ts
+++ b/e2e/ai-chat.spec.ts
@@ -5,30 +5,21 @@ import { waitForAuthenticated } from './utils/auth';
 // src/hooks.server.ts based on Accept-Language (see the precedent in
 // e2e/upgrade-checkout-failure.spec.ts), which would break selectors on
 // non-English runners.
-test.describe('AI Chat - Lazy Warm Thread', () => {
-	test('navigating to AI Chat resolves a thread on the chat route', async ({ page }) => {
+test.describe('AI Chat - Warm Thread', () => {
+	test('sidebar navigation opens the prewarmed composer without a loading state', async ({
+		page
+	}) => {
 		await page.goto('/en/app');
 		await waitForAuthenticated(page);
 
-		// Click the AI Chat sidebar item
 		const aiChatLink = page.getByTestId('sidebar-nav-ai-chat');
 		await expect(aiChatLink).toBeVisible();
-		await aiChatLink.click();
+		await expect(aiChatLink).toHaveAttribute('href', /\/en\/app\/ai-chat\?thread=.+/);
 
-		// The chat route creates or reuses a warm thread, then canonicalizes the URL.
+		await aiChatLink.click();
 		await page.waitForURL(/\/app\/ai-chat\?thread=/, { timeout: 10000 });
 
-		// The chat textarea should be visible (no loading screen)
 		await expect(page.locator('textarea')).toBeVisible({ timeout: 10000 });
-	});
-
-	test('sidebar AI Chat href points directly to the chat route', async ({ page }) => {
-		await page.goto('/en/app');
-		await waitForAuthenticated(page);
-
-		const aiChatAnchor = page.getByTestId('sidebar-nav-ai-chat');
-		await expect(aiChatAnchor).toBeVisible();
-		await expect(aiChatAnchor).toHaveAttribute('href', '/en/app/ai-chat');
 	});
 
 	test('direct navigation to /ai-chat without thread param redirects to warm thread', async ({
@@ -49,9 +40,12 @@ test.describe('AI Chat - Lazy Warm Thread', () => {
 		await waitForAuthenticated(page);
 
 		const aiChatLink = page.getByTestId('sidebar-nav-ai-chat');
+		await expect(aiChatLink).toHaveAttribute('href', /\/en\/app\/ai-chat\?thread=.+/);
+		const firstHref = await aiChatLink.getAttribute('href');
+		expect(firstHref).toBeTruthy();
+		const firstThreadId = new URL(firstHref!, page.url()).searchParams.get('thread');
 		await aiChatLink.click();
 		await page.waitForURL(/\/app\/ai-chat\?thread=/, { timeout: 10000 });
-		const firstThreadId = new URL(page.url()).searchParams.get('thread');
 		expect(firstThreadId).toBeTruthy();
 
 		// Leave the chat route entirely so the return click is a genuine navigation
@@ -60,6 +54,7 @@ test.describe('AI Chat - Lazy Warm Thread', () => {
 		await page.goto('/en/app');
 		await waitForAuthenticated(page);
 		await expect(aiChatLink).toBeVisible();
+		await expect(aiChatLink).toHaveAttribute('href', new RegExp(`\\?thread=${firstThreadId}$`));
 
 		await aiChatLink.click();
 		await page.waitForURL(/\/app\/ai-chat\?thread=/, { timeout: 10000 });

--- a/scripts/app-shell-performance.test.ts
+++ b/scripts/app-shell-performance.test.ts
@@ -29,15 +29,16 @@ describe('app shell performance invariants', () => {
 		expect(source).toContain('let { items, hasMore, onShowMore }');
 	});
 
-	it('defers warm-thread lookup and creation to the AI chat route', () => {
+	it('prewarms the normal AI Chat navigation path', () => {
 		const layout = fs.readFileSync(appLayoutPath, 'utf8');
 		const sidebar = fs.readFileSync(sidebarConfigPath, 'utf8');
 
-		expect(layout).not.toContain('getWarmThread');
-		expect(layout).not.toContain('getOrCreateWarmThread');
-		expect(layout).toContain("Digit2: localizedHref('/app/ai-chat')");
-		expect(sidebar).toContain("url: localizedHref('/app/ai-chat')");
-		expect(sidebar).not.toContain('warmThreadId');
+		expect(layout).toContain('api.aiChat.threads.getWarmThread');
+		expect(layout).toContain('api.aiChat.threads.getOrCreateWarmThread');
+		expect(layout).toContain('`/app/ai-chat?thread=${warmThreadId}`');
+		expect(sidebar).toContain('warmThreadId?: string | null');
+		expect(sidebar).toContain('url: aiChatUrl');
+		expect(sidebar).toContain('activeThreadId === warmThreadId');
 	});
 
 	it('disables unused PostHog survey code', () => {

--- a/src/lib/components/authenticated/configs/app-sidebar-config.ts
+++ b/src/lib/components/authenticated/configs/app-sidebar-config.ts
@@ -25,6 +25,7 @@ export function getAppSidebarConfig(
 	pageState: PageState,
 	userRole?: string,
 	aiChatThreads?: AiChatThread[],
+	warmThreadId?: string | null,
 	newConversationLabel?: string
 ): SidebarConfig {
 	const { pathname, search, lang } = pageState;
@@ -40,6 +41,10 @@ export function getAppSidebarConfig(
 		isActive: activeThreadId === thread._id,
 		timestamp: thread.lastMessageAt
 	}));
+
+	const aiChatUrl = warmThreadId
+		? localizedHref(`/app/ai-chat?thread=${warmThreadId}`)
+		: localizedHref('/app/ai-chat');
 
 	return {
 		header: {
@@ -58,12 +63,13 @@ export function getAppSidebarConfig(
 			},
 			{
 				translationKey: 'app.sidebar.ai_chat',
-				url: localizedHref('/app/ai-chat'),
+				url: aiChatUrl,
 				icon: BotMessageSquareIcon,
 				isActive: pathname.startsWith(`/${lang}/app/ai-chat`),
 				collapsible: true,
 				subItems: aiChatSubItems,
 				kbd: [ctrlSymbol, '⇧', '2'],
+				disableNav: !!activeThreadId && activeThreadId === warmThreadId,
 				testId: 'sidebar-nav-ai-chat'
 			}
 		],

--- a/src/routes/[[lang]]/app/+layout.svelte
+++ b/src/routes/[[lang]]/app/+layout.svelte
@@ -6,10 +6,11 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { tick } from 'svelte';
+	import { tick, onDestroy } from 'svelte';
 	import { localizedHref } from '$lib/utils/i18n';
-	import { useQuery } from 'convex-svelte';
+	import { useQuery, useConvexClient } from 'convex-svelte';
 	import { api } from '$lib/convex/_generated/api';
+	import { ConvexError } from 'convex/values';
 	import { getTranslate } from '@tolgee/svelte';
 	import type { LayoutData } from './$types';
 	import type { Snippet } from 'svelte';
@@ -23,11 +24,11 @@
 
 	let { children, data }: Props = $props();
 
+	const client = useConvexClient();
 	const viewer = $derived(data.viewer as typeof data.viewer & { role?: string });
 
 	// Match the sidebar's initial display count; "Show more" bumps this limit,
-	// which reactively re-runs the query for the rest. The chat route creates a
-	// warm thread only when the user opens AI Chat without a thread id.
+	// which reactively re-runs the query for the rest.
 	const THREAD_LOAD_MORE_STEP = 5;
 	let threadListLimit = $state(10);
 	const threadsQuery = useQuery(api.aiChat.threads.listThreads, () => ({
@@ -38,6 +39,40 @@
 	function loadMoreThreads(): void {
 		threadListLimit += THREAD_LOAD_MORE_STEP;
 	}
+
+	// Keep one empty thread ready so normal AI Chat navigation opens the
+	// composer immediately. The route still resolves direct URLs without a
+	// thread id as a fallback.
+	const warmThreadQuery = useQuery(api.aiChat.threads.getWarmThread, {});
+	const warmThreadId = $derived(warmThreadQuery.data?.threadId ?? null);
+
+	let ensureWarmInFlight = $state(false);
+	let ensureWarmBlocked = $state(false);
+	let ensureWarmUnblockTimer: ReturnType<typeof setTimeout> | undefined;
+
+	$effect(() => {
+		if (warmThreadQuery.data === null && !ensureWarmInFlight && !ensureWarmBlocked && viewer) {
+			ensureWarmInFlight = true;
+			client
+				.mutation(api.aiChat.threads.getOrCreateWarmThread, {})
+				.catch((error) => {
+					console.error('[app] Failed to ensure warm thread:', error);
+					ensureWarmBlocked = true;
+					const retryAfter =
+						error instanceof ConvexError
+							? ((error.data as { retryAfter?: number })?.retryAfter ?? 60000)
+							: 60000;
+					ensureWarmUnblockTimer = setTimeout(() => {
+						ensureWarmBlocked = false;
+					}, retryAfter);
+				})
+				.finally(() => {
+					ensureWarmInFlight = false;
+				});
+		}
+	});
+
+	onDestroy(() => clearTimeout(ensureWarmUnblockTimer));
 
 	// Chat pages need fullControl (manage own scroll containers)
 	const fullControl = $derived(
@@ -55,7 +90,7 @@
 		if (e.ctrlKey && e.shiftKey && !e.altKey && !e.metaKey) {
 			const shiftRoutes: Record<string, string> = {
 				Digit1: localizedHref('/app/community-chat'),
-				Digit2: localizedHref('/app/ai-chat')
+				Digit2: localizedHref(warmThreadId ? `/app/ai-chat?thread=${warmThreadId}` : '/app/ai-chat')
 			};
 			url = shiftRoutes[e.code];
 		} else if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
@@ -80,6 +115,7 @@
 			{ pathname: page.url.pathname, search: page.url.search, lang: page.params.lang },
 			viewer?.role,
 			aiChatThreads,
+			warmThreadId,
 			$t('ai_chat.thread.no_messages')
 		)
 	);


### PR DESCRIPTION
Closes #733

The app-shell performance change moved warm-thread creation onto the AI Chat route, so normal new-thread navigation showed a loading spinner before the composer appeared.

The app shell now keeps one empty thread ready and sends sidebar and keyboard navigation directly to it. Direct URLs without a thread ID retain the route-level fallback and race guards. The initial sidebar query remains limited to 10 threads.

Regression guard: added app-shell invariant and AI Chat sidebar E2E coverage

Verified with targeted static checks and `bun run test:unit -- scripts/app-shell-performance.test.ts`. The local AI Chat E2E was blocked in the pre-existing sign-in setup timeout before the feature tests ran.