### PR TITLE
fix(dx): Guard preview-admin seed against local backends

### DIFF
--- a/src/lib/convex/previewDev.ts
+++ b/src/lib/convex/previewDev.ts
@@ -31,7 +31,10 @@ async function findUserByEmail(ctx: MutationCtx, email: string): Promise<BetterA
 	return (user as BetterAuthUser | null) ?? null;
 }
 
-// Invoked by preview deploy script (scripts/deploy.ts)
+// Invoked by preview deploy script (scripts/deploy.ts). NOT for local dev:
+// `bun run dev` already seeds admin@local.dev via localDev:ensureSeededAdmin;
+// running this locally would create a second, pointless admin. The guard
+// below makes that mistake loud.
 export const ensurePreviewAdmin = internalMutation({
 	args: {},
 	returns: v.object({
@@ -41,6 +44,16 @@ export const ensurePreviewAdmin = internalMutation({
 		skipped: v.boolean()
 	}),
 	handler: async (ctx) => {
+		// Mirror of the localDev guard: each seeder refuses to run in the other's
+		// environment, so grabbing the wrong one fails with a pointer instead of
+		// silently minting an extra admin.
+		if (process.env.LOCAL_CONVEX_DEV === 'true') {
+			throw new Error(
+				'previewDev:ensurePreviewAdmin is for preview deployments only. ' +
+					'On a local dev backend the admin is already seeded by ' +
+					'localDev:ensureSeededAdmin — sign in as admin@local.dev.'
+			);
+		}
 		const password = process.env.PREVIEW_ADMIN_PASSWORD?.trim();
 		if (!password) {
 			throw new Error(


### PR DESCRIPTION
The two admin seeders mirror each other's environments but only one direction is guarded: `localDev:ensureSeededAdmin` refuses to run outside `LOCAL_CONVEX_DEV=true`, while `previewDev:ensurePreviewAdmin` happily runs on a local backend. Someone reaching for the wrong seeder sets `PREVIEW_ADMIN_PASSWORD` by hand and silently mints a second, pointless admin next to the automatically seeded `admin@local.dev` — exactly that happened in a downstream fork session.

The preview seeder now fails fast where `LOCAL_CONVEX_DEV=true` with a message pointing at the already-seeded local admin, mirroring the existing inverse guard in `localDev.ts`, and its invocation comment names the local counterpart. Both seeders' behavior in their own environments is unchanged; verified with static checks and the Convex typecheck.

Regression guard: not warranted — the change is a single environment guard whose failure mode is a thrown error with instructions; both seeders are unchanged in their own environments.
