### PR TITLE
docs(skills): Use btca-local in reviews

### DIFF
--- a/.agents/skills/triage-reviews/SKILL.md
+++ b/.agents/skills/triage-reviews/SKILL.md
@@ -33,7 +33,7 @@ For EVERY finding, verify against real code before accepting or rejecting:
 2. **Check if the issue still exists** — it may already be fixed in a later commit
 3. **Verify correctness** using:
    - Code analysis (read surrounding context, trace call paths)
-   - Run `btca resources` to see what's available, then `btca ask -r <resource> -q "..."` for library/framework questions
+   - Invoke the `btca-local` skill for library/framework questions, then inspect the relevant repository clones registered in `btca.config.jsonc`
    - Web search for API behavior, language semantics, or CVEs
 4. **Classify** each finding:
    - **Valid** — real bug, real gap, or real improvement needed


### PR DESCRIPTION
The review-triage skill still referenced the removed `btca` CLI even though dependency research now runs through the local skill and registered repository clones.

This updates the verification guidance to invoke `btca-local` and inspect resources from `btca.config.jsonc`.

Verified with staged static checks and `git diff --check`.