### PR TITLE
refactor(ai): Split the shared chat model constant

### DIFF
--- a/scripts/model-eval.ts
+++ b/scripts/model-eval.ts
@@ -9,13 +9,13 @@
  * Not CI. Burns OpenRouter credits. Needs OPENROUTER_API_KEY (env or
  * .env.convex.local).
  *
- *   bun run model:eval                                 # check the model in use (CHAT_MODEL_ID)
+ *   bun run model:eval                                 # check the AI chat model in use
  *   bun run model:eval -- --model openai/gpt-5-mini    # check a candidate
  *   bun run model:eval -- --model a --model b          # compare several
  *   bun run model:eval -- --json /tmp/eval.json        # also write raw results
  */
 import { writeFileSync } from 'node:fs';
-import { CHAT_MODEL_ID } from '../src/lib/convex/utils/chatModel.ts';
+import { AI_CHAT_MODEL_ID } from '../src/lib/convex/utils/chatModel.ts';
 import {
 	checkCatalog,
 	checkImage,
@@ -39,7 +39,7 @@ function parseArgs(argv: string[]): { models: string[]; jsonPath: string | null 
 		if (argv[i] === '--model' && argv[i + 1]) models.push(argv[++i]!);
 		else if (argv[i] === '--json' && argv[i + 1]) jsonPath = argv[++i]!;
 	}
-	if (models.length === 0) models.push(CHAT_MODEL_ID);
+	if (models.length === 0) models.push(AI_CHAT_MODEL_ID);
 	return { models, jsonPath };
 }
 

--- a/src/lib/convex/aiChat/agent.ts
+++ b/src/lib/convex/aiChat/agent.ts
@@ -1,7 +1,7 @@
 import { Agent } from '@convex-dev/agent';
 import { components } from '../_generated/api';
 import { orModel } from '../aiUsage/capture';
-import { CHAT_MODEL_ID } from '../utils/chatModel';
+import { AI_CHAT_MODEL_ID } from '../utils/chatModel';
 import { getGeocoding, getWeather } from './tools/weather';
 
 /**
@@ -50,7 +50,7 @@ Communication style:
 export const aiChatAgent = new Agent(components.agent, {
 	name: 'Assistant',
 
-	languageModel: orModel(CHAT_MODEL_ID, {
+	languageModel: orModel(AI_CHAT_MODEL_ID, {
 		extraBody: {
 			reasoning: { enabled: true }
 		}

--- a/src/lib/convex/aiChat/titles.ts
+++ b/src/lib/convex/aiChat/titles.ts
@@ -2,7 +2,7 @@ import { internalAction } from '../_generated/server';
 import { v } from 'convex/values';
 import { internal } from '../_generated/api';
 import { generateText } from 'ai';
-import { CHAT_MODEL_ID } from '../utils/chatModel';
+import { TITLE_MODEL_ID } from '../utils/chatModel';
 import { getAutumnSdk } from '../autumn';
 import { orModel, captureDirect } from '../aiUsage/capture';
 import { recordAiUsage } from '../aiUsage/record';
@@ -52,7 +52,7 @@ export const generateThreadTitle = internalAction({
 		let raw: string;
 		try {
 			const { text, usage, providerMetadata } = await generateText({
-				model: orModel(CHAT_MODEL_ID),
+				model: orModel(TITLE_MODEL_ID),
 				temperature: 0.3,
 				prompt: `Summarize the following user message into a short, descriptive conversation title of 3 to 6 words. Use title case. Do not use quotation marks or trailing punctuation. Respond with the title only, nothing else.\n\nMessage:\n${source}`
 			});
@@ -60,7 +60,7 @@ export const generateThreadTitle = internalAction({
 			await recordAiUsage(ctx, {
 				feature: 'ai_chat_title',
 				userId: args.userId,
-				models: [captureDirect(usage, providerMetadata, CHAT_MODEL_ID)]
+				models: [captureDirect(usage, providerMetadata, TITLE_MODEL_ID)]
 			});
 		} catch (err) {
 			console.warn('[generateThreadTitle] LLM call failed', err);

--- a/src/lib/convex/pricing/prices.test.ts
+++ b/src/lib/convex/pricing/prices.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { PRICES, costOf } from './prices';
-import { CHAT_MODEL_ID } from '../utils/chatModel';
+import { AI_CHAT_MODEL_ID, SUPPORT_MODEL_ID, TITLE_MODEL_ID } from '../utils/chatModel';
 
 // One million input + one million output tokens, so the expected USD for a
 // model is exactly (in + out) dollars (1M tokens at $X/Mtok = $X).
@@ -49,10 +49,16 @@ describe('costOf', () => {
 		expect(costOf('unknown/model-x', SAMPLE)).toBeNull();
 	});
 
-	// Regression guard against PRICES/chatModel divergence: the chat model the app
-	// actually runs must always have a price row, or computed-cost fallback breaks.
-	it('keeps a price row for CHAT_MODEL_ID', () => {
-		expect(PRICES[CHAT_MODEL_ID]).toBeDefined();
-		expect(costOf(CHAT_MODEL_ID, SAMPLE)).not.toBeNull();
+	// Regression guard against PRICES/chatModel divergence: every model the app
+	// actually runs must have a price row, or computed-cost fallback breaks.
+	// Each workload is listed separately so raising one of them alone still
+	// trips this when its new model has no row.
+	it.each([
+		['AI_CHAT_MODEL_ID', AI_CHAT_MODEL_ID],
+		['SUPPORT_MODEL_ID', SUPPORT_MODEL_ID],
+		['TITLE_MODEL_ID', TITLE_MODEL_ID]
+	])('keeps a price row for %s', (_label, modelId) => {
+		expect(PRICES[modelId]).toBeDefined();
+		expect(costOf(modelId, SAMPLE)).not.toBeNull();
 	});
 });

--- a/src/lib/convex/pricing/prices.ts
+++ b/src/lib/convex/pricing/prices.ts
@@ -1,9 +1,9 @@
 export type ModelPrice = { in: number; out: number; reasoning?: number; cachedIn?: number };
-// $ per 1M tokens. Seed = the app's chat model. Keep in sync with
-// utils/chatModel.ts (CHAT_MODEL_ID).
+// $ per 1M tokens. Seed = the app's chat models. Keep in sync with
+// utils/chatModel.ts; every model id used there needs a row.
 export const PRICES: Record<string, ModelPrice> = {
-	// CHAT_MODEL_ID placeholder zero-rate — fill in the real $/Mtok; native
-	// OpenRouter cost is used when present, this is the fallback.
+	// Placeholder zero-rate — fill in the real $/Mtok; native OpenRouter cost is
+	// used when present, this is the fallback.
 	'google/gemma-4-26b-a4b-it': { in: 0.0, out: 0.0 }
 };
 const PER_TOKEN = 1 / 1_000_000;

--- a/src/lib/convex/support/agent.ts
+++ b/src/lib/convex/support/agent.ts
@@ -1,7 +1,7 @@
 import { Agent } from '@convex-dev/agent';
 import { components } from '../_generated/api';
 import { orModel } from '../aiUsage/capture';
-import { CHAT_MODEL_ID } from '../utils/chatModel';
+import { SUPPORT_MODEL_ID } from '../utils/chatModel';
 import { LEGAL_CONFIG } from '../../config/legal';
 import { requestHandoff } from './tools/handoff';
 
@@ -58,7 +58,7 @@ export const supportAgent = new Agent(components.agent, {
 	name: 'Kai',
 
 	// Language model configuration
-	languageModel: orModel(CHAT_MODEL_ID, {
+	languageModel: orModel(SUPPORT_MODEL_ID, {
 		extraBody: {
 			reasoning: { effort: 'low' }
 		}

--- a/src/lib/convex/utils/chatModel.ts
+++ b/src/lib/convex/utils/chatModel.ts
@@ -1,12 +1,28 @@
 /**
- * Single source of truth for the OpenRouter chat model used by both the AI chat
- * assistant (`aiChat/agent.ts`) and the support agent Kai (`support/agent.ts`).
+ * OpenRouter model ids for the three chat-shaped workloads, kept apart on
+ * purpose: they have genuinely different requirements, and a shared constant
+ * silently drags all three along whenever one of them is upgraded.
  *
- * Model migrations (e.g. Gemma 4 → 5) are now a one-line change here.
- *
- * Reasoning configuration stays at each agent's call site — the two agents
- * intentionally diverge (medium for Pro AI chat, 'low' for the public anonymous
- * support surface) and that divergence should remain visible at the agent
- * definition rather than hidden behind a default.
+ * Reasoning configuration stays at each call site — the agents intentionally
+ * diverge (medium for the Pro AI chat, 'low' for the public anonymous support
+ * surface) and that divergence should remain visible at the agent definition
+ * rather than hidden behind a default.
  */
-export const CHAT_MODEL_ID = 'google/gemma-4-26b-a4b-it';
+
+/** The AI chat assistant (`aiChat/agent.ts`): open-ended, tool-using turns. */
+export const AI_CHAT_MODEL_ID = 'google/gemma-4-26b-a4b-it';
+
+/**
+ * The support agent Kai (`support/agent.ts`): answers from a fixed prompt with
+ * one escalation tool, on a public anonymous surface. It talks to prospects
+ * about the product, so answer quality matters more than tool choreography —
+ * upgrade it on support-eval evidence, not because the assistant moved.
+ */
+export const SUPPORT_MODEL_ID = 'google/gemma-4-26b-a4b-it';
+
+/**
+ * Thread-title generation (`aiChat/titles.ts`): a few words from the opening
+ * message, no reasoning, no tools. The cheapest capable model wins here; it has
+ * no reason to track whichever model the assistant runs.
+ */
+export const TITLE_MODEL_ID = 'google/gemma-4-26b-a4b-it';


### PR DESCRIPTION
One `CHAT_MODEL_ID` served three different workloads: the AI chat assistant, the support agent Kai, and thread-title generation. Their requirements diverge sharply — the assistant runs open-ended tool-using turns, Kai answers from a fixed prompt with a single escalation tool on a public anonymous surface, and title generation produces a few words with no tools and no reasoning.

Sharing one id means upgrading the assistant silently upgrades the other two. That is not hypothetical: a downstream fork moved its assistant to a stronger model twice, and both times Kai and the title generator came along unexamined, ending up on a model priced 4x input and 3x output over the one that was actually chosen for them — for turning an opening message into a title.

Each workload now owns its constant, all three still pointing at the same model, so this change is behavior-neutral and only makes the next upgrade an explicit decision per surface. The pricing regression guard now checks each id separately, so raising one alone still trips when its new model has no price row.

Verified with the full unit suite (907 tests) and `bun scripts/static-checks.ts` on every changed file.