### PR TITLE
feat(chat): Compact pill composer and field-sizing autosize

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -536,7 +536,8 @@
 		},
 		"tooltip": {
 			"attach_files": "Dateien anhängen",
-			"mark_bug": "Fehler markieren"
+			"mark_bug": "Fehler markieren",
+			"more_actions": "Weitere Aktionen"
 		}
 	},
 	"common": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -536,7 +536,8 @@
 		},
 		"tooltip": {
 			"attach_files": "Attach files",
-			"mark_bug": "Mark the bug"
+			"mark_bug": "Mark the bug",
+			"more_actions": "More actions"
 		}
 	},
 	"common": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -536,7 +536,8 @@
 		},
 		"tooltip": {
 			"attach_files": "Adjuntar archivos",
-			"mark_bug": "Marcar el error"
+			"mark_bug": "Marcar el error",
+			"more_actions": "Más acciones"
 		}
 	},
 	"common": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -536,7 +536,8 @@
 		},
 		"tooltip": {
 			"attach_files": "Joindre des fichiers",
-			"mark_bug": "Marquer le bug"
+			"mark_bug": "Marquer le bug",
+			"more_actions": "Plus d’actions"
 		}
 	},
 	"common": {

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -738,7 +738,7 @@
 	     put when the field grows — no radius jump between layouts. -->
 	<PromptInput
 		class={compact
-			? `relative z-20 rounded-[25px] bg-popover ${compactMultiline ? 'p-0' : 'p-1.5'}`
+			? `relative z-20 rounded-[25px] border-0 bg-popover shadow-none ${compactMultiline ? 'p-0' : 'p-1.5'}`
 			: 'relative z-20 bg-popover p-0'}
 		value={ctx.inputValue}
 		isLoading={ctx.core.isSending}
@@ -792,13 +792,10 @@
 						/>
 						{#if !ctx.inputValue}
 							<!-- Decorative rotating hint; the textarea carries the accessible name. -->
-							<div
-								class="pointer-events-none absolute inset-0 overflow-hidden px-1"
-								aria-hidden="true"
-							>
+							<div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
 								{#key visiblePlaceholder}
 									<span
-										class="absolute inset-0 flex items-center truncate text-base leading-5 text-muted-foreground"
+										class="absolute inset-0 flex items-center truncate px-1 text-base leading-5 text-muted-foreground"
 										in:fly={{
 											y: prefersReducedMotion.current ? 0 : 8,
 											duration: prefersReducedMotion.current ? 0 : 180

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -795,7 +795,7 @@
 							<div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
 								{#key visiblePlaceholder}
 									<span
-										class="absolute inset-0 flex items-center truncate px-1 text-base leading-5 text-muted-foreground"
+										class="absolute inset-0 flex items-center truncate px-1 text-base leading-5 text-muted-foreground md:text-sm"
 										in:fly={{
 											y: prefersReducedMotion.current ? 0 : 8,
 											duration: prefersReducedMotion.current ? 0 : 180

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { tick, type Snippet } from 'svelte';
+	import { onDestroy, tick, type Snippet } from 'svelte';
+	import { prefersReducedMotion } from 'svelte/motion';
+	import { fly } from 'svelte/transition';
 	import { toast } from 'svelte-sonner';
 	import { getTranslate } from '@tolgee/svelte';
 	import {
@@ -11,10 +13,13 @@
 	import { PromptSuggestion } from '$lib/components/prompt-kit/prompt-suggestion';
 	import { FileUpload, FileUploadTrigger } from '$lib/components/prompt-kit/file-upload';
 	import { Button } from '$lib/components/ui/button';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import CameraIcon from '@lucide/svelte/icons/camera';
+	import ImageIcon from '@lucide/svelte/icons/image';
 	import PaperclipIcon from '@lucide/svelte/icons/paperclip';
+	import PlusIcon from '@lucide/svelte/icons/plus';
 	import ChatAttachments from './ChatAttachments.svelte';
 	import { haptic } from '$lib/hooks/use-haptic.svelte';
 	import { getChatUIContext } from './chat-context.svelte.js';
@@ -37,9 +42,12 @@
 		suggestions = [],
 		placeholder = 'Type a message...',
 		placeholderNoSuggestions,
+		placeholders = [],
+		inputLabel,
 		showCameraButton = false,
 		showFileButton = true,
 		showHandoffButton = false,
+		compact = false,
 		isHandedOff = false,
 		isRateLimited = false,
 		onScreenshot,
@@ -55,12 +63,18 @@
 		placeholder?: string;
 		/** Placeholder text when suggestions are not visible */
 		placeholderNoSuggestions?: string;
+		/** Placeholder copy to rotate through in compact mode */
+		placeholders?: string[];
+		/** Accessible input name when it differs from the visible placeholder */
+		inputLabel?: string;
 		/** Whether to show camera/screenshot button */
 		showCameraButton?: boolean;
 		/** Whether to show file upload button */
 		showFileButton?: boolean;
 		/** Whether to show the handoff to human button */
 		showHandoffButton?: boolean;
+		/** Whether to use the compact single-row composer */
+		compact?: boolean;
 		/** Whether thread is already handed off to humans */
 		isHandedOff?: boolean;
 		/** Whether user is rate limited from sending messages */
@@ -81,7 +95,12 @@
 
 	const ctx = getChatUIContext();
 
-	let containerEl: HTMLDivElement;
+	let containerEl = $state<HTMLDivElement>();
+	let fileInputEl = $state<HTMLInputElement>();
+	let placeholderIndex = $state(0);
+	let placeholderTimer: ReturnType<typeof setInterval> | undefined;
+	const focusComposer = () => containerEl?.querySelector<HTMLTextAreaElement>('textarea')?.focus();
+	ctx.registerComposerFocus(focusComposer);
 
 	// Use centralized isProcessing from context (single source of truth)
 	// When handed off to human support, don't block - use fire-and-forget pattern
@@ -97,6 +116,67 @@
 	const activePlaceholder = $derived(
 		showSuggestions ? placeholder : (placeholderNoSuggestions ?? placeholder)
 	);
+	// Compact mode rotates through the caller's suggestion copy as vanishing hints.
+	const rotatingPlaceholders = $derived(compact ? placeholders : []);
+	// Content-based key so the index only resets when the copy actually changes
+	// (locale or thread switch), not on every re-derivation of the same list.
+	const placeholderKey = $derived(rotatingPlaceholders.join(''));
+	const visiblePlaceholder = $derived(
+		rotatingPlaceholders.length > 0
+			? rotatingPlaceholders[placeholderIndex % rotatingPlaceholders.length]
+			: activePlaceholder
+	);
+	// A stable accessible name for the compact field; the rotating hint is decorative.
+	const composerLabel = $derived(inputLabel ?? placeholderNoSuggestions ?? placeholder);
+	// Pause rotation while typing, under reduced motion, or with fewer than two hints.
+	const canRotate = $derived(
+		compact && rotatingPlaceholders.length >= 2 && !ctx.inputValue && !prefersReducedMotion.current
+	);
+
+	function stopPlaceholderRotation() {
+		if (placeholderTimer !== undefined) {
+			clearInterval(placeholderTimer);
+			placeholderTimer = undefined;
+		}
+	}
+
+	function startPlaceholderRotation() {
+		stopPlaceholderRotation();
+		if (document.visibilityState !== 'visible') return;
+		placeholderTimer = setInterval(() => {
+			placeholderIndex = (placeholderIndex + 1) % rotatingPlaceholders.length;
+		}, 3000);
+	}
+
+	function handleVisibilityChange() {
+		if (document.visibilityState === 'visible' && canRotate) startPlaceholderRotation();
+		else stopPlaceholderRotation();
+	}
+
+	$effect(() => {
+		if (!canRotate) {
+			stopPlaceholderRotation();
+			return;
+		}
+		startPlaceholderRotation();
+		return stopPlaceholderRotation;
+	});
+
+	// Restart from the first hint whenever the rotation copy changes.
+	$effect(() => {
+		void placeholderKey;
+		placeholderIndex = 0;
+	});
+
+	$effect(() => {
+		document.addEventListener('visibilitychange', handleVisibilityChange);
+		return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+	});
+
+	onDestroy(() => {
+		stopPlaceholderRotation();
+		ctx.unregisterComposerFocus(focusComposer);
+	});
 
 	// Check if last assistant message is complete (for handoff button visibility)
 	const lastAssistantComplete = $derived.by(() => {
@@ -151,6 +231,120 @@
 
 	function handleCameraClick() {
 		onScreenshot?.();
+	}
+
+	function openFilePicker() {
+		fileInputEl?.click();
+	}
+
+	function handleFileInput(event: Event) {
+		const input = event.currentTarget as HTMLInputElement;
+		void handleFilesAdded(Array.from(input.files ?? []));
+		input.value = '';
+	}
+
+	// Compact layout switches ChatGPT-style once the text wraps: the pill
+	// (rounded-full, inline actions) becomes a rounded box with the action row
+	// below the textarea. Wrapping is detected from the textarea's scrollHeight
+	// vs its single-line height, re-measured on every input/layout change.
+	let compactWrapper: HTMLDivElement | undefined = $state();
+	let compactMultiline = $state(false);
+	// True once the textarea content exceeds its max height and starts to
+	// scroll internally; the overflowing text then fades into the composer
+	// background at both edges instead of clipping hard.
+	let compactScrollable = $state(false);
+	// Wrap detection must not read the textarea's live geometry: switching the
+	// layout changes the field's width (inline actions vs full row), so the same
+	// text can wrap in the pill but fit expanded — geometry-based checks
+	// oscillate at that boundary. Instead the text is measured with canvas
+	// measureText against the width the field has IN THE PILL layout; that
+	// reference width is layout-independent, so the decision is stable.
+	let measureCanvas: CanvasRenderingContext2D | null = null;
+	function textNeedsWrap(textarea: HTMLTextAreaElement, pillWidth: number): boolean {
+		const value = textarea.value;
+		if (!value) return false;
+		if (value.includes('\n')) return true;
+		measureCanvas ??= document.createElement('canvas').getContext('2d');
+		if (!measureCanvas) return textarea.scrollHeight > 44;
+		const s = getComputedStyle(textarea);
+		measureCanvas.font = `${s.fontStyle} ${s.fontWeight} ${s.fontSize} ${s.fontFamily}`;
+		return measureCanvas.measureText(value).width > pillWidth;
+	}
+
+	// The pill-layout text width: wrapper minus both inline action bars and the
+	// horizontal paddings. Captured while in the pill; kept as the reference
+	// while expanded so the decision does not depend on the current layout.
+	let pillTextWidth = 0;
+
+	$effect(() => {
+		if (!compact || !compactWrapper || typeof ResizeObserver === 'undefined') return;
+		const wrapper = compactWrapper;
+		const measure = () => {
+			const textarea = wrapper.querySelector<HTMLTextAreaElement>('textarea');
+			if (!textarea) return;
+			if (!compactMultiline) {
+				// Only re-capture the reference width while the pill is showing.
+				pillTextWidth = textarea.clientWidth - 10;
+			}
+			compactMultiline = pillTextWidth > 0 && textNeedsWrap(textarea, pillTextWidth);
+			compactScrollable = textarea.scrollHeight > textarea.clientHeight + 1;
+		};
+		measure();
+		const observer = new ResizeObserver(measure);
+		observer.observe(wrapper);
+		return () => observer.disconnect();
+	});
+
+	// Re-measure after every value change once the DOM settled — covers typing,
+	// paste, draft restore, and ?prompt= prefill alike.
+	$effect(() => {
+		if (!compact) return;
+		void ctx.inputValue;
+		tick().then(() => {
+			const textarea = compactWrapper?.querySelector<HTMLTextAreaElement>('textarea');
+			if (!textarea) return;
+			if (!compactMultiline) pillTextWidth = textarea.clientWidth - 10;
+			compactMultiline = pillTextWidth > 0 && textNeedsWrap(textarea, pillTextWidth);
+			compactScrollable = textarea.scrollHeight > textarea.clientHeight + 1;
+		});
+	});
+
+	// Window-level drag/drop for the compact composer. The non-compact path gets
+	// this from <FileUpload>; the compact path handles it here so a dropped file
+	// attaches (and, critically, so the browser doesn't navigate away to open it).
+	let dragActive = $state(false);
+	let dragDepth = 0;
+	const dropEnabled = $derived(compact && showFileButton && !isRateLimited);
+
+	function handleWindowDragEnter(event: DragEvent) {
+		if (!dropEnabled) return;
+		event.preventDefault();
+		dragDepth += 1;
+		if (event.dataTransfer?.types.includes('Files')) dragActive = true;
+	}
+
+	function handleWindowDragOver(event: DragEvent) {
+		if (!dropEnabled) return;
+		event.preventDefault();
+	}
+
+	function handleWindowDragLeave(event: DragEvent) {
+		if (!dropEnabled) return;
+		event.preventDefault();
+		dragDepth -= 1;
+		if (dragDepth <= 0) {
+			dragDepth = 0;
+			dragActive = false;
+		}
+	}
+
+	function handleWindowDrop(event: DragEvent) {
+		if (!dropEnabled) return;
+		event.preventDefault();
+		dragDepth = 0;
+		dragActive = false;
+		const files = event.dataTransfer?.files;
+		if (files?.length) void handleFilesAdded(Array.from(files));
 	}
 
 	/**
@@ -363,6 +557,155 @@
 	}
 </script>
 
+<svelte:window
+	ondragenter={handleWindowDragEnter}
+	ondragover={handleWindowDragOver}
+	ondragleave={handleWindowDragLeave}
+	ondrop={handleWindowDrop}
+/>
+
+{#snippet leftActions()}
+	<div class="flex items-center gap-2">
+		{#if actionsLeft}
+			{@render actionsLeft()}
+		{:else if compact && (showFileButton || showCameraButton)}
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger>
+					{#snippet child({ props })}
+						<Button
+							{...props}
+							variant="ghost"
+							size="icon"
+							class="size-9 rounded-full"
+							aria-label={$t('chat.tooltip.more_actions')}
+						>
+							<PlusIcon class="size-[18px]" aria-hidden="true" />
+						</Button>
+					{/snippet}
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content align="start" side="top" class="w-48">
+					{#if showFileButton}
+						<DropdownMenu.Item onclick={openFilePicker}>
+							<PaperclipIcon class="size-4" aria-hidden="true" />
+							{$t('chat.tooltip.attach_files')}
+						</DropdownMenu.Item>
+					{/if}
+					{#if showCameraButton}
+						<DropdownMenu.Item onclick={handleCameraClick}>
+							<ImageIcon class="size-4" aria-hidden="true" />
+							{$t('chat.tooltip.mark_bug')}
+						</DropdownMenu.Item>
+					{/if}
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+			{#if showFileButton}
+				<!-- Triggered only via the menu / drop; `hidden` keeps it out of the tab
+				     order and the a11y tree. -->
+				<input
+					bind:this={fileInputEl}
+					type="file"
+					multiple
+					accept={ALLOWED_FILE_EXTENSIONS}
+					hidden
+					aria-hidden="true"
+					tabindex="-1"
+					onchange={handleFileInput}
+				/>
+			{/if}
+		{:else}
+			{#if showCameraButton}
+				<PromptInputAction>
+					{#snippet tooltip()}
+						<p>{$t('chat.tooltip.mark_bug')}</p>
+					{/snippet}
+					{#snippet children(props)}
+						<Button
+							{...props}
+							variant="outline"
+							size="icon"
+							class={compact
+								? 'size-9 rounded-full border-0 bg-transparent shadow-none'
+								: 'size-9 rounded-full'}
+							onclick={handleCameraClick}
+							aria-label={$t('chat.tooltip.mark_bug')}
+						>
+							<CameraIcon class="h-[18px] w-[18px]" />
+						</Button>
+					{/snippet}
+				</PromptInputAction>
+			{/if}
+			{#if showFileButton}
+				<FileUpload
+					onFilesAdded={handleFilesAdded}
+					multiple={true}
+					accept={ALLOWED_FILE_EXTENSIONS}
+				>
+					<PromptInputAction>
+						{#snippet tooltip()}
+							<p>{$t('chat.tooltip.attach_files')}</p>
+						{/snippet}
+						{#snippet children(props)}
+							<FileUploadTrigger asChild={true}>
+								<Button
+									{...props}
+									variant="outline"
+									size="icon"
+									class={compact
+										? 'size-9 rounded-full border-0 bg-transparent shadow-none'
+										: 'size-9 rounded-full'}
+									aria-label={$t('chat.tooltip.attach_files')}
+								>
+									<PaperclipIcon class="h-[18px] w-[18px]" />
+								</Button>
+							</FileUploadTrigger>
+						{/snippet}
+					</PromptInputAction>
+				</FileUpload>
+			{/if}
+		{/if}
+	</div>
+{/snippet}
+
+{#snippet rightActions()}
+	{#if actionsRight}
+		{@render actionsRight()}
+	{:else}
+		<div class="flex min-w-0 items-center gap-2">
+			{#if showHandoffButton}
+				{@const isVisible =
+					ctx.core.threadId !== null &&
+					ctx.displayMessages.length > 1 &&
+					!isHandedOff &&
+					hasShownHandoffButton}
+				<div
+					class="min-w-0 transition-opacity duration-200 {isVisible
+						? 'opacity-100'
+						: 'pointer-events-none opacity-0'}"
+					inert={!isVisible ? true : undefined}
+				>
+					<PromptSuggestion class="max-w-full" onclick={() => onRequestHandoff?.()}>
+						<span class="block truncate">{$t('chat.action.talk_to_human')}</span>
+					</PromptSuggestion>
+				</div>
+			{/if}
+			<Button
+				size="icon"
+				disabled={!canSend}
+				onclick={handleSend}
+				class="size-9 shrink-0 rounded-full"
+				aria-label={$t('chat.aria.send')}
+				data-testid="chat-input-send"
+			>
+				{#if ctx.isProcessing && !isHandedOff}
+					<LoaderCircleIcon class="h-[18px] w-[18px] motion-safe:animate-spin" />
+				{:else}
+					<ArrowUpIcon class="h-[18px] w-[18px]" />
+				{/if}
+			</Button>
+		</div>
+	{/if}
+{/snippet}
+
 <div bind:this={containerEl} class={className}>
 	<!-- Suggestion chips - shown when starting new conversation or after messages loaded and empty -->
 	<!-- isNewConversation: show immediately for draft threads (eager creation) -->
@@ -390,120 +733,124 @@
 			{/key}
 		</div>
 	{/if}
+	<!-- Fixed 25px radius: the one-line pill is 48px tall (36px field + 12px
+	     padding) plus its border, so 25px is fully round there and simply stays
+	     put when the field grows — no radius jump between layouts. -->
 	<PromptInput
-		class="relative z-20 bg-popover p-0"
+		class={compact
+			? `relative z-20 rounded-[25px] bg-popover ${compactMultiline ? 'p-0' : 'p-1.5'}`
+			: 'relative z-20 bg-popover p-0'}
 		value={ctx.inputValue}
 		isLoading={ctx.core.isSending}
 		onValueChange={handleValueChange}
 		onSubmit={handleSend}
 	>
-		<div class="flex flex-col">
-			{#if ctx.attachments.length > 0}
-				<ChatAttachments
-					class="mx-3 mt-3"
-					attachments={ctx.attachments}
-					onRemove={handleRemoveAttachment}
-					columns={2}
-				/>
-			{/if}
-
-			<PromptInputTextarea
-				placeholder={activePlaceholder}
-				class="min-h-[44px] pt-3 pl-4 text-base leading-[1.3]"
-				onpaste={handlePaste}
-				maxlength={MAX_MESSAGE_LENGTH}
-			/>
-
-			<PromptInputActions class="mt-5 flex w-full items-center justify-between gap-2 px-3 pb-3">
-				<div class="flex items-center gap-2">
-					{#if actionsLeft}
-						{@render actionsLeft()}
-					{:else}
-						{#if showCameraButton}
-							<PromptInputAction>
-								{#snippet tooltip()}
-									<p>{$t('chat.tooltip.mark_bug')}</p>
-								{/snippet}
-								{#snippet children(props)}
-									<Button
-										{...props}
-										variant="outline"
-										size="icon"
-										class="size-9 rounded-full"
-										onclick={handleCameraClick}
-										aria-label={$t('chat.tooltip.mark_bug')}
-									>
-										<CameraIcon class="h-[18px] w-[18px]" />
-									</Button>
-								{/snippet}
-							</PromptInputAction>
-						{/if}
-						{#if showFileButton}
-							<FileUpload
-								onFilesAdded={handleFilesAdded}
-								multiple={true}
-								accept={ALLOWED_FILE_EXTENSIONS}
-							>
-								<PromptInputAction>
-									{#snippet tooltip()}
-										<p>{$t('chat.tooltip.attach_files')}</p>
-									{/snippet}
-									{#snippet children(props)}
-										<FileUploadTrigger asChild={true}>
-											<Button
-												{...props}
-												variant="outline"
-												size="icon"
-												class="size-9 rounded-full"
-												aria-label={$t('chat.tooltip.attach_files')}
-											>
-												<PaperclipIcon class="h-[18px] w-[18px]" />
-											</Button>
-										</FileUploadTrigger>
-									{/snippet}
-								</PromptInputAction>
-							</FileUpload>
-						{/if}
-					{/if}
-				</div>
-
-				{#if actionsRight}
-					{@render actionsRight()}
-				{:else}
-					<div class="flex min-w-0 items-center gap-2">
-						{#if showHandoffButton}
-							{@const isVisible =
-								ctx.core.threadId !== null &&
-								ctx.displayMessages.length > 1 &&
-								!isHandedOff &&
-								hasShownHandoffButton}
-							<div
-								class="min-w-0 transition-opacity duration-200 {isVisible
-									? 'opacity-100'
-									: 'pointer-events-none opacity-0'}"
-								inert={!isVisible ? true : undefined}
-							>
-								<PromptSuggestion class="max-w-full" onclick={() => onRequestHandoff?.()}>
-									<span class="block truncate">{$t('chat.action.talk_to_human')}</span>
-								</PromptSuggestion>
-							</div>
-						{/if}
-						<Button
-							size="icon"
-							disabled={!canSend}
-							onclick={handleSend}
-							class="size-9 shrink-0 rounded-full"
-							aria-label={$t('chat.aria.send')}
-						>
-							{#if ctx.isProcessing && !isHandedOff}
-								<LoaderCircleIcon class="h-[18px] w-[18px] motion-safe:animate-spin" />
-							{:else}
-								<ArrowUpIcon class="h-[18px] w-[18px]" />
-							{/if}
-						</Button>
+		{#if compact}
+			<div class="relative flex min-w-0 flex-col" bind:this={compactWrapper}>
+				{#if dragActive}
+					<div
+						class="pointer-events-none absolute inset-0 z-30 flex items-center justify-center gap-2 rounded-[25px] bg-popover/90 text-sm font-medium text-muted-foreground backdrop-blur-sm"
+						aria-hidden="true"
+					>
+						<PaperclipIcon class="size-4" />
+						{$t('chat.tooltip.attach_files')}
 					</div>
 				{/if}
-			</PromptInputActions>
-		</div>
+				{#if ctx.attachments.length > 0}
+					<ChatAttachments
+						class="mx-1 mb-1"
+						attachments={ctx.attachments}
+						onRemove={handleRemoveAttachment}
+						columns={2}
+					/>
+				{/if}
+				<!-- Single line: actions inline beside the textarea (pill). Multi-line:
+				     the textarea spans the full width and the actions drop to a row
+				     below (ChatGPT-style). Only the action bars move between branches;
+				     the textarea itself never remounts, so focus and caret survive the
+				     layout switch mid-typing. -->
+				<div class="flex min-w-0 items-end gap-1">
+					{#if !compactMultiline}
+						<PromptInputActions class="shrink-0">
+							{@render leftActions()}
+						</PromptInputActions>
+					{/if}
+					<!-- Expanded: inset the textarea's right edge so its scrollbar sits
+					     where the corner rounding stops instead of colliding with it. -->
+					<div class="relative min-w-0 flex-1 {compactMultiline ? 'pr-1.5' : ''}">
+						<PromptInputTextarea
+							placeholder=""
+							aria-label={composerLabel}
+							class="min-h-9 py-2 text-base leading-5 {compactMultiline
+								? 'pr-2 pl-3'
+								: 'px-1'} {compactScrollable
+								? '[mask-image:linear-gradient(to_bottom,transparent_0,black_20px,black_calc(100%-20px),transparent_100%)]'
+								: ''}"
+							onpaste={handlePaste}
+							maxlength={MAX_MESSAGE_LENGTH}
+							data-testid="chat-input-textarea"
+						/>
+						{#if !ctx.inputValue}
+							<!-- Decorative rotating hint; the textarea carries the accessible name. -->
+							<div
+								class="pointer-events-none absolute inset-0 overflow-hidden px-1"
+								aria-hidden="true"
+							>
+								{#key visiblePlaceholder}
+									<span
+										class="absolute inset-0 flex items-center truncate text-base leading-5 text-muted-foreground"
+										in:fly={{
+											y: prefersReducedMotion.current ? 0 : 8,
+											duration: prefersReducedMotion.current ? 0 : 180
+										}}
+										out:fly={{
+											y: prefersReducedMotion.current ? 0 : -8,
+											duration: prefersReducedMotion.current ? 0 : 140
+										}}
+									>
+										{visiblePlaceholder}
+									</span>
+								{/key}
+							</div>
+						{/if}
+					</div>
+					{#if !compactMultiline}
+						<PromptInputActions class="min-w-0 shrink-0">
+							{@render rightActions()}
+						</PromptInputActions>
+					{/if}
+				</div>
+				{#if compactMultiline}
+					<PromptInputActions class="flex w-full items-center justify-between gap-1 px-1.5 pb-1.5">
+						{@render leftActions()}
+						<div class="flex min-w-0 items-center gap-1">
+							{@render rightActions()}
+						</div>
+					</PromptInputActions>
+				{/if}
+			</div>
+		{:else}
+			<div class="flex flex-col">
+				{#if ctx.attachments.length > 0}
+					<ChatAttachments
+						class="mx-3 mt-3"
+						attachments={ctx.attachments}
+						onRemove={handleRemoveAttachment}
+						columns={2}
+					/>
+				{/if}
+				<PromptInputTextarea
+					placeholder={activePlaceholder}
+					class="min-h-[44px] pt-3 pl-4 text-base leading-[1.3]"
+					onpaste={handlePaste}
+					maxlength={MAX_MESSAGE_LENGTH}
+					data-testid="chat-input-textarea"
+				/>
+				<PromptInputActions class="mt-5 flex w-full items-center justify-between gap-2 px-3 pb-3">
+					{@render leftActions()}
+					{@render rightActions()}
+				</PromptInputActions>
+			</div>
+		{/if}
 	</PromptInput>
 </div>

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -91,6 +91,9 @@ export class ChatUIContext {
 	 * rather than by array index. */
 	attachments = $state<Attachment[]>([]);
 
+	/** The one composer mounted inside this ChatRoot. */
+	private composerFocus?: () => void;
+
 	/** Tracks if we've ever displayed messages in this session */
 	private _hasEverDisplayedMessages = false;
 
@@ -230,6 +233,18 @@ export class ChatUIContext {
 	 */
 	setMessagesReady(ready: boolean): void {
 		this.messagesReady = ready;
+	}
+
+	registerComposerFocus(handler: () => void): void {
+		this.composerFocus = handler;
+	}
+
+	unregisterComposerFocus(handler: () => void): void {
+		if (this.composerFocus === handler) this.composerFocus = undefined;
+	}
+
+	focusComposer(): void {
+		this.composerFocus?.();
 	}
 
 	/**

--- a/src/lib/components/prompt-kit/prompt-input/PromptInputTextarea.svelte
+++ b/src/lib/components/prompt-kit/prompt-input/PromptInputTextarea.svelte
@@ -5,23 +5,21 @@
 	import type { HTMLTextareaAttributes } from 'svelte/elements';
 	import { watch } from 'runed';
 
-	let {
-		class: className,
-		onkeydown,
-		onpaste,
-		disableAutosize = false,
-		...restProps
-	}: HTMLTextareaAttributes & {
-		disableAutosize?: boolean;
-	} = $props();
+	let { class: className, onkeydown, onpaste, ...restProps }: HTMLTextareaAttributes = $props();
 
 	const context = promptInputContext.get();
 
-	// Auto-resize. Always reset to `auto` before measuring so the textarea can
-	// shrink as well as grow: the earlier `scrollTop === 0` guard skipped the
-	// reset while the field was scrolled, which left it stuck at a tall height.
+	// The base Textarea carries `field-sizing-content`, so engines that support
+	// it grow and shrink the field with its content — including re-wrapping on
+	// width changes — without any JS measurement. The context maxHeight becomes
+	// a plain CSS clamp below. Engines without field-sizing (Safari, Firefox)
+	// fall back to the previous JS autosize.
+	const supportsFieldSizing = typeof CSS !== 'undefined' && CSS.supports('field-sizing', 'content');
+
+	// Fallback auto-resize. Always reset to `auto` before measuring so the
+	// textarea can shrink as well as grow.
 	function resize() {
-		if (disableAutosize) return;
+		if (supportsFieldSizing) return;
 		const ta = context.textareaRef;
 		if (!ta) return;
 		ta.style.height = 'auto';
@@ -32,20 +30,22 @@
 	}
 
 	// Re-measure on value/maxHeight changes...
-	watch([() => context.value, () => context.maxHeight, () => disableAutosize], resize);
+	watch([() => context.value, () => context.maxHeight], resize);
 
 	// ...and on width changes. scrollHeight is width-dependent, so a height
-	// measured while the field was narrow (e.g. the empty placeholder wrapping in
-	// a resizable pane) is a fixed pixel value that would otherwise never recover
-	// when the field widens again. A ResizeObserver re-runs the measurement so the
-	// height tracks the current width instead of latching.
+	// measured while the field was narrow is a fixed pixel value that would
+	// otherwise never recover when the field widens again.
 	$effect(() => {
 		const ta = context.textareaRef;
-		if (!ta || disableAutosize || typeof ResizeObserver === 'undefined') return;
+		if (!ta || supportsFieldSizing || typeof ResizeObserver === 'undefined') return;
 		const observer = new ResizeObserver(() => resize());
 		observer.observe(ta);
 		return () => observer.disconnect();
 	});
+
+	const maxHeightStyle = $derived(
+		typeof context.maxHeight === 'number' ? `${context.maxHeight}px` : context.maxHeight
+	);
 
 	function handleKeyDown(e: KeyboardEvent & { currentTarget: HTMLTextAreaElement }) {
 		if (e.key === 'Enter' && !e.shiftKey) {
@@ -70,6 +70,7 @@
 		'min-h-[44px] w-full resize-none border-none !bg-transparent text-foreground shadow-none outline-none focus-visible:ring-0 focus-visible:ring-offset-0',
 		className
 	)}
+	style="max-height: {maxHeightStyle}"
 	rows={1}
 	disabled={context.disabled}
 	{...restProps}

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -172,6 +172,7 @@
 			/>
 			<ChatInput
 				class="mx-4"
+				compact
 				placeholder={$t('ai_chat.input.placeholder')}
 				suggestions={[]}
 				showFileButton={hasMessagesAvailable}


### PR DESCRIPTION
The prompt-input textarea carried two stacked sizing mechanisms: native `field-sizing: content` on the base Textarea and a JS autosize (scrollHeight measurement, inline pixel heights, ResizeObserver) layered on top that constantly overrode it. Engines that support field-sizing now size the field purely in CSS with the context maxHeight as a plain `max-height` clamp; the JS path remains only as a feature-detected fallback for Safari and Firefox. The unused `disableAutosize` prop is dropped.

On top of that this ports the compact composer the downstream app uses in its AI chat: a rounded pill with inline action buttons that expands ChatGPT-style once the text wraps — textarea full width, actions in a row below, and the textarea never remounts so focus and caret survive the layout switch. Wrap detection measures the text with canvas measureText against the pill-layout reference width, which is layout-independent and therefore stable at the boundary (live geometry checks oscillate because the layout switch changes the field width). Overflowing content scrolls internally behind an edge fade. The compact path also brings window-level drag/drop, a plus-menu for attachments, extension-aware MIME fallbacks for pasted/dropped files, rotating placeholder hints, and a composer-focus registry on the chat context. The AI chat now uses the compact composer; the support widget keeps the classic full-width layout.

Both pieces shipped downstream in cadenza-app (#595 and the Scheduled-panel stack) where the Agent Desk composer exercises them daily; the ported files are byte-identical where shared, so the next template sync reconciles cleanly. Static checks and all 896 unit tests pass; verify the pill→expand behavior in the preview's AI chat.