### PR TITLE
chore(skills): Register upstream sync

### DIFF
--- a/.agents/skills/upstream-sync/SKILL.md
+++ b/.agents/skills/upstream-sync/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: upstream-sync
+description: Review and integrate upstream saas-starter template changes into a fork. Detects the fork point (forks are content-copies that share no git ancestor), lists every upstream commit since the last sync, and guides reviewing each one to integrate, skip as already-present, or exclude with a reason, adapting to this fork's divergences (branding, theme, env/deploy, i18n, fork-owned features), then ships one consolidated PR. Use when asked to sync or update from upstream, pull template changes, review what the template added, or apply an upstream fix.
+argument-hint: '[--type fix|feat|...] [--tag security]'
+allowed-tools: Bash, Read, Edit, Grep, Glob
+---
+
+# Upstream Template Sync
+
+Pull later template changes into this fork. The goal is to review **every** upstream
+enhancement, understand it, and integrate what fits — bug fixes, features, refactors,
+chores, and security fixes alike. Security fixes are never optional and apply first,
+but this is a comprehensive review, not a security-only pass.
+
+This fork was created by **content-copy** (GitHub "Use this template"), so it shares
+**NO git ancestor** with upstream: `git merge`, `git rebase`, and `gh repo sync` do
+not apply. The link to upstream is tree-SHA identity; every sync is a triaged,
+manually-adapted port.
+
+## When to use
+
+- "sync from upstream", "pull template changes", "what did saas-starter add", "apply the upstream fix".
+
+## When to STOP and ask the human
+
+- A candidate commit touches a file this fork has heavily rewritten (auth, schema, deploy config) — show the diff, do not auto-apply.
+- Fork-point detection returns a `closest-tree GUESS` (the bootstrap commit was edited) — confirm before proceeding.
+- A ported commit needs an env var that does not exist as a preview deployment default.
+- Before opening the PR, and before any merge. Never auto-merge.
+
+## Step 1 — Discover (read-only, never writes)
+
+```bash
+bun skills/upstream-sync/scripts/find-fork-point.ts        # fork point via tree-SHA match
+bun skills/upstream-sync/scripts/list-upstream-changes.ts  # every commit since last sync, oldest-first
+```
+
+The list scopes from `.upstream-sync.json`'s `lastSynced` (falls back to the fork
+point on the first sync). Each row shows a priority tag, the divergence categories
+it touches, and the file count. Oldest-first is the integration/dependency order.
+`--json` gives machine output; `--type` / `--tag` narrow the view (review-all stays
+the default). The upstream defaults to the template this skill shipped from; if this
+fork was forked from another fork, pass `--upstream <url>` (or set `upstreamUrl` in the
+marker) to point at the right template.
+
+## Step 2 — Isolated worktree off main
+
+Never work in the shared checkout (a parallel process can sweep up staged files).
+
+```bash
+bun run worktree chore/upstream-sync --base main
+```
+
+## Step 3 — Detect THIS fork's divergences
+
+Do not assume; detect from the diff against the fork point. Categories: branding/legal
+config, theme/design tokens, env/deploy config, i18n content, fork-owned features. See
+[reference/divergence-categories.md](reference/divergence-categories.md). A commit
+touching a diverged file needs extra care: re-apply the upstream _intent_ onto the
+fork's values. A commit that touches no diverged area is **not** a free pass — it still
+gets the full Step 4 verdict. Divergence categories change how much adaptation a commit
+needs, never whether you review it.
+
+## Step 4 — Review and classify every commit
+
+The priority tag and divergence categories from Step 1 are **hints only** — for
+ordering and for how much adaptation a commit needs. They are never a gate or a
+substitute for review. Read **every** commit's actual diff and give it an explicit
+verdict; never integrate, skip, or exclude a commit from its label alone, and never
+blind-apply an untagged or unlabeled commit. "Security first" is about apply order, not
+about which commits to look at — you look at all of them.
+
+Process oldest-first (dependency order). Apply security and bug fixes first, then
+features/refactors/chores. For each commit, from its diff, decide:
+
+- **Integrate** — applies to this fork (possibly adapted).
+- **Already present** — the fork already has equivalent code (grep / `git log` the fork). Skip.
+- **Exclude** — conflicts with a deliberate fork divergence, or re-introduces something
+  the fork removed. Record `{sha, reason}` in `.upstream-sync.json` so it is not
+  re-triaged next sync.
+
+Map **cross-commit dependencies**: a later commit often assumes an earlier one (a
+shared helper, a schema column that became required, a new lint/CI guard, a token
+rename). Port prerequisites first or together; never batch-apply the whole range.
+The review unit is the squashed first-parent commit; for an oversized commit, triage
+within it by file/hunk. See [reference/triage.md](reference/triage.md).
+
+## Step 5 — Apply, dependency-aware
+
+Cherry-pick or hand-port in order.
+
+- **Branding/theme/config**: re-apply the upstream _intent_ on the fork's values; never clobber fork branding or tokens.
+- **i18n JSON conflicts**: use a JSON-aware 3-way deep merge, NEVER a line-based resolver (it corrupts nested objects). See [reference/i18n-merge.md](reference/i18n-merge.md), then run the locale-parity test.
+- Skip any commit that purely reverts a fork choice (rebrand, font, removed feature).
+
+## Step 6 — Validate against WHOLE-PROJECT CI (not file-scoped)
+
+`scripts/static-checks.ts` is file-scoped and misses project-wide gates. Run the
+project-wide lint, type check, unit tests, and a build before the PR. A newly ported
+ESLint rule fires on ALL pre-existing fork files. If a ported commit adds a typed env
+var, ensure it exists as a preview deployment default (CI's `convex deploy` fails on a
+missing required var; a green local build does not cover the deploy step). See
+[reference/ci-gotchas.md](reference/ci-gotchas.md).
+
+## Step 7 — Ship ONE consolidated PR (never a stack)
+
+One branch off current `main` with all integrated commits, grouped thematically for
+readable history but applied in dependency order. Do NOT stack PRs (deleting a stack
+base closes its child; rebasing a stack onto a moving main re-conflicts on i18n). List
+excluded SHAs + reasons in the PR body. Confirm with the human before opening it; merge
+only once the **required** checks are green (a non-required check may stay UNSTABLE).
+After merge, persist the marker:
+`bun skills/upstream-sync/scripts/find-fork-point.ts --mark-synced <upstreamHEAD>`
+(updates `lastSynced` + `syncedAt`), then add any `excluded` entries you recorded and
+commit `.upstream-sync.json`.
+
+## Large syncs (many commits): fan out per-commit, not per-category
+
+Run the two discovery scripts once, then parallelize the _triage_ one agent per commit
+(plus an adversarial recheck of every dismissal) — the commit is the atomic unit of
+intent and the only granularity where cross-commit dependencies are visible. A single
+**lead** owns the one worktree branch and is the only writer (serialized commits);
+subagents return patches + verdicts + dependency notes as text, the lead applies them
+in dependency order. Keep the invariant: one branch, one writer, one consolidated PR.
+
+## Template-bug linkage (do not strip on rebrand)
+
+Keep the AGENTS.md "SaaS Starter Template Bugs" section intact through rebrands; file
+template-originated bugs upstream using its issue template. Fixes flow down (this skill);
+bug reports flow up.

--- a/.agents/skills/upstream-sync/reference/ci-gotchas.md
+++ b/.agents/skills/upstream-sync/reference/ci-gotchas.md
@@ -1,0 +1,49 @@
+# CI gotchas a local file-scoped check misses
+
+A green `scripts/static-checks.ts` (file-scoped) and a green local `build` do NOT cover
+the gates that fail an upstream-sync PR in CI. Check these explicitly before the PR.
+
+## 1. Whole-project lint, not file-scoped
+
+CI runs the project-wide `lint` script (`eslint .` + `oxlint`). When a ported commit adds
+a new ESLint rule, that rule fires on **all pre-existing fork files**, not just the files
+the commit changed — so a file-scoped check passes while CI fails. Always run the full
+project lint before the PR:
+
+```bash
+bun run lint        # eslint . && oxlint, the same gate CI runs
+```
+
+Fix every pre-existing violation the new rule surfaces (it is part of integrating the
+rule), or the rule's PR cannot merge.
+
+## 2. Typed-env deploys need a preview default
+
+If a ported commit adopts typed environment variables (declaring required vars that the
+backend deploy validates), the CI deploy step runs the backend deploy and **fails on a
+missing required var** — even though the local build never deploys. For each newly
+required var, ensure it exists as a preview deployment default (and in production) before
+merging. A required var that is set dynamically per-deploy must still have a default so
+the presence check passes.
+
+## 3. The deploy step is push-driven
+
+Deploy runs in CI, not locally. A green local build proves compilation, not deployability.
+Backend-deploy permission/secret problems (e.g. a deploy key lacking a permission a new
+command needs) only surface in the CI build log — read it there rather than trusting the
+local build.
+
+## 4. Merge state
+
+The required checks are what gate the merge. A non-required check (e.g. a third-party PR
+sync bot) can keep the PR's overall state `UNSTABLE` permanently; merge once the
+**required** set is green rather than waiting for a clean overall state.
+
+## Pre-PR checklist
+
+```bash
+bun run lint            # whole-project (eslint . + oxlint)
+bun run check:convex    # or the repo's backend typecheck
+bun run test:unit
+bun run build
+```

--- a/.agents/skills/upstream-sync/reference/divergence-categories.md
+++ b/.agents/skills/upstream-sync/reference/divergence-categories.md
@@ -1,0 +1,42 @@
+# Detecting this fork's divergences
+
+A fork diverges from the template in a few predictable areas. Detect them from the actual
+diff against the fork point — never hardcode fork specifics. When an upstream commit
+touches a file in a diverged area, re-apply the upstream _intent_ on top of the fork's
+values; do not clobber the fork's choices.
+
+Get the fork's divergence surface once:
+
+```bash
+# files the fork changed vs the template baseline (forkPoint from .upstream-sync.json)
+git diff --name-only <forkPoint> HEAD
+```
+
+Cross-reference that list with each candidate commit's changed files (the
+`list-upstream-changes.ts` output already tags categories per commit).
+
+## Categories (generic shapes)
+
+- **branding / legal** — brand name, wordmark, logo, legal/operator/address config, SEO
+  defaults, marketing copy, manifest/favicon. Upstream changes here usually must be
+  re-expressed with the fork's brand values, not copied verbatim.
+- **theme / design tokens** — global CSS, design tokens, Tailwind theme, color/spacing
+  scales, fonts. A fork that re-themed will conflict on token files; keep the fork's
+  token values, take only genuinely new tokens or structural fixes.
+- **env / deploy config** — env schema, deploy scripts, CI workflows, platform config
+  (wrangler/vercel/docker), backend component/config. Adapt to the fork's deploy targets;
+  a fork may have disabled a platform the template still ships.
+- **i18n content** — translation JSON. Resolve with the JSON-aware 3-way deep merge
+  (see i18n-merge.md), never line-based.
+- **fork-owned features** — directories/modules the fork added that the template has no
+  concept of. Upstream rarely touches these; if a refactor does (e.g. a renamed shared
+  helper the fork's feature imports), port the rename into the fork's feature too.
+
+## Decision
+
+- File NOT in the fork's divergence surface → the commit usually applies cleanly (still
+  review intent).
+- File IN a diverged area → adapt. If the fork rewrote that file heavily (auth, schema,
+  deploy config), STOP and show the human the diff rather than auto-applying.
+- Commit purely reverts a fork choice (re-adds removed feature, restores template brand
+  or font) → exclude with a reason.

--- a/.agents/skills/upstream-sync/reference/i18n-merge.md
+++ b/.agents/skills/upstream-sync/reference/i18n-merge.md
@@ -1,0 +1,40 @@
+# i18n conflict resolution: JSON-aware 3-way deep merge
+
+When an upstream commit changes translation JSON the fork has also edited, **never use a
+line-based merge resolver** — it corrupts nested objects (orphan commas, duplicated or
+broken keys, `"a": {,`). Resolve at the JSON object level.
+
+## The merge
+
+Use git's three stages of the conflicted file:
+
+- `git show :1:src/i18n/<locale>.json` — base (the common version before either side)
+- `git show :2:src/i18n/<locale>.json` — ours (the fork's current values)
+- `git show :3:src/i18n/<locale>.json` — theirs (upstream's new version)
+
+Deep-merge recursively:
+
+- Start from **ours** (keep the fork's translated values and structure).
+- Fold in keys that exist in **theirs** but not in ours (genuinely new upstream keys).
+- For a key changed on both sides, keep **ours** (the fork's wording wins) unless the
+  upstream change is a structural fix the fork wants.
+- Do not re-add a key that ours deliberately deleted from base.
+
+Write valid JSON back (tabs/indent per the repo's prettier config), then run prettier.
+
+## Reconcile locale parity
+
+After merging, every locale must have the same leaf keys as the base locale (usually
+`en.json`). New upstream keys must be added to all locales (translate them). Run the
+repo's locale guards:
+
+```bash
+bun run test:unit -- scripts/locale-parity.test.ts scripts/i18n-used-keys.test.ts
+```
+
+If the repo has an orphan-key guard, run it too and prune/allowlist as that skill directs.
+
+## Tolgee ordering (if the fork uses Tolgee)
+
+`bun run i18n:pull` before editing the JSON, `bun run i18n:push` after, so local edits
+are not overwritten and changes reach the translation backend.

--- a/.agents/skills/upstream-sync/reference/triage.md
+++ b/.agents/skills/upstream-sync/reference/triage.md
@@ -1,0 +1,52 @@
+# Per-commit triage
+
+The review unit is the **squashed first-parent commit** on upstream's default branch.
+Upstream squash-merges PRs, so each commit is the canonical, net, reviewed diff of one
+PR. Do not pull pre-squash branch commits — they carry intra-PR churn (WIP, fix-the-fix,
+reverts that net out) and give worse signal. For an oversized commit, triage _within_ it
+by file/hunk instead.
+
+## Order
+
+Process oldest-first; that is the dependency/integration order. Apply security and bug
+fixes first, then features/refactors/chores — but review all of them, not just security.
+
+## Verdict per commit
+
+Reach the verdict from the commit's **actual diff**, not from its priority tag or
+category labels. Those are hints (ordering + how much adaptation), never a gate: an
+untagged or unlabeled commit still gets read and given a verdict, and is never
+blind-applied.
+
+- **integrate** — applies to this fork. May need adaptation (see divergence-categories.md).
+- **already-present** — the fork already has equivalent behavior. Verify before skipping:
+  grep the fork for the symbol/string/file the commit adds; check `git log` for an
+  independent equivalent. A substring match in a _different_ key/path is not a hit.
+- **exclude** — conflicts with a deliberate fork divergence, or re-introduces something
+  the fork intentionally removed/changed (rebrand, font, dropped feature). Record
+  `{ "sha": "<sha>", "reason": "<one line>" }` in `.upstream-sync.json.excluded` so the
+  next sync does not re-triage it.
+
+## Cross-commit dependencies (the main trap)
+
+A later commit frequently assumes an earlier one landed:
+
+- a shared helper/module a later commit imports,
+- a schema field that an earlier commit made required,
+- a new ESLint/CI guard a later commit's code must satisfy,
+- a design-token / symbol rename.
+
+Cherry-picking out of order then fails (missing import, type error, lint error). Before
+applying, scan the remaining commits for references to anything this commit introduces,
+and port prerequisites first or together. Never batch-apply the whole range blind.
+
+## Adversarial recheck of dismissals
+
+For every "already-present" and "exclude" verdict, re-verify against the real file at the
+cited path before trusting it — dismissals are where real fixes get silently dropped.
+
+## Oversized commits
+
+A commit touching dozens of files (audit/omnibus PRs) is still one unit, but triage it
+file-by-file: some hunks integrate, some are already-present, some conflict with fork
+divergence. Resolve each part on its own verdict.

--- a/.agents/skills/upstream-sync/scripts/find-fork-point.ts
+++ b/.agents/skills/upstream-sync/scripts/find-fork-point.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env bun
+/**
+ * find-fork-point.ts — locate the upstream commit this fork was copied from.
+ *
+ * Forks of this template are created by content-copy (GitHub "Use this template"),
+ * so they share NO git ancestor with upstream: `git merge-base`, `rebase`, and
+ * `gh repo sync` do not apply. The only reliable link is TREE-SHA identity — the
+ * fork's bootstrap commit copied an upstream tree verbatim, so its tree SHA equals
+ * some upstream commit's tree SHA. This script finds that commit.
+ *
+ * Read-only: it adds + fetches the `upstream` remote and prints results. It never
+ * modifies the working tree or writes any file. Persist the result yourself in
+ * `.upstream-sync.json` (this script prints a ready-to-commit block).
+ *
+ * Usage:
+ *   bun skills/upstream-sync/scripts/find-fork-point.ts [--upstream <git-url>] [--json]
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseArgs } from 'node:util';
+
+// Default upstream = the template this skill ships from (the template's own
+// identity, inherited by every fork — not a fork specific). Override via the
+// marker's `upstreamUrl` or `--upstream`.
+const DEFAULT_UPSTREAM = 'https://github.com/stickerdaniel/saas-starter.git';
+const MARKER = '.upstream-sync.json';
+
+const SCRUBBED = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_OBJECT_DIRECTORY'];
+function gitEnv(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	for (const k of SCRUBBED) delete env[k];
+	return env;
+}
+function git(args: string[], allowFail = false): string {
+	try {
+		return execFileSync('git', args, { encoding: 'utf-8', env: gitEnv() }).trim();
+	} catch (err) {
+		if (allowFail) return '';
+		throw err;
+	}
+}
+
+function readMarker(root: string): Record<string, unknown> | null {
+	const p = join(root, MARKER);
+	if (!existsSync(p)) return null;
+	try {
+		return JSON.parse(readFileSync(p, 'utf-8'));
+	} catch {
+		return null;
+	}
+}
+
+function main() {
+	const { values } = parseArgs({
+		args: Bun.argv.slice(2),
+		options: {
+			upstream: { type: 'string' },
+			json: { type: 'boolean', default: false },
+			// Persist the marker after a successful sync: --mark-synced <upstreamSha>
+			// (omit the value to use the current upstream HEAD). This is the only
+			// write path; without it the script is strictly read-only.
+			'mark-synced': { type: 'string' }
+		},
+		strict: false
+	});
+
+	const root = git(['rev-parse', '--show-toplevel']);
+	const marker = readMarker(root);
+	const upstreamUrl =
+		(values.upstream as string) || (marker?.upstreamUrl as string) || DEFAULT_UPSTREAM;
+
+	// Safety: if this IS the upstream template repo, there is nothing to sync.
+	const originUrl = git(['remote', 'get-url', 'origin'], true);
+	const norm = (u: string) =>
+		u.replace(/\.git$/, '').replace(/^git@github\.com:/, 'https://github.com/');
+	if (originUrl && norm(originUrl) === norm(upstreamUrl)) {
+		console.error(
+			'This repository IS the upstream template (origin === upstream). Nothing to sync.\n' +
+				'Run this skill from a fork created from the template instead.'
+		);
+		process.exit(2);
+	}
+
+	// Ensure the `upstream` remote exists and points at the template, then fetch.
+	const existing = git(['remote', 'get-url', 'upstream'], true);
+	if (!existing) git(['remote', 'add', 'upstream', upstreamUrl]);
+	else if (norm(existing) !== norm(upstreamUrl))
+		git(['remote', 'set-url', 'upstream', upstreamUrl]);
+	console.error(`Fetching upstream (${upstreamUrl}) ...`);
+	git(['fetch', '--quiet', 'upstream']);
+
+	// Fork root = the parentless bootstrap commit (content-copy starts history fresh).
+	// If several roots exist, take the oldest by committer date.
+	const roots = git(['rev-list', '--max-parents=0', '--date-order', 'HEAD'])
+		.split('\n')
+		.filter(Boolean);
+	const forkRoot = roots[roots.length - 1];
+	const forkTree = git(['rev-parse', `${forkRoot}^{tree}`]);
+
+	// Scan upstream history for a commit whose tree SHA is identical (exact match).
+	const pairs = git(['log', '--format=%H %T', 'upstream/main']).split('\n').filter(Boolean);
+	const matches = pairs.filter((l) => l.endsWith(' ' + forkTree)).map((l) => l.split(' ')[0]);
+
+	let forkPoint: string;
+	let method: string;
+	if (matches.length >= 1) {
+		forkPoint = matches[0]; // newest identical-tree commit (rev-list is newest-first)
+		method =
+			matches.length === 1
+				? 'exact-tree'
+				: `exact-tree (${matches.length} identical-tree commits, took newest)`;
+	} else {
+		// Fallback: bootstrap was edited after copy, so no tree is identical. Pick the
+		// upstream commit with the SMALLEST diff to the fork root tree. This is a GUESS.
+		console.error(
+			'No exact tree-SHA match — bootstrap commit was likely edited. Computing closest tree (GUESS)...'
+		);
+		let best = '';
+		let bestChanges = Number.POSITIVE_INFINITY;
+		for (const c of pairs.map((l) => l.split(' ')[0]).slice(0, 400)) {
+			const stat = git(['diff', '--shortstat', forkTree, `${c}^{tree}`], true);
+			const n = [...stat.matchAll(/(\d+) (insertion|deletion)/g)].reduce(
+				(a, m) => a + Number(m[1]),
+				0
+			);
+			if (n < bestChanges) {
+				bestChanges = n;
+				best = c;
+			}
+		}
+		forkPoint = best;
+		method = `closest-tree GUESS (~${bestChanges} line diff) — CONFIRM before syncing`;
+	}
+
+	const forkPointSubject = git(['log', '-1', '--format=%s', forkPoint], true);
+	const upstreamHead = git(['rev-parse', 'upstream/main']);
+	const lastSynced = (marker?.lastSynced as string) || forkPoint;
+	const ahead = git(
+		['rev-list', '--count', '--no-merges', '--first-parent', `${lastSynced}..upstream/main`],
+		true
+	);
+
+	const suggestedMarker = {
+		upstreamUrl,
+		forkPoint,
+		lastSynced,
+		syncedAt: (marker?.syncedAt as string) || null,
+		excluded: (marker?.excluded as unknown[]) || []
+	};
+
+	// Write path (opt-in): persist the marker after a successful sync.
+	const mark = values['mark-synced'] as string | boolean | undefined;
+	if (mark !== undefined) {
+		const newLastSynced = typeof mark === 'string' && mark ? mark : upstreamHead;
+		// Reject anything that is not a real upstream commit — a bogus lastSynced would
+		// silently break the next sync's `<lastSynced>..upstream/main` range.
+		const resolved = git(['rev-parse', '--verify', '--quiet', `${newLastSynced}^{commit}`], true);
+		if (!resolved) {
+			console.error(`--mark-synced: "${newLastSynced}" is not a valid commit.`);
+			process.exit(1);
+		}
+		// `merge-base --is-ancestor` signals via exit code (no stdout), so check by throw.
+		let reachable = true;
+		try {
+			execFileSync('git', ['merge-base', '--is-ancestor', resolved, 'upstream/main'], {
+				env: gitEnv()
+			});
+		} catch {
+			reachable = false;
+		}
+		if (!reachable) {
+			console.error(`--mark-synced: ${resolved.slice(0, 8)} is not reachable from upstream/main.`);
+			process.exit(1);
+		}
+		const written = {
+			...suggestedMarker,
+			lastSynced: resolved,
+			syncedAt: new Date().toISOString()
+		};
+		writeFileSync(join(root, MARKER), JSON.stringify(written, null, '\t') + '\n', 'utf-8');
+		console.error(`Wrote ${MARKER}: lastSynced=${resolved.slice(0, 8)}. Review and commit it.`);
+		return;
+	}
+
+	if (values.json) {
+		console.log(
+			JSON.stringify(
+				{
+					forkPoint,
+					method,
+					forkPointSubject,
+					upstreamHead,
+					candidateCount: Number(ahead) || 0,
+					suggestedMarker
+				},
+				null,
+				2
+			)
+		);
+		return;
+	}
+
+	console.log('');
+	console.log(`Fork point:   ${forkPoint}  (${method})`);
+	console.log(`              ${forkPointSubject}`);
+	console.log(
+		`Last synced:  ${lastSynced}${marker?.lastSynced ? '' : '  (no marker yet — defaults to fork point)'}`
+	);
+	console.log(`Upstream HEAD: ${upstreamHead}`);
+	console.log(
+		`Candidate commits to review: ${ahead || '0'}  (git log --no-merges --first-parent ${lastSynced.slice(0, 8)}..upstream/main)`
+	);
+	console.log('');
+	console.log(`Next: bun skills/upstream-sync/scripts/list-upstream-changes.ts`);
+	console.log('');
+	console.log(`Suggested ${MARKER} (or run --mark-synced after a successful sync):`);
+	console.log(JSON.stringify(suggestedMarker, null, '\t'));
+}
+
+if (import.meta.main) main();

--- a/.agents/skills/upstream-sync/scripts/list-upstream-changes.test.ts
+++ b/.agents/skills/upstream-sync/scripts/list-upstream-changes.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { categoriesFor, classify } from './list-upstream-changes';
+
+describe('classify', () => {
+	it('tags explicit security signals', () => {
+		expect(
+			classify('chore(deps): update vite to v8.0.16 [security] (#579)', 'renovate[bot]').priority
+		).toBe('security');
+		expect(classify('fix: patch CVE-2025-1234 in parser', 'a').priority).toBe('security');
+		expect(classify('fix(forms): prevent SQL injection', 'a').priority).toBe('security');
+		expect(classify('fix(auth): revoke sessions on reset', 'a').priority).toBe('security');
+		expect(classify('fix(ui): sanitize untrusted markdown', 'a').priority).toBe('security');
+		expect(classify('fix: close an auth bypass on admin routes', 'a').priority).toBe('security');
+		// secret/credential handling stays tagged (review-all: missing it is worse than an early look)
+		expect(classify('ci(workflows): harden token and secret handling', 'a').priority).toBe(
+			'security'
+		);
+	});
+
+	it('does NOT over-tag the common phrase "dependency injection"', () => {
+		// the real false positive the qualifier fix removes
+		expect(classify('feat: add dependency injection container', 'a').priority).toBe('feat');
+		expect(classify('refactor: tidy the injection wiring', 'a').priority).toBe('refactor');
+	});
+
+	it('derives the conventional type and non-security priority', () => {
+		expect(classify('feat(home): new hero', 'a')).toEqual({ priority: 'feat', type: 'feat' });
+		expect(classify('fix(ui): button radius', 'a')).toEqual({ priority: 'fix', type: 'fix' });
+		expect(classify('refactor(convex): tidy', 'a')).toEqual({
+			priority: 'refactor',
+			type: 'refactor'
+		});
+		expect(classify('chore(deps): bump x', 'a').priority).toBe('chore');
+	});
+
+	it('treats renovate/dependabot non-security bumps as chore', () => {
+		expect(classify('fix(deps): update all non-major dependencies', 'renovate[bot]').priority).toBe(
+			'chore'
+		);
+	});
+
+	it('falls back to type "other" without a conventional prefix', () => {
+		expect(classify('Sunray backdrop on marketing subpages', 'a')).toEqual({
+			priority: 'other',
+			type: 'other'
+		});
+	});
+});
+
+describe('categoriesFor', () => {
+	it('maps paths to divergence categories', () => {
+		expect(categoriesFor(['src/i18n/en.json'])).toEqual(['i18n']);
+		expect(categoriesFor(['src/routes/layout.css'])).toEqual(['theme']);
+		expect(categoriesFor(['.github/workflows/ci.yml'])).toEqual(['env/deploy']);
+		expect(categoriesFor(['src/lib/convex/schema.ts'])).toEqual(['backend']);
+		expect(categoriesFor(['e2e/login.spec.ts'])).toEqual(['tests']);
+		expect(categoriesFor(['package.json'])).toEqual(['config']);
+		expect(categoriesFor(['src/lib/config/legal.ts'])).toEqual(['branding']);
+	});
+
+	it('returns multiple distinct categories and none for unrelated files', () => {
+		const cats = categoriesFor(['src/i18n/de.json', 'src/lib/convex/auth.ts', 'README.md']);
+		expect(cats).toContain('i18n');
+		expect(cats).toContain('backend');
+		expect(cats).toHaveLength(2);
+		expect(categoriesFor(['src/lib/components/Button.svelte'])).toEqual([]);
+	});
+});

--- a/.agents/skills/upstream-sync/scripts/list-upstream-changes.ts
+++ b/.agents/skills/upstream-sync/scripts/list-upstream-changes.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+/**
+ * list-upstream-changes.ts — list upstream commits to review for this fork.
+ *
+ * Lists every upstream commit since the last sync (or the fork point) so EACH can
+ * be reviewed, understood, and consciously integrated or excluded. This is not a
+ * security-only tool: all enhancements are candidates. Each commit gets a priority
+ * tag (security highest) and the divergence categories it touches, but nothing is
+ * filtered out by default — comprehensive review is the goal.
+ *
+ * Unit of review = the squashed first-parent commit on upstream's default branch.
+ * Upstream squash-merges PRs, so each commit is the canonical, net, reviewed unit
+ * of "what landed"; do NOT drop to pre-squash branch commits (intra-PR churn, worse
+ * signal). For an oversized commit, triage WITHIN it by file/hunk.
+ *
+ * Read-only: prints only, never writes. Commits are listed oldest-first, which is
+ * the dependency/integration order.
+ *
+ * Usage:
+ *   bun skills/upstream-sync/scripts/list-upstream-changes.ts [--json] [--type <t>] [--tag security]
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseArgs } from 'node:util';
+
+const MARKER = '.upstream-sync.json';
+const SCRUBBED = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_OBJECT_DIRECTORY'];
+function gitEnv(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	for (const k of SCRUBBED) delete env[k];
+	return env;
+}
+function git(args: string[], allowFail = false): string {
+	try {
+		return execFileSync('git', args, {
+			encoding: 'utf-8',
+			env: gitEnv(),
+			maxBuffer: 64 * 1024 * 1024
+		}).trim();
+	} catch (err) {
+		if (allowFail) return '';
+		throw err;
+	}
+}
+
+// Divergence categories: which fork-divergence area a changed path belongs to.
+// Generic shapes, not fork specifics — used to flag commits that need adaptation.
+const CATEGORY_RULES: Array<[string, RegExp]> = [
+	['i18n', /^src\/i18n\/|\bmessages?\/|\.ftl$/],
+	['theme', /layout\.css$|app\.css$|tailwind|theme|design-?tokens|design-?system/i],
+	[
+		'env/deploy',
+		/^\.env|wrangler|vercel|fly\.|dockerfile|^scripts\/deploy|convex\.config|\.github\/workflows\//i
+	],
+	['branding', /legal|brand|marketing|logo|seo|manifest|favicon/i],
+	['backend', /^src\/lib\/convex\/|^convex\//],
+	['tests', /(^|\/)e2e\/|\.test\.|\.spec\./],
+	[
+		'config',
+		/package\.json$|tsconfig|eslint|oxlint|\.prettier|knip|components\.json$|svelte\.config/i
+	]
+];
+export function categoriesFor(files: string[]): string[] {
+	const hit = new Set<string>();
+	for (const f of files) for (const [cat, re] of CATEGORY_RULES) if (re.test(f)) hit.add(cat);
+	return [...hit];
+}
+
+// Security signals. Lean toward catching (this is a review-all tool, so a missed
+// tag is worse than an early look): keep secret/credential handling. Only "injection"
+// is qualified, because bare "injection" matches the common phrase "dependency
+// injection" and would mis-tag ordinary refactors.
+const SECURITY_RE =
+	/\b(cve-\d+|vulnerab(?:le|ility)|\brce\b|\bxss\b|\bcsrf\b|\bssrf\b|auth(?:n|z)?[ -]?bypass|(?:sql|code|command|html|ldap|xpath|template|header|prompt)[ -]?injection|sanitiz(?:e|ation|ing)|secret|credential|exfiltrat)\b/;
+
+export function classify(subject: string, author: string): { priority: string; type: string } {
+	const s = subject.toLowerCase();
+	const security =
+		/\[security\]/.test(s) || SECURITY_RE.test(s) || /^(fix|chore|sec)\((auth|security)\)/.test(s);
+	const m = subject.match(/^(\w+)(\([^)]*\))?!?:/);
+	const type = m ? m[1].toLowerCase() : 'other';
+	const isBot = /(renovate|dependabot)\[bot\]/i.test(author);
+	// Bot dependency bumps are routine chores even when typed fix(deps); only a real
+	// security signal lifts them above chore.
+	const priority = security ? 'security' : isBot ? 'chore' : type === 'fix' ? 'fix' : type;
+	return { priority, type };
+}
+
+function main() {
+	const { values } = parseArgs({
+		args: Bun.argv.slice(2),
+		options: {
+			json: { type: 'boolean', default: false },
+			type: { type: 'string' },
+			tag: { type: 'string' }
+		},
+		strict: false
+	});
+
+	const root = git(['rev-parse', '--show-toplevel']);
+	let marker: Record<string, unknown> | null = null;
+	if (existsSync(join(root, MARKER))) {
+		try {
+			marker = JSON.parse(readFileSync(join(root, MARKER), 'utf-8'));
+		} catch {
+			marker = null;
+		}
+	}
+	let base = (marker?.lastSynced as string) || (marker?.forkPoint as string);
+	if (!base) {
+		// First run, no marker yet: derive the fork point from the sibling script.
+		console.error('No marker yet — deriving fork point via find-fork-point.ts ...');
+		const out = execFileSync('bun', [join(import.meta.dir, 'find-fork-point.ts'), '--json'], {
+			encoding: 'utf-8',
+			env: gitEnv(),
+			maxBuffer: 16 * 1024 * 1024
+		});
+		base = JSON.parse(out).forkPoint;
+	}
+	git(['fetch', '--quiet', 'upstream'], true);
+
+	const excluded = new Set(((marker?.excluded as Array<{ sha?: string }>) || []).map((e) => e.sha));
+
+	// Oldest-first first-parent squash commits since base; %x09 = tab field sep.
+	const raw = git([
+		'log',
+		'--no-merges',
+		'--first-parent',
+		'--reverse',
+		'--format=%h%x09%an%x09%s',
+		`${base}..upstream/main`
+	]);
+	const rows = raw ? raw.split('\n') : [];
+
+	const commits = rows.map((line) => {
+		const [sha, author, subject] = line.split('\t');
+		const files = git(['show', '--name-only', '--format=', sha], true).split('\n').filter(Boolean);
+		const { priority, type } = classify(subject, author);
+		return {
+			sha,
+			author,
+			subject,
+			type,
+			priority,
+			files: files.length,
+			categories: categoriesFor(files),
+			alreadyExcluded: excluded.has(sha)
+		};
+	});
+
+	let view = commits;
+	if (values.type) view = view.filter((c) => c.type === values.type);
+	if (values.tag) view = view.filter((c) => c.priority === values.tag || c.type === values.tag);
+
+	if (values.json) {
+		console.log(JSON.stringify({ base, count: view.length, commits: view }, null, 2));
+		return;
+	}
+
+	const byPriority: Record<string, number> = {};
+	for (const c of commits) byPriority[c.priority] = (byPriority[c.priority] || 0) + 1;
+
+	console.log('');
+	console.log(
+		`Upstream commits to review (oldest first = integration order), since ${base.slice(0, 8)}:`
+	);
+	console.log(
+		`Total ${commits.length}  ·  ` +
+			Object.entries(byPriority)
+				.map(([k, v]) => `${k}:${v}`)
+				.join('  ')
+	);
+	console.log(
+		'Review EVERY commit by reading its diff — integrate, mark already-present, or exclude with a reason.'
+	);
+	console.log(
+		'Tags/categories are hints only (ordering + how much adaptation), never a gate: do not skip, integrate, or exclude a commit from its label.'
+	);
+	console.log('');
+	for (const c of view) {
+		const tag = c.priority === 'security' ? '🔒security' : c.priority;
+		const cats = c.categories.length ? ` [${c.categories.join(',')}]` : '';
+		const ex = c.alreadyExcluded ? ' (already excluded)' : '';
+		console.log(
+			`${c.sha}  ${tag.padEnd(10)} ${String(c.files).padStart(3)}f${cats}  ${c.subject}${ex}`
+		);
+	}
+	console.log('');
+	console.log(
+		'A category flags a fork-divergence area to adapt carefully. NO category is not a free pass —'
+	);
+	console.log(
+		'still read the diff and give that commit a verdict; never blind-apply an untagged one.'
+	);
+	console.log('Oversized commit? Triage within it by file/hunk, not by pre-squash branch commits.');
+}
+
+// Only run when invoked directly, so importing this module (e.g. from tests) does
+// not trigger the git fetch / network side effects in main().
+if (import.meta.main) main();

--- a/.claude/skills/upstream-sync
+++ b/.claude/skills/upstream-sync
@@ -1,1 +1,1 @@
-../../skills/upstream-sync
+../../.agents/skills/upstream-sync

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -31,6 +31,11 @@
 			"source": "stickerdaniel/linkedin-mcp-server",
 			"sourceType": "github",
 			"computedHash": "c148529762a856a8f08a4db4b08c1bf7409281347d545f022e04a8e301af6868"
+		},
+		"upstream-sync": {
+			"source": "/Users/daniel/Documents/development/svelte/saas-starter.worktrees/chore-register-upstream-sync/skills/upstream-sync",
+			"sourceType": "local",
+			"computedHash": "38b10bb7432b76649048ee4e9333255373164392c60607964de47d4009f3213f"
 		}
 	}
 }


### PR DESCRIPTION
Register the existing upstream-sync workflow through the Skills CLI so Codex and Claude Code discover the same project skill. The universal skill copy lives under `.agents/skills`, while Claude follows the generated symlink.\n\nVerified with the upstream-sync unit tests and `npx skills list --json`.