### PR TITLE
fix(dialog): Derive footer bleed from theme tokens

### DIFF
--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -182,7 +182,9 @@
 <Dialog.Root bind:open={isDialogOpen}>
 	<Dialog.Content
 		class={displayDimensions ? '!max-w-none' : 'sm:max-w-4xl'}
-		style={displayDimensions ? `width: ${displayDimensions.width + 48}px;` : ''}
+		style={displayDimensions
+			? `width: calc(${displayDimensions.width}px + var(--dialog-inset) * 2);`
+			: ''}
 	>
 		<Dialog.Header>
 			<Dialog.Title

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -31,7 +31,7 @@
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+			'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-(--dialog-gap) rounded-xl bg-background p-(--dialog-inset) text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
 			className
 		)}
 		{...restProps}

--- a/src/lib/components/ui/dialog/dialog-footer.svelte
+++ b/src/lib/components/ui/dialog/dialog-footer.svelte
@@ -18,11 +18,17 @@
 	} = $props();
 </script>
 
+<!--
+	Deviates from the shadcn-svelte registry default: this footer bleeds to the card
+	edge with a tinted bar instead of sitting inside the dialog padding. The negative
+	margins must cancel Dialog.Content's padding exactly, so both read --dialog-inset.
+	A `shadcn-svelte` update will overwrite this file; reapply the bleed afterwards.
+-->
 <div
 	bind:this={ref}
 	data-slot="dialog-footer"
 	class={cn(
-		'-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end',
+		'-mx-(--dialog-inset) -mb-(--dialog-inset) flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 px-(--dialog-inset) py-4 sm:flex-row sm:justify-end',
 		className
 	)}
 	{...restProps}

--- a/src/routes/[[lang]]/admin/settings/founder-welcome-card.svelte
+++ b/src/routes/[[lang]]/admin/settings/founder-welcome-card.svelte
@@ -158,7 +158,9 @@
 </Item.Root>
 
 <Dialog.Root open={dialogOpen} onOpenChange={handleDialogOpenChange}>
-	<Dialog.Content class="sm:max-w-lg">
+	<Dialog.Content
+		class="flex max-h-[calc(100dvh-2rem)] min-h-0 flex-col overflow-hidden sm:max-w-lg"
+	>
 		<Dialog.Header>
 			<Dialog.Title><T keyName="admin.settings.founder_welcome.title" /></Dialog.Title>
 			<Dialog.Description>
@@ -166,89 +168,91 @@
 			</Dialog.Description>
 		</Dialog.Header>
 
-		<Field.Group>
-			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+		<div class="-mx-1 min-h-0 overflow-y-auto px-1 pb-1">
+			<Field.Group>
+				<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+					<Field.Field>
+						<Field.Label for="config-name">
+							<T keyName="admin.settings.founder_welcome.config_name_label" />
+						</Field.Label>
+						<Input id="config-name" bind:value={editName} />
+					</Field.Field>
+					<Field.Field>
+						<Field.Label for="config-title">
+							<T keyName="admin.settings.founder_welcome.config_title_label" />
+						</Field.Label>
+						<Input
+							id="config-title"
+							placeholder={$t('admin.settings.founder_welcome.setup_title_placeholder')}
+							bind:value={editTitle}
+						/>
+					</Field.Field>
+				</div>
 				<Field.Field>
-					<Field.Label for="config-name">
-						<T keyName="admin.settings.founder_welcome.config_name_label" />
-					</Field.Label>
-					<Input id="config-name" bind:value={editName} />
-				</Field.Field>
-				<Field.Field>
-					<Field.Label for="config-title">
-						<T keyName="admin.settings.founder_welcome.config_title_label" />
+					<Field.Label for="config-reply-to">
+						<T keyName="admin.settings.founder_welcome.config_reply_to_label" />
 					</Field.Label>
 					<Input
-						id="config-title"
-						placeholder={$t('admin.settings.founder_welcome.setup_title_placeholder')}
-						bind:value={editTitle}
+						id="config-reply-to"
+						type="email"
+						placeholder={$t('admin.settings.founder_welcome.config_reply_to_placeholder')}
+						bind:value={editReplyTo}
+						aria-invalid={replyToError ? 'true' : undefined}
+						aria-describedby={replyToError ? 'config-reply-to-error' : undefined}
 					/>
+					<Field.Error id="config-reply-to-error" errors={translateFormError(replyToError, $t)} />
 				</Field.Field>
-			</div>
-			<Field.Field>
-				<Field.Label for="config-reply-to">
-					<T keyName="admin.settings.founder_welcome.config_reply_to_label" />
-				</Field.Label>
-				<Input
-					id="config-reply-to"
-					type="email"
-					placeholder={$t('admin.settings.founder_welcome.config_reply_to_placeholder')}
-					bind:value={editReplyTo}
-					aria-invalid={replyToError ? 'true' : undefined}
-					aria-describedby={replyToError ? 'config-reply-to-error' : undefined}
-				/>
-				<Field.Error id="config-reply-to-error" errors={translateFormError(replyToError, $t)} />
-			</Field.Field>
-			<Field.Field>
-				<Field.Label for="config-subject">
-					<T keyName="admin.settings.founder_welcome.config_subject_label" />
-				</Field.Label>
-				<Input id="config-subject" bind:value={editSubject} />
-			</Field.Field>
-			<Field.Field>
-				<Field.Label for="config-body">
-					<T keyName="admin.settings.founder_welcome.config_body_label" />
-				</Field.Label>
-				{#if editingBody || !editBody}
-					<TemplateTextarea
-						id="config-body"
-						rows={8}
-						variables={['userFirstName', 'userLastName', 'founderName', 'founderTitle']}
-						bind:value={editBody}
-						onfocus={() => {
-							editingBody = true;
-						}}
-						onblur={async () => {
-							if (!editBody) return;
-							editingBody = false;
-							await tick();
-							document.getElementById('config-body-preview')?.focus();
-						}}
-					/>
-					<Field.Description>
-						<T keyName="admin.settings.founder_welcome.variables_label" />
-						{' {{userFirstName}}, {{userLastName}}, {{founderName}}, {{founderTitle}}'}
-					</Field.Description>
-				{:else}
-					<button
-						id="config-body-preview"
-						type="button"
-						class="max-h-60 w-full cursor-text overflow-y-auto rounded-md border bg-muted/30 p-3 text-left text-sm"
-						onclick={async () => {
-							editingBody = true;
-							await tick();
-							const el = document.getElementById('config-body') as HTMLTextAreaElement | null;
-							el?.focus();
-						}}
-					>
-						<p class="whitespace-pre-wrap">{previewText}</p>
-					</button>
-				{/if}
-			</Field.Field>
-		</Field.Group>
+				<Field.Field>
+					<Field.Label for="config-subject">
+						<T keyName="admin.settings.founder_welcome.config_subject_label" />
+					</Field.Label>
+					<Input id="config-subject" bind:value={editSubject} />
+				</Field.Field>
+				<Field.Field>
+					<Field.Label for="config-body">
+						<T keyName="admin.settings.founder_welcome.config_body_label" />
+					</Field.Label>
+					{#if editingBody || !editBody}
+						<TemplateTextarea
+							id="config-body"
+							rows={8}
+							variables={['userFirstName', 'userLastName', 'founderName', 'founderTitle']}
+							bind:value={editBody}
+							onfocus={() => {
+								editingBody = true;
+							}}
+							onblur={async () => {
+								if (!editBody) return;
+								editingBody = false;
+								await tick();
+								document.getElementById('config-body-preview')?.focus();
+							}}
+						/>
+						<Field.Description>
+							<T keyName="admin.settings.founder_welcome.variables_label" />
+							{' {{userFirstName}}, {{userLastName}}, {{founderName}}, {{founderTitle}}'}
+						</Field.Description>
+					{:else}
+						<button
+							id="config-body-preview"
+							type="button"
+							class="max-h-60 w-full cursor-text overflow-y-auto rounded-md border bg-muted/30 p-3 text-left text-sm"
+							onclick={async () => {
+								editingBody = true;
+								await tick();
+								const el = document.getElementById('config-body') as HTMLTextAreaElement | null;
+								el?.focus();
+							}}
+						>
+							<p class="whitespace-pre-wrap">{previewText}</p>
+						</button>
+					{/if}
+				</Field.Field>
+			</Field.Group>
+		</div>
 
 		<Dialog.Footer
-			class="flex-col items-stretch gap-4 sm:flex-row sm:items-center sm:justify-between"
+			class="-mt-(--dialog-gap) flex-col items-stretch gap-4 sm:flex-row sm:items-center sm:justify-between"
 		>
 			<div>
 				{#if isContactPerson}

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -40,6 +40,11 @@
 :root {
 	--scrollbar-w: 3px;
 	--radius: 0.625rem;
+	/* Dialog padding and section spacing. The footer bleeds to the card edge with
+	   negative margins of exactly --dialog-inset, so both sides must read the same
+	   value. Change these here, never in the dialog components. */
+	--dialog-inset: 1rem;
+	--dialog-gap: 1rem;
 	--background: oklch(1 0 0);
 	--foreground: oklch(0.141 0.005 285.823);
 	--card: oklch(1 0 0);


### PR DESCRIPTION
Closes #758

`Dialog.Content` set `p-4` while `Dialog.Footer` bled to the card edge with `-mx-4 -mb-4`. Those two numbers had to match exactly for the tinted bar to land flush, but nothing enforced it, so changing the dialog padding silently left a gutter on one side or clipped the bar on the other. A third copy of the number lived in JavaScript, where the attachment dialog added a hardcoded `48` to the image width — 16px more than the padding it was meant to cancel, which is why that dialog has always been slightly too wide.

Both sides now read `--dialog-inset` and `--dialog-gap`, declared next to `--radius` where a fork already edits its theme. Change the value once and the padding, the bleed and the attachment width move together. Radius needed no token: `rounded-xl` and `rounded-b-xl` both derive from `--radius` already, so they were never the loose end. The tokens live in plain `:root` rather than `@theme`, because `@theme inline` variables are inlined at their use sites and never emitted as custom properties, so a `var()` reference to one resolves to nothing.

The registry default puts the footer inside the dialog padding with no tinted bar, so this construction is ours to maintain and a `shadcn-svelte` update will overwrite it. `dialog-footer.svelte` now says so, and says what to restore.

The founder welcome dialog overflowed the viewport at 900x700, measuring `-30px` to `730px` with its title, close button and actions off-screen. It now clips and scrolls its body. The `-mx-1 px-1 pb-1` on the scroll container is deliberate: focus rings would otherwise be cut off by the clipping edge. The footer takes `-mt-(--dialog-gap)` to cancel the one inherited section gap, since between a clipping edge and a divider that gap reads as an abrupt cut rather than spacing.

<!-- pr-media:start -->
| Founder welcome dialog at 900x700, footer flush and body scrolling |
| --- |
| <img width="1800" alt="Founder welcome dialog at 900x700, footer flush and body scrolling" src="https://github.com/user-attachments/assets/a2aef58f-f6b7-4a97-8c9b-aed80277a0ab" /> |
<!-- pr-media:end -->

Regression guard: not warranted. Bounding-box assertions on padding would pin the exact structure this change exists to make adjustable, and break on any legitimate redesign.

Verified in the browser at 900x700: the founder dialog now spans 16px to 684px with header and close visible, footer overhang 0 on all sides and no gap between the scroll edge and the divider. Setting `--dialog-inset` to `2.5rem` at runtime moves the content padding and the footer bleed together, overhang staying at 0. The command menu's `p-2 pb-11` override still wins over the token, dark mode inherits both values from `:root`, and the attachment dialog computes 432px for a 400px image instead of the previous 448px. Static checks pass.
