### PR TITLE
refactor(imports): Enforce explicit rune extensions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
 	"npm.packageManager": "bun",
 	"editor.formatOnSave": true,
+	"typescript.preferences.importModuleSpecifierEnding": "js",
 	"eslint.validate": ["javascript", "javascriptreact", "typescript", "svelte"],
 	"files.associations": {
 		"*.css": "tailwindcss"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,7 @@ import requireMotionGuardTransitionRule from './eslint/rules/require-motion-guar
 import requireFieldErrorAssociationRule from './eslint/rules/require-field-error-association.js';
 import requireGuardedServerConvexClientRule from './eslint/rules/require-guarded-server-convex-client.js';
 import noFrozenAuthPageDataRule from './eslint/rules/no-frozen-auth-page-data.js';
+import requireSvelteModuleExtensionRule from './eslint/rules/require-svelte-module-extension.js';
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
 const localPlugin = {
@@ -37,7 +38,8 @@ const localPlugin = {
 		'require-motion-guard-transition': requireMotionGuardTransitionRule,
 		'require-field-error-association': requireFieldErrorAssociationRule,
 		'require-guarded-server-convex-client': requireGuardedServerConvexClientRule,
-		'no-frozen-auth-page-data': noFrozenAuthPageDataRule
+		'no-frozen-auth-page-data': noFrozenAuthPageDataRule,
+		'require-svelte-module-extension': requireSvelteModuleExtensionRule
 	}
 };
 
@@ -119,7 +121,11 @@ export default defineConfig(
 	// Prevent barrel imports from large icon libraries (breaks tree-shaking)
 	{
 		files: ['src/**/*.{ts,js,svelte}'],
+		plugins: {
+			local: localPlugin
+		},
 		rules: {
+			'local/require-svelte-module-extension': 'error',
 			'@typescript-eslint/no-restricted-imports': [
 				'error',
 				{

--- a/eslint/rules/require-svelte-module-extension.js
+++ b/eslint/rules/require-svelte-module-extension.js
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * ESLint rule: require-svelte-module-extension
+ *
+ * Requires imports of `.svelte.ts` rune modules to use their explicit real
+ * extension instead of the emitted `.svelte.js` form or shortened `.svelte`
+ * form. Real component imports keep their `.svelte` extension.
+ *
+ * Why: the shortened form is ambiguous with component imports and is invalid
+ * in Node ESM output. TypeScript rewrites explicit `.ts` extensions on emit.
+ *
+ * ❌ import { state } from './state.svelte.js';
+ * ❌ import { state } from './state.svelte';
+ * ✅ import { state } from './state.svelte.ts';
+ * ✅ import Component from './Component.svelte';
+ * ✅ import { state } from './state.svelte.js';   // when state.svelte.js is the real file
+ */
+
+function isSupportedSpecifier(specifier) {
+	return specifier.startsWith('./') || specifier.startsWith('../') || specifier.startsWith('$lib/');
+}
+
+function resolveSpecifier(specifier, filename, cwd) {
+	if (specifier.startsWith('$lib/')) {
+		return path.resolve(cwd, 'src/lib', specifier.slice('$lib/'.length));
+	}
+
+	return path.resolve(path.dirname(filename), specifier);
+}
+
+/**
+ * Only rewrite when a `.svelte.ts` module is what actually sits on disk. A
+ * project may legitimately hold a JavaScript `foo.svelte.js` rune module, and
+ * rewriting that specifier would autofix a working import into a missing file.
+ */
+function targetsTypeScriptModule(basePath) {
+	return fs.existsSync(`${basePath}.svelte.ts`) && !fs.existsSync(`${basePath}.svelte.js`);
+}
+
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Require explicit .svelte.ts extensions for Svelte rune module imports'
+		},
+		fixable: 'code',
+		schema: [],
+		messages: {
+			emittedExtension:
+				'Use the explicit real .svelte.ts extension for this rune module instead of .svelte.js.',
+			shortenedExtension:
+				'Use the explicit real .svelte.ts extension; the shortened .svelte form is ambiguous with components and invalid for Node ESM output.'
+		}
+	},
+	create(context) {
+		const filename = context.filename ?? context.getFilename();
+		const cwd = context.cwd ?? process.cwd();
+		const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+		function checkSource(node) {
+			if (!node || typeof node.value !== 'string') return;
+
+			const specifier = node.value;
+			if (!isSupportedSpecifier(specifier)) return;
+
+			let messageId;
+			let replacement;
+
+			if (specifier.endsWith('.svelte.js')) {
+				const stem = specifier.slice(0, -'.svelte.js'.length);
+				if (!targetsTypeScriptModule(resolveSpecifier(stem, filename, cwd))) return;
+				messageId = 'emittedExtension';
+				replacement = `${stem}.svelte.ts`;
+			} else if (specifier.endsWith('.svelte')) {
+				const resolved = resolveSpecifier(specifier, filename, cwd);
+				// An existing component file with the same stem always wins.
+				if (fs.existsSync(resolved) || !fs.existsSync(`${resolved}.ts`)) return;
+				messageId = 'shortenedExtension';
+				replacement = `${specifier}.ts`;
+			} else {
+				return;
+			}
+
+			context.report({
+				node,
+				messageId,
+				fix(fixer) {
+					const raw = sourceCode.getText(node);
+					const quote = raw[0] === '"' ? '"' : "'";
+					return fixer.replaceText(node, `${quote}${replacement}${quote}`);
+				}
+			});
+		}
+
+		return {
+			ImportDeclaration: (node) => checkSource(node.source),
+			ExportNamedDeclaration: (node) => checkSource(node.source),
+			ExportAllDeclaration: (node) => checkSource(node.source),
+			ImportExpression: (node) => checkSource(node.source)
+		};
+	}
+};

--- a/eslint/rules/require-svelte-module-extension.test.ts
+++ b/eslint/rules/require-svelte-module-extension.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Linter } from 'eslint';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { parser } from 'typescript-eslint';
+import rule from './require-svelte-module-extension.js';
+
+let fixtures: string;
+let filename: string;
+
+beforeAll(() => {
+	fixtures = fs.mkdtempSync(path.join(import.meta.dirname, 'tmp-svelte-module-extension-'));
+	filename = path.join(fixtures, 'consumer.ts');
+	fs.writeFileSync(path.join(fixtures, 'rune.svelte.ts'), 'export const state = {};');
+	fs.writeFileSync(path.join(fixtures, 'js-rune.svelte.js'), 'export const state = {};');
+	fs.writeFileSync(path.join(fixtures, 'Foo.svelte'), '<p>Fixture</p>');
+	fs.writeFileSync(path.join(fixtures, 'collision.svelte'), '<p>Component fixture</p>');
+	fs.writeFileSync(path.join(fixtures, 'collision.svelte.ts'), 'export const state = {};');
+});
+
+afterAll(() => {
+	fs.rmSync(fixtures, { recursive: true, force: true });
+});
+
+function lint(code: string) {
+	const linter = new Linter();
+	return linter.verifyAndFix(
+		code,
+		[
+			{
+				files: ['**/*.ts'],
+				languageOptions: { parser },
+				plugins: { local: { rules: { 'require-svelte-module-extension': rule } } },
+				rules: { 'local/require-svelte-module-extension': 'error' }
+			}
+		],
+		{ filename }
+	);
+}
+
+describe('require-svelte-module-extension', () => {
+	it('allows an explicit .svelte.ts rune module import', () => {
+		expect(lint(`import { state } from './rune.svelte.ts';`).messages).toHaveLength(0);
+	});
+
+	it('allows a real component import', () => {
+		expect(lint(`import Foo from './Foo.svelte';`).messages).toHaveLength(0);
+	});
+
+	it('allows an ordinary module import', () => {
+		expect(lint(`import { utility } from './utils.js';`).messages).toHaveLength(0);
+	});
+
+	it('allows an import of a real .svelte.js rune module', () => {
+		expect(lint(`import { state } from './js-rune.svelte.js';`).messages).toHaveLength(0);
+	});
+
+	it('fixes the emitted .svelte.js form when only the .svelte.ts module exists', () => {
+		const result = lint(`import type { State } from './rune.svelte.js';`);
+		expect(result.fixed).toBe(true);
+		expect(result.output).toBe(`import type { State } from './rune.svelte.ts';`);
+		expect(result.messages).toHaveLength(0);
+	});
+
+	it('fixes a shortened rune module import', () => {
+		const result = lint(`export { state } from './rune.svelte';`);
+		expect(result.fixed).toBe(true);
+		expect(result.output).toBe(`export { state } from './rune.svelte.ts';`);
+		expect(result.messages).toHaveLength(0);
+	});
+
+	it('allows a .svelte.js import when neither module form exists', () => {
+		expect(lint(`import { state } from './absent.svelte.js';`).messages).toHaveLength(0);
+	});
+
+	it('allows a shortened import when a same-stem component exists', () => {
+		expect(lint(`import Collision from './collision.svelte';`).messages).toHaveLength(0);
+	});
+
+	it('fixes a dynamic rune module import', () => {
+		const result = lint(`const module = import('./rune.svelte');`);
+		expect(result.fixed).toBe(true);
+		expect(result.output).toBe(`const module = import('./rune.svelte.ts');`);
+	});
+});

--- a/src/blocks/pricing/pricing-three.svelte
+++ b/src/blocks/pricing/pricing-three.svelte
@@ -18,7 +18,7 @@
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 
 	const { customer, checkout, openBillingPortal } = useCustomer();
 	const upgradeOperation = useAutumnOperation(checkout);

--- a/src/lib/chat/core/chat-draft-manager.test.ts
+++ b/src/lib/chat/core/chat-draft-manager.test.ts
@@ -16,7 +16,7 @@ const localStorageMock: Storage = {
 	key: (index: number) => [...storage.keys()][index] ?? null
 };
 
-import { ChatDraftManager } from './chat-draft-manager.svelte';
+import { ChatDraftManager } from './chat-draft-manager.svelte.ts';
 
 describe('ChatDraftManager', () => {
 	let manager: ChatDraftManager;

--- a/src/lib/chat/core/index.ts
+++ b/src/lib/chat/core/index.ts
@@ -59,9 +59,9 @@ export type { UploadResult, ProgressCallback } from './file-uploader.js';
 export { uploadFileWithProgress, uploadToStorage } from './file-uploader.js';
 
 // Chat core
-export type { ChatCoreAPI, ChatCoreOptions, CreateThreadResult } from './chat-core.svelte.js';
+export type { ChatCoreAPI, ChatCoreOptions, CreateThreadResult } from './chat-core.svelte.ts';
 
-export { ChatCore, createChatCore } from './chat-core.svelte.js';
+export { ChatCore, createChatCore } from './chat-core.svelte.ts';
 
 // Draft persistence
-export { ChatDraftManager } from './chat-draft-manager.svelte.js';
+export { ChatDraftManager } from './chat-draft-manager.svelte.ts';

--- a/src/lib/chat/ui/AttachmentTextPreview.svelte
+++ b/src/lib/chat/ui/AttachmentTextPreview.svelte
@@ -5,7 +5,7 @@
 	import { mode } from 'mode-watcher';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import { getTranslate } from '@tolgee/svelte';
-	import { tryGetChatUIContext } from './chat-context.svelte.js';
+	import { tryGetChatUIContext } from './chat-context.svelte.ts';
 	import { getPreviewKind, buildCodeMarkdown, capPreviewText } from '../core/attachmentPreview.js';
 
 	const { t } = getTranslate();

--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -4,13 +4,13 @@
 	import ImageIcon from '@lucide/svelte/icons/image';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import { getTranslate } from '@tolgee/svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import Progress from '$lib/components/ui/progress/progress.svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import AttachmentTextPreview from './AttachmentTextPreview.svelte';
 	import { isTextPreviewable } from '../core/attachmentPreview.js';
 	import type { Attachment, UploadState } from '../core/types.js';
-	import type { ChatAlignment } from './chat-context.svelte.js';
+	import type { ChatAlignment } from './chat-context.svelte.ts';
 
 	const { t } = getTranslate();
 

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -21,8 +21,8 @@
 	import PaperclipIcon from '@lucide/svelte/icons/paperclip';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import ChatAttachments from './ChatAttachments.svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
-	import { getChatUIContext } from './chat-context.svelte.js';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+	import { getChatUIContext } from './chat-context.svelte.ts';
 	import { processImage } from '$lib/media/process-image';
 	import {
 		ALLOWED_FILE_EXT_MIME,

--- a/src/lib/chat/ui/ChatMessage.svelte
+++ b/src/lib/chat/ui/ChatMessage.svelte
@@ -6,7 +6,7 @@
 	import ChatReasoning from './ChatReasoning.svelte';
 	import MessageBubble from './MessageBubble.svelte';
 	import InlineEmailPrompt from './InlineEmailPrompt.svelte';
-	import { getChatUIContext } from './chat-context.svelte.js';
+	import { getChatUIContext } from './chat-context.svelte.ts';
 	import { deriveOrderedParts, LEADING_REASONING_KEY, type OrderedPart } from './ordered-parts.js';
 	import { type DisplayMessage, type Attachment } from '../core/types.js';
 	import { AI_CHAT_LIMIT_NOTICE } from '$lib/convex/constants';

--- a/src/lib/chat/ui/ChatMessages.svelte
+++ b/src/lib/chat/ui/ChatMessages.svelte
@@ -11,7 +11,7 @@
 	} from '$lib/components/prompt-kit/chat-container';
 	import { ScrollButton } from '$lib/components/prompt-kit/scroll-button';
 	import ProgressiveBlur from '$blocks/magic/ProgressiveBlur.svelte';
-	import { getChatUIContext } from './chat-context.svelte.js';
+	import { getChatUIContext } from './chat-context.svelte.ts';
 	import { isHandoffAnchor } from './handoff-anchor.js';
 	import ChatMessage from './ChatMessage.svelte';
 	import type { DisplayMessage, Attachment } from '../core/types.js';

--- a/src/lib/chat/ui/ChatRoot.svelte
+++ b/src/lib/chat/ui/ChatRoot.svelte
@@ -2,14 +2,14 @@
 	import { useQuery, useConvexClient } from 'convex-svelte';
 	import { onDestroy, type Snippet } from 'svelte';
 	import type { UIMessage } from '@convex-dev/agent';
-	import { ChatCore, type ChatCoreAPI } from '../core/chat-core.svelte.js';
+	import { ChatCore, type ChatCoreAPI } from '../core/chat-core.svelte.ts';
 	import { CHAT_PAGE_SIZE, type DisplayMessage } from '../core/types.js';
 	import {
 		ChatUIContext,
 		setChatUIContext,
 		type UploadConfig,
 		type ChatAlignment
-	} from './chat-context.svelte.js';
+	} from './chat-context.svelte.ts';
 	import {
 		buildDisplayMessages,
 		dedupeChatDisplayMessages,

--- a/src/lib/chat/ui/InlineEmailPrompt.svelte
+++ b/src/lib/chat/ui/InlineEmailPrompt.svelte
@@ -9,7 +9,7 @@
 	import { toast } from 'svelte-sonner';
 	import { emailSchema } from '$lib/schemas/auth';
 	import { getTranslate } from '@tolgee/svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 
 	const { t } = getTranslate();
 

--- a/src/lib/chat/ui/MessageBubble.svelte
+++ b/src/lib/chat/ui/MessageBubble.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import type { Snippet } from 'svelte';
-	import type { ChatAlignment } from './chat-context.svelte.js';
+	import type { ChatAlignment } from './chat-context.svelte.ts';
 
 	let {
 		align,

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -9,10 +9,10 @@ import { getContext, setContext, untrack } from 'svelte';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { toast } from 'svelte-sonner';
 import type { ConvexClient } from 'convex/browser';
-import type { ChatCore } from '../core/chat-core.svelte.js';
+import type { ChatCore } from '../core/chat-core.svelte.ts';
 import type { DisplayMessage, Attachment, MessageRole } from '../core/types.js';
 import { uploadFileWithProgress } from '../core/file-uploader.js';
-import { FadeOnLoad } from '$lib/utils/fade-on-load.svelte.js';
+import { FadeOnLoad } from '$lib/utils/fade-on-load.svelte.ts';
 
 /**
  * Message alignment - controls which side messages appear on

--- a/src/lib/chat/ui/chat-context.test.ts
+++ b/src/lib/chat/ui/chat-context.test.ts
@@ -6,8 +6,8 @@
  */
 
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
-import { ChatUIContext } from './chat-context.svelte.js';
-import type { ChatCore } from '../core/chat-core.svelte.js';
+import { ChatUIContext } from './chat-context.svelte.ts';
+import type { ChatCore } from '../core/chat-core.svelte.ts';
 import type { ConvexClient } from 'convex/browser';
 import type { Attachment } from '../core/types.js';
 

--- a/src/lib/chat/ui/index.ts
+++ b/src/lib/chat/ui/index.ts
@@ -6,14 +6,14 @@
  */
 
 // Context
-export type { UploadConfig } from './chat-context.svelte.js';
+export type { UploadConfig } from './chat-context.svelte.ts';
 
 export {
 	ChatUIContext,
 	setChatUIContext,
 	getChatUIContext,
 	tryGetChatUIContext
-} from './chat-context.svelte.js';
+} from './chat-context.svelte.ts';
 
 // Types
 /**

--- a/src/lib/components/ErrorDisplay.svelte
+++ b/src/lib/components/ErrorDisplay.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
-	import { useGlobalSearchContext } from '$lib/components/global-search/context.svelte';
+	import { useGlobalSearchContext } from '$lib/components/global-search/context.svelte.ts';
 	import * as Empty from '$lib/components/ui/empty/index.js';
 	import * as InputGroup from '$lib/components/ui/input-group/index.js';
 	import * as Kbd from '$lib/components/ui/kbd/index.js';

--- a/src/lib/components/RiveBackground.svelte
+++ b/src/lib/components/RiveBackground.svelte
@@ -19,7 +19,7 @@
 <script lang="ts">
 	import { onMount, tick } from 'svelte';
 	import { useMutationObserver } from 'runed';
-	import { TAILWIND_BREAKPOINTS, useMedia } from '$lib/hooks/use-media.svelte';
+	import { TAILWIND_BREAKPOINTS, useMedia } from '$lib/hooks/use-media.svelte.ts';
 	import { Spotlight } from '$lib/components/ui/spotlight/index.js';
 	import type { Component } from 'svelte';
 

--- a/src/lib/components/ai-elements/conversation/Conversation.svelte
+++ b/src/lib/components/ai-elements/conversation/Conversation.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <script lang="ts">
-	import { StickToBottomContext, stickToBottomContext } from './stick-to-bottom-context.svelte.js';
+	import { StickToBottomContext, stickToBottomContext } from './stick-to-bottom-context.svelte.ts';
 
 	let {
 		class: className,

--- a/src/lib/components/ai-elements/conversation/ConversationContent.svelte
+++ b/src/lib/components/ai-elements/conversation/ConversationContent.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <script lang="ts">
-	import { stickToBottomContext } from './stick-to-bottom-context.svelte.js';
+	import { stickToBottomContext } from './stick-to-bottom-context.svelte.ts';
 	import { watch } from 'runed';
 
 	let {

--- a/src/lib/components/ai-elements/conversation/ConversationScrollButton.svelte
+++ b/src/lib/components/ai-elements/conversation/ConversationScrollButton.svelte
@@ -16,7 +16,7 @@
 <script lang="ts">
 	import { buttonVariants } from '$lib/components/ui/button';
 	import ArrowDown from '@lucide/svelte/icons/arrow-down';
-	import { stickToBottomContext } from './stick-to-bottom-context.svelte.js';
+	import { stickToBottomContext } from './stick-to-bottom-context.svelte.ts';
 	import { fly } from 'svelte/transition';
 	import { prefersReducedMotion } from 'svelte/motion';
 	import { backOut } from 'svelte/easing';

--- a/src/lib/components/ai-elements/conversation/index.ts
+++ b/src/lib/components/ai-elements/conversation/index.ts
@@ -2,7 +2,7 @@ export { default as Conversation } from './Conversation.svelte';
 export { default as ConversationContent } from './ConversationContent.svelte';
 export { default as ConversationEmptyState } from './ConversationEmptyState.svelte';
 export { default as ConversationScrollButton } from './ConversationScrollButton.svelte';
-export { stickToBottomContext, StickToBottomContext } from './stick-to-bottom-context.svelte.js';
+export { stickToBottomContext, StickToBottomContext } from './stick-to-bottom-context.svelte.ts';
 
 export type { ConversationProps } from './Conversation.svelte';
 export type { ConversationContentProps } from './ConversationContent.svelte';

--- a/src/lib/components/ai-elements/prompt-input/PromptInput.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInput.svelte
@@ -7,7 +7,7 @@
 		AttachmentsContext,
 		attachmentsContext,
 		type PromptInputMessage
-	} from './attachments-context.svelte.js';
+	} from './attachments-context.svelte.ts';
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ai-elements/prompt-input/PromptInputActionAddAttachments.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputActionAddAttachments.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { attachmentsContext } from './attachments-context.svelte.js';
+	import { attachmentsContext } from './attachments-context.svelte.ts';
 	import PromptInputActionMenuItem from './PromptInputActionMenuItem.svelte';
 	import ImageIcon from '@lucide/svelte/icons/image';
 

--- a/src/lib/components/ai-elements/prompt-input/PromptInputAttachment.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputAttachment.svelte
@@ -3,7 +3,7 @@
 	import { getTranslate } from '@tolgee/svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
-	import { attachmentsContext, type FileWithId } from './attachments-context.svelte.js';
+	import { attachmentsContext, type FileWithId } from './attachments-context.svelte.ts';
 	import PaperclipIcon from '@lucide/svelte/icons/paperclip';
 	import XIcon from '@lucide/svelte/icons/x';
 

--- a/src/lib/components/ai-elements/prompt-input/PromptInputAttachments.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputAttachments.svelte
@@ -2,7 +2,7 @@
 	import { cn } from '$lib/utils';
 	import type { Snippet } from 'svelte';
 	import { ElementSize } from 'runed';
-	import { attachmentsContext, type FileWithId } from './attachments-context.svelte.js';
+	import { attachmentsContext, type FileWithId } from './attachments-context.svelte.ts';
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ai-elements/prompt-input/PromptInputProvider.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputProvider.svelte
@@ -2,7 +2,7 @@
 	import {
 		PromptInputController,
 		promptInputProviderContext
-	} from './attachments-context.svelte.js';
+	} from './attachments-context.svelte.ts';
 
 	import type { Snippet } from 'svelte';
 	interface Props {

--- a/src/lib/components/ai-elements/prompt-input/PromptInputSubmit.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputSubmit.svelte
@@ -4,7 +4,7 @@
 	import type { ButtonVariant, ButtonSize } from '$lib/components/ui/button/index.js';
 	import type { HTMLButtonAttributes } from 'svelte/elements';
 	import type { WithChildren, WithoutChildren } from 'bits-ui';
-	import type { ChatStatus } from './attachments-context.svelte.js';
+	import type { ChatStatus } from './attachments-context.svelte.ts';
 	import SendIcon from '@lucide/svelte/icons/send';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import SquareIcon from '@lucide/svelte/icons/square';

--- a/src/lib/components/ai-elements/prompt-input/PromptInputTextarea.svelte
+++ b/src/lib/components/ai-elements/prompt-input/PromptInputTextarea.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
-	import { attachmentsContext } from './attachments-context.svelte.js';
+	import { attachmentsContext } from './attachments-context.svelte.ts';
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/ai-elements/prompt-input/index.ts
+++ b/src/lib/components/ai-elements/prompt-input/index.ts
@@ -52,4 +52,4 @@ export {
 	type FileWithId,
 	type PromptInputMessage,
 	type ChatStatus
-} from './attachments-context.svelte.js';
+} from './attachments-context.svelte.ts';

--- a/src/lib/components/app/app-auth-oauth-bootstrap.svelte
+++ b/src/lib/components/app/app-auth-oauth-bootstrap.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
-	import { commitOAuthSuccessIfPending } from '$lib/hooks/last-auth-method.svelte';
+	import { commitOAuthSuccessIfPending } from '$lib/hooks/last-auth-method.svelte.ts';
 
 	const auth = useAuth();
 

--- a/src/lib/components/authenticated/auth-connection-fallback.svelte
+++ b/src/lib/components/authenticated/auth-connection-fallback.svelte
@@ -3,7 +3,7 @@
 	import { onMount } from 'svelte';
 	import { invalidate } from '$app/navigation';
 	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
-	import { clockSkewContext } from '$lib/hooks/clock-skew.svelte';
+	import { clockSkewContext } from '$lib/hooks/clock-skew.svelte.ts';
 	import { armReloadGuard, hasReloadGuard, shouldAutoReload } from './auth-fallback-recovery';
 	import * as Empty from '$lib/components/ui/empty/index.js';
 	import { Button } from '$lib/components/ui/button';

--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -8,7 +8,7 @@
 	import type { ComponentProps } from 'svelte';
 	import { T } from '@tolgee/svelte';
 	import type { NavItem, NavSubItem, SidebarConfig, User } from './types';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { PersistedState } from 'runed';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import SidebarThreadList from './sidebar-thread-list.svelte';

--- a/src/lib/components/authenticated/configs/admin-sidebar-config.ts
+++ b/src/lib/components/authenticated/configs/admin-sidebar-config.ts
@@ -1,5 +1,5 @@
 import { localizedHref } from '$lib/utils/i18n';
-import { cmdOrCtrl, ctrlSymbol } from '$lib/hooks/is-mac.svelte';
+import { cmdOrCtrl, ctrlSymbol } from '$lib/hooks/is-mac.svelte.ts';
 import LayoutDashboardIcon from '@lucide/svelte/icons/layout-dashboard';
 import UsersIcon from '@lucide/svelte/icons/users';
 import MessagesSquareIcon from '@lucide/svelte/icons/messages-square';

--- a/src/lib/components/authenticated/configs/app-sidebar-config.ts
+++ b/src/lib/components/authenticated/configs/app-sidebar-config.ts
@@ -1,5 +1,5 @@
 import { localizedHref } from '$lib/utils/i18n';
-import { cmdOrCtrl, ctrlSymbol } from '$lib/hooks/is-mac.svelte';
+import { cmdOrCtrl, ctrlSymbol } from '$lib/hooks/is-mac.svelte.ts';
 import MessagesSquareIcon from '@lucide/svelte/icons/messages-square';
 import BotMessageSquareIcon from '@lucide/svelte/icons/bot-message-square';
 import ServerCogIcon from '@lucide/svelte/icons/server-cog';

--- a/src/lib/components/authenticated/sidebar-thread-list.svelte
+++ b/src/lib/components/authenticated/sidebar-thread-list.svelte
@@ -2,7 +2,7 @@
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { DEFAULT_LANGUAGE } from '$lib/i18n/languages';
 	import autoAnimate from '@formkit/auto-animate';
 	import { getTranslate } from '@tolgee/svelte';

--- a/src/lib/components/clock-skew-banner.svelte
+++ b/src/lib/components/clock-skew-banner.svelte
@@ -2,7 +2,7 @@
 	import { browser } from '$app/environment';
 	import { T } from '@tolgee/svelte';
 	import { PersistedState } from 'runed';
-	import { clockSkewContext } from '$lib/hooks/clock-skew.svelte';
+	import { clockSkewContext } from '$lib/hooks/clock-skew.svelte.ts';
 	import { Button } from '$lib/components/ui/button';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 

--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -9,7 +9,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
-	import { supportThreadContext } from './support-thread-context.svelte';
+	import { supportThreadContext } from './support-thread-context.svelte.ts';
 	import { CHAT_PAGE_SIZE, MAX_MESSAGE_LENGTH } from '$lib/chat/core/types';
 	import { getTranslate } from '@tolgee/svelte';
 	import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';

--- a/src/lib/components/customer-support/customer-support.svelte
+++ b/src/lib/components/customer-support/customer-support.svelte
@@ -7,12 +7,12 @@
 	import { page } from '$app/state';
 	import AIChatbar from '$lib/components/customer-support/ai-chatbar.svelte';
 	import FeedbackButton from '$lib/components/customer-support/feedback-button.svelte';
-	import { SupportThreadContext, supportThreadContext } from './support-thread-context.svelte';
+	import { SupportThreadContext, supportThreadContext } from './support-thread-context.svelte.ts';
 	import { ChatUIContext, type UploadConfig } from '$lib/chat';
 	import { browser } from '$app/environment';
 	import { generateAnonymousUserId, isAnonymousUser } from '$lib/convex/utils/anonymousUser';
-	import { supportUserId } from './support-user-id.svelte';
-	import { useSupportUrlState } from './use-support-url-state.svelte';
+	import { supportUserId } from './support-user-id.svelte.ts';
+	import { useSupportUrlState } from './use-support-url-state.svelte.ts';
 	import { getTranslate } from '@tolgee/svelte';
 	import { loadSentry } from '$lib/monitoring/sentry';
 	import { PUBLIC_SENTRY_DSN } from '$env/static/public';

--- a/src/lib/components/customer-support/feedback-button.svelte
+++ b/src/lib/components/customer-support/feedback-button.svelte
@@ -5,7 +5,7 @@
 	import FeedbackWidget from './feedback-widget.svelte';
 	import { on } from 'svelte/events';
 	import type { ChatUIContext } from '$lib/chat';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { getTranslate } from '@tolgee/svelte';
 
 	const { t } = getTranslate();

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -3,13 +3,13 @@
 	import { authClient } from '$lib/auth-client';
 	import { watch } from 'runed';
 	import { api } from '$lib/convex/_generated/api';
-	import { supportThreadContext } from './support-thread-context.svelte';
+	import { supportThreadContext } from './support-thread-context.svelte.ts';
 	import { lockscroll } from '@svelte-put/lockscroll';
-	import { IsMobile } from '$lib/hooks/is-mobile.svelte.js';
+	import { IsMobile } from '$lib/hooks/is-mobile.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { ConvexError } from 'convex/values';
 	import { getTranslate } from '@tolgee/svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';
 
 	// Import new chat components

--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotCanvas.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotCanvas.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Stage, Layer, Line, Rect, Ellipse, Arrow } from 'svelte-konva';
-	import { screenshotEditorContext } from './screenshot-editor-context.svelte';
+	import { screenshotEditorContext } from './screenshot-editor-context.svelte.ts';
 	import type { LineShape, RectShape, CircleShape, ArrowShape } from './types';
 
 	const editor = screenshotEditorContext.get();

--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotEditor.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotEditor.svelte
@@ -11,9 +11,9 @@
 	import {
 		ScreenshotEditorState,
 		screenshotEditorContext
-	} from './screenshot-editor-context.svelte';
+	} from './screenshot-editor-context.svelte.ts';
 	import ScreenshotToolbar from './ScreenshotToolbar.svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import ScreenshotCanvas from './ScreenshotCanvas.svelte';
 
 	const { t } = getTranslate();

--- a/src/lib/components/customer-support/screenshot-editor/ScreenshotToolbar.svelte
+++ b/src/lib/components/customer-support/screenshot-editor/ScreenshotToolbar.svelte
@@ -10,7 +10,7 @@
 	import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
-	import { screenshotEditorContext } from './screenshot-editor-context.svelte';
+	import { screenshotEditorContext } from './screenshot-editor-context.svelte.ts';
 	import { DEFAULT_COLORS } from './types';
 	import { getTranslate } from '@tolgee/svelte';
 

--- a/src/lib/components/customer-support/support-thread-context.svelte.ts
+++ b/src/lib/components/customer-support/support-thread-context.svelte.ts
@@ -1,5 +1,5 @@
 import { Context } from 'runed';
-import { ChatDraftManager } from '$lib/chat/core/chat-draft-manager.svelte';
+import { ChatDraftManager } from '$lib/chat/core/chat-draft-manager.svelte.ts';
 import type { ConvexClient } from 'convex/browser';
 import { api } from '$lib/convex/_generated/api';
 import type { Attachment } from '$lib/chat';
@@ -613,7 +613,7 @@ export class SupportThreadContext {
  * @example
  * ```svelte
  * <script lang="ts">
- *   import { supportThreadContext } from './support-thread-context.svelte';
+ *   import { supportThreadContext } from './support-thread-context.svelte.ts';
  *
  *   const thread = supportThreadContext.get();
  *

--- a/src/lib/components/customer-support/support-ticket-migration-bootstrap.svelte
+++ b/src/lib/components/customer-support/support-ticket-migration-bootstrap.svelte
@@ -7,7 +7,7 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import { api } from '$lib/convex/_generated/api';
 	import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';
-	import { supportUserId } from './support-user-id.svelte';
+	import { supportUserId } from './support-user-id.svelte.ts';
 
 	const auth = useAuth();
 	const convexClient = useConvexClient();

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -9,9 +9,9 @@
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import UsersRoundIcon from '@lucide/svelte/icons/users-round';
-	import { supportThreadContext } from './support-thread-context.svelte';
+	import { supportThreadContext } from './support-thread-context.svelte.ts';
 	import AvatarHeading from './avatar-heading.svelte';
-	import { FadeOnLoad } from '$lib/utils/fade-on-load.svelte.js';
+	import { FadeOnLoad } from '$lib/utils/fade-on-load.svelte.ts';
 	import memberFour from '$blocks/team/avatars/member-four.webp';
 	import memberTwo from '$blocks/team/avatars/member-two.webp';
 	import memberFive from '$blocks/team/avatars/member-five.webp';

--- a/src/lib/components/data-table-checkbox.svelte
+++ b/src/lib/components/data-table-checkbox.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { getTranslate } from '@tolgee/svelte';
 	import type { ComponentProps } from 'svelte';
 

--- a/src/lib/components/global-search/command-menu.svelte
+++ b/src/lib/components/global-search/command-menu.svelte
@@ -19,8 +19,8 @@
 		type SearchRouteEntry,
 		type SearchRouteGroup
 	} from './search-routes';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
-	import { useGlobalSearchContext } from './context.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+	import { useGlobalSearchContext } from './context.svelte.ts';
 
 	type MenuRouteItem = SearchRouteEntry & {
 		id: string;

--- a/src/lib/components/global-search/command-trigger.svelte
+++ b/src/lib/components/global-search/command-trigger.svelte
@@ -3,8 +3,8 @@
 	import * as Kbd from '$lib/components/ui/kbd/index.js';
 	import { cn } from '$lib/utils.js';
 	import { getTranslate } from '@tolgee/svelte';
-	import { cmdOrCtrl } from '$lib/hooks/is-mac.svelte';
-	import { useGlobalSearchContext } from './context.svelte';
+	import { cmdOrCtrl } from '$lib/hooks/is-mac.svelte.ts';
+	import { useGlobalSearchContext } from './context.svelte.ts';
 
 	interface Props {
 		class?: string;

--- a/src/lib/components/global-search/global-search-shell.svelte
+++ b/src/lib/components/global-search/global-search-shell.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
 	import { onMount, tick } from 'svelte';
-	import { useGlobalSearchContext } from './context.svelte';
+	import { useGlobalSearchContext } from './context.svelte.ts';
 
 	const globalSearch = useGlobalSearchContext();
 

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -18,7 +18,7 @@
 	import UserXIcon from '@lucide/svelte/icons/user-x';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { localizedHref } from '$lib/utils/i18n';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { useCustomer, useAutumnOperation } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
 

--- a/src/lib/components/prompt-kit/chat-container/chat-container-root.svelte
+++ b/src/lib/components/prompt-kit/chat-container/chat-container-root.svelte
@@ -4,7 +4,7 @@
 		chatContainerContext,
 		type ResizeMode,
 		type InitialMode
-	} from './chat-container-context.svelte';
+	} from './chat-container-context.svelte.ts';
 	import type { Snippet } from 'svelte';
 	import { cn } from '$lib/utils';
 	import { watch } from 'runed';

--- a/src/lib/components/prompt-kit/chat-container/index.ts
+++ b/src/lib/components/prompt-kit/chat-container/index.ts
@@ -1,4 +1,4 @@
 export { default as ChatContainerRoot } from './chat-container-root.svelte';
 export { default as ChatContainerContent } from './chat-container-content.svelte';
 export { default as ChatContainerScrollAnchor } from './chat-container-scroll-anchor.svelte';
-export { chatContainerContext, ChatContainerContext } from './chat-container-context.svelte';
+export { chatContainerContext, ChatContainerContext } from './chat-container-context.svelte.ts';

--- a/src/lib/components/prompt-kit/file-upload/file-upload-content.svelte
+++ b/src/lib/components/prompt-kit/file-upload/file-upload-content.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fileUploadContext } from './file-upload-context.svelte';
+	import { fileUploadContext } from './file-upload-context.svelte.ts';
 	import type { Snippet } from 'svelte';
 	import { IsMounted } from 'runed';
 	import { cn } from '$lib/utils';

--- a/src/lib/components/prompt-kit/file-upload/file-upload-trigger.svelte
+++ b/src/lib/components/prompt-kit/file-upload/file-upload-trigger.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fileUploadContext } from './file-upload-context.svelte';
+	import { fileUploadContext } from './file-upload-context.svelte.ts';
 	import type { Snippet } from 'svelte';
 
 	type Props = {

--- a/src/lib/components/prompt-kit/file-upload/file-upload.svelte
+++ b/src/lib/components/prompt-kit/file-upload/file-upload.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import { FileUploadContext, fileUploadContext } from './file-upload-context.svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { FileUploadContext, fileUploadContext } from './file-upload-context.svelte.ts';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 
 	type Props = {
 		onFilesAdded: (files: File[]) => void;

--- a/src/lib/components/prompt-kit/file-upload/index.ts
+++ b/src/lib/components/prompt-kit/file-upload/index.ts
@@ -1,4 +1,4 @@
 export { default as FileUpload } from './file-upload.svelte';
 export { default as FileUploadTrigger } from './file-upload-trigger.svelte';
 export { default as FileUploadContent } from './file-upload-content.svelte';
-export { FileUploadContext } from './file-upload-context.svelte';
+export { FileUploadContext } from './file-upload-context.svelte.ts';

--- a/src/lib/components/prompt-kit/message/Message.svelte
+++ b/src/lib/components/prompt-kit/message/Message.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	import { MessageClass, messageContext, type MessageSchema } from './message-context.svelte.js';
+	import { MessageClass, messageContext, type MessageSchema } from './message-context.svelte.ts';
 	import type { Snippet } from 'svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
 

--- a/src/lib/components/prompt-kit/message/index.ts
+++ b/src/lib/components/prompt-kit/message/index.ts
@@ -4,4 +4,4 @@ export { default as MessageContent } from './MessageContent.svelte';
 export { default as MessageActions } from './MessageActions.svelte';
 export { default as MessageAction } from './MessageAction.svelte';
 
-export * from './message-context.svelte.js';
+export * from './message-context.svelte.ts';

--- a/src/lib/components/prompt-kit/prompt-input/PromptInput.svelte
+++ b/src/lib/components/prompt-kit/prompt-input/PromptInput.svelte
@@ -6,7 +6,7 @@
 		PromptInputClass,
 		promptInputContext,
 		type PromptInputSchema
-	} from './prompt-input-context.svelte.js';
+	} from './prompt-input-context.svelte.ts';
 
 	let {
 		class: className,

--- a/src/lib/components/prompt-kit/prompt-input/PromptInputAction.svelte
+++ b/src/lib/components/prompt-kit/prompt-input/PromptInputAction.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import type { Snippet } from 'svelte';
-	import { promptInputContext } from './prompt-input-context.svelte.js';
+	import { promptInputContext } from './prompt-input-context.svelte.ts';
 
 	let {
 		tooltip,

--- a/src/lib/components/prompt-kit/prompt-input/PromptInputTextarea.svelte
+++ b/src/lib/components/prompt-kit/prompt-input/PromptInputTextarea.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import Textarea from '$lib/components/ui/textarea/textarea.svelte';
-	import { promptInputContext } from './prompt-input-context.svelte.js';
+	import { promptInputContext } from './prompt-input-context.svelte.ts';
 	import type { HTMLTextareaAttributes } from 'svelte/elements';
 	import { watch } from 'runed';
 

--- a/src/lib/components/prompt-kit/prompt-input/index.ts
+++ b/src/lib/components/prompt-kit/prompt-input/index.ts
@@ -2,4 +2,4 @@ export { default as PromptInput } from './PromptInput.svelte';
 export { default as PromptInputTextarea } from './PromptInputTextarea.svelte';
 export { default as PromptInputActions } from './PromptInputActions.svelte';
 export { default as PromptInputAction } from './PromptInputAction.svelte';
-export * from './prompt-input-context.svelte.js';
+export * from './prompt-input-context.svelte.ts';

--- a/src/lib/components/prompt-kit/scroll-button/ScrollButton.svelte
+++ b/src/lib/components/prompt-kit/scroll-button/ScrollButton.svelte
@@ -17,7 +17,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { getTranslate } from '@tolgee/svelte';
 	import ChevronDown from '@lucide/svelte/icons/chevron-down';
-	import { chatContainerContext } from '../chat-container/chat-container-context.svelte.js';
+	import { chatContainerContext } from '../chat-container/chat-container-context.svelte.ts';
 	import { browser } from '$app/environment';
 
 	const { t } = getTranslate();

--- a/src/lib/components/prompt-kit/scroll-button/index.ts
+++ b/src/lib/components/prompt-kit/scroll-button/index.ts
@@ -1,4 +1,4 @@
 export { default as ScrollButton } from './ScrollButton.svelte';
 
 // Re-export chat container context
-export { chatContainerContext } from '../chat-container/chat-container-context.svelte.js';
+export { chatContainerContext } from '../chat-container/chat-container-context.svelte.ts';

--- a/src/lib/components/tables/convex-cursor-table-shell.svelte
+++ b/src/lib/components/tables/convex-cursor-table-shell.svelte
@@ -4,7 +4,7 @@
 	import ChevronsRightIcon from '@lucide/svelte/icons/chevrons-right';
 	import ChevronLeftIcon from '@lucide/svelte/icons/chevron-left';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { getTranslate } from '@tolgee/svelte';
 	import type { Snippet } from 'svelte';
 	import { Input } from '$lib/components/ui/input/index.js';

--- a/src/lib/components/ui/confirm-delete-dialog/confirm-delete-dialog.svelte
+++ b/src/lib/components/ui/confirm-delete-dialog/confirm-delete-dialog.svelte
@@ -29,7 +29,7 @@
 				}
 			}
 
-			import('$lib/hooks/use-haptic.svelte')
+			import('$lib/hooks/use-haptic.svelte.ts')
 				.then((m) => m.haptic.trigger('warning'))
 				.catch(() => {});
 			this.loading = true;
@@ -89,7 +89,7 @@
 <script lang="ts">
 	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import * as Field from '$lib/components/ui/field/index.js';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { getTranslate } from '@tolgee/svelte';
 	import { Input } from '$lib/components/ui/input';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';

--- a/src/lib/components/ui/copy-button/copy-button.svelte
+++ b/src/lib/components/ui/copy-button/copy-button.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { buttonVariants } from '$lib/components/ui/button';
-	import { UseClipboard } from '$lib/hooks/use-clipboard.svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { UseClipboard } from '$lib/hooks/use-clipboard.svelte.ts';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { cn } from '$lib/utils.js';
 	import { getTranslate } from '@tolgee/svelte';
 	import CheckIcon from '@lucide/svelte/icons/check';

--- a/src/lib/components/ui/copy-button/types.ts
+++ b/src/lib/components/ui/copy-button/types.ts
@@ -1,6 +1,6 @@
 import type { Snippet } from 'svelte';
 import type { ButtonProps } from '$lib/components/ui/button';
-import type { UseClipboard } from '$lib/hooks/use-clipboard.svelte';
+import type { UseClipboard } from '$lib/hooks/use-clipboard.svelte.ts';
 import type { HTMLButtonAttributes } from 'svelte/elements';
 import type { WithChildren, WithoutChildren } from 'bits-ui';
 

--- a/src/lib/components/ui/data-table/index.ts
+++ b/src/lib/components/ui/data-table/index.ts
@@ -1,3 +1,3 @@
 export { default as FlexRender } from './flex-render.svelte';
 export { renderComponent, renderSnippet } from './render-helpers.js';
-export { createSvelteTable } from './data-table.svelte.js';
+export { createSvelteTable } from './data-table.svelte.ts';

--- a/src/lib/components/ui/language-switcher/language-switcher.svelte
+++ b/src/lib/components/ui/language-switcher/language-switcher.svelte
@@ -3,7 +3,7 @@
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { Button } from '$lib/components/ui/button';
 	import type { LanguageSwitcherProps } from './types';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { getTranslate } from '@tolgee/svelte';
 
 	const { t } = getTranslate();

--- a/src/lib/components/ui/light-switch/light-switch.svelte
+++ b/src/lib/components/ui/light-switch/light-switch.svelte
@@ -3,7 +3,7 @@
 	import MoonIcon from '@lucide/svelte/icons/moon';
 	import { getTranslate } from '@tolgee/svelte';
 	import { toggleMode } from 'mode-watcher';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import type { LightSwitchProps } from './types';
 

--- a/src/lib/components/ui/password/password-copy.svelte
+++ b/src/lib/components/ui/password/password-copy.svelte
@@ -2,7 +2,7 @@
 	import { CopyButton } from '$lib/components/ui/copy-button';
 	import type { PasswordCopyButtonProps } from './types.js';
 	import { cn } from '$lib/utils.js';
-	import { usePasswordCopy } from './password.svelte.js';
+	import { usePasswordCopy } from './password.svelte.ts';
 
 	let { ref = $bindable(null), class: className, ...rest }: PasswordCopyButtonProps = $props();
 

--- a/src/lib/components/ui/password/password-input.svelte
+++ b/src/lib/components/ui/password/password-input.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { cn } from '$lib/utils.js';
 	import { box, mergeProps } from 'svelte-toolbelt';
-	import { usePasswordInput } from './password.svelte.js';
+	import { usePasswordInput } from './password.svelte.ts';
 	import type { PasswordInputProps } from './types.js';
 	import { Input } from '$lib/components/ui/input';
 

--- a/src/lib/components/ui/password/password-strength.svelte
+++ b/src/lib/components/ui/password/password-strength.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { tv } from 'tailwind-variants';
-	import { usePasswordStrength } from './password.svelte.js';
+	import { usePasswordStrength } from './password.svelte.ts';
 	import type { PasswordStrengthProps } from './types.js';
 	import { Meter } from 'bits-ui';
 	import { cn } from '$lib/utils.js';

--- a/src/lib/components/ui/password/password-toggle-visibility.svelte
+++ b/src/lib/components/ui/password/password-toggle-visibility.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { getTranslate } from '@tolgee/svelte';
 	import { Toggle } from '$lib/components/ui/toggle';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import EyeIcon from '@lucide/svelte/icons/eye';
 	import EyeOffIcon from '@lucide/svelte/icons/eye-off';
-	import { usePasswordToggleVisibility } from './password.svelte.js';
+	import { usePasswordToggleVisibility } from './password.svelte.ts';
 	import type { PasswordToggleVisibilityProps } from './types.js';
 	import { cn } from '$lib/utils.js';
 

--- a/src/lib/components/ui/password/password.svelte
+++ b/src/lib/components/ui/password/password.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { box } from 'svelte-toolbelt';
-	import { usePassword } from './password.svelte.js';
+	import { usePassword } from './password.svelte.ts';
 	import type { PasswordRootProps } from './types';
 	import { cn } from '$lib/utils.js';
 

--- a/src/lib/components/ui/sidebar/context.svelte.ts
+++ b/src/lib/components/ui/sidebar/context.svelte.ts
@@ -1,4 +1,4 @@
-import { IsMobile } from '$lib/hooks/is-mobile.svelte.js';
+import { IsMobile } from '$lib/hooks/is-mobile.svelte.ts';
 import { getContext, setContext } from 'svelte';
 import { SIDEBAR_KEYBOARD_SHORTCUT } from './constants.js';
 

--- a/src/lib/components/ui/sidebar/index.ts
+++ b/src/lib/components/ui/sidebar/index.ts
@@ -1,4 +1,4 @@
-import { useSidebar } from './context.svelte.js';
+import { useSidebar } from './context.svelte.ts';
 import Content from './sidebar-content.svelte';
 import Footer from './sidebar-footer.svelte';
 import GroupAction from './sidebar-group-action.svelte';

--- a/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-button.svelte
@@ -31,7 +31,7 @@
 	import { mergeProps } from 'bits-ui';
 	import type { ComponentProps, Snippet } from 'svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
-	import { useSidebar } from './context.svelte.js';
+	import { useSidebar } from './context.svelte.ts';
 
 	let {
 		ref = $bindable(null),

--- a/src/lib/components/ui/sidebar/sidebar-provider.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-provider.svelte
@@ -9,7 +9,7 @@
 		SIDEBAR_WIDTH,
 		SIDEBAR_WIDTH_ICON
 	} from './constants.js';
-	import { setSidebar } from './context.svelte.js';
+	import { setSidebar } from './context.svelte.ts';
 
 	let {
 		ref = $bindable(null),

--- a/src/lib/components/ui/sidebar/sidebar-rail.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-rail.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { getTranslate } from '@tolgee/svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { cn, type WithElementRef } from '$lib/utils.js';
 	import type { HTMLAttributes } from 'svelte/elements';
-	import { useSidebar } from './context.svelte.js';
+	import { useSidebar } from './context.svelte.ts';
 
 	const { t } = getTranslate();
 

--- a/src/lib/components/ui/sidebar/sidebar-trigger.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-trigger.svelte
@@ -2,10 +2,10 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import PanelLeftIcon from '@lucide/svelte/icons/panel-left';
 	import { getTranslate } from '@tolgee/svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { cn } from '$lib/utils.js';
 	import type { ComponentProps } from 'svelte';
-	import { useSidebar } from './context.svelte.js';
+	import { useSidebar } from './context.svelte.ts';
 
 	const { t } = getTranslate();
 

--- a/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/src/lib/components/ui/sidebar/sidebar.svelte
@@ -4,7 +4,7 @@
 	import { cn, type WithElementRef } from '$lib/utils.js';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { SIDEBAR_WIDTH_MOBILE } from './constants.js';
-	import { useSidebar } from './context.svelte.js';
+	import { useSidebar } from './context.svelte.ts';
 
 	const { t } = getTranslate();
 

--- a/src/lib/hooks/use-clipboard.svelte.ts
+++ b/src/lib/hooks/use-clipboard.svelte.ts
@@ -10,7 +10,7 @@ type Options = {
  * ## Usage
  * ```svelte
  * <script lang="ts">
- * 		import { UseClipboard } from "$lib/hooks/use-clipboard.svelte";
+ * 		import { UseClipboard } from "$lib/hooks/use-clipboard.svelte.ts";
  *
  * 		const clipboard = new UseClipboard();
  * </script>

--- a/src/lib/tables/convex/create-convex-cursor-table.test.ts
+++ b/src/lib/tables/convex/create-convex-cursor-table.test.ts
@@ -7,7 +7,7 @@ import {
 	hasPageBoundaryChanged,
 	hasTotalCountChanged,
 	hasQueryIdentityChanged
-} from './create-convex-cursor-table.svelte';
+} from './create-convex-cursor-table.svelte.ts';
 import type { CursorListResult } from './contract';
 
 function page(

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,8 +10,8 @@
 	import AppAutumnProvider from '$lib/components/app/app-autumn-provider.svelte';
 	import AppPostHogBootstrap from '$lib/components/app/app-posthog-bootstrap.svelte';
 	import ClockSkewBanner from '$lib/components/clock-skew-banner.svelte';
-	import { ClockSkewState, clockSkewContext } from '$lib/hooks/clock-skew.svelte';
-	import { setGlobalSearchContext } from '$lib/components/global-search/context.svelte';
+	import { ClockSkewState, clockSkewContext } from '$lib/hooks/clock-skew.svelte.ts';
+	import { setGlobalSearchContext } from '$lib/components/global-search/context.svelte.ts';
 	import GlobalSearchShell from '$lib/components/global-search/global-search-shell.svelte';
 	import { languageContext } from '$lib/i18n/context';
 	import { DEFAULT_LANGUAGE, getLanguage } from '$lib/i18n/languages';

--- a/src/routes/[[lang]]/(auth)/+layout.svelte
+++ b/src/routes/[[lang]]/(auth)/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import { AuthFlowManager, authFlowContext } from '$lib/hooks/auth-flow.svelte';
+	import { AuthFlowManager, authFlowContext } from '$lib/hooks/auth-flow.svelte.ts';
 
 	interface Props {
 		children?: Snippet;

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -12,11 +12,11 @@
 	import { localizedHref } from '$lib/utils/i18n';
 	import { resolve } from '$app/paths';
 	import { T, getTranslate } from '@tolgee/svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { forgotPasswordSchema } from './schema.js';
 	import { slide } from 'svelte/transition';
 	import { prefersReducedMotion } from 'svelte/motion';
-	import { authFlowContext } from '$lib/hooks/auth-flow.svelte';
+	import { authFlowContext } from '$lib/hooks/auth-flow.svelte.ts';
 	import { getAuthErrorKey } from '$lib/utils/auth-messages';
 	import { translateValidationErrors } from '$lib/utils/validation-i18n.js';
 

--- a/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
@@ -13,7 +13,7 @@
 	import { localizedHref } from '$lib/utils/i18n';
 	import { resolve } from '$app/paths';
 	import { T, getTranslate } from '@tolgee/svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { PASSWORD_MIN_LENGTH, resetPasswordSchema } from './schema.js';
 	import { page } from '$app/state';
 	import { slide } from 'svelte/transition';

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -12,8 +12,8 @@
 	import { localizedHref } from '$lib/utils/i18n';
 	import { resolve } from '$app/paths';
 	import { T, getTranslate } from '@tolgee/svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
-	import { authFlowContext } from '$lib/hooks/auth-flow.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+	import { authFlowContext } from '$lib/hooks/auth-flow.svelte.ts';
 	import {
 		type LastAuthMethod,
 		type PendingOAuthProvider,
@@ -22,7 +22,7 @@
 		clearPendingOAuthProvider,
 		setLastSuccessfulAuthMethod,
 		clearLastSuccessfulAuthMethod
-	} from '$lib/hooks/last-auth-method.svelte';
+	} from '$lib/hooks/last-auth-method.svelte.ts';
 	import { getAuthErrorKey } from '$lib/utils/auth-messages';
 	import { safeRedirectPath } from '$lib/utils/url';
 	import SignInForm from './SignInForm.svelte';

--- a/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
@@ -3,7 +3,7 @@
 	import KeyIcon from '@lucide/svelte/icons/key-round';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import type { LastAuthMethod, PendingOAuthProvider } from '$lib/hooks/last-auth-method.svelte';
+	import type { LastAuthMethod, PendingOAuthProvider } from '$lib/hooks/last-auth-method.svelte.ts';
 
 	type OAuthProviderAvailability = {
 		google?: boolean;

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -10,7 +10,7 @@
 	import * as Password from '$lib/components/ui/password';
 	import { translateFormError, translateValidationErrors } from '$lib/utils/validation-i18n.js';
 	import OAuthButtons from './OAuthButtons.svelte';
-	import type { LastAuthMethod, PendingOAuthProvider } from '$lib/hooks/last-auth-method.svelte';
+	import type { LastAuthMethod, PendingOAuthProvider } from '$lib/hooks/last-auth-method.svelte.ts';
 
 	type Props = {
 		id: string;

--- a/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignUpForm.svelte
@@ -11,7 +11,7 @@
 	import * as Password from '$lib/components/ui/password';
 	import { translateFormError, translateValidationErrors } from '$lib/utils/validation-i18n.js';
 	import OAuthButtons from './OAuthButtons.svelte';
-	import type { LastAuthMethod, PendingOAuthProvider } from '$lib/hooks/last-auth-method.svelte';
+	import type { LastAuthMethod, PendingOAuthProvider } from '$lib/hooks/last-auth-method.svelte.ts';
 
 	type Props = {
 		id: string;

--- a/src/routes/[[lang]]/(auth)/signup/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signup/+page.svelte
@@ -12,8 +12,8 @@
 	import { localizedHref } from '$lib/utils/i18n';
 	import { resolve } from '$app/paths';
 	import { T, getTranslate } from '@tolgee/svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
-	import { authFlowContext } from '$lib/hooks/auth-flow.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+	import { authFlowContext } from '$lib/hooks/auth-flow.svelte.ts';
 	import {
 		type PendingOAuthProvider,
 		lastSuccessfulAuthMethod,
@@ -21,7 +21,7 @@
 		clearPendingOAuthProvider,
 		clearLastSuccessfulAuthMethod,
 		type LastAuthMethod
-	} from '$lib/hooks/last-auth-method.svelte';
+	} from '$lib/hooks/last-auth-method.svelte.ts';
 	import { getAuthErrorKey } from '$lib/utils/auth-messages';
 	import { safeRedirectPath } from '$lib/utils/url';
 	import SignUpForm from '../signin/SignUpForm.svelte';

--- a/src/routes/[[lang]]/admin/audit-log/+page.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/+page.svelte
@@ -7,11 +7,11 @@
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { useConvexClient } from 'convex-svelte';
-	import { adminCache } from '$lib/hooks/admin-cache.svelte';
+	import { adminCache } from '$lib/hooks/admin-cache.svelte.ts';
 	import { api } from '$lib/convex/_generated/api.js';
 	import { createSvelteTable, FlexRender } from '$lib/components/ui/data-table/index.js';
 	import ConvexCursorTableShell from '$lib/components/tables/convex-cursor-table-shell.svelte';
-	import { createConvexCursorTable } from '$lib/tables/convex/create-convex-cursor-table.svelte';
+	import { createConvexCursorTable } from '$lib/tables/convex/create-convex-cursor-table.svelte.ts';
 	import type { CursorListResult } from '$lib/tables/convex/contract';
 	import type { AuditLogItem } from '$lib/convex/admin/auditLog/queries';
 	import { browser } from '$app/environment';

--- a/src/routes/[[lang]]/admin/audit-log/data-table-filters.svelte
+++ b/src/routes/[[lang]]/admin/audit-log/data-table-filters.svelte
@@ -4,7 +4,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Skeleton } from '$lib/components/ui/skeleton/index.js';
 	import XIcon from '@lucide/svelte/icons/x';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { useQuery } from 'convex-svelte';
 	import { api } from '$lib/convex/_generated/api.js';

--- a/src/routes/[[lang]]/admin/settings/add-email-dialog.svelte
+++ b/src/routes/[[lang]]/admin/settings/add-email-dialog.svelte
@@ -5,7 +5,7 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import { T, getTranslate } from '@tolgee/svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { addEmailForm } from './data.remote';
 	import { addEmailSchema } from './email-schema';

--- a/src/routes/[[lang]]/admin/settings/data-table-filters.svelte
+++ b/src/routes/[[lang]]/admin/settings/data-table-filters.svelte
@@ -2,7 +2,7 @@
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import XIcon from '@lucide/svelte/icons/x';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { T, getTranslate } from '@tolgee/svelte';
 
 	const { t } = getTranslate();

--- a/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
+++ b/src/routes/[[lang]]/admin/settings/notification-recipients-table.svelte
@@ -13,11 +13,11 @@
 	import { setContext } from 'svelte';
 	import { createSvelteTable, FlexRender } from '$lib/components/ui/data-table/index.js';
 	import ConvexCursorTableShell from '$lib/components/tables/convex-cursor-table-shell.svelte';
-	import { createConvexCursorTable } from '$lib/tables/convex/create-convex-cursor-table.svelte';
+	import { createConvexCursorTable } from '$lib/tables/convex/create-convex-cursor-table.svelte.ts';
 	import type { CursorListResult } from '$lib/tables/convex/contract';
 	import { columns } from './columns.js';
 	import type { NotificationRecipient } from '$lib/convex/admin/notificationPreferences/queries';
-	import { adminCache } from '$lib/hooks/admin-cache.svelte';
+	import { adminCache } from '$lib/hooks/admin-cache.svelte.ts';
 	import AddEmailDialog from './add-email-dialog.svelte';
 	import { browser } from '$app/environment';
 	import DataTableFilters from './data-table-filters.svelte';

--- a/src/routes/[[lang]]/admin/settings/recipients-toggle.svelte
+++ b/src/routes/[[lang]]/admin/settings/recipients-toggle.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 	import { getContext } from 'svelte';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { getTranslate } from '@tolgee/svelte';
 	import type { RowSelectionState } from '@tanstack/table-core';

--- a/src/routes/[[lang]]/admin/support/+page.svelte
+++ b/src/routes/[[lang]]/admin/support/+page.svelte
@@ -8,7 +8,7 @@
 	import { resolve } from '$app/paths';
 	import { useQuery, usePaginatedQuery } from 'convex-svelte';
 	import { api } from '$lib/convex/_generated/api';
-	import { useMedia } from '$lib/hooks/use-media.svelte';
+	import { useMedia } from '$lib/hooks/use-media.svelte.ts';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import * as Sheet from '$lib/components/ui/sheet';
 	import * as Drawer from '$lib/components/ui/drawer';
@@ -17,8 +17,11 @@
 	import ThreadList from './thread-list.svelte';
 	import ThreadChat from './thread-chat.svelte';
 	import ThreadDetails from './thread-details.svelte';
-	import { AdminSupportUIManager, adminSupportUIContext } from '$lib/hooks/admin-support-ui.svelte';
-	import { adminCache } from '$lib/hooks/admin-cache.svelte';
+	import {
+		AdminSupportUIManager,
+		adminSupportUIContext
+	} from '$lib/hooks/admin-support-ui.svelte.ts';
+	import { adminCache } from '$lib/hooks/admin-cache.svelte.ts';
 	import { ChatDraftManager } from '$lib/chat';
 	import { browser } from '$app/environment';
 

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -7,9 +7,9 @@
 	import ChatRoot from '$lib/chat/ui/ChatRoot.svelte';
 	import ChatMessages from '$lib/chat/ui/ChatMessages.svelte';
 	import ChatInput from '$lib/chat/ui/ChatInput.svelte';
-	import { ChatUIContext, type UploadConfig } from '$lib/chat/ui/chat-context.svelte';
-	import { ChatCore } from '$lib/chat/core/chat-core.svelte';
-	import type { ChatDraftManager } from '$lib/chat/core/chat-draft-manager.svelte';
+	import { ChatUIContext, type UploadConfig } from '$lib/chat/ui/chat-context.svelte.ts';
+	import { ChatCore } from '$lib/chat/core/chat-core.svelte.ts';
+	import type { ChatDraftManager } from '$lib/chat/core/chat-draft-manager.svelte.ts';
 	import { createOptimisticUpdate, type ListMessagesArgs } from '$lib/chat/core/optimistic';
 	import { CHAT_PAGE_SIZE } from '$lib/chat/core/types';
 	import { Button } from '$lib/components/ui/button';
@@ -18,9 +18,9 @@
 	import PanelRightIcon from '@lucide/svelte/icons/panel-right';
 	import PanelBottomOpen from '@lucide/svelte/icons/panel-bottom-open';
 	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
-	import { useMedia } from '$lib/hooks/use-media.svelte';
+	import { useMedia } from '$lib/hooks/use-media.svelte.ts';
 	import { SlidingHeader } from '$lib/components/ui/sliding-header';
-	import { adminSupportUIContext } from '$lib/hooks/admin-support-ui.svelte';
+	import { adminSupportUIContext } from '$lib/hooks/admin-support-ui.svelte.ts';
 	import { getTranslate } from '@tolgee/svelte';
 	import { page } from '$app/state';
 

--- a/src/routes/[[lang]]/admin/support/thread-details.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-details.svelte
@@ -11,7 +11,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { T, getTranslate } from '@tolgee/svelte';
 

--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -11,7 +11,7 @@
 	import Loader2Icon from '@lucide/svelte/icons/loader-2';
 	import { formatDistanceToNow } from 'date-fns';
 	import { watch } from 'runed';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { InfiniteLoader, LoaderState } from 'svelte-infinite';
 	import { page } from '$app/state';

--- a/src/routes/[[lang]]/admin/users/+page.svelte
+++ b/src/routes/[[lang]]/admin/users/+page.svelte
@@ -26,12 +26,12 @@
 	import { authClient } from '$lib/auth-client.js';
 	import { toast } from 'svelte-sonner';
 	import { setContext } from 'svelte';
-	import { adminCache } from '$lib/hooks/admin-cache.svelte';
+	import { adminCache } from '$lib/hooks/admin-cache.svelte.ts';
 	import type { PageData } from './$types';
 	import { type UserRole, type AdminUserData } from '$lib/convex/admin/types';
 	import { createSvelteTable, FlexRender } from '$lib/components/ui/data-table/index.js';
 	import ConvexCursorTableShell from '$lib/components/tables/convex-cursor-table-shell.svelte';
-	import { createConvexCursorTable } from '$lib/tables/convex/create-convex-cursor-table.svelte';
+	import { createConvexCursorTable } from '$lib/tables/convex/create-convex-cursor-table.svelte.ts';
 	import type { CursorListResult } from '$lib/tables/convex/contract';
 	import { createColumns } from './columns.js';
 	import DataTableFilters from './data-table-filters.svelte';

--- a/src/routes/[[lang]]/admin/users/data-table-actions.svelte
+++ b/src/routes/[[lang]]/admin/users/data-table-actions.svelte
@@ -18,7 +18,7 @@
 	import LogoutIcon from '@lucide/svelte/icons/log-out';
 	import ShieldIcon from '@lucide/svelte/icons/shield';
 	import CheckIcon from '@lucide/svelte/icons/check';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { T } from '@tolgee/svelte';
 	import { USER_ROLES } from '$lib/convex/admin/types';
 	import { getContext } from 'svelte';

--- a/src/routes/[[lang]]/admin/users/data-table-filters.svelte
+++ b/src/routes/[[lang]]/admin/users/data-table-filters.svelte
@@ -2,7 +2,7 @@
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import XIcon from '@lucide/svelte/icons/x';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { T, getTranslate } from '@tolgee/svelte';
 
 	const { t } = getTranslate();

--- a/src/routes/[[lang]]/app/ai-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/+page.svelte
@@ -10,7 +10,7 @@
 	import { useCustomer, useAutumnOperation } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
 	import { getTranslate } from '@tolgee/svelte';
 	import { toast } from 'svelte-sonner';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import ThreadChat from './thread-chat.svelte';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -7,9 +7,9 @@
 	import ChatMessages from '$lib/chat/ui/ChatMessages.svelte';
 	import ChatInput from '$lib/chat/ui/ChatInput.svelte';
 	import { PromptSuggestion } from '$lib/components/prompt-kit/prompt-suggestion';
-	import { ChatUIContext, type UploadConfig } from '$lib/chat/ui/chat-context.svelte';
-	import { ChatCore } from '$lib/chat/core/chat-core.svelte';
-	import { ChatDraftManager } from '$lib/chat/core/chat-draft-manager.svelte';
+	import { ChatUIContext, type UploadConfig } from '$lib/chat/ui/chat-context.svelte.ts';
+	import { ChatCore } from '$lib/chat/core/chat-core.svelte.ts';
+	import { ChatDraftManager } from '$lib/chat/core/chat-draft-manager.svelte.ts';
 	import MessageQuotaBanner from '$lib/components/message-quota-banner.svelte';
 	import { getTranslate } from '@tolgee/svelte';
 	import { page } from '$app/state';

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -18,11 +18,11 @@
 	import { ScrollButton } from '$lib/components/prompt-kit/scroll-button';
 	import * as Avatar from '$lib/components/ui/avatar/index.js';
 	import ProgressiveBlur from '$blocks/magic/ProgressiveBlur.svelte';
-	import { FadeOnLoad } from '$lib/utils/fade-on-load.svelte.js';
+	import { FadeOnLoad } from '$lib/utils/fade-on-load.svelte.ts';
 	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
 	import MessageQuotaBanner from '$lib/components/message-quota-banner.svelte';
 	import { MAX_MESSAGE_LENGTH } from '$lib/chat/core/types';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { mode } from 'mode-watcher';
 	import { tick, onMount } from 'svelte';

--- a/src/routes/[[lang]]/app/settings/account-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/account-settings.svelte
@@ -8,7 +8,7 @@
 	import { Progress } from '$lib/components/ui/progress/index.js';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import { uploadToStorage } from '$lib/chat';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { useConvexClient } from 'convex-svelte';

--- a/src/routes/[[lang]]/app/settings/email-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/email-settings.svelte
@@ -8,7 +8,7 @@
 	import * as InputGroup from '$lib/components/ui/input-group/index.js';
 	import * as Item from '$lib/components/ui/item/index.js';
 	import * as Field from '$lib/components/ui/field/index.js';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import InfoIcon from '@lucide/svelte/icons/info';

--- a/src/routes/[[lang]]/app/settings/password-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/password-settings.svelte
@@ -9,7 +9,7 @@
 	import * as Item from '$lib/components/ui/item/index.js';
 	import * as Field from '$lib/components/ui/field/index.js';
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import InfoIcon from '@lucide/svelte/icons/info';

--- a/src/routes/[[lang]]/app/settings/security-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/security-settings.svelte
@@ -6,7 +6,7 @@
 	import * as Card from '$lib/components/ui/card/index.js';
 	import * as Alert from '$lib/components/ui/alert/index.js';
 	import * as Item from '$lib/components/ui/item/index.js';
-	import { haptic } from '$lib/hooks/use-haptic.svelte';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { page } from '$app/state';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
-		"rewriteRelativeImportExtensions": true,
+		// This app type-checks with noEmit and builds through Vite, so explicit .ts specifiers
+		// must be allowed rather than rewritten; rewriting rejects aliases with TS2877.
+		"allowImportingTsExtensions": true,
 		"allowJs": true,
 		"checkJs": true,
 		"esModuleInterop": true,


### PR DESCRIPTION
Rune modules currently use three competing import forms: emitted-style `.svelte.js`, shortened `.svelte`, and explicit `.svelte.ts`. The repository contained 155 inconsistent specifiers. The shortened form is ambiguous with component imports, can lose to a same-stem component file during resolution, and is invalid in Node ESM output.

Standardize rune-module imports on their explicit real `.svelte.ts` extension and enforce the convention with an autofixable local ESLint rule. The rule covers relative and `$lib` static imports, type imports, re-exports, and literal dynamic imports while preserving real `.svelte` component imports. The checked-in VS Code setting aligns future auto-imports with the convention.

Explicit source extensions are now ecosystem-aligned: [`sv` 0.16 scaffolding](https://github.com/sveltejs/cli/pull/801) enables TypeScript's extension-aware behavior, TypeScript 5.7 introduced [`rewriteRelativeImportExtensions`](https://www.typescriptlang.org/tsconfig/rewriteRelativeImportExtensions.html), and SvelteKit packaging added `.ts`-to-`.js` rewriting support in [#14936](https://github.com/sveltejs/kit/pull/14936). The shortened form remains the current language-tools default tracked in [sveltejs/language-tools#2620](https://github.com/sveltejs/language-tools/issues/2620), but inheriting that default would retain the component ambiguity. The declaration-file limitation in [microsoft/TypeScript#61037](https://github.com/microsoft/TypeScript/issues/61037) does not apply because this repository is an application rather than a published library.

TypeScript 6 rejects non-relative `.ts` alias specifiers with TS2877 when `rewriteRelativeImportExtensions` is enabled because aliases cannot be rewritten during TypeScript emit. This application emits through Vite rather than `tsc`, so `allowImportingTsExtensions` correctly expresses the no-emit type-checking contract. The `sv` scaffolder default suits projects that emit through `tsc`; it is not useful for this application's build path.

Verified with static checks for all 119 changed files, the full types scope, 7 focused ESLint rule tests, 903 unit tests, a whole-repository ESLint pass, and a production build.
