### PR TITLE
fix(auth): Replace log out with stop impersonating

### DIFF
--- a/e2e/admin-impersonation.spec.ts
+++ b/e2e/admin-impersonation.spec.ts
@@ -133,8 +133,11 @@ test.describe('Admin Impersonation', () => {
 		await expect(page.locator('#user-menu-trigger')).toContainText(targetEmail);
 
 		// Stop impersonating from the user menu. This restores the admin session and
-		// navigates back to the users table.
+		// navigates back to the users table. Log out is hidden while impersonating: it
+		// would end the impersonated user's session and strand the admin logged out.
 		await page.locator('#user-menu-trigger').click();
+		await expect(page.getByTestId('app-user-menu-stop-impersonating')).toBeVisible();
+		await expect(page.getByTestId('logout-button')).toHaveCount(0);
 		await page.getByTestId('app-user-menu-stop-impersonating').click();
 
 		await page.waitForURL(/\/en\/admin\/users/, { timeout: 30000 });

--- a/e2e/admin-impersonation.spec.ts
+++ b/e2e/admin-impersonation.spec.ts
@@ -132,12 +132,46 @@ test.describe('Admin Impersonation', () => {
 		await expect(page.getByTestId('impersonation-banner')).toBeVisible({ timeout: 15000 });
 		await expect(page.locator('#user-menu-trigger')).toContainText(targetEmail);
 
-		// Stop impersonating from the user menu. This restores the admin session and
-		// navigates back to the users table. Log out is hidden while impersonating: it
-		// would end the impersonated user's session and strand the admin logged out.
+		// Log out is hidden while impersonating: signing out would end the
+		// impersonated user's session and leave the admin stranded, because Better
+		// Auth never redeems the admin_session cookie on sign out.
 		await page.locator('#user-menu-trigger').click();
 		await expect(page.getByTestId('app-user-menu-stop-impersonating')).toBeVisible();
 		await expect(page.getByTestId('logout-button')).toHaveCount(0);
+		await page.keyboard.press('Escape');
+
+		// The same guard holds on the marketing header, which the app sidebar logo
+		// links to. Holding the session read open pins the pre-hydration state: the
+		// server renders an authenticated shell, so a guard keyed on "not
+		// impersonating" would serve a live log out button in this window.
+		let releaseSession = () => {};
+		const sessionHeld = new Promise<void>((resolve) => {
+			releaseSession = resolve;
+		});
+		await page.route('**/api/auth/get-session**', async (route) => {
+			await sessionHeld;
+			await route.continue();
+		});
+
+		await page.goto('/en/pricing');
+		await page.waitForLoadState('domcontentloaded');
+		await expect(page.getByTestId('marketing-nav-dashboard')).toBeVisible({ timeout: 15000 });
+		await expect(page.getByTestId('marketing-nav-logout')).toHaveCount(0);
+
+		releaseSession();
+		await expect(page.getByTestId('marketing-nav-stop-impersonating')).toBeVisible({
+			timeout: 15000
+		});
+		await expect(page.getByTestId('marketing-nav-logout')).toHaveCount(0);
+		await page.unroute('**/api/auth/get-session**');
+
+		// Stop impersonating from the user menu. This restores the admin session and
+		// navigates back to the users table.
+		await page.goto('/en/app/community-chat');
+		await page.waitForLoadState('domcontentloaded');
+		await waitForAuthenticated(page);
+		await expect(page.getByTestId('impersonation-banner')).toBeVisible({ timeout: 15000 });
+		await page.locator('#user-menu-trigger').click();
 		await page.getByTestId('app-user-menu-stop-impersonating').click();
 
 		await page.waitForURL(/\/en\/admin\/users/, { timeout: 30000 });

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -10,8 +10,10 @@
 	import Menu from '@lucide/svelte/icons/menu';
 	import X from '@lucide/svelte/icons/x';
 	import LogOut from '@lucide/svelte/icons/log-out';
+	import UserXIcon from '@lucide/svelte/icons/user-x';
 	import Logo from '$lib/components/icons/logo.svelte';
 	import { authClient } from '$lib/auth-client';
+	import { ImpersonationState } from '$lib/hooks/use-impersonation.svelte.ts';
 	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { LEGAL_CONFIG } from '$lib/config/legal';
@@ -20,6 +22,11 @@
 	const auth = useAuth();
 	let signingOut = $state(false);
 	const isAuthenticated = $derived(auth.isAuthenticated && !signingOut);
+
+	// The app shell links here from the sidebar logo, so an impersonating admin can
+	// reach this header. Signing out from here would end the impersonated session
+	// and strand the admin, so the control becomes Stop Impersonating instead.
+	const impersonation = new ImpersonationState();
 
 	// Capture once at mount: did the server have a valid JWT?
 	const ssrAuthenticated = auth.isAuthenticated;
@@ -163,15 +170,29 @@
 									>
 										<T keyName="nav.dashboard" />
 									</Button>
-									<Button
-										variant="outline"
-										size="icon"
-										class="size-8"
-										onclick={() => signOut()}
-										aria-label={$t('aria.logout')}
-									>
-										<LogOut class="size-4" />
-									</Button>
+									{#if impersonation.isImpersonating}
+										<Button
+											variant="outline"
+											size="icon"
+											class="size-8 text-warning hover:text-warning"
+											onclick={() => impersonation.stop($t)}
+											aria-label={$t('app.user_menu.stop_impersonating')}
+											data-testid="marketing-nav-stop-impersonating"
+										>
+											<UserXIcon class="size-4" />
+										</Button>
+									{:else}
+										<Button
+											variant="outline"
+											size="icon"
+											class="size-8"
+											onclick={() => signOut()}
+											aria-label={$t('aria.logout')}
+											data-testid="marketing-nav-logout"
+										>
+											<LogOut class="size-4" />
+										</Button>
+									{/if}
 								{:else if isAtTop}
 									<Button variant="ghost" size="sm" href={localizedHref('/signin')}>
 										<T keyName="nav.login" />

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -181,7 +181,7 @@
 										>
 											<UserXIcon class="size-4" />
 										</Button>
-									{:else}
+									{:else if impersonation.canSignOut}
 										<Button
 											variant="outline"
 											size="icon"

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -185,7 +185,9 @@
 				</DropdownMenu.Group>
 				<DropdownMenu.Separator />
 				<!-- While impersonating, signing out would end the impersonated user's session
-				     and leave the admin logged out entirely, so only offer Stop Impersonating. -->
+				     and leave the admin logged out entirely, so only offer Stop Impersonating.
+				     Neither shows until the session resolves, so log out is never live on an
+				     unresolved session. -->
 				{#if impersonation.isImpersonating}
 					<DropdownMenu.Item
 						onclick={() => impersonation.stop($t)}
@@ -195,7 +197,7 @@
 						<UserXIcon />
 						<T keyName="app.user_menu.stop_impersonating" />
 					</DropdownMenu.Item>
-				{:else}
+				{:else if impersonation.canSignOut}
 					<DropdownMenu.Item onclick={() => signOut()} data-testid="logout-button">
 						<LogOutIcon />
 						<T keyName="app.user_menu.logout" />

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -19,6 +19,7 @@
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { localizedHref } from '$lib/utils/i18n';
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+	import { ImpersonationState } from '$lib/hooks/use-impersonation.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { useCustomer, useAutumnOperation } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
 
@@ -34,12 +35,7 @@
 	// Impersonation state comes from the live session, not a parent prop: while an
 	// admin impersonates a user the session carries impersonatedBy, so the app
 	// shell reads it directly to show the banner and the Stop control.
-	let isImpersonating = $state(false);
-	$effect(() => {
-		return authClient.useSession().subscribe((s) => {
-			isImpersonating = !!s.data?.session?.impersonatedBy;
-		});
-	});
+	const impersonation = new ImpersonationState();
 
 	// Autumn subscription state
 	const autumn = useCustomer();
@@ -96,31 +92,9 @@
 			await goto(resolve(localizedHref('/')));
 		}
 	}
-
-	async function stopImpersonating() {
-		haptic.trigger('warning');
-		try {
-			const result = await authClient.admin.stopImpersonating();
-			if (result.error) {
-				toast.error($t('app.user_menu.impersonation_stop_failed'));
-				return;
-			}
-			toast.success($t('app.user_menu.impersonation_stopped'));
-			// Stopping restored the admin session cookie, but Better Auth's convex
-			// plugin does not re-mint the SSR JWT cookie on stop. Force a session read
-			// so the server issues a fresh convex_jwt for the admin before we navigate,
-			// otherwise SSR resolves the still-alive impersonated token.
-			await authClient.getSession({ query: { disableCookieCache: true } });
-			// Full document navigation, not a client-side goto: the app must boot with
-			// the fresh JWT and new Convex subscriptions bound to the admin identity.
-			window.location.assign(localizedHref('/admin/users'));
-		} catch {
-			toast.error($t('app.user_menu.impersonation_stop_failed'));
-		}
-	}
 </script>
 
-{#if isImpersonating}
+{#if impersonation.isImpersonating}
 	<div
 		class="mb-2 rounded-md border border-warning/20 bg-warning/10 px-3 py-2 text-xs font-medium text-warning"
 		data-testid="impersonation-banner"
@@ -135,7 +109,7 @@
 				{#snippet child({ props })}
 					<Button
 						variant="ghost"
-						class="h-12 w-full justify-start gap-2 px-2 data-[state=open]:bg-muted {isImpersonating
+						class="h-12 w-full justify-start gap-2 px-2 data-[state=open]:bg-muted {impersonation.isImpersonating
 							? 'ring-2 ring-warning'
 							: ''}"
 						{...props}
@@ -209,22 +183,24 @@
 						<T keyName="app.user_menu.billing" />
 					</DropdownMenu.Item>
 				</DropdownMenu.Group>
-				{#if isImpersonating}
-					<DropdownMenu.Separator />
+				<DropdownMenu.Separator />
+				<!-- While impersonating, signing out would end the impersonated user's session
+				     and leave the admin logged out entirely, so only offer Stop Impersonating. -->
+				{#if impersonation.isImpersonating}
 					<DropdownMenu.Item
-						onclick={() => stopImpersonating()}
+						onclick={() => impersonation.stop($t)}
 						class="text-warning"
 						data-testid="app-user-menu-stop-impersonating"
 					>
 						<UserXIcon />
 						<T keyName="app.user_menu.stop_impersonating" />
 					</DropdownMenu.Item>
+				{:else}
+					<DropdownMenu.Item onclick={() => signOut()} data-testid="logout-button">
+						<LogOutIcon />
+						<T keyName="app.user_menu.logout" />
+					</DropdownMenu.Item>
 				{/if}
-				<DropdownMenu.Separator />
-				<DropdownMenu.Item onclick={() => signOut()} data-testid="logout-button">
-					<LogOutIcon />
-					<T keyName="app.user_menu.logout" />
-				</DropdownMenu.Item>
 			</DropdownMenu.Content>
 		</DropdownMenu.Root>
 	</Sidebar.MenuItem>

--- a/src/lib/hooks/use-impersonation.svelte.ts
+++ b/src/lib/hooks/use-impersonation.svelte.ts
@@ -1,0 +1,61 @@
+import { authClient } from '$lib/auth-client';
+import { localizedHref } from '$lib/utils/i18n';
+import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+import { toast } from 'svelte-sonner';
+
+/**
+ * Live impersonation state plus the exit action, shared by every shell that
+ * offers a session control.
+ *
+ * While an admin impersonates a user, Better Auth's `signOut` deletes the
+ * impersonated session and its cookie, and never redeems the `admin_session`
+ * cookie that `stopImpersonating` needs. A plain log out therefore strands the
+ * admin fully signed out and destroys the target's session as a side effect, so
+ * every surface with a log out control has to swap it for Stop Impersonating.
+ *
+ * Instantiated per component — never a module-level singleton, which would leak
+ * across SSR requests.
+ */
+export class ImpersonationState {
+	/** True while the current session carries `impersonatedBy`. */
+	isImpersonating = $state(false);
+
+	/**
+	 * Subscribes to the live session. Call during component init so the
+	 * subscription is torn down with the component.
+	 */
+	constructor() {
+		$effect(() => {
+			return authClient.useSession().subscribe((s) => {
+				this.isImpersonating = !!s.data?.session?.impersonatedBy;
+			});
+		});
+	}
+
+	/**
+	 * Restores the admin session and navigates back to the users table.
+	 *
+	 * @param t - Tolgee translate function ($t from getTranslate())
+	 */
+	async stop(t: (key: string) => string): Promise<void> {
+		haptic.trigger('warning');
+		try {
+			const result = await authClient.admin.stopImpersonating();
+			if (result.error) {
+				toast.error(t('app.user_menu.impersonation_stop_failed'));
+				return;
+			}
+			toast.success(t('app.user_menu.impersonation_stopped'));
+			// Stopping restored the admin session cookie, but Better Auth's convex
+			// plugin does not re-mint the SSR JWT cookie on stop. Force a session read
+			// so the server issues a fresh convex_jwt for the admin before we navigate,
+			// otherwise SSR resolves the still-alive impersonated token.
+			await authClient.getSession({ query: { disableCookieCache: true } });
+			// Full document navigation, not a client-side goto: the app must boot with
+			// the fresh JWT and new Convex subscriptions bound to the admin identity.
+			window.location.assign(localizedHref('/admin/users'));
+		} catch {
+			toast.error(t('app.user_menu.impersonation_stop_failed'));
+		}
+	}
+}

--- a/src/lib/hooks/use-impersonation.svelte.ts
+++ b/src/lib/hooks/use-impersonation.svelte.ts
@@ -17,8 +17,30 @@ import { toast } from 'svelte-sonner';
  * across SSR requests.
  */
 export class ImpersonationState {
-	/** True while the current session carries `impersonatedBy`. */
-	isImpersonating = $state(false);
+	#impersonating = $state(false);
+	#resolved = $state(false);
+
+	/** True once the session carries `impersonatedBy`. False while unresolved. */
+	get isImpersonating(): boolean {
+		return this.#impersonating;
+	}
+
+	/**
+	 * Whether a log out control may be shown.
+	 *
+	 * A plain `!isImpersonating` would conflate "not impersonating" with "session
+	 * not loaded yet", and the session starts out pending with no data. On an SSR
+	 * authenticated page the shell renders before the first session read resolves,
+	 * so the log out control would be live during that window — exactly the trap
+	 * this state exists to prevent. Gate on a resolved session instead.
+	 *
+	 * A failed session read counts as resolved: the alternative is a surface with
+	 * no way out at all, and Better Auth clears the data on a 401 so the shell
+	 * falls back to its signed-out rendering anyway.
+	 */
+	get canSignOut(): boolean {
+		return this.#resolved && !this.#impersonating;
+	}
 
 	/**
 	 * Subscribes to the live session. Call during component init so the
@@ -27,7 +49,10 @@ export class ImpersonationState {
 	constructor() {
 		$effect(() => {
 			return authClient.useSession().subscribe((s) => {
-				this.isImpersonating = !!s.data?.session?.impersonatedBy;
+				this.#impersonating = !!s.data?.session?.impersonatedBy;
+				// Stays true across refetches that already hold data, so a background
+				// session refresh never flickers the control back to its pending state.
+				this.#resolved = !s.isPending;
 			});
 		});
 	}
@@ -45,12 +70,18 @@ export class ImpersonationState {
 				toast.error(t('app.user_menu.impersonation_stop_failed'));
 				return;
 			}
-			toast.success(t('app.user_menu.impersonation_stopped'));
 			// Stopping restored the admin session cookie, but Better Auth's convex
 			// plugin does not re-mint the SSR JWT cookie on stop. Force a session read
 			// so the server issues a fresh convex_jwt for the admin before we navigate,
-			// otherwise SSR resolves the still-alive impersonated token.
-			await authClient.getSession({ query: { disableCookieCache: true } });
+			// otherwise SSR resolves the still-alive impersonated token. The fetch
+			// resolves errors as { error } instead of throwing, so the catch below
+			// would miss a failed refresh and navigate on the target's identity.
+			const refreshed = await authClient.getSession({ query: { disableCookieCache: true } });
+			if (refreshed.error || !refreshed.data) {
+				toast.error(t('app.user_menu.impersonation_stop_failed'));
+				return;
+			}
+			toast.success(t('app.user_menu.impersonation_stopped'));
 			// Full document navigation, not a client-side goto: the app must boot with
 			// the fresh JWT and new Convex subscriptions bound to the admin identity.
 			window.location.assign(localizedHref('/admin/users'));

--- a/src/lib/hooks/use-impersonation.svelte.ts
+++ b/src/lib/hooks/use-impersonation.svelte.ts
@@ -16,11 +16,25 @@ import { toast } from 'svelte-sonner';
  * Instantiated per component — never a module-level singleton, which would leak
  * across SSR requests.
  */
+/**
+ * Whether the server has confirmed a stop during this document load.
+ *
+ * Module scope, not per instance: the stale session lives in Better Auth's
+ * global store, so an instance-local latch dies with the first client-side
+ * navigation. Leaving the app shell for the marketing shell would build a fresh
+ * state, read the same stale session, and put the dead Stop control back.
+ *
+ * A full document load resets this, which is exactly the intended lifetime: a
+ * new impersonation always starts with one (see the admin users table).
+ *
+ * Plain `let`, written only from `stop()` — a browser-only path — so no SSR
+ * request can ever observe another request's value.
+ */
+let stopConfirmedThisLoad = false;
+
 export class ImpersonationState {
 	#impersonating = $state(false);
 	#resolved = $state(false);
-	// Plain field, not $state: a latch read inside the subscription, never rendered.
-	#stopConfirmed = false;
 
 	/** True once the session carries `impersonatedBy`. False while unresolved. */
 	get isImpersonating(): boolean {
@@ -52,12 +66,11 @@ export class ImpersonationState {
 		$effect(() => {
 			return authClient.useSession().subscribe((s) => {
 				// Once the server has confirmed a stop, any session still carrying
-				// impersonatedBy is a stale in-flight read: Better Auth writes every
-				// completed refresh into the store unconditionally, with no generation
-				// check, so one started before the stop can land after it and revive a
-				// session that no longer exists. This instance cannot legitimately
-				// impersonate again, since a successful stop navigates away.
-				if (!this.#stopConfirmed) {
+				// impersonatedBy is stale: Better Auth writes every completed refresh
+				// into its store unconditionally, with no generation check, and neither
+				// the stop nor the refresh matches its session-signal listeners, so the
+				// store keeps serving a session the server already deleted.
+				if (!stopConfirmedThisLoad) {
 					this.#impersonating = !!s.data?.session?.impersonatedBy;
 				}
 				// Stays true across refetches that already hold data, so a background
@@ -87,7 +100,7 @@ export class ImpersonationState {
 			// impersonated session. Leaving the flag set would leave Stop as the only
 			// control on a session that can no longer be stopped, and every further
 			// click would fail with "You are not impersonating anyone".
-			this.#stopConfirmed = true;
+			stopConfirmedThisLoad = true;
 			this.#impersonating = false;
 
 			// Better Auth's convex plugin does not re-mint the SSR JWT cookie on stop.

--- a/src/lib/hooks/use-impersonation.svelte.ts
+++ b/src/lib/hooks/use-impersonation.svelte.ts
@@ -70,12 +70,22 @@ export class ImpersonationState {
 				toast.error(t('app.user_menu.impersonation_stop_failed'));
 				return;
 			}
-			// Stopping restored the admin session cookie, but Better Auth's convex
-			// plugin does not re-mint the SSR JWT cookie on stop. Force a session read
-			// so the server issues a fresh convex_jwt for the admin before we navigate,
-			// otherwise SSR resolves the still-alive impersonated token. The fetch
-			// resolves errors as { error } instead of throwing, so the catch below
-			// would miss a failed refresh and navigate on the target's identity.
+			// The server has stopped the impersonation: the target's session is gone
+			// and the admin session cookie is live again. Record that before the
+			// refresh, because neither this call nor the refresh below matches Better
+			// Auth's session-signal listeners, so the store keeps serving the stale
+			// impersonated session. Leaving the flag set would leave Stop as the only
+			// control on a session that can no longer be stopped, and every further
+			// click would fail with "You are not impersonating anyone".
+			this.#impersonating = false;
+
+			// Better Auth's convex plugin does not re-mint the SSR JWT cookie on stop.
+			// Force a session read so the server issues a fresh convex_jwt for the
+			// admin before we navigate, otherwise SSR resolves the still-alive
+			// impersonated token. The fetch resolves errors as { error } instead of
+			// throwing, so the catch below would miss a failed refresh and navigate on
+			// the target's identity. Log out stays available as the exit here, and it
+			// is safe now: it ends the admin's own restored session, not the target's.
 			const refreshed = await authClient.getSession({ query: { disableCookieCache: true } });
 			if (refreshed.error || !refreshed.data) {
 				toast.error(t('app.user_menu.impersonation_stop_failed'));

--- a/src/lib/hooks/use-impersonation.svelte.ts
+++ b/src/lib/hooks/use-impersonation.svelte.ts
@@ -19,6 +19,8 @@ import { toast } from 'svelte-sonner';
 export class ImpersonationState {
 	#impersonating = $state(false);
 	#resolved = $state(false);
+	// Plain field, not $state: a latch read inside the subscription, never rendered.
+	#stopConfirmed = false;
 
 	/** True once the session carries `impersonatedBy`. False while unresolved. */
 	get isImpersonating(): boolean {
@@ -49,7 +51,15 @@ export class ImpersonationState {
 	constructor() {
 		$effect(() => {
 			return authClient.useSession().subscribe((s) => {
-				this.#impersonating = !!s.data?.session?.impersonatedBy;
+				// Once the server has confirmed a stop, any session still carrying
+				// impersonatedBy is a stale in-flight read: Better Auth writes every
+				// completed refresh into the store unconditionally, with no generation
+				// check, so one started before the stop can land after it and revive a
+				// session that no longer exists. This instance cannot legitimately
+				// impersonate again, since a successful stop navigates away.
+				if (!this.#stopConfirmed) {
+					this.#impersonating = !!s.data?.session?.impersonatedBy;
+				}
 				// Stays true across refetches that already hold data, so a background
 				// session refresh never flickers the control back to its pending state.
 				this.#resolved = !s.isPending;
@@ -77,6 +87,7 @@ export class ImpersonationState {
 			// impersonated session. Leaving the flag set would leave Stop as the only
 			// control on a session that can no longer be stopped, and every further
 			// click would fail with "You are not impersonating anyone".
+			this.#stopConfirmed = true;
 			this.#impersonating = false;
 
 			// Better Auth's convex plugin does not re-mint the SSR JWT cookie on stop.


### PR DESCRIPTION
The user menu offered Log out and Stop Impersonating side by side while an admin was impersonating someone. Better Auth's `signOut` only deletes the current session row and its cookie, and during an impersonation that is the impersonated user's session. The `admin_session` cookie that `stopImpersonating` needs to restore the admin is never redeemed, so logging out stranded the admin fully signed out and destroyed the target's session as a side effect.

Both surfaces that carry a log out control now swap it for Stop Impersonating: the app user menu, and the marketing header, which the app and admin sidebar logos link to. They share the session subscription and the exit action through `ImpersonationState`.

Neither control renders until the session actually resolves. The subscription starts pending with no data, so a guard keyed on "not impersonating" cannot tell an unresolved session apart from a normal one, and an SSR authenticated page would render a live log out button in that window. The exit action also checks the result of its session refresh, which resolves errors as `{ error }` rather than throwing, so a failed refresh no longer reports success and navigates on the target's identity.

Regression guard: added e2e/admin-impersonation.spec.ts coverage that holds the session request open and asserts no log out control on either surface while impersonating

Verified by running the impersonation E2E spec against both the fixed and a deliberately reverted guard, confirming the new case fails without the fix; full lint and types checks pass.