### PR TITLE
fix(chat): Log the cause of a failed upload

### DIFF
--- a/e2e/ai-chat-upload-failure.spec.ts
+++ b/e2e/ai-chat-upload-failure.spec.ts
@@ -44,9 +44,15 @@ test.describe('AI Chat - upload failure', () => {
 		await expect(failedChip).toBeVisible({ timeout: 20000 });
 		await expect(failedChip).toContainText('dropped.txt');
 
-		// The point of the fix: unlike a toast, it is still there later.
-		await page.waitForTimeout(6000);
-		await expect(failedChip).toBeVisible();
+		// The point of the fix: a Sonner toast self-dismisses after 4s, so the
+		// message has to outlive that window. Asserted by holding the condition
+		// rather than sleeping: this fails the moment the chip disappears,
+		// instead of only noticing after a fixed wait.
+		const toastLifetimeMs = 4000;
+		const deadline = Date.now() + toastLifetimeMs * 1.5;
+		while (Date.now() < deadline) {
+			await expect(failedChip).toBeVisible({ timeout: 1000 });
+		}
 
 		// Sending would render an attachment the backend never received.
 		await page.locator('textarea').fill('Here are my notes');

--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -317,7 +317,7 @@
 				class="relative flex w-full items-center justify-between gap-2 overflow-hidden rounded-lg px-2 py-2 transition-transform {fullWidthTiles
 					? ''
 					: 'sm:w-[calc(50%-0.25rem)]'} {isInteractive
-					? 'cursor-pointer active:translate-y-px'
+					? 'cursor-pointer motion-safe:active:scale-[0.98]'
 					: ''} {readonly && !hasFailed
 					? 'border text-foreground transition-colors'
 					: 'bg-secondary/50'}"

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -579,6 +579,10 @@ export class ChatUIContext {
 			// Cancelation is not a failure: removeAttachment/clearAttachments
 			// already took the attachment away, so there is no state to write.
 			if (isAbortError(error) || !isCurrent()) return;
+			// The tile shows a translated cause; the specifics that identify the
+			// failure — HTTP status, and the Convex message kept in `cause` — have
+			// no place in the UI but are what makes a report actionable.
+			console.error('[ChatUIContext] Upload failed:', error);
 			this.patchAttachment(key, {
 				uploadState: {
 					status: 'error',


### PR DESCRIPTION
Follow-up to #760, from its review.

`runUpload` read the failure code off the error and then dropped the error. The transport had just been changed to keep the HTTP status and the Convex message in `cause` so a failure could be diagnosed, and nothing consumed either. The tile shows a translated cause, which is what the user needs and useless in a bug report, so the specifics now go to the console the way the rest of the chat layer reports failures.

Two smaller things from the same review. The attachment tile became a control in #760 when it took over retry, so it gets the press feedback the other pressables in this repo have, under `motion-safe`. And the E2E spec proved the message outlives a toast by sleeping four-plus seconds and then looking; it now holds the assertion across that window instead, so it fails at the moment the message disappears rather than only noticing afterwards.

One review point was not adopted: the spec selects `[data-upload-failed]` rather than a `data-testid`, which `e2e/AGENTS.md` explicitly prefers — testids are for when semantic selection is unstable, and this attribute is the state under test.

Regression guard: covered by e2e/ai-chat-upload-failure.spec.ts, which now asserts the persistence window instead of sleeping through it.

Verified with the full unit suite (933 tests), targeted static checks, and the upload-failure E2E spec, where the new log line appears once per failure.
