### PR TITLE
fix(chat): Keep upload failures on the attachment

### DIFF
--- a/e2e/ai-chat-upload-failure.spec.ts
+++ b/e2e/ai-chat-upload-failure.spec.ts
@@ -40,18 +40,17 @@ test.describe('AI Chat - upload failure', () => {
 
 		await attachNotes(page, 'dropped.txt');
 
-		const alert = page.getByTestId('attachment-upload-error');
-		await expect(alert).toBeVisible({ timeout: 20000 });
-		await expect(alert).toContainText('dropped.txt');
+		const failedChip = page.locator('[data-upload-failed]');
+		await expect(failedChip).toBeVisible({ timeout: 20000 });
+		await expect(failedChip).toContainText('dropped.txt');
 
 		// The point of the fix: unlike a toast, it is still there later.
 		await page.waitForTimeout(6000);
-		await expect(alert).toBeVisible();
+		await expect(failedChip).toBeVisible();
 
 		// Sending would render an attachment the backend never received.
 		await page.locator('textarea').fill('Here are my notes');
-		await expect(page.getByTestId('attachment-upload-error')).toBeVisible();
-		await expect(page.locator('[data-upload-failed]')).toBeVisible();
+		await expect(failedChip).toBeVisible();
 	});
 
 	test('retry recovers the attachment once the connection is back', async ({ page }) => {
@@ -67,14 +66,15 @@ test.describe('AI Chat - upload failure', () => {
 
 		await attachNotes(page, 'recovered.txt');
 
-		const alert = page.getByTestId('attachment-upload-error');
-		await expect(alert).toBeVisible({ timeout: 20000 });
+		const failedChip = page.locator('[data-upload-failed]');
+		await expect(failedChip).toBeVisible({ timeout: 20000 });
 
-		await alert.getByRole('button').click();
+		// The tile itself is the retry control; there is no separate button.
+		await failedChip.click();
 
 		// Recovery is complete when the error is gone and the chip became
 		// openable, which only happens once the upload has committed.
-		await expect(alert).toBeHidden({ timeout: 20000 });
+		await expect(failedChip).toBeHidden({ timeout: 20000 });
 		await expect(page.getByTestId('attachment-chip').first()).toHaveAttribute('role', 'button', {
 			timeout: 20000
 		});

--- a/e2e/ai-chat-upload-failure.spec.ts
+++ b/e2e/ai-chat-upload-failure.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, type Page } from '@playwright/test';
+import { waitForAuthenticated } from './utils/auth';
+
+/**
+ * A dropped upload used to leave a four-second toast and nothing else, so a
+ * reload or a glance away lost the file with no trace. These assert the two
+ * properties that prevent that: the failure persists, and it can be recovered
+ * from without re-picking the file.
+ */
+
+const NOTES = 'Upload failure regression notes.\n';
+
+/**
+ * The presigned storage endpoint. It is served by the Convex deployment, not
+ * the app origin, so this matches on the path the backend hands out rather than
+ * on a route in this repo.
+ */
+const STORAGE_UPLOAD = /\/api\/storage\/upload/;
+
+/** Attach a text file through the hidden input the composer renders. */
+async function attachNotes(page: Page, name: string) {
+	await page
+		.locator('input[type="file"]')
+		.first()
+		.setInputFiles({ name, mimeType: 'text/plain', buffer: Buffer.from(NOTES, 'utf8') });
+}
+
+test.describe('AI Chat - upload failure', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/app/ai-chat');
+		await waitForAuthenticated(page);
+		await page.waitForURL(/\/app\/ai-chat\?thread=/, { timeout: 15000 });
+		await expect(page.locator('textarea')).toBeVisible({ timeout: 10000 });
+	});
+
+	test('a failed upload stays visible and blocks sending until resolved', async ({ page }) => {
+		// Kill the storage POST only. Presign and commit stay reachable, so this
+		// exercises the transport failure a flaky connection produces.
+		await page.route(STORAGE_UPLOAD, (route) => route.abort('connectionfailed'));
+
+		await attachNotes(page, 'dropped.txt');
+
+		const alert = page.getByTestId('attachment-upload-error');
+		await expect(alert).toBeVisible({ timeout: 20000 });
+		await expect(alert).toContainText('dropped.txt');
+
+		// The point of the fix: unlike a toast, it is still there later.
+		await page.waitForTimeout(6000);
+		await expect(alert).toBeVisible();
+
+		// Sending would render an attachment the backend never received.
+		await page.locator('textarea').fill('Here are my notes');
+		await expect(page.getByTestId('attachment-upload-error')).toBeVisible();
+		await expect(page.locator('[data-upload-failed]')).toBeVisible();
+	});
+
+	test('retry recovers the attachment once the connection is back', async ({ page }) => {
+		let failNext = true;
+		await page.route(STORAGE_UPLOAD, async (route) => {
+			if (failNext) {
+				failNext = false;
+				await route.abort('connectionfailed');
+				return;
+			}
+			await route.continue();
+		});
+
+		await attachNotes(page, 'recovered.txt');
+
+		const alert = page.getByTestId('attachment-upload-error');
+		await expect(alert).toBeVisible({ timeout: 20000 });
+
+		await alert.getByRole('button').click();
+
+		// Recovery is complete when the error is gone and the chip became
+		// openable, which only happens once the upload has committed.
+		await expect(alert).toBeHidden({ timeout: 20000 });
+		await expect(page.getByTestId('attachment-chip').first()).toHaveAttribute('role', 'button', {
+			timeout: 20000
+		});
+	});
+});

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -506,7 +506,9 @@
 			"max_attachments": "Maximal {max} Anhänge erlaubt",
 			"pasted_file_too_large": "Eingefügte Datei zu groß",
 			"upload_failed": "Hochladen von \"{filename}\" fehlgeschlagen",
-			"upload_failed_description": "Hochladen fehlgeschlagen"
+			"upload_network": "Die Verbindung wurde unterbrochen. Die Datei wurde nicht gespeichert.",
+			"upload_retry": "Erneut versuchen",
+			"upload_server": "Das Hochladen konnte nicht abgeschlossen werden. Die Datei wurde nicht gespeichert."
 		},
 		"input": {
 			"placeholder": "Nachricht eingeben...",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -506,9 +506,10 @@
 			"max_attachments": "Maximal {max} Anhänge erlaubt",
 			"pasted_file_too_large": "Eingefügte Datei zu groß",
 			"upload_failed": "Hochladen von \"{filename}\" fehlgeschlagen",
-			"upload_network": "Die Verbindung wurde unterbrochen. Die Datei wurde nicht gespeichert.",
-			"upload_retry": "Erneut versuchen",
-			"upload_server": "Das Hochladen konnte nicht abgeschlossen werden. Die Datei wurde nicht gespeichert."
+			"upload_network": "Verbindung unterbrochen.",
+			"upload_readd_hint": "Datei erneut hinzufügen.",
+			"upload_retry_hint": "Zum Wiederholen klicken.",
+			"upload_server": "Upload abgelehnt."
 		},
 		"input": {
 			"placeholder": "Nachricht eingeben...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -506,9 +506,10 @@
 			"max_attachments": "Maximum {max} attachments allowed",
 			"pasted_file_too_large": "Pasted file too large",
 			"upload_failed": "Failed to upload \"{filename}\"",
-			"upload_network": "The connection was lost. The file was not saved.",
-			"upload_retry": "Try again",
-			"upload_server": "The upload could not be completed. The file was not saved."
+			"upload_network": "Connection lost.",
+			"upload_readd_hint": "Add the file again.",
+			"upload_retry_hint": "Click to try again.",
+			"upload_server": "Upload rejected."
 		},
 		"input": {
 			"placeholder": "Type a message...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -506,7 +506,9 @@
 			"max_attachments": "Maximum {max} attachments allowed",
 			"pasted_file_too_large": "Pasted file too large",
 			"upload_failed": "Failed to upload \"{filename}\"",
-			"upload_failed_description": "Upload failed"
+			"upload_network": "The connection was lost. The file was not saved.",
+			"upload_retry": "Try again",
+			"upload_server": "The upload could not be completed. The file was not saved."
 		},
 		"input": {
 			"placeholder": "Type a message...",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -506,9 +506,10 @@
 			"max_attachments": "Máximo {max} adjuntos permitidos",
 			"pasted_file_too_large": "Archivo pegado muy grande",
 			"upload_failed": "No se pudo subir \"{filename}\"",
-			"upload_network": "Se perdió la conexión. El archivo no se guardó.",
-			"upload_retry": "Reintentar",
-			"upload_server": "No se pudo completar la subida. El archivo no se guardó."
+			"upload_network": "Conexión perdida.",
+			"upload_readd_hint": "Añade el archivo de nuevo.",
+			"upload_retry_hint": "Haz clic para reintentar.",
+			"upload_server": "Subida rechazada."
 		},
 		"input": {
 			"placeholder": "Escribe un mensaje...",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -506,7 +506,9 @@
 			"max_attachments": "Máximo {max} adjuntos permitidos",
 			"pasted_file_too_large": "Archivo pegado muy grande",
 			"upload_failed": "No se pudo subir \"{filename}\"",
-			"upload_failed_description": "Error al subir"
+			"upload_network": "Se perdió la conexión. El archivo no se guardó.",
+			"upload_retry": "Reintentar",
+			"upload_server": "No se pudo completar la subida. El archivo no se guardó."
 		},
 		"input": {
 			"placeholder": "Escribe un mensaje...",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -506,7 +506,9 @@
 			"max_attachments": "Maximum {max} pièces jointes autorisées",
 			"pasted_file_too_large": "Fichier collé trop volumineux",
 			"upload_failed": "Échec du téléversement de « {filename} »",
-			"upload_failed_description": "Échec du téléversement"
+			"upload_network": "La connexion a été perdue. Le fichier n'a pas été enregistré.",
+			"upload_retry": "Réessayer",
+			"upload_server": "Le téléversement n'a pas pu aboutir. Le fichier n'a pas été enregistré."
 		},
 		"input": {
 			"placeholder": "Tapez un message...",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -506,9 +506,10 @@
 			"max_attachments": "Maximum {max} pièces jointes autorisées",
 			"pasted_file_too_large": "Fichier collé trop volumineux",
 			"upload_failed": "Échec du téléversement de « {filename} »",
-			"upload_network": "La connexion a été perdue. Le fichier n'a pas été enregistré.",
-			"upload_retry": "Réessayer",
-			"upload_server": "Le téléversement n'a pas pu aboutir. Le fichier n'a pas été enregistré."
+			"upload_network": "Connexion perdue.",
+			"upload_readd_hint": "Ajoutez de nouveau le fichier.",
+			"upload_retry_hint": "Cliquez pour réessayer.",
+			"upload_server": "Téléversement refusé."
 		},
 		"input": {
 			"placeholder": "Tapez un message...",

--- a/src/lib/chat/core/file-uploader.test.ts
+++ b/src/lib/chat/core/file-uploader.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Unit tests for the upload transport layer.
+ *
+ * These pin the error vocabulary the UI depends on: every failure mode maps to
+ * a stable UploadErrorCode, and a cancelation stays an AbortError DOMException
+ * rather than becoming an UploadError, because callers outside the chat (the
+ * avatar upload) distinguish the two.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { UploadError, uploadToStorage, uploadFileWithProgress } from './file-uploader.js';
+import type { ConvexClient } from 'convex/browser';
+
+type XhrHandlers = Record<string, () => void>;
+
+/**
+ * Minimal XMLHttpRequest stand-in. `send` triggers the scripted outcome so a
+ * test states only what the server did, not how XHR dispatches events.
+ */
+function stubXhr(outcome: {
+	status?: number;
+	responseText?: string;
+	fail?: 'network';
+	onSend?: (xhr: { abort: () => void }) => void;
+}) {
+	const handlers: XhrHandlers = {};
+	const uploadHandlers: XhrHandlers = {};
+	const abort = vi.fn(() => handlers.abort?.());
+
+	const xhr = {
+		status: outcome.status ?? 200,
+		statusText: '',
+		responseText: outcome.responseText ?? JSON.stringify({ storageId: 'storage-1' }),
+		upload: {
+			addEventListener: (event: string, handler: () => void) => {
+				uploadHandlers[event] = handler;
+			}
+		},
+		addEventListener: (event: string, handler: () => void) => {
+			handlers[event] = handler;
+		},
+		open: vi.fn(),
+		setRequestHeader: vi.fn(),
+		abort,
+		send: vi.fn(() => {
+			if (outcome.onSend) {
+				outcome.onSend(xhr);
+				return;
+			}
+			if (outcome.fail === 'network') handlers.error?.();
+			else handlers.load?.();
+		})
+	};
+
+	// `new XMLHttpRequest()` needs a constructable stand-in, so this is a
+	// function declaration returning the shared instance rather than an arrow.
+	vi.stubGlobal('XMLHttpRequest', function XMLHttpRequestStub() {
+		return xhr;
+	});
+	return { xhr, abort };
+}
+
+const noProgress = () => {};
+const blob = new Blob(['payload'], { type: 'text/plain' });
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('uploadToStorage error codes', () => {
+	it('reports a transport error as network', async () => {
+		stubXhr({ fail: 'network' });
+
+		const error = await uploadToStorage('https://storage.test', blob, noProgress).catch((e) => e);
+
+		expect(error).toBeInstanceOf(UploadError);
+		expect(error.code).toBe('network');
+	});
+
+	it('reports a rejected status as http and keeps the status', async () => {
+		stubXhr({ status: 413 });
+
+		const error = await uploadToStorage('https://storage.test', blob, noProgress).catch((e) => e);
+
+		expect(error).toBeInstanceOf(UploadError);
+		expect(error.code).toBe('http');
+		expect(error.status).toBe(413);
+	});
+
+	it('reports unparseable output as parse', async () => {
+		stubXhr({ responseText: 'not json' });
+
+		const error = await uploadToStorage('https://storage.test', blob, noProgress).catch((e) => e);
+
+		expect(error).toBeInstanceOf(UploadError);
+		expect(error.code).toBe('parse');
+	});
+
+	it('treats a 200 without a storageId as parse, not success', async () => {
+		// Regression: this used to resolve with undefined and only fail later,
+		// during the commit, where the cause was no longer visible.
+		stubXhr({ responseText: JSON.stringify({}) });
+
+		const error = await uploadToStorage('https://storage.test', blob, noProgress).catch((e) => e);
+
+		expect(error).toBeInstanceOf(UploadError);
+		expect(error.code).toBe('parse');
+	});
+
+	it('resolves with the storage id on success', async () => {
+		stubXhr({ responseText: JSON.stringify({ storageId: 'storage-42' }) });
+
+		await expect(uploadToStorage('https://storage.test', blob, noProgress)).resolves.toBe(
+			'storage-42'
+		);
+	});
+});
+
+describe('uploadToStorage cancelation', () => {
+	it('aborts the request and rejects with AbortError, not UploadError', async () => {
+		// The avatar upload distinguishes cancelation from failure by error type,
+		// so this must not become an UploadError.
+		const controller = new AbortController();
+		const { abort } = stubXhr({ onSend: () => controller.abort() });
+
+		const error = await uploadToStorage(
+			'https://storage.test',
+			blob,
+			noProgress,
+			controller.signal
+		).catch((e) => e);
+
+		expect(abort).toHaveBeenCalled();
+		expect(error).toBeInstanceOf(DOMException);
+		expect(error.name).toBe('AbortError');
+		expect(error).not.toBeInstanceOf(UploadError);
+	});
+
+	it('rejects immediately when the signal is already aborted', async () => {
+		stubXhr({});
+		const controller = new AbortController();
+		controller.abort();
+
+		const error = await uploadToStorage(
+			'https://storage.test',
+			blob,
+			noProgress,
+			controller.signal
+		).catch((e) => e);
+
+		expect(error.name).toBe('AbortError');
+	});
+});
+
+describe('uploadFileWithProgress', () => {
+	const api = {
+		generateUploadUrl: 'generateUploadUrl' as never,
+		saveUploadedFile: 'saveUploadedFile' as never
+	};
+
+	function stubClient(overrides?: Partial<ConvexClient>): ConvexClient {
+		return {
+			mutation: vi.fn(async () => ({
+				uploadUrl: 'https://storage.test',
+				uploadToken: 'token-1'
+			})),
+			action: vi.fn(async () => ({ fileId: 'file-1', url: 'https://cdn.test/file-1' })),
+			...overrides
+		} as unknown as ConvexClient;
+	}
+
+	it('reports a failing presign as server', async () => {
+		stubXhr({});
+		const client = stubClient({
+			mutation: vi.fn(async () => {
+				throw new Error('Rate limit exceeded. Try again in 60 seconds.');
+			}) as never
+		});
+
+		const error = await uploadFileWithProgress(client, blob, 'doc.txt', noProgress, api).catch(
+			(e) => e
+		);
+
+		expect(error).toBeInstanceOf(UploadError);
+		expect(error.code).toBe('server');
+		// The raw English server text stays reachable for logs but never for the UI.
+		expect((error.cause as Error).message).toContain('Rate limit');
+	});
+
+	it('reports a failing commit as server', async () => {
+		stubXhr({});
+		const client = stubClient({
+			action: vi.fn(async () => {
+				throw new Error('Failed to get download URL for uploaded file');
+			}) as never
+		});
+
+		const error = await uploadFileWithProgress(client, blob, 'doc.txt', noProgress, api).catch(
+			(e) => e
+		);
+
+		expect(error.code).toBe('server');
+	});
+
+	it('does not register the file when canceled after the transfer', async () => {
+		// Cancelation cannot stop an action already in flight, so the guard has to
+		// sit before it; otherwise removing an attachment mid-commit leaves a
+		// stored file nothing references.
+		const controller = new AbortController();
+		stubXhr({ onSend: () => controller.abort() });
+		const client = stubClient();
+
+		const error = await uploadFileWithProgress(
+			client,
+			blob,
+			'doc.txt',
+			noProgress,
+			api,
+			undefined,
+			undefined,
+			controller.signal
+		).catch((e) => e);
+
+		expect(error.name).toBe('AbortError');
+		expect(client.action).not.toHaveBeenCalled();
+	});
+
+	it('returns the committed file on success', async () => {
+		stubXhr({});
+		const client = stubClient();
+
+		await expect(
+			uploadFileWithProgress(client, blob, 'doc.txt', noProgress, api)
+		).resolves.toMatchObject({ fileId: 'file-1', storageId: 'storage-1' });
+	});
+});

--- a/src/lib/chat/core/file-uploader.ts
+++ b/src/lib/chat/core/file-uploader.ts
@@ -21,6 +21,62 @@ export interface UploadResult {
 export type ProgressCallback = (progress: number) => void;
 
 /**
+ * What went wrong during an upload, independent of how it is phrased to the
+ * user. The transport layer has no access to translations, so it reports a code
+ * and the UI picks the message.
+ *
+ * `network` / `http` / `parse` come from the storage POST itself. `server`
+ * covers the Convex stages around it (presign, commit), which fail for reasons
+ * the browser cannot inspect. All four are worth retrying; the transfer is the
+ * only thing that went wrong.
+ */
+export type UploadErrorCode = 'network' | 'http' | 'parse' | 'server';
+
+const UPLOAD_ERROR_MESSAGE: Record<UploadErrorCode, string> = {
+	network: 'Network error during upload',
+	http: 'Upload rejected by storage',
+	parse: 'Malformed upload response',
+	server: 'Upload could not be registered'
+};
+
+/**
+ * An upload failure with a machine-readable cause.
+ *
+ * `message` stays English on purpose: it is developer-facing (logs, stack
+ * traces). Anything shown to a user must be derived from `code` so it can be
+ * translated. Two things are deliberately NOT UploadErrors:
+ * cancelation stays the web-standard `DOMException` named `AbortError`, and
+ * client-side validation failures (e.g. an image that will not compress under
+ * the size cap) keep throwing their own already-translated Error, because they
+ * are not retryable and the caller phrases them better than a generic code can.
+ */
+export class UploadError extends Error {
+	readonly code: UploadErrorCode;
+	/** HTTP status, present only for `code === 'http'`. */
+	readonly status?: number;
+
+	constructor(code: UploadErrorCode, status?: number, options?: { cause?: unknown }) {
+		super(UPLOAD_ERROR_MESSAGE[code], options);
+		this.name = 'UploadError';
+		this.code = code;
+		this.status = status;
+	}
+}
+
+/**
+ * Run a Convex call, reporting any rejection as a `server` upload failure.
+ * An abort passes through untouched so cancelation stays distinguishable.
+ */
+async function asServerFailure<T>(call: Promise<T>): Promise<T> {
+	try {
+		return await call;
+	} catch (error) {
+		if (error instanceof DOMException && error.name === 'AbortError') throw error;
+		throw new UploadError('server', undefined, { cause: error });
+	}
+}
+
+/**
  * Upload a file to Convex storage with progress tracking
  *
  * This function handles the complete upload flow:
@@ -34,6 +90,8 @@ export type ProgressCallback = (progress: number) => void;
  * @param onProgress - Callback for progress updates (0-100)
  * @param api - Convex API endpoints for file operations
  * @param dimensions - Optional image dimensions for storage
+ * @param accessKey - Optional access key for file control
+ * @param signal - Aborts the transfer; rejects with an `AbortError` DOMException
  * @returns Object containing fileId and url
  */
 export async function uploadFileWithProgress(
@@ -49,26 +107,41 @@ export async function uploadFileWithProgress(
 		getGenerateUploadUrlArgs?: () => Record<string, unknown>;
 	},
 	dimensions?: { width: number; height: number },
-	accessKey?: string
+	accessKey?: string,
+	signal?: AbortSignal
 ): Promise<UploadResult> {
 	// 1. Generate upload URL (with optional extra args for rate limiting)
 	const uploadUrlArgs = api.getGenerateUploadUrlArgs?.() ?? {};
-	const { uploadUrl, uploadToken } = await client.mutation(api.generateUploadUrl, uploadUrlArgs);
+	// The Convex stages are wrapped so callers get one error vocabulary for the
+	// whole upload. Their raw messages are English server strings (rate limits,
+	// download-URL failures) that must not reach the UI; `cause` keeps them for
+	// logs.
+	const { uploadUrl, uploadToken } = await asServerFailure(
+		client.mutation(api.generateUploadUrl, uploadUrlArgs)
+	);
 
 	// 2. Upload file with progress tracking
-	const storageId = await uploadToStorage(uploadUrl, file, onProgress);
+	const storageId = await uploadToStorage(uploadUrl, file, onProgress, signal);
+
+	// Cancelation between the transfer and the commit must not register the
+	// file: the caller has already discarded the attachment, so a committed
+	// record would have nothing referencing it. This is the last cancelable
+	// point — once the action below is in flight it runs to completion.
+	if (signal?.aborted) throw new DOMException('Upload canceled', 'AbortError');
 
 	// 3. Register file with agent component (including dimensions for images)
-	const result = await client.action(api.saveUploadedFile, {
-		storageId,
-		uploadToken,
-		filename,
-		mimeType: file.type,
-		locale: api.locale,
-		accessKey,
-		width: dimensions?.width,
-		height: dimensions?.height
-	});
+	const result = await asServerFailure(
+		client.action(api.saveUploadedFile, {
+			storageId,
+			uploadToken,
+			filename,
+			mimeType: file.type,
+			locale: api.locale,
+			accessKey,
+			width: dimensions?.width,
+			height: dimensions?.height
+		})
+	);
 
 	// Ensure progress is 100% after completion
 	onProgress(100);
@@ -117,17 +190,24 @@ export async function uploadToStorage(
 			if (xhr.status === 200) {
 				try {
 					const response = JSON.parse(xhr.responseText);
+					// A 200 with a well-formed but storageId-less body used to resolve
+					// with undefined, which only surfaced later as a confusing commit
+					// failure. Treat it as the malformed response it is.
+					if (typeof response?.storageId !== 'string' || response.storageId === '') {
+						reject(new UploadError('parse'));
+						return;
+					}
 					resolve(response.storageId);
 				} catch {
-					reject(new Error('Failed to parse upload response'));
+					reject(new UploadError('parse'));
 				}
 			} else {
-				reject(new Error(`Upload failed: ${xhr.statusText}`));
+				reject(new UploadError('http', xhr.status));
 			}
 		});
 
 		// Handle errors
-		xhr.addEventListener('error', () => reject(new Error('Network error during upload')));
+		xhr.addEventListener('error', () => reject(new UploadError('network')));
 		xhr.addEventListener('abort', () => reject(new DOMException('Upload canceled', 'AbortError')));
 
 		// Start upload

--- a/src/lib/chat/core/file-uploader.ts
+++ b/src/lib/chat/core/file-uploader.ts
@@ -54,12 +54,19 @@ export class UploadError extends Error {
 	readonly code: UploadErrorCode;
 	/** HTTP status, present only for `code === 'http'`. */
 	readonly status?: number;
+	/**
+	 * The underlying failure, for logs. Declared here rather than relying on
+	 * `Error.cause`, which the lib version the Convex build targets does not
+	 * know about.
+	 */
+	readonly cause?: unknown;
 
 	constructor(code: UploadErrorCode, status?: number, options?: { cause?: unknown }) {
-		super(UPLOAD_ERROR_MESSAGE[code], options);
+		super(UPLOAD_ERROR_MESSAGE[code]);
 		this.name = 'UploadError';
 		this.code = code;
 		this.status = status;
+		this.cause = options?.cause;
 	}
 }
 

--- a/src/lib/chat/core/index.ts
+++ b/src/lib/chat/core/index.ts
@@ -54,9 +54,9 @@ export {
 export { StreamCacheManager } from './stream-cache.js';
 
 // File upload
-export type { UploadResult, ProgressCallback } from './file-uploader.js';
+export type { UploadResult, ProgressCallback, UploadErrorCode } from './file-uploader.js';
 
-export { uploadFileWithProgress, uploadToStorage } from './file-uploader.js';
+export { uploadFileWithProgress, uploadToStorage, UploadError } from './file-uploader.js';
 
 // Chat core
 export type { ChatCoreAPI, ChatCoreOptions, CreateThreadResult } from './chat-core.svelte.ts';

--- a/src/lib/chat/core/types.ts
+++ b/src/lib/chat/core/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ProviderMetadata } from 'ai';
+import type { UploadErrorCode } from './file-uploader.js';
 
 /**
  * Upload state for tracking file upload progress
@@ -14,7 +15,12 @@ export type UploadState = {
 	status: 'uploading' | 'success' | 'error';
 	progress: number; // 0-100
 	fileId?: string; // Convex fileId after success
-	error?: string; // Error message if failed
+	/**
+	 * Why the upload failed, as a code rather than a message. Rendering
+	 * translates it, so the reason survives a language switch and no English
+	 * transport string can leak into the UI. Present only when status is 'error'.
+	 */
+	error?: UploadErrorCode;
 };
 
 /**

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -59,6 +59,7 @@ export type {
 	CreateThreadResult,
 	UploadResult,
 	ProgressCallback,
+	UploadErrorCode,
 	ChatCoreAPI,
 	ChatCoreOptions
 } from './core/index.js';
@@ -81,6 +82,7 @@ export {
 	StreamCacheManager,
 	uploadFileWithProgress,
 	uploadToStorage,
+	UploadError,
 	ChatCore,
 	createChatCore,
 	ChatDraftManager

--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -163,12 +163,13 @@
 	}
 
 	/**
-	 * Key for the failure list. Uses the upload id rather than name+size,
-	 * which is not unique among failures: two images picked under different
+	 * Identity for keyed lists. Composer attachments carry an upload id; prefer
+	 * it, because name+size is not unique: two images picked under different
 	 * names (photo.jpg, photo.jpeg) pass dedup, then both get renamed to
-	 * photo.webp at the same encoded size, and one network outage fails both.
+	 * photo.webp at the same encoded size. Duplicate keys make Svelte throw.
+	 * Sent attachments have no id and fall back to the derived key.
 	 */
-	function failureKey(attachment: Attachment): string {
+	function attachmentKey(attachment: Attachment): string {
 		return ('key' in attachment && attachment.key) || getKey(attachment);
 	}
 
@@ -278,7 +279,7 @@
 		class="flex flex-wrap gap-2 {className}"
 		style="flex-direction: {flexDirection}; flex-wrap: {flexWrap}; justify-content: flex-start; align-content: flex-end;"
 	>
-		{#each readonly && align === 'right' ? [...attachments].reverse() : attachments as attachment, index (getKey(attachment))}
+		{#each readonly && align === 'right' ? [...attachments].reverse() : attachments as attachment, index (attachmentKey(attachment))}
 			{@const thumbnailUrl = getThumbnailUrl(attachment)}
 			{@const filename = getFilename(attachment)}
 			{@const uploadState = getUploadState(attachment)}
@@ -369,7 +370,7 @@
 <!-- Failures live beside the grid, not inside a tile: tiles are half-width and
      cannot hold a readable message plus an action. Alert carries role="alert",
      so appearing here is announced without extra wiring. -->
-{#each failedAttachments as { attachment, index } (failureKey(attachment))}
+{#each failedAttachments as { attachment, index } (attachmentKey(attachment))}
 	{@const filename = getFilename(attachment)}
 	{@const code = getUploadState(attachment)?.error}
 	<Alert.Root variant="destructive" data-testid="attachment-upload-error" class="mt-2 {className}">

--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -369,7 +369,11 @@
 			{$t(code ? UPLOAD_ERROR_KEY[code] : 'chat.error.upload_server')}
 		</Alert.Description>
 		{#if onRetry}
-			<Alert.Action>
+			<!-- In flow rather than Alert.Action: that slot is absolutely
+			     positioned with a fixed 4.5rem reservation, which a translated
+			     label outgrows — at 390px the German title ran underneath it.
+			     col-start-2 keeps it aligned with the text beside the icon. -->
+			<div class="col-start-2 mt-2">
 				<Button
 					variant="outline"
 					size="sm"
@@ -380,7 +384,7 @@
 				>
 					{$t('chat.error.upload_retry')}
 				</Button>
-			</Alert.Action>
+			</div>
 		{/if}
 	</Alert.Root>
 {/each}

--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -7,8 +7,6 @@
 	import { getTranslate } from '@tolgee/svelte';
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import Progress from '$lib/components/ui/progress/progress.svelte';
-	import { Button } from '$lib/components/ui/button';
-	import * as Alert from '$lib/components/ui/alert';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import AttachmentTextPreview from './AttachmentTextPreview.svelte';
 	import { isTextPreviewable } from '../core/attachmentPreview.js';
@@ -51,14 +49,21 @@
 		server: 'chat.error.upload_server'
 	};
 
-	/** Composer-only: a sent message's attachments carry no actionable failure. */
-	const failedAttachments = $derived(
-		readonly
-			? []
-			: attachments
-					.map((attachment, index) => ({ attachment, index }))
-					.filter(({ attachment }) => getUploadState(attachment)?.status === 'error')
-	);
+	/**
+	 * The one line a failed tile shows under the filename: what went wrong, and
+	 * the way out. There is no automatic retry, so the tile itself is the
+	 * control — without a retry handler the file has to be added again.
+	 */
+	function failureText(code: UploadErrorCode | undefined, retryable: boolean): string {
+		const cause = $t(code ? UPLOAD_ERROR_KEY[code] : 'chat.error.upload_server');
+		return `${cause} ${$t(retryable ? 'chat.error.upload_retry_hint' : 'chat.error.upload_readd_hint')}`;
+	}
+
+	// Tiles pair up two per row from sm upwards. Below that the row is too narrow
+	// for a filename plus a failure reason, so each takes the full width. A lone
+	// attachment also spans the row: halving it would truncate the reason while
+	// the other half sits empty.
+	const fullWidthTiles = $derived(attachments.length === 1);
 
 	// Flex direction and wrap based on alignment and readonly state
 	const flexDirection = $derived(readonly ? (align === 'right' ? 'row-reverse' : 'row') : 'row');
@@ -285,34 +290,43 @@
 			{@const uploadState = getUploadState(attachment)}
 			{@const isUploading = uploadState?.status === 'uploading'}
 			{@const hasFailed = uploadState?.status === 'error'}
-			<!-- A failed image keeps its local preview, so canOpen() would still
-			     say yes; opening it would suggest the file exists somewhere. -->
-			{@const isClickable = !isUploading && !hasFailed && canOpen(attachment)}
 			{@const originalIndex =
 				readonly && align === 'right' ? attachments.length - 1 - index : index}
+			<!-- A failed image keeps its local preview, so canOpen() would still
+			     say yes; opening it would suggest the file exists somewhere.
+			     A failed tile activates the retry instead. -->
+			{@const canRetry = hasFailed && !readonly && !!onRetry}
+			{@const isClickable = !isUploading && !hasFailed && canOpen(attachment)}
+			{@const isInteractive = isClickable || canRetry}
+			{@const activate = () => {
+				if (canRetry) {
+					haptic.trigger('light');
+					onRetry?.(originalIndex);
+				} else if (isClickable) {
+					handleOpen(attachment);
+				}
+			}}
 
-			<!-- tabindex and role are set together: when isClickable, role="button" makes this interactive -->
+			<!-- tabindex and role are set together: when interactive, role="button" makes this actionable -->
 			<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 			<div
 				data-testid="attachment-chip"
 				data-upload-failed={hasFailed ? '' : undefined}
-				class="relative flex items-center justify-between gap-2 overflow-hidden rounded-lg px-2 py-2 transition-transform {isClickable
+				class="relative flex w-full items-center justify-between gap-2 overflow-hidden rounded-lg px-2 py-2 transition-transform {fullWidthTiles
+					? ''
+					: 'sm:w-[calc(50%-0.25rem)]'} {isInteractive
 					? 'cursor-pointer active:translate-y-px'
-					: ''} {hasFailed
-					? 'bg-destructive/5 ring-1 ring-destructive/40'
-					: readonly
-						? 'border text-foreground transition-colors'
-						: 'bg-secondary/50'}"
-				style="width: {attachments.length === 1 && readonly
-					? '100%'
-					: 'calc(50% - 0.25rem)'}; box-sizing: border-box;"
-				role={isClickable ? 'button' : undefined}
-				tabindex={isClickable ? 0 : undefined}
-				onclick={() => isClickable && handleOpen(attachment)}
+					: ''} {readonly && !hasFailed
+					? 'border text-foreground transition-colors'
+					: 'bg-secondary/50'}"
+				style="box-sizing: border-box;"
+				role={isInteractive ? 'button' : undefined}
+				tabindex={isInteractive ? 0 : undefined}
+				onclick={activate}
 				onkeydown={(e) => {
-					if (isClickable && (e.key === 'Enter' || e.key === ' ')) {
+					if (isInteractive && (e.key === 'Enter' || e.key === ' ')) {
 						e.preventDefault();
-						handleOpen(attachment);
+						activate();
 					}
 				}}
 			>
@@ -338,8 +352,14 @@
 							<FileIcon class="size-4 shrink-0" />
 						{/if}
 					</div>
-					<div class="flex flex-1 flex-col gap-1 overflow-hidden">
+					<div class="flex flex-1 flex-col gap-0 overflow-hidden leading-tight">
 						<span class="truncate text-sm" title={filename}>{filename}</span>
+						{#if hasFailed}
+							{@const code = uploadState?.error}
+							<span class="truncate text-xs text-destructive" title={failureText(code, canRetry)}>
+								{failureText(code, canRetry)}
+							</span>
+						{/if}
 					</div>
 				</div>
 				{#if !readonly}
@@ -366,36 +386,3 @@
 		{/each}
 	</div>
 {/if}
-
-<!-- Failures live beside the grid, not inside a tile: tiles are half-width and
-     cannot hold a readable message plus an action. Alert carries role="alert",
-     so appearing here is announced without extra wiring. -->
-{#each failedAttachments as { attachment, index } (attachmentKey(attachment))}
-	{@const filename = getFilename(attachment)}
-	{@const code = getUploadState(attachment)?.error}
-	<Alert.Root variant="destructive" data-testid="attachment-upload-error" class="mt-2 {className}">
-		<TriangleAlertIcon />
-		<Alert.Title>{$t('chat.error.upload_failed', { filename })}</Alert.Title>
-		<Alert.Description>
-			{$t(code ? UPLOAD_ERROR_KEY[code] : 'chat.error.upload_server')}
-		</Alert.Description>
-		{#if onRetry}
-			<!-- In flow rather than Alert.Action: that slot is absolutely
-			     positioned with a fixed 4.5rem reservation, which a translated
-			     label outgrows — at 390px the German title ran underneath it.
-			     col-start-2 keeps it aligned with the text beside the icon. -->
-			<div class="col-start-2 mt-2">
-				<Button
-					variant="outline"
-					size="sm"
-					onclick={() => {
-						haptic.trigger('light');
-						onRetry(index);
-					}}
-				>
-					{$t('chat.error.upload_retry')}
-				</Button>
-			</div>
-		{/if}
-	</Alert.Root>
-{/each}

--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -162,6 +162,16 @@
 		return `attachment-${Math.random()}`;
 	}
 
+	/**
+	 * Key for the failure list. Uses the upload id rather than name+size,
+	 * which is not unique among failures: two images picked under different
+	 * names (photo.jpg, photo.jpeg) pass dedup, then both get renamed to
+	 * photo.webp at the same encoded size, and one network outage fails both.
+	 */
+	function failureKey(attachment: Attachment): string {
+		return ('key' in attachment && attachment.key) || getKey(attachment);
+	}
+
 	function handleOpen(attachment: Attachment) {
 		const openUrl = getOpenUrl(attachment);
 		if (!openUrl) return;
@@ -359,7 +369,7 @@
 <!-- Failures live beside the grid, not inside a tile: tiles are half-width and
      cannot hold a readable message plus an action. Alert carries role="alert",
      so appearing here is announced without extra wiring. -->
-{#each failedAttachments as { attachment, index } (getKey(attachment))}
+{#each failedAttachments as { attachment, index } (failureKey(attachment))}
 	{@const filename = getFilename(attachment)}
 	{@const code = getUploadState(attachment)?.error}
 	<Alert.Root variant="destructive" data-testid="attachment-upload-error" class="mt-2 {className}">

--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -3,13 +3,17 @@
 	import FileIcon from '@lucide/svelte/icons/file';
 	import ImageIcon from '@lucide/svelte/icons/image';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import { getTranslate } from '@tolgee/svelte';
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import Progress from '$lib/components/ui/progress/progress.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import * as Alert from '$lib/components/ui/alert';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import AttachmentTextPreview from './AttachmentTextPreview.svelte';
 	import { isTextPreviewable } from '../core/attachmentPreview.js';
 	import type { Attachment, UploadState } from '../core/types.js';
+	import type { UploadErrorCode } from '../core/file-uploader.js';
 	import type { ChatAlignment } from './chat-context.svelte.ts';
 
 	const { t } = getTranslate();
@@ -17,6 +21,7 @@
 	let {
 		attachments = [],
 		onRemove,
+		onRetry,
 		columns: _columns = 2,
 		readonly = false,
 		align = 'right',
@@ -24,12 +29,36 @@
 	}: {
 		attachments?: Attachment[];
 		onRemove?: (index: number) => void;
+		/** Retry a failed upload. Without it, a failure offers only discard. */
+		onRetry?: (index: number) => void;
 		columns?: number;
 		readonly?: boolean;
 		/** Alignment - controls flex direction for readonly attachments */
 		align?: ChatAlignment;
 		class?: string;
 	} = $props();
+
+	/**
+	 * Translation key per failure cause. Written out in full so the orphan-key
+	 * check can see the references; a template-built key would look unused.
+	 * `parse` shares the server wording: a malformed response is a server fault,
+	 * and retrying is the only thing the user can do about either.
+	 */
+	const UPLOAD_ERROR_KEY: Record<UploadErrorCode, string> = {
+		network: 'chat.error.upload_network',
+		http: 'chat.error.upload_server',
+		parse: 'chat.error.upload_server',
+		server: 'chat.error.upload_server'
+	};
+
+	/** Composer-only: a sent message's attachments carry no actionable failure. */
+	const failedAttachments = $derived(
+		readonly
+			? []
+			: attachments
+					.map((attachment, index) => ({ attachment, index }))
+					.filter(({ attachment }) => getUploadState(attachment)?.status === 'error')
+	);
 
 	// Flex direction and wrap based on alignment and readonly state
 	const flexDirection = $derived(readonly ? (align === 'right' ? 'row-reverse' : 'row') : 'row');
@@ -244,7 +273,10 @@
 			{@const filename = getFilename(attachment)}
 			{@const uploadState = getUploadState(attachment)}
 			{@const isUploading = uploadState?.status === 'uploading'}
-			{@const isClickable = !isUploading && canOpen(attachment)}
+			{@const hasFailed = uploadState?.status === 'error'}
+			<!-- A failed image keeps its local preview, so canOpen() would still
+			     say yes; opening it would suggest the file exists somewhere. -->
+			{@const isClickable = !isUploading && !hasFailed && canOpen(attachment)}
 			{@const originalIndex =
 				readonly && align === 'right' ? attachments.length - 1 - index : index}
 
@@ -252,9 +284,14 @@
 			<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 			<div
 				data-testid="attachment-chip"
+				data-upload-failed={hasFailed ? '' : undefined}
 				class="relative flex items-center justify-between gap-2 overflow-hidden rounded-lg px-2 py-2 transition-transform {isClickable
 					? 'cursor-pointer active:translate-y-px'
-					: ''} {readonly ? 'border text-foreground transition-colors' : 'bg-secondary/50'}"
+					: ''} {hasFailed
+					? 'bg-destructive/5 ring-1 ring-destructive/40'
+					: readonly
+						? 'border text-foreground transition-colors'
+						: 'bg-secondary/50'}"
 				style="width: {attachments.length === 1 && readonly
 					? '100%'
 					: 'calc(50% - 0.25rem)'}; box-sizing: border-box;"
@@ -274,6 +311,8 @@
 					>
 						{#if uploadState?.status === 'uploading'}
 							<LoaderCircleIcon class="size-4 shrink-0 motion-safe:animate-spin" />
+						{:else if hasFailed}
+							<TriangleAlertIcon class="size-4 shrink-0 text-destructive" />
 						{:else if thumbnailUrl}
 							<img
 								src={thumbnailUrl}
@@ -316,3 +355,32 @@
 		{/each}
 	</div>
 {/if}
+
+<!-- Failures live beside the grid, not inside a tile: tiles are half-width and
+     cannot hold a readable message plus an action. Alert carries role="alert",
+     so appearing here is announced without extra wiring. -->
+{#each failedAttachments as { attachment, index } (getKey(attachment))}
+	{@const filename = getFilename(attachment)}
+	{@const code = getUploadState(attachment)?.error}
+	<Alert.Root variant="destructive" data-testid="attachment-upload-error" class="mt-2 {className}">
+		<TriangleAlertIcon />
+		<Alert.Title>{$t('chat.error.upload_failed', { filename })}</Alert.Title>
+		<Alert.Description>
+			{$t(code ? UPLOAD_ERROR_KEY[code] : 'chat.error.upload_server')}
+		</Alert.Description>
+		{#if onRetry}
+			<Alert.Action>
+				<Button
+					variant="outline"
+					size="sm"
+					onclick={() => {
+						haptic.trigger('light');
+						onRetry(index);
+					}}
+				>
+					{$t('chat.error.upload_retry')}
+				</Button>
+			</Alert.Action>
+		{/if}
+	</Alert.Root>
+{/each}

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -492,6 +492,10 @@
 		ctx.removeAttachment(index);
 	}
 
+	function handleRetryAttachment(index: number) {
+		ctx.retryUpload(index);
+	}
+
 	function handleSuggestionClick(text: string) {
 		ctx.setInputValue(text);
 		tick().then(() => {
@@ -761,6 +765,7 @@
 						class="mx-1 mb-1"
 						attachments={ctx.attachments}
 						onRemove={handleRemoveAttachment}
+						onRetry={handleRetryAttachment}
 						columns={2}
 					/>
 				{/if}
@@ -833,6 +838,7 @@
 						class="mx-3 mt-3"
 						attachments={ctx.attachments}
 						onRemove={handleRemoveAttachment}
+						onRetry={handleRetryAttachment}
 						columns={2}
 					/>
 				{/if}

--- a/src/lib/chat/ui/attachment-keys.test.ts
+++ b/src/lib/chat/ui/attachment-keys.test.ts
@@ -5,10 +5,10 @@ import { describe, expect, it } from 'vitest';
 const source = readFileSync(resolve('src/lib/chat/ui/ChatAttachments.svelte'), 'utf8');
 
 /**
- * Both keyed lists must identify composer attachments by their upload id.
- * Name and size are not unique: photo.jpg and photo.jpeg pass dedup as
- * different source names, then preprocessing renames both to photo.webp at the
- * same encoded size, and Svelte throws each_key_duplicate.
+ * Keyed lists must identify composer attachments by their upload id. Name and
+ * size are not unique: photo.jpg and photo.jpeg pass dedup as different source
+ * names, then preprocessing renames both to photo.webp at the same encoded
+ * size, and Svelte throws each_key_duplicate.
  *
  * Pinned in source because reproducing it in a browser test needs two images
  * that survive dedup and then encode to byte-identical sizes, which is fragile
@@ -21,7 +21,7 @@ describe('ChatAttachments keyed lists', () => {
 			(match) => match[1]
 		);
 
-		expect(keyExpressions.length).toBe(2);
+		expect(keyExpressions.length).toBeGreaterThan(0);
 		for (const expression of keyExpressions) {
 			expect(expression).toBe('attachmentKey(attachment)');
 		}

--- a/src/lib/chat/ui/attachment-keys.test.ts
+++ b/src/lib/chat/ui/attachment-keys.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve('src/lib/chat/ui/ChatAttachments.svelte'), 'utf8');
+
+/**
+ * Both keyed lists must identify composer attachments by their upload id.
+ * Name and size are not unique: photo.jpg and photo.jpeg pass dedup as
+ * different source names, then preprocessing renames both to photo.webp at the
+ * same encoded size, and Svelte throws each_key_duplicate.
+ *
+ * Pinned in source because reproducing it in a browser test needs two images
+ * that survive dedup and then encode to byte-identical sizes, which is fragile
+ * to arrange and would break for reasons unrelated to the keying.
+ */
+describe('ChatAttachments keyed lists', () => {
+	it('keys every each block by the shared attachment identity', () => {
+		// The key is the final parenthesised expression of an {#each ...} tag.
+		const keyExpressions = [...source.matchAll(/\{#each .*?\(([A-Za-z]+\(attachment\))\)\}/g)].map(
+			(match) => match[1]
+		);
+
+		expect(keyExpressions.length).toBe(2);
+		for (const expression of keyExpressions) {
+			expect(expression).toBe('attachmentKey(attachment)');
+		}
+	});
+
+	it('prefers the upload id over the derived name+size key', () => {
+		const helper = source.match(
+			/function attachmentKey\(attachment: Attachment\): string \{([^}]*)\}/s
+		)?.[1];
+
+		expect(helper).toBeDefined();
+		expect(helper).toContain('attachment.key');
+		// Sent attachments carry no id, so the derived key stays as the fallback.
+		expect(helper).toContain('getKey(attachment)');
+	});
+});

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -511,8 +511,13 @@ export class ChatUIContext {
 			// reading) leaves nothing to retry, and preprocessing already throws
 			// its own translated message. Those keep the old behavior: drop the
 			// attachment, say why once.
+			//
+			// Unless the user got there first: preprocessing cannot be canceled,
+			// so it may still reject long after the chip was discarded, and
+			// reporting a failure for a file nobody is waiting on is noise.
+			const stillPresent = this.attachments.some((a) => 'key' in a && a.key === key);
 			this.discardAttachment(key);
-			if (isAbortError(error)) return;
+			if (isAbortError(error) || !stillPresent) return;
 			const translate = this.uploadConfig?.translate;
 			toast.error(
 				translate?.('chat.error.upload_failed', { filename: initialName }) ??

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -10,14 +10,31 @@ import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { toast } from 'svelte-sonner';
 import type { ConvexClient } from 'convex/browser';
 import type { ChatCore } from '../core/chat-core.svelte.ts';
-import type { DisplayMessage, Attachment, MessageRole } from '../core/types.js';
-import { uploadFileWithProgress } from '../core/file-uploader.js';
+import type { DisplayMessage, Attachment, MessageRole, UploadState } from '../core/types.js';
+import { uploadFileWithProgress, UploadError } from '../core/file-uploader.js';
 import { FadeOnLoad } from '$lib/utils/fade-on-load.svelte.ts';
 
 /**
  * Message alignment - controls which side messages appear on
  */
 export type ChatAlignment = 'left' | 'right';
+
+/**
+ * A ready-to-send upload: what the transport receives after any client-side
+ * preprocessing. Retained per attachment so a retry repeats the same transfer
+ * instead of redoing the preprocessing, which is neither free nor idempotent
+ * (image re-encoding renames the file and changes its bytes).
+ */
+type UploadJob = {
+	blob: File | Blob;
+	filename: string;
+	dimensions?: { width: number; height: number };
+};
+
+/** A canceled upload, which the user caused and does not need to be told about. */
+function isAbortError(error: unknown): boolean {
+	return error instanceof DOMException && error.name === 'AbortError';
+}
 
 /**
  * Configuration for file uploads
@@ -90,6 +107,17 @@ export class ChatUIContext {
 	 * used by upload methods to apply progress/success/error updates by value
 	 * rather than by array index. */
 	attachments = $state<Attachment[]>([]);
+
+	/** Cancels the in-flight upload of an attachment, keyed by its stable `key`. */
+	private readonly uploadAborters = new SvelteMap<string, AbortController>();
+
+	/**
+	 * The exact payload each failed attachment would need to try again. Held
+	 * because retrying from the picked file is not equivalent: images are
+	 * re-encoded before upload, and screenshots never had a File to begin with.
+	 * Only kept while the attachment is present, so a discarded blob is freed.
+	 */
+	private readonly retryJobs = new SvelteMap<string, UploadJob>();
 
 	/** The one composer mounted inside this ChatRoot. */
 	private composerFocus?: () => void;
@@ -281,11 +309,27 @@ export class ChatUIContext {
 	}
 
 	/**
+	 * Cancel an attachment's in-flight upload and drop everything held for it.
+	 * Attachments handed in from outside may have no `key` and never started an
+	 * upload, so a missing entry is normal rather than an error.
+	 */
+	private releaseUpload(attachment: Attachment): void {
+		const key = 'key' in attachment ? attachment.key : undefined;
+		if (!key) return;
+		this.uploadAborters.get(key)?.abort();
+		this.uploadAborters.delete(key);
+		this.retryJobs.delete(key);
+	}
+
+	/**
 	 * Remove attachment at index
 	 */
 	removeAttachment(index: number): void {
 		const removed = this.attachments[index];
-		if (removed) this.revokePreview(removed);
+		if (removed) {
+			this.releaseUpload(removed);
+			this.revokePreview(removed);
+		}
 		this.attachments = this.attachments.filter((_, i) => i !== index);
 	}
 
@@ -294,6 +338,7 @@ export class ChatUIContext {
 	 */
 	clearAttachments(): void {
 		for (const attachment of this.attachments) {
+			this.releaseUpload(attachment);
 			this.revokePreview(attachment);
 		}
 		this.attachments = [];
@@ -441,54 +486,117 @@ export class ChatUIContext {
 				);
 			}
 
-			const accessKey = this.uploadConfig?.getAccessKey?.();
-			const result = await uploadFileWithProgress(
-				this.client,
-				uploadBlob,
-				uploadName,
-				(progress) => {
-					// Update progress for this specific attachment by stable key
-					this.attachments = this.attachments.map((a) =>
-						'key' in a &&
-						a.key === key &&
-						(a.type === 'file' || a.type === 'screenshot') &&
-						a.uploadState
-							? { ...a, uploadState: { ...a.uploadState, progress } }
-							: a
-					);
-				},
-				this.uploadConfig,
-				width && height ? { width, height } : undefined,
-				accessKey
-			);
-
-			// Mark as success
-			this.attachments = this.attachments.map((a) =>
-				'key' in a && a.key === key
-					? {
-							...a,
-							url: result.url,
-							uploadState: { status: 'success' as const, progress: 100, fileId: result.fileId }
-						}
-					: a
-			);
+			await this.runUpload(key, {
+				blob: uploadBlob,
+				filename: uploadName,
+				dimensions: width && height ? { width, height } : undefined
+			});
 		} catch (error) {
-			// Remove failed attachment by key (not stale index) and show toast
-			const failed = this.attachments.find((a) => 'key' in a && a.key === key);
-			if (failed) this.revokePreview(failed);
-			this.attachments = this.attachments.filter((a) => !('key' in a) || a.key !== key);
+			// A failure before the transfer (image preprocessing, dimension
+			// reading) leaves nothing to retry, and preprocessing already throws
+			// its own translated message. Those keep the old behavior: drop the
+			// attachment, say why once.
+			this.discardAttachment(key);
+			if (isAbortError(error)) return;
 			const translate = this.uploadConfig?.translate;
 			toast.error(
 				translate?.('chat.error.upload_failed', { filename: initialName }) ??
 					`Failed to upload "${initialName}"`,
-				{
-					description:
-						error instanceof Error
-							? error.message
-							: (translate?.('chat.error.upload_failed_description') ?? 'Upload failed')
-				}
+				{ description: error instanceof Error ? error.message : undefined }
 			);
 		}
+	}
+
+	/**
+	 * Run one upload attempt for an existing attachment and record the outcome
+	 * on it. Shared by the file path, the screenshot path, and retry, so all
+	 * three produce the same states.
+	 *
+	 * Never throws: a failure becomes a visible, retryable attachment state
+	 * rather than an exception the caller has to translate again.
+	 */
+	private async runUpload(key: string, job: UploadJob): Promise<void> {
+		if (!this.uploadConfig) return;
+
+		const aborter = new AbortController();
+		this.uploadAborters.set(key, aborter);
+		this.retryJobs.set(key, job);
+		this.patchAttachment(key, { uploadState: { status: 'uploading', progress: 0 } });
+
+		try {
+			const result = await uploadFileWithProgress(
+				this.client,
+				job.blob,
+				job.filename,
+				(progress) => {
+					this.patchUploadState(key, (state) => ({ ...state, progress }));
+				},
+				this.uploadConfig,
+				job.dimensions,
+				this.uploadConfig.getAccessKey?.(),
+				aborter.signal
+			);
+
+			this.patchAttachment(key, {
+				url: result.url,
+				uploadState: { status: 'success', progress: 100, fileId: result.fileId }
+			});
+			// The bytes are on the server now; holding them would pin memory for
+			// an attachment that can no longer fail.
+			this.retryJobs.delete(key);
+		} catch (error) {
+			// Cancelation is not a failure: removeAttachment/clearAttachments
+			// already took the attachment away, so there is no state to write.
+			if (isAbortError(error)) return;
+			this.patchAttachment(key, {
+				uploadState: {
+					status: 'error',
+					progress: 0,
+					error: error instanceof UploadError ? error.code : 'server'
+				}
+			});
+		} finally {
+			this.uploadAborters.delete(key);
+		}
+	}
+
+	/**
+	 * Try a failed upload again with the exact payload of the first attempt.
+	 * No-op when the attachment has no retained job, which is the case for
+	 * failures that happened before the transfer.
+	 */
+	retryUpload(index: number): void {
+		const attachment = this.attachments[index];
+		if (!attachment || !('key' in attachment) || !attachment.key) return;
+		const job = this.retryJobs.get(attachment.key);
+		if (!job) return;
+		void this.runUpload(attachment.key, job);
+	}
+
+	/** Apply a partial update to the attachment with this key. */
+	private patchAttachment(key: string, patch: Partial<Attachment>): void {
+		this.attachments = this.attachments.map((a) =>
+			'key' in a && a.key === key ? ({ ...a, ...patch } as Attachment) : a
+		);
+	}
+
+	/** Update the upload state of the attachment with this key, if it has one. */
+	private patchUploadState(key: string, next: (state: UploadState) => UploadState): void {
+		this.attachments = this.attachments.map((a) =>
+			'key' in a && a.key === key && (a.type === 'file' || a.type === 'screenshot') && a.uploadState
+				? { ...a, uploadState: next(a.uploadState) }
+				: a
+		);
+	}
+
+	/** Remove an attachment by key and release everything held for it. */
+	private discardAttachment(key: string): void {
+		const attachment = this.attachments.find((a) => 'key' in a && a.key === key);
+		if (attachment) {
+			this.releaseUpload(attachment);
+			this.revokePreview(attachment);
+		}
+		this.attachments = this.attachments.filter((a) => !('key' in a) || a.key !== key);
 	}
 
 	/**
@@ -520,53 +628,9 @@ export class ChatUIContext {
 
 		this.attachments = [...this.attachments, newAttachment];
 
-		try {
-			const accessKey = this.uploadConfig?.getAccessKey?.();
-			const result = await uploadFileWithProgress(
-				this.client,
-				blob,
-				filename,
-				(progress) => {
-					this.attachments = this.attachments.map((a) =>
-						'key' in a &&
-						a.key === key &&
-						(a.type === 'file' || a.type === 'screenshot') &&
-						a.uploadState
-							? { ...a, uploadState: { ...a.uploadState, progress } }
-							: a
-					);
-				},
-				this.uploadConfig,
-				dimensions,
-				accessKey
-			);
-
-			// Mark as success
-			this.attachments = this.attachments.map((a) =>
-				'key' in a && a.key === key
-					? {
-							...a,
-							url: result.url,
-							uploadState: { status: 'success' as const, progress: 100, fileId: result.fileId }
-						}
-					: a
-			);
-		} catch (error) {
-			// Remove failed attachment by key and show toast
-			const failed = this.attachments.find((a) => 'key' in a && a.key === key);
-			if (failed) this.revokePreview(failed);
-			this.attachments = this.attachments.filter((a) => !('key' in a) || a.key !== key);
-			const translate = this.uploadConfig?.translate;
-			toast.error(
-				translate?.('chat.error.upload_failed', { filename }) ?? `Failed to upload "${filename}"`,
-				{
-					description:
-						error instanceof Error
-							? error.message
-							: (translate?.('chat.error.upload_failed_description') ?? 'Upload failed')
-				}
-			);
-		}
+		// No preprocessing here: the blob and its dimensions are already what
+		// gets uploaded, so they double as the retry payload unchanged.
+		await this.runUpload(key, { blob, filename, dimensions });
 	}
 
 	/**
@@ -610,10 +674,24 @@ export class ChatUIContext {
 	}
 
 	/**
+	 * Whether any attachment failed to upload.
+	 *
+	 * Blocks sending, because only successful uploads reach the backend while
+	 * the whole attachment list is rendered optimistically: sending anyway would
+	 * show the user a file that was never stored. The inline error offers retry
+	 * and discard, so this is a prompt to decide, not a dead end.
+	 */
+	get hasFailedUploads(): boolean {
+		return this.attachments.some(
+			(a) => (a.type === 'file' || a.type === 'screenshot') && a.uploadState?.status === 'error'
+		);
+	}
+
+	/**
 	 * Check if message can be sent
 	 */
 	get canSend(): boolean {
-		return !this.hasUploadingFiles && !!this.inputValue.trim();
+		return !this.hasUploadingFiles && !this.hasFailedUploads && !!this.inputValue.trim();
 	}
 
 	/**

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -518,10 +518,20 @@ export class ChatUIContext {
 	private async runUpload(key: string, job: UploadJob): Promise<void> {
 		if (!this.uploadConfig) return;
 
+		// Starting an attempt cancels any earlier one for the same attachment, so
+		// a double-click on retry cannot leave a request running unattended.
+		this.uploadAborters.get(key)?.abort();
 		const aborter = new AbortController();
 		this.uploadAborters.set(key, aborter);
 		this.retryJobs.set(key, job);
 		this.patchAttachment(key, { uploadState: { status: 'uploading', progress: 0 } });
+
+		/**
+		 * Whether this attempt is still the current one. A superseded attempt
+		 * must not write state or clear the live attempt's aborter; without this
+		 * a slow first try could stamp its failure over a newer success.
+		 */
+		const isCurrent = () => this.uploadAborters.get(key) === aborter;
 
 		try {
 			const result = await uploadFileWithProgress(
@@ -529,7 +539,7 @@ export class ChatUIContext {
 				job.blob,
 				job.filename,
 				(progress) => {
-					this.patchUploadState(key, (state) => ({ ...state, progress }));
+					if (isCurrent()) this.patchUploadState(key, (state) => ({ ...state, progress }));
 				},
 				this.uploadConfig,
 				job.dimensions,
@@ -537,6 +547,7 @@ export class ChatUIContext {
 				aborter.signal
 			);
 
+			if (!isCurrent()) return;
 			this.patchAttachment(key, {
 				url: result.url,
 				uploadState: { status: 'success', progress: 100, fileId: result.fileId }
@@ -547,7 +558,7 @@ export class ChatUIContext {
 		} catch (error) {
 			// Cancelation is not a failure: removeAttachment/clearAttachments
 			// already took the attachment away, so there is no state to write.
-			if (isAbortError(error)) return;
+			if (isAbortError(error) || !isCurrent()) return;
 			this.patchAttachment(key, {
 				uploadState: {
 					status: 'error',
@@ -556,7 +567,7 @@ export class ChatUIContext {
 				}
 			});
 		} finally {
-			this.uploadAborters.delete(key);
+			if (isCurrent()) this.uploadAborters.delete(key);
 		}
 	}
 

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -486,6 +486,15 @@ export class ChatUIContext {
 				);
 			}
 
+			// Preprocessing and dimension reading are awaited above and cannot be
+			// canceled, so the user may have discarded the attachment by now.
+			// Starting the transfer would upload a file nothing references and
+			// leave map entries behind for a key that is gone.
+			if (!this.attachments.some((a) => 'key' in a && a.key === key)) {
+				this.retryJobs.delete(key);
+				return;
+			}
+
 			await this.runUpload(key, {
 				blob: uploadBlob,
 				filename: uploadName,

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -237,6 +237,12 @@ export class ChatUIContext {
 		) {
 			this.messagesFade.reset();
 			this._hasEverDisplayedMessages = false;
+			// Attachments belong to the thread they were picked in. Every surface
+			// reuses one context across threads and swaps only the text draft, so
+			// without this a file follows the user and is sent in the wrong
+			// conversation — and a failed one blocks sending there. Also cancels
+			// any transfer still running for the thread being left.
+			this.clearAttachments();
 		}
 		this._lastThreadId = currentThreadId;
 

--- a/src/lib/chat/ui/chat-context.test.ts
+++ b/src/lib/chat/ui/chat-context.test.ts
@@ -266,6 +266,34 @@ describe('ChatUIContext upload failures', () => {
 		expect(ctx.hasFailedUploads).toBe(false);
 	});
 
+	it('does not upload when the attachment is removed during preprocessing', async () => {
+		// Preprocessing is awaited and cannot be canceled, so the composer may be
+		// empty by the time it resolves. Uploading anyway would store a file
+		// nothing references.
+		stubTransport();
+		const client = succeedingClient();
+		const ctx = new ChatUIContext(mockCore, client, uploadConfig);
+
+		let removeDuringPreprocess: (() => void) | undefined;
+		const preprocessing = new Promise<void>((resolve) => {
+			removeDuringPreprocess = resolve;
+		});
+		const upload = ctx.uploadFile(textFile(), 'notes.txt', {
+			preprocess: async (input) => {
+				await preprocessing;
+				return { blob: input, mimeType: 'text/plain', filename: 'notes.txt' };
+			}
+		});
+
+		await vi.waitFor(() => expect(ctx.attachments).toHaveLength(1));
+		ctx.removeAttachment(0);
+		removeDuringPreprocess?.();
+		await upload;
+
+		expect(ctx.attachments).toHaveLength(0);
+		expect(client.mutation).not.toHaveBeenCalled();
+	});
+
 	it('does nothing when retrying an attachment with no retained payload', () => {
 		const ctx = new ChatUIContext(mockCore, succeedingClient(), uploadConfig);
 		ctx.addAttachments([fileAttachment(undefined)]);

--- a/src/lib/chat/ui/chat-context.test.ts
+++ b/src/lib/chat/ui/chat-context.test.ts
@@ -230,6 +230,42 @@ describe('ChatUIContext upload failures', () => {
 		expect(ctx.hasFailedUploads).toBe(false);
 	});
 
+	it('lets a second retry supersede a slow first one', async () => {
+		// Double-clicking retry must not leave the earlier attempt able to stamp
+		// its own outcome over the newer one.
+		stubTransport();
+		const client = succeedingClient();
+		let attempt = 0;
+		let releaseFirst: (() => void) | undefined;
+		client.mutation = vi.fn(async () => {
+			attempt++;
+			if (attempt === 1) throw new Error('Rate limit exceeded');
+			if (attempt === 2) {
+				// Hold the second attempt open until the third has settled.
+				await new Promise<void>((resolve) => {
+					releaseFirst = resolve;
+				});
+				throw new Error('Rate limit exceeded');
+			}
+			return { uploadUrl: 'https://storage.test', uploadToken: 't' };
+		}) as never;
+		const ctx = new ChatUIContext(mockCore, client, uploadConfig);
+		await ctx.uploadFile(textFile(), 'notes.txt');
+
+		ctx.retryUpload(0); // stalls
+		await vi.waitFor(() => expect(attempt).toBe(2));
+		ctx.retryUpload(0); // supersedes
+		await vi.waitFor(() => expect(soleUploadState(ctx)?.status).toBe('success'));
+
+		// Let the superseded attempt finish failing. Its outcome must be dropped,
+		// not written over the success that already landed.
+		releaseFirst?.();
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		expect(soleUploadState(ctx)?.status).toBe('success');
+		expect(ctx.hasFailedUploads).toBe(false);
+	});
+
 	it('does nothing when retrying an attachment with no retained payload', () => {
 		const ctx = new ChatUIContext(mockCore, succeedingClient(), uploadConfig);
 		ctx.addAttachments([fileAttachment(undefined)]);

--- a/src/lib/chat/ui/chat-context.test.ts
+++ b/src/lib/chat/ui/chat-context.test.ts
@@ -107,4 +107,160 @@ describe('ChatUIContext attachment cleanup', () => {
 		expect(revokeSpy).not.toHaveBeenCalled();
 		expect(ctx.attachments).toHaveLength(0);
 	});
+
+	it('tolerates attachments that never started an upload', () => {
+		// Attachments can arrive from outside with no key (handleSend restores
+		// them after a failed send), so releasing them must not assume one.
+		const ctx = new ChatUIContext(mockCore, mockClient);
+		ctx.addAttachments([{ type: 'image', url: 'https://example.com/a.png' }]);
+
+		expect(() => ctx.clearAttachments()).not.toThrow();
+		expect(ctx.attachments).toHaveLength(0);
+	});
+});
+
+describe('ChatUIContext upload failures', () => {
+	const uploadConfig = {
+		generateUploadUrl: 'generateUploadUrl' as never,
+		saveUploadedFile: 'saveUploadedFile' as never
+	};
+
+	/** A client whose presign step fails, so no transport stub is needed. */
+	function failingClient(): ConvexClient {
+		return {
+			mutation: vi.fn(async () => {
+				throw new Error('Rate limit exceeded');
+			}),
+			action: vi.fn()
+		} as unknown as ConvexClient;
+	}
+
+	function succeedingClient(): ConvexClient {
+		return {
+			mutation: vi.fn(async () => ({ uploadUrl: 'https://storage.test', uploadToken: 't' })),
+			action: vi.fn(async () => ({ fileId: 'file-9', url: 'https://cdn.test/file-9' }))
+		} as unknown as ConvexClient;
+	}
+
+	/** Transport stub that succeeds; the Convex client decides the outcome. */
+	function stubTransport() {
+		const handlers: Record<string, () => void> = {};
+		const xhr = {
+			status: 200,
+			responseText: JSON.stringify({ storageId: 'storage-9' }),
+			upload: { addEventListener: () => {} },
+			addEventListener: (event: string, handler: () => void) => {
+				handlers[event] = handler;
+			},
+			open: () => {},
+			setRequestHeader: () => {},
+			abort: () => handlers.abort?.(),
+			send: () => handlers.load?.()
+		};
+		vi.stubGlobal('XMLHttpRequest', function XMLHttpRequestStub() {
+			return xhr;
+		});
+	}
+
+	const textFile = () => new File(['hello'], 'notes.txt', { type: 'text/plain' });
+
+	/** Upload state of the only attachment, narrowed out of the Attachment union. */
+	function soleUploadState(ctx: ChatUIContext) {
+		const attachment = ctx.attachments[0];
+		if (!attachment || (attachment.type !== 'file' && attachment.type !== 'screenshot')) {
+			throw new Error('expected a single file or screenshot attachment');
+		}
+		return attachment.uploadState;
+	}
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('keeps a failed upload visible instead of removing it', async () => {
+		const ctx = new ChatUIContext(mockCore, failingClient(), uploadConfig);
+
+		await ctx.uploadFile(textFile(), 'notes.txt');
+
+		expect(ctx.attachments).toHaveLength(1);
+		expect(soleUploadState(ctx)).toMatchObject({ status: 'error', error: 'server' });
+	});
+
+	it('blocks sending while an upload has failed', async () => {
+		const ctx = new ChatUIContext(mockCore, failingClient(), uploadConfig);
+		ctx.setInputValue('here is the file');
+
+		await ctx.uploadFile(textFile(), 'notes.txt');
+
+		expect(ctx.hasFailedUploads).toBe(true);
+		expect(ctx.canSend).toBe(false);
+	});
+
+	it('allows sending again once the failed attachment is discarded', async () => {
+		const ctx = new ChatUIContext(mockCore, failingClient(), uploadConfig);
+		ctx.setInputValue('here is the file');
+		await ctx.uploadFile(textFile(), 'notes.txt');
+
+		ctx.removeAttachment(0);
+
+		expect(ctx.canSend).toBe(true);
+	});
+
+	it('retries with the same payload and succeeds', async () => {
+		stubTransport();
+		const client = succeedingClient();
+		// Fail once, then let the same client succeed on the retry.
+		let firstCall = true;
+		client.mutation = vi.fn(async () => {
+			if (firstCall) {
+				firstCall = false;
+				throw new Error('Rate limit exceeded');
+			}
+			return { uploadUrl: 'https://storage.test', uploadToken: 't' };
+		}) as never;
+		const ctx = new ChatUIContext(mockCore, client, uploadConfig);
+		await ctx.uploadFile(textFile(), 'notes.txt');
+
+		ctx.retryUpload(0);
+		await vi.waitFor(() => {
+			expect(soleUploadState(ctx)?.status).toBe('success');
+		});
+
+		expect(ctx.canSend).toBe(false); // no input text yet
+		expect(ctx.hasFailedUploads).toBe(false);
+	});
+
+	it('does nothing when retrying an attachment with no retained payload', () => {
+		const ctx = new ChatUIContext(mockCore, succeedingClient(), uploadConfig);
+		ctx.addAttachments([fileAttachment(undefined)]);
+
+		expect(() => ctx.retryUpload(0)).not.toThrow();
+	});
+
+	it('aborts the in-flight upload when the attachment is removed', async () => {
+		const abort = vi.fn();
+		const originalAbort = AbortController.prototype.abort;
+		AbortController.prototype.abort = function patchedAbort(this: AbortController, reason) {
+			abort();
+			return originalAbort.call(this, reason);
+		};
+
+		try {
+			// A client that never settles keeps the upload in flight for removal.
+			const client = {
+				mutation: vi.fn(() => new Promise(() => {})),
+				action: vi.fn()
+			} as unknown as ConvexClient;
+			const ctx = new ChatUIContext(mockCore, client, uploadConfig);
+			void ctx.uploadFile(textFile(), 'notes.txt');
+			await vi.waitFor(() => expect(ctx.attachments).toHaveLength(1));
+
+			ctx.removeAttachment(0);
+
+			expect(abort).toHaveBeenCalled();
+			expect(ctx.attachments).toHaveLength(0);
+		} finally {
+			AbortController.prototype.abort = originalAbort;
+		}
+	});
 });

--- a/src/lib/chat/ui/chat-context.test.ts
+++ b/src/lib/chat/ui/chat-context.test.ts
@@ -294,6 +294,35 @@ describe('ChatUIContext upload failures', () => {
 		expect(client.mutation).not.toHaveBeenCalled();
 	});
 
+	it('drops attachments when navigating between threads', () => {
+		// Every surface reuses one context across threads and swaps only the text
+		// draft, so an attachment would otherwise be sent in the wrong thread —
+		// and a failed one would block sending there.
+		const core = { threadId: 'thread-a' } as unknown as ChatCore;
+		const ctx = new ChatUIContext(core, succeedingClient(), uploadConfig);
+		ctx.setDisplayMessages([]);
+		ctx.addAttachments([fileAttachment(undefined)]);
+
+		(core as { threadId: string }).threadId = 'thread-b';
+		ctx.setDisplayMessages([]);
+
+		expect(ctx.attachments).toHaveLength(0);
+	});
+
+	it('keeps attachments when a new thread gets its id', () => {
+		// null -> id is this conversation being created, not a move to another
+		// one: a file attached while creation was in flight belongs here.
+		const core = { threadId: null } as unknown as ChatCore;
+		const ctx = new ChatUIContext(core, succeedingClient(), uploadConfig);
+		ctx.setDisplayMessages([]);
+		ctx.addAttachments([fileAttachment(undefined)]);
+
+		(core as { threadId: string | null }).threadId = 'thread-a';
+		ctx.setDisplayMessages([]);
+
+		expect(ctx.attachments).toHaveLength(1);
+	});
+
 	it('does nothing when retrying an attachment with no retained payload', () => {
 		const ctx = new ChatUIContext(mockCore, succeedingClient(), uploadConfig);
 		ctx.addAttachments([fileAttachment(undefined)]);

--- a/src/lib/chat/ui/chat-context.test.ts
+++ b/src/lib/chat/ui/chat-context.test.ts
@@ -6,10 +6,13 @@
  */
 
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { toast } from 'svelte-sonner';
 import { ChatUIContext } from './chat-context.svelte.ts';
 import type { ChatCore } from '../core/chat-core.svelte.ts';
 import type { ConvexClient } from 'convex/browser';
 import type { Attachment } from '../core/types.js';
+
+vi.mock('svelte-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 
 const mockCore = {} as ChatCore;
 const mockClient = {} as ConvexClient;
@@ -173,6 +176,10 @@ describe('ChatUIContext upload failures', () => {
 		return attachment.uploadState;
 	}
 
+	beforeEach(() => {
+		vi.mocked(toast.error).mockClear();
+	});
+
 	afterEach(() => {
 		vi.unstubAllGlobals();
 	});
@@ -321,6 +328,45 @@ describe('ChatUIContext upload failures', () => {
 		ctx.setDisplayMessages([]);
 
 		expect(ctx.attachments).toHaveLength(1);
+	});
+
+	it('stays quiet when preprocessing fails after the attachment was removed', async () => {
+		// Preprocessing cannot be canceled, so it can reject long after the chip
+		// was discarded. Reporting that failure would be noise about a file the
+		// user already dismissed.
+		const ctx = new ChatUIContext(mockCore, succeedingClient(), uploadConfig);
+
+		let failPreprocess: (() => void) | undefined;
+		const preprocessing = new Promise<void>((resolve) => {
+			failPreprocess = resolve;
+		});
+		const upload = ctx.uploadFile(textFile(), 'notes.txt', {
+			preprocess: async () => {
+				await preprocessing;
+				throw new Error('Image could not be compressed below 5 MB');
+			}
+		});
+
+		await vi.waitFor(() => expect(ctx.attachments).toHaveLength(1));
+		ctx.removeAttachment(0);
+		failPreprocess?.();
+		await upload;
+
+		expect(ctx.attachments).toHaveLength(0);
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('reports a preprocessing failure for an attachment still in the composer', async () => {
+		const ctx = new ChatUIContext(mockCore, succeedingClient(), uploadConfig);
+
+		await ctx.uploadFile(textFile(), 'notes.txt', {
+			preprocess: async () => {
+				throw new Error('Image could not be compressed below 5 MB');
+			}
+		});
+
+		expect(ctx.attachments).toHaveLength(0);
+		expect(toast.error).toHaveBeenCalled();
 	});
 
 	it('does nothing when retrying an attachment with no retained payload', () => {

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -116,11 +116,6 @@
 			// Load draft for new thread (or empty for new conversation)
 			const draft = threadContext.getDraft(currentThreadId);
 			chatUIContext.setInputValue(draft);
-
-			// Only the text is per-thread; the widget reuses one chat context, so
-			// attachments would otherwise follow the visitor into the next thread
-			// and be sent there. Also cancels any transfer still in flight.
-			if (previousThreadId !== undefined) chatUIContext.clearAttachments();
 		}
 	);
 

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -116,6 +116,11 @@
 			// Load draft for new thread (or empty for new conversation)
 			const draft = threadContext.getDraft(currentThreadId);
 			chatUIContext.setInputValue(draft);
+
+			// Only the text is per-thread; the widget reuses one chat context, so
+			// attachments would otherwise follow the visitor into the next thread
+			// and be sent there. Also cancels any transfer still in flight.
+			if (previousThreadId !== undefined) chatUIContext.clearAttachments();
 		}
 	);
 

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -116,6 +116,17 @@
 			// Load draft for new thread (or empty for new conversation)
 			const draft = threadContext.getDraft(currentThreadId);
 			chatUIContext.setInputValue(draft);
+
+			// ChatUIContext drops attachments when the thread id changes, but it
+			// cannot tell an abandoned compose from a conversation receiving its
+			// warm id: both look like null -> id. Compose that is left without
+			// ever getting an id (back out, or creation fails) would otherwise
+			// carry its attachment into whichever thread is opened next.
+			// isNewConversation is the missing signal — selectThread clears it,
+			// warm-id assignment does not.
+			if (previousThreadId === null && !threadContext.isNewConversation) {
+				chatUIContext.clearAttachments();
+			}
 		}
 	);
 

--- a/src/routes/[[lang]]/app/settings/account-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/account-settings.svelte
@@ -7,7 +7,7 @@
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { Progress } from '$lib/components/ui/progress/index.js';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
-	import { uploadToStorage } from '$lib/chat';
+	import { uploadToStorage, UploadError } from '$lib/chat';
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { T, getTranslate } from '@tolgee/svelte';
@@ -109,6 +109,11 @@
 				toast.error(
 					$t('settings.account.avatar.rate_limited', { seconds: Math.ceil(retryAfter / 1000) })
 				);
+			} else if (error instanceof UploadError) {
+				// Its message is developer-facing English; the transport reports a
+				// code precisely so the UI can phrase the failure in the user's
+				// language.
+				toast.error($t('settings.account.avatar.upload_failed'));
 			} else {
 				const message =
 					error instanceof Error ? error.message : $t('settings.account.avatar.upload_failed');


### PR DESCRIPTION
A chat upload that failed left a four-second Sonner toast and nothing else. The attachment was removed from the composer at the same moment, so a reload or a glance away lost the file with no trace of it ever having been picked — the same shape as an incident on a downstream fork, where a 3.96 MB PDF died at 96% and the user went on believing it had been sent.

Failures now stay on the attachment itself, as a second line under the filename where file metadata already lives. Warning icon and red text carry it, no outline, so the composer does not grow a panel. The tile is the retry control: there is no automatic retry anywhere in this flow, and the processed upload payload is retained so a retry repeats the same transfer rather than redoing image preprocessing, which renames the file and changes its bytes. Sending is blocked while a failure is present, because only successful uploads reach the backend while the whole attachment list renders optimistically — sending anyway would show the user a file that was never stored.

The wording used to be hardcoded English thrown from the transport and piped raw into the toast description, so a German user saw a translated title above an English detail line. `file-uploader.ts` now throws a typed `UploadError` carrying a code, and the Convex presign and commit stages are wrapped so their English server strings (rate limits, download-URL failures) stay in `cause` for logs instead of reaching the UI. Rendering picks the wording from the code, so it follows the active language. The avatar upload stops surfacing raw transport text for the same reason. A 200 response with no `storageId` used to resolve with `undefined` and fail later during the commit, where the cause was no longer visible; it is now reported as the malformed response it is.

Cancelling was also a lie: `uploadToStorage` had accepted an `AbortSignal` since #630, but `uploadFileWithProgress` never passed one on, so removing an attachment dropped the tile while the request kept running and finished uploading a file the user had already dismissed. The signal is now threaded through, including the window between transfer and registration, where a late commit would otherwise store a file nothing references. That window is the boundary: once the commit action is in flight it runs to completion.

Several ownership bugs surfaced while making failures persist, each of which needed a fix of its own. Every chat surface reuses one `ChatUIContext` across threads and swapped only the text draft, so an attachment picked in one conversation would have been sent in the next — and a failed one would have blocked sending in a thread the user never attached anything to. Two rapid retry clicks left the first attempt running, and a slow failure could stamp itself over a success that had already landed. Removing an attachment during image preprocessing still started the transfer. And the tile list keyed on name and size, which is not unique: `photo.jpg` and `photo.jpeg` pass dedup as different source names, then both get renamed to `photo.webp` at the same encoded size, and Svelte throws `each_key_duplicate`, taking down the composer.

Deliberately out of scope: a `beforeunload` guard. A reload mid-transfer still kills both the upload and this in-memory state, so the exact 96%-reload failure remains unprevented. It touches all three upload surfaces and belongs in its own PR with a shared "an upload is running" signal.

<!-- pr-media:start -->
| Upload failed, reason under the filename | Two failures, one line each | Failure at 390px | Failure in German |
| --- | --- | --- | --- |
| <img width="450" alt="Upload failed, reason under the filename" src="https://github.com/user-attachments/assets/c0df3393-728b-4265-881c-25417bec14e2" /> | <img width="450" alt="Two failures, one line each" src="https://github.com/user-attachments/assets/bd7ac383-fcbd-47e2-94bf-aa766784c486" /> | <img width="450" alt="Failure at 390px" src="https://github.com/user-attachments/assets/f42eb257-d3cc-48f8-9be1-def3c67dc611" /> | <img width="450" alt="Failure in German" src="https://github.com/user-attachments/assets/4ab58e47-0121-4ea6-bf5e-df9c42e4c8b0" /> |
<!-- pr-media:end -->

Regression guard: added file-uploader.test.ts, chat-context.test.ts cases and e2e/ai-chat-upload-failure.spec.ts. The uploader test pins every failure mode to its code and fixes that cancellation stays an `AbortError` `DOMException`, which the avatar upload distinguishes by type; the context tests cover the retained failure, the send block, cancellation on removal, retry, thread navigation, and each ownership bug above; the E2E spec aborts the storage route in a real browser and asserts the message still stands six seconds later, then that clicking the tile recovers it. Every one of those was run against a deliberately reverted fix first to confirm it fails without it. The keying is pinned in source rather than a browser test, because reproducing the collision needs two images that survive dedup and then encode to identical sizes.

Verified with the full unit suite (933 tests), `bun scripts/static-checks.ts --scope types`, `bun run check:convex`, and the AI chat E2E specs. The screenshots above were inspected at desktop and 390px in both English and German; the German pass is what caught the reason being truncated at half tile width.


