### PR TITLE
fix(cache): Mark authenticated HTML private at the origin

### DIFF
--- a/scripts/authenticated-cache-control.test.ts
+++ b/scripts/authenticated-cache-control.test.ts
@@ -1,0 +1,38 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Convention guard on top of the behavioral tests in
+ * src/lib/server/cache-control.test.ts: every `public` Cache-Control the
+ * policy module sets must sit in a branch guarded by the absence of a session
+ * token, so a refactor cannot accidentally serve authenticated documents as
+ * publicly cacheable. The response-level assertions live in the co-located
+ * unit test; this scan only pins the guard convention.
+ */
+
+const policySource = fs.readFileSync(path.resolve('src/lib/server/cache-control.ts'), 'utf-8');
+
+describe('cache-control guard convention', () => {
+	it('gates every public cache-control on the absence of a session token', () => {
+		const publicSets = [
+			...policySource.matchAll(/response\.headers\.set\('Cache-Control', 'public[^']*'\)/g)
+		];
+		expect(publicSets.length).toBeGreaterThan(0);
+		for (const match of publicSets) {
+			const before = policySource.slice(0, match.index);
+			const guardStart = Math.max(before.lastIndexOf('if ('), before.lastIndexOf('} else if ('));
+			const guard = policySource.slice(guardStart, policySource.indexOf(') {', guardStart));
+			expect(
+				guard,
+				`public Cache-Control at offset ${match.index} lacks a !event.locals.token guard`
+			).toContain('!event.locals.token');
+		}
+	});
+
+	it('keeps the hook delegating to the tested policy module', () => {
+		const hooksSource = fs.readFileSync(path.resolve('src/hooks.server.ts'), 'utf-8');
+		expect(hooksSource).toContain("from '$lib/server/cache-control'");
+		expect(hooksSource).toContain('applyCacheControl(event, response)');
+	});
+});

--- a/scripts/patch-cf-worker.test.ts
+++ b/scripts/patch-cf-worker.test.ts
@@ -153,20 +153,20 @@ describe('patch-cf-worker', () => {
 		expect(result).not.toContain('$1.ASSETS');
 	});
 
-	it('stays in sync with the handleCacheControl header in hooks.server.ts', () => {
-		// The injected worker header and the SSR hook header are the same policy
+	it('stays in sync with the applyCacheControl header in cache-control.ts', () => {
+		// The injected worker header and the SSR policy header are the same policy
 		// declared in two places; if they drift, prerendered and SSR marketing
 		// pages silently diverge in cache behavior.
 		const result = applyMarkdownPatch(WORKER_FIXTURE)!;
 		const injected = result.match(/res\.headers\.set\("Cache-Control", "([^"]+)"\)/)?.[1];
 		expect(injected).toBeTruthy();
 
-		const hooksSource = fs.readFileSync(path.resolve('src/hooks.server.ts'), 'utf-8');
+		const policySource = fs.readFileSync(path.resolve('src/lib/server/cache-control.ts'), 'utf-8');
 		// Isolate the marketing branch (matchPublicMarketingRoute up to its Vary
 		// header) so the auth-group branch cannot mask a drifted marketing value.
-		const marketingBranch = hooksSource.slice(
-			hooksSource.indexOf('matchPublicMarketingRoute(event.url.pathname)'),
-			hooksSource.indexOf("response.headers.set('Vary', 'Accept')")
+		const marketingBranch = policySource.slice(
+			policySource.indexOf('matchPublicMarketingRoute(event.url.pathname)'),
+			policySource.indexOf("response.headers.set('Vary', 'Accept')")
 		);
 		expect(marketingBranch).toContain(`'Cache-Control', '${injected}'`);
 	});

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -9,6 +9,7 @@ import {
 } from '$lib/marketing/public-routes';
 import { createMarketingMarkdownResponse, isMarkdownRequest } from '$lib/markdown/marketing';
 import { devNotice } from '$lib/dev/notice';
+import { applyCacheControl } from '$lib/server/cache-control';
 import { decodeJwtPayload } from '$lib/server/jwt';
 import { resolveConvexToken } from '$lib/server/convex-jwt';
 import { loadSentry } from '$lib/monitoring/sentry';
@@ -230,43 +231,7 @@ const authFirstPattern: Handle = async function authFirstPattern({ event, resolv
  */
 const handleCacheControl: Handle = async function handleCacheControl({ event, resolve }) {
 	const response = await resolve(event);
-
-	if (
-		response.status === 200 &&
-		!event.locals.token &&
-		matchPublicMarketingRoute(event.url.pathname)
-	) {
-		// Marketing HTML shells reference content-hashed JS chunks. A cached shell
-		// that survives a deploy points at chunks the new asset set no longer
-		// serves, preventing hydration and arming the client-side recovery
-		// backstop. no-cache keeps every reuse conditional (a 304 keeps
-		// revalidation cheap) and, unlike the previous max-age=0 + s-maxage combo,
-		// leaves the response non-edge-cacheable — so a fixed zone Browser Cache
-		// TTL (default 4h) cannot rewrite the browser-facing max-age back up to
-		// 14400, which it does to any edge-cacheable response and which let stale
-		// shells sit in browsers for hours after a deploy. Immutable assets remain
-		// long-cacheable. This string must stay in sync with the prerendered
-		// marketing HTML header in scripts/patch-cf-worker.ts.
-		response.headers.set('Cache-Control', 'public, no-cache');
-		// These URLs also serve markdown via Accept header. CF edge ignores Vary, so
-		// this is safe only because every route reaching this branch is non-prerendered
-		// and the markdown variant is private (kept out of shared caches).
-		response.headers.set('Vary', 'Accept');
-	} else if (
-		response.status === 200 &&
-		!event.locals.token &&
-		event.route.id?.includes('/(auth)/')
-	) {
-		// Auth-group HTML shells (signin, signup, forgot-password, ...) reference the
-		// same content-hashed chunks as the marketing shells but fell through the
-		// marketing matcher and shipped with no Cache-Control at all, leaving
-		// freshness to cache heuristics. Same policy as the marketing branch: any
-		// reuse must revalidate so a shell never outlives its chunk set. No
-		// Vary: Accept though, these routes have no markdown variant. Matching on
-		// the route group keeps new auth pages covered automatically.
-		response.headers.set('Cache-Control', 'public, no-cache');
-	}
-
+	applyCacheControl(event, response);
 	return response;
 };
 

--- a/src/lib/server/cache-control.test.ts
+++ b/src/lib/server/cache-control.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { applyCacheControl } from './cache-control';
+
+/**
+ * Response-level tests for the document Cache-Control policy (see
+ * scripts/AGENTS.md — a security header needs a hook plus a response test).
+ * The invariant under guard: authenticated HTML must leave the origin with an
+ * explicit `private` policy, because a header-less response lets a downstream
+ * proxy fallback (Caddy/nginx on self-hosted forks) make it shared-cacheable.
+ */
+
+type EventInit = { path?: string; token?: string | null; routeId?: string | null };
+
+function makeEvent({ path = '/en/app', token = null, routeId = null }: EventInit) {
+	return {
+		url: new URL(`https://example.com${path}`),
+		locals: { token },
+		route: { id: routeId }
+	};
+}
+
+function htmlResponse(headers: Record<string, string> = {}, status = 200): Response {
+	return new Response('<!doctype html>', {
+		status,
+		headers: { 'content-type': 'text/html; charset=utf-8', ...headers }
+	});
+}
+
+describe('applyCacheControl', () => {
+	it('marks authenticated HTML private when no policy exists', () => {
+		const response = htmlResponse();
+		applyCacheControl(makeEvent({ token: 'jwt', path: '/en/app' }), response);
+		expect(response.headers.get('cache-control')).toBe('private, no-cache');
+	});
+
+	it('keeps a stricter route-owned policy, regardless of header casing', () => {
+		const response = htmlResponse({ 'Cache-Control': 'no-store' });
+		applyCacheControl(makeEvent({ token: 'jwt' }), response);
+		expect(response.headers.get('cache-control')).toBe('no-store');
+	});
+
+	it('leaves authenticated non-HTML responses untouched', () => {
+		const response = new Response('{}', {
+			headers: { 'content-type': 'application/json' }
+		});
+		applyCacheControl(makeEvent({ token: 'jwt' }), response);
+		expect(response.headers.has('cache-control')).toBe(false);
+	});
+
+	it('leaves unauthenticated non-marketing HTML untouched', () => {
+		const response = htmlResponse();
+		applyCacheControl(makeEvent({ path: '/en/app', routeId: '/[[lang]]/app' }), response);
+		expect(response.headers.has('cache-control')).toBe(false);
+	});
+
+	it('keeps unauthenticated marketing HTML publicly revalidatable', () => {
+		const response = htmlResponse();
+		applyCacheControl(makeEvent({ path: '/en' }), response);
+		expect(response.headers.get('cache-control')).toBe('public, no-cache');
+		expect(response.headers.get('vary')).toBe('Accept');
+	});
+
+	it('keeps unauthenticated auth-group HTML publicly revalidatable', () => {
+		const response = htmlResponse();
+		applyCacheControl(
+			makeEvent({ path: '/en/signin', routeId: '/[[lang]]/(auth)/signin' }),
+			response
+		);
+		expect(response.headers.get('cache-control')).toBe('public, no-cache');
+	});
+
+	it('never marks a token-carrying request public, even on marketing paths', () => {
+		// A signed-in user browsing the landing page still gets the personalized
+		// SSR document (header shows their account), so it must not enter shared
+		// caches.
+		const response = htmlResponse();
+		applyCacheControl(makeEvent({ path: '/en', token: 'jwt' }), response);
+		expect(response.headers.get('cache-control')).toBe('private, no-cache');
+	});
+
+	it('never emits a freshness lifetime on any document', () => {
+		// Document shells reference content-hashed chunks, and the deploy
+		// recovery only covers the running app — SvelteKit has no hook for a
+		// stale shell whose initial entry import 404s. Revalidation on every
+		// reuse is the only guard for that path, so no branch may ever grant a
+		// max-age/s-maxage window during which a cached shell can outlive its
+		// chunk set.
+		const cases: EventInit[] = [
+			{ path: '/en' },
+			{ path: '/en/signin', routeId: '/[[lang]]/(auth)/signin' },
+			{ path: '/en/app', token: 'jwt' },
+			{ path: '/en', token: 'jwt' }
+		];
+		for (const init of cases) {
+			const response = htmlResponse();
+			applyCacheControl(makeEvent(init), response);
+			expect(response.headers.get('cache-control') ?? '').not.toMatch(/max-age/i);
+		}
+	});
+});

--- a/src/lib/server/cache-control.ts
+++ b/src/lib/server/cache-control.ts
@@ -1,0 +1,66 @@
+import { matchPublicMarketingRoute } from '$lib/marketing/public-routes';
+
+/**
+ * Cache-Control policy for document responses, applied by the
+ * handleCacheControl hook. Extracted so the policy is testable against real
+ * Response objects; see scripts/AGENTS.md — a security header needs a server
+ * hook plus a response test.
+ */
+export function applyCacheControl(
+	event: { url: URL; locals: { token?: string | null }; route: { id: string | null } },
+	response: Response
+): void {
+	if (
+		response.status === 200 &&
+		!event.locals.token &&
+		matchPublicMarketingRoute(event.url.pathname)
+	) {
+		// Marketing HTML shells reference content-hashed JS chunks. A cached shell
+		// that survives a deploy points at chunks the new asset set no longer
+		// serves, preventing hydration and arming the client-side recovery
+		// backstop. no-cache keeps every reuse conditional (a 304 keeps
+		// revalidation cheap) and, unlike the previous max-age=0 + s-maxage combo,
+		// leaves the response non-edge-cacheable — so a fixed zone Browser Cache
+		// TTL (default 4h) cannot rewrite the browser-facing max-age back up to
+		// 14400, which it does to any edge-cacheable response and which let stale
+		// shells sit in browsers for hours after a deploy. Immutable assets remain
+		// long-cacheable. This string must stay in sync with the prerendered
+		// marketing HTML header in scripts/patch-cf-worker.ts.
+		//
+		// Revalidation is load-bearing, not an optimization detail: the deploy
+		// recovery (version poll, beforeNavigate guard, vite:preloadError reload)
+		// only covers the running app. SvelteKit has no mechanism for the initial
+		// document load — a stale shell whose entry import 404s dies before any
+		// listener exists. Never widen this to a max-age.
+		response.headers.set('Cache-Control', 'public, no-cache');
+		// These URLs also serve markdown via Accept header. CF edge ignores Vary, so
+		// this is safe only because every route reaching this branch is non-prerendered
+		// and the markdown variant is private (kept out of shared caches).
+		response.headers.set('Vary', 'Accept');
+	} else if (
+		response.status === 200 &&
+		!event.locals.token &&
+		event.route.id?.includes('/(auth)/')
+	) {
+		// Auth-group HTML shells (signin, signup, forgot-password, ...) reference the
+		// same content-hashed chunks as the marketing shells but fell through the
+		// marketing matcher and shipped with no Cache-Control at all, leaving
+		// freshness to cache heuristics. Same policy as the marketing branch: any
+		// reuse must revalidate so a shell never outlives its chunk set. No
+		// Vary: Accept though, these routes have no markdown variant. Matching on
+		// the route group keeps new auth pages covered automatically.
+		response.headers.set('Cache-Control', 'public, no-cache');
+	} else if (
+		event.locals.token &&
+		response.headers.get('content-type')?.includes('text/html') &&
+		!response.headers.has('cache-control')
+	) {
+		// Authenticated documents serialize viewer data into the HTML. Without an
+		// explicit header they leave freshness AND shareability to whatever sits
+		// in front of the origin; a self-hosted fork adding a well-meaning
+		// proxy-level Cache-Control fallback (Caddy/nginx) would otherwise make
+		// them shared-cacheable. Declare private at the origin so no downstream
+		// fallback can widen them.
+		response.headers.set('Cache-Control', 'private, no-cache');
+	}
+}


### PR DESCRIPTION
Authenticated documents serialize viewer data (name, email, avatar) into the HTML, but `handleCacheControl` set no Cache-Control on them at all — only unauthenticated marketing and auth shells got a header. That leaves shareability to whatever sits in front of the origin. On CF Workers this is currently harmless, but a self-hosted fork putting Caddy or nginx in front of the origin and adding a well-meaning header fallback for prerendered HTML (which arrives header-less by design) fills exactly that gap and silently turns authenticated pages shared-cacheable. This is not hypothetical: our fork hit precisely this with a Caddy fallback rule during the last template sync.

The document cache policy moves into an `applyCacheControl` helper the hook delegates to, which declares `private, no-cache` on authenticated HTML when no stricter header already exists, so a downstream fallback can never widen it, and route handlers that set their own policy (e.g. `no-store`) keep it. Response-level tests cover the behavior against real Response objects (private on authenticated HTML, stricter policies preserved regardless of header casing, non-HTML and non-marketing responses untouched, marketing and auth shells still publicly revalidatable, and a token-carrying request never public even on marketing paths); a source-scan guard additionally pins every public branch to the absence of a session token.

Regression guard: added src/lib/server/cache-control.test.ts

Verified with the new response-level spec, the convention guard, and the updated patch-cf-worker sync tests (32 passing) plus file-scoped static checks.


