### PR TITLE
docs(agents): Drop --delete-branch from the merge command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ The pre-commit hook intentionally runs fast staged lint only, so commit freely w
 
 For reviews and audits, fetch and inspect `origin/main` rather than the shared main checkout, which may intentionally lag behind. Revalidate every finding against that baseline before reporting or changing code.
 
-Open PRs as drafts because ready PRs can auto-merge. Mark a PR ready only after all follow-up work is done, then run `gh pr merge <n> --squash --auto --delete-branch`.
+Open PRs as drafts because ready PRs can auto-merge. Mark a PR ready only after all follow-up work is done, then run `gh pr merge <n> --squash --auto` without `--delete-branch`: the repository deletes merged branches itself, which lets GitHub retarget the next stacked PR onto the merged base. An explicit `--delete-branch` deletes the branch outside the merge flow and force-closes dependent stacked PRs instead. After each merge in a stack, rebase the retargeted PR onto the new base before merging it.
 
 Except for truly small UI-only or docs-only changes, monitor the branch through green required CI, merge it, and verify a green production deployment. If a required check fails, read its provider logs and guide it to green; never override an unexplained failure.
 


### PR DESCRIPTION
Merging the bottom of a stacked PR chain with `gh pr merge --squash --auto --delete-branch` force-closes the next stacked PR: the CLI deletes the branch as a separate API call outside the merge flow, which skips GitHub's automatic base change for dependent PRs (timeline shows `base_ref_deleted` → `closed`). The repository's `delete_branch_on_merge` setting already deletes merged branches inside the merge flow — exactly the path that triggers the automatic retargeting. Seen live in a downstream fork; without the flag the dependent PR was retargeted onto main as intended.

The merge instruction now says to merge without `--delete-branch` and to rebase the retargeted PR onto the new base after each merge in a stack.

Regression guard: not warranted — documentation-only change.