### PR TITLE
fix(chat): Lift the composer off the chat surface

### DIFF
--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -738,7 +738,7 @@
 	     put when the field grows — no radius jump between layouts. -->
 	<PromptInput
 		class={compact
-			? `relative z-20 rounded-[25px] border-0 bg-popover shadow-none ${compactMultiline ? 'p-0' : 'p-1.5'}`
+			? `composer-elevation relative z-20 rounded-[25px] border-0 bg-popover ${compactMultiline ? 'p-0' : 'p-1.5'}`
 			: 'relative z-20 bg-popover p-0'}
 		value={ctx.inputValue}
 		isLoading={ctx.core.isSending}

--- a/src/lib/components/authenticated/authenticated-layout.svelte
+++ b/src/lib/components/authenticated/authenticated-layout.svelte
@@ -71,7 +71,15 @@
 			{threadsHasMore}
 			{onLoadMoreThreads}
 		/>
-		<Sidebar.Inset id="main-content" class={fullControl ? 'flex flex-col overflow-hidden' : ''}>
+		<!-- Chat pages drop the inset's white so the sidebar tone carries the whole
+		     surface, header included. The composer pill is bg-popover (white), which
+		     on bg-background had no edge at all in light mode; against the sidebar
+		     tone it reads as its own surface. Dark mode keeps the inset, where
+		     sidebar and popover are the same value and only background differs. -->
+		<Sidebar.Inset
+			id="main-content"
+			class={fullControl ? 'flex flex-col overflow-hidden bg-sidebar dark:bg-background' : ''}
+		>
 			<AuthenticatedHeader {routePrefix} {rootLabel} />
 
 			{#if fullControl}

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -439,6 +439,21 @@
 	transition-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
 }
 
+/* Composer elevation. The pill is white on a barely darker surface, so the edge
+   has to come from the shadow rather than the fill: a hairline ring drawn as
+   spread, one near shadow for contact, and a wide ambient pass. Dark mode keeps
+   the fill difference it already has and drops this. */
+@utility composer-elevation {
+	box-shadow:
+		0 0 0 1px rgb(0 0 0 / 0.04),
+		0 2px 8px 0 rgb(0 0 0 / 0.04),
+		0 4px 80px 8px rgb(0 0 0 / 0.024);
+}
+
+:where(.dark) .composer-elevation {
+	box-shadow: none;
+}
+
 @utility marketing-shell-panel {
 	border-color: rgb(0 0 0 / 0.06);
 	background: linear-gradient(137deg, rgb(252 252 255 / 0.9) 4.87%, rgb(240 240 248 / 0.95) 75.88%);


### PR DESCRIPTION
The compact composer pill is `bg-popover`, which resolves to the same value as `bg-background` in light mode, both `oklch(1 0 0)`. Once the wrapper border and shadow came off in #751 the pill had no edge left at all, so on the AI chat it read as a caret floating on an empty page.

Chat pages now drop the inset's white and let the sidebar tone carry the whole surface, header and breadcrumbs included, and the pill gets its own elevation instead of a border. That construction is measured from ChatGPT's composer, where the fill difference is only 0.009 L and three shadow layers do the separating: a hairline ring drawn as spread, a near shadow for contact, and a wide ambient pass. It has no border at all. The shadow lives in a `@utility` next to the existing ones rather than an arbitrary value repeated at the call site, since no Tailwind step has a spread-drawn ring.

The inset keeps `bg-background` in dark mode, which matters more here than it looks: `--sidebar` and `--popover` are both `oklch(0.21 0.006 285.885)` there, so carrying the sidebar tone across would recreate the exact collapse this fixes in light.

Regression guard: not warranted, purely presentational token and shadow classes with no behavior to pin.

Verified in the browser at 1280px in both modes: light gives a 0.985 surface against a 1.000 pill with all three shadow layers present and `border-width: 0`; dark keeps the inset at 0.141 against a flat 0.21 pill. Static checks pass.