### PR TITLE
fix(sidebar): Preserve load-more animation

### DIFF
--- a/scripts/app-shell-performance.test.ts
+++ b/scripts/app-shell-performance.test.ts
@@ -10,16 +10,19 @@ const posthogPath = path.resolve('src/lib/analytics/posthog.ts');
 const threadListPath = path.resolve('src/lib/components/authenticated/sidebar-thread-list.svelte');
 
 describe('app shell performance invariants', () => {
-	it('loads only the initially visible AI chat threads', () => {
+	it('preserves the visible thread list while loading more', () => {
 		const source = fs.readFileSync(appLayoutPath, 'utf8');
 
 		expect(source).toContain('api.aiChat.threads.listThreads');
-		// Initial page of 10, growable via the query so "Show more" reflects the
-		// real backend count instead of a client-only slice.
+		// Keep the initial query small without clearing the existing DOM while the
+		// next page loads, so AutoAnimate observes the appended thread rows.
 		expect(source).toContain('let threadListLimit = $state(10)');
 		expect(source).toMatch(/listThreads,[\s\S]*limit:\s*threadListLimit/);
 		expect(source).not.toMatch(/listThreads,[\s\S]*limit:\s*50/);
 		expect(source).toContain('threadsQuery.data?.hasMore');
+		expect(source).toMatch(
+			/listThreads,[\s\S]*limit:\s*threadListLimit[\s\S]*keepPreviousData:\s*true/
+		);
 	});
 
 	it('drives the sidebar Show more from the backend hasMore, not a client slice', () => {

--- a/src/routes/[[lang]]/app/+layout.svelte
+++ b/src/routes/[[lang]]/app/+layout.svelte
@@ -31,9 +31,11 @@
 	// which reactively re-runs the query for the rest.
 	const THREAD_LOAD_MORE_STEP = 5;
 	let threadListLimit = $state(10);
-	const threadsQuery = useQuery(api.aiChat.threads.listThreads, () => ({
-		limit: threadListLimit
-	}));
+	const threadsQuery = useQuery(
+		api.aiChat.threads.listThreads,
+		() => ({ limit: threadListLimit }),
+		{ keepPreviousData: true }
+	);
 	const aiChatThreads = $derived(threadsQuery.data?.threads ?? []);
 	const aiChatThreadsHasMore = $derived(threadsQuery.data?.hasMore ?? false);
 	function loadMoreThreads(): void {


### PR DESCRIPTION
Changing the sidebar thread limit cleared the current query result, unmounted the thread list, and detached AutoAnimate before the larger result arrived. The Show more row therefore jumped instead of moving with the appended threads.

Keep the previous query result while the expanded limit loads so keyed rows stay mounted and AutoAnimate observes the new entries. Extend the app-shell regression guard to require this continuity without restoring the old 50-thread eager query.

<!-- pr-media:start -->
| Sidebar load-more animation |
| --- |
| <img width="1800" alt="Sidebar load-more animation" src="https://github.com/user-attachments/assets/a5ebeb15-8106-473e-a2f2-f97ebe0808c6" /> |
<!-- pr-media:end -->

Regression guard: added app shell performance invariant

Verified with targeted static checks, full Svelte and Convex type checks, the focused Vitest guard, and the authenticated AI Chat Playwright suite.
