### PR TITLE
fix(uploads): Ask before leaving mid-transfer

### DIFF
--- a/e2e/signout.spec.ts
+++ b/e2e/signout.spec.ts
@@ -1,11 +1,31 @@
-import { test } from '@playwright/test';
+import { test, expect, type Route } from '@playwright/test';
 import { waitForAuthenticated } from './utils/auth';
 
-// Uses pre-authenticated session state from setup
-test('signout works', async ({ page }) => {
-	// Already authenticated via session state - go directly to app
-	await page.goto('/app');
+// Uses pre-authenticated session state from setup.
+//
+// Signing out revokes the shared session on the server, so this project runs
+// last and the suite can afford exactly one logout. The upload guard has to be
+// exercised on that one: it exempts sign-out deliberately, and getting that
+// wrong strands the user on a page whose session is already gone.
+test('signout works, and is not stopped by an upload in flight', async ({ page }) => {
+	await page.goto('/app/ai-chat');
 	await waitForAuthenticated(page);
+	await page.waitForURL(/\/app\/ai-chat\?thread=/, { timeout: 15000 });
+	await expect(page.locator('textarea')).toBeVisible({ timeout: 10000 });
+
+	// Hold the storage POST open so a transfer is running across the whole logout.
+	await page.route(/\/api\/storage\/upload/, (_route: Route) => {});
+	await page
+		.locator('input[type="file"]')
+		.first()
+		.setInputFiles({
+			name: 'in-flight.txt',
+			mimeType: 'text/plain',
+			buffer: Buffer.from('Signout regression notes.\n', 'utf8')
+		});
+	await expect(page.getByTestId('attachment-chip').first().getByRole('progressbar')).toBeVisible({
+		timeout: 15000
+	});
 
 	// Click user menu and sign out
 	await page.locator('#user-menu-trigger').click();
@@ -13,5 +33,5 @@ test('signout works', async ({ page }) => {
 
 	// Should redirect away from app after logout (to home or signin page)
 	// With i18n, this could be /en, /en/signin, etc.
-	await page.waitForURL(/.*\/[a-z]{2}(\/signin)?(\?.*)?$/, { timeout: 10000 });
+	await page.waitForURL(/.*\/[a-z]{2}(\/signin)?(\?.*)?$/, { timeout: 15000 });
 });

--- a/e2e/upload-navigation-guard.spec.ts
+++ b/e2e/upload-navigation-guard.spec.ts
@@ -132,19 +132,4 @@ test.describe('Upload navigation guard', () => {
 		await expect(notice).toBeVisible({ timeout: 10000 });
 		expect(page.url()).toBe(urlBeforeClick);
 	});
-
-	// Runs last: it ends the shared session.
-	test('signing out is not stopped by a transfer', async ({ page }) => {
-		// The session is destroyed before the redirect, so a guard that stopped
-		// this would leave the user signed out on a page they cannot use.
-		await stallUpload(page);
-
-		await attachNotes(page, 'in-flight.txt');
-		await expect(uploadInFlight(page)).toBeVisible({ timeout: 15000 });
-
-		await page.locator('#user-menu-trigger').click();
-		await page.getByTestId('logout-button').click();
-
-		await page.waitForURL(/.*\/[a-z]{2}(\/signin)?(\?.*)?$/, { timeout: 15000 });
-	});
 });

--- a/e2e/upload-navigation-guard.spec.ts
+++ b/e2e/upload-navigation-guard.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, type Page, type Route } from '@playwright/test';
+import { waitForAuthenticated } from './utils/auth';
+
+/**
+ * A file that is still transferring dies with the page, and dies quietly: the
+ * progress bar disappears and the user assumes the file arrived. These assert
+ * that leaving is announced, and the far more important converse, that an
+ * ordinary departure is not.
+ */
+
+const NOTES = 'Navigation guard regression notes.\n';
+
+/** Presigned storage endpoint, served by Convex rather than by a route in this repo. */
+const STORAGE_UPLOAD = /\/api\/storage\/upload/;
+
+/**
+ * Hold the storage POST open so the upload stays in flight for the whole test.
+ * The routes are never fulfilled; Playwright drops them when the page goes away.
+ */
+async function stallUpload(page: Page): Promise<void> {
+	await page.route(STORAGE_UPLOAD, (_route: Route) => {
+		// Deliberately unanswered: an upload that neither finishes nor fails.
+	});
+}
+
+/** The composer's progress bar, which only renders while a transfer is running. */
+function uploadInFlight(page: Page) {
+	return page.getByTestId('attachment-chip').first().getByRole('progressbar');
+}
+
+async function attachNotes(page: Page, name: string): Promise<void> {
+	await page
+		.locator('input[type="file"]')
+		.first()
+		.setInputFiles({ name, mimeType: 'text/plain', buffer: Buffer.from(NOTES, 'utf8') });
+}
+
+/**
+ * Whether the page would make the browser ask before unloading.
+ *
+ * A synthetic beforeunload runs the same listener chain a reload does, and
+ * whether it ends up prevented is exactly what decides if the browser prompts.
+ * Watching for a real dialog via page.close({ runBeforeUnload: true }) looks
+ * more faithful but proves nothing: Chromium raises one for the mere presence
+ * of a listener, and SvelteKit always registers one, so that assertion holds
+ * even with the guard removed.
+ */
+async function wouldPromptOnUnload(page: Page): Promise<boolean> {
+	return page.evaluate(() => {
+		const event = new Event('beforeunload', { cancelable: true });
+		window.dispatchEvent(event);
+		return event.defaultPrevented;
+	});
+}
+
+/**
+ * The Convex client raises its own unload warning while one of its requests is
+ * outstanding (`unsavedChangesWarning`, on by default), and an upload opens
+ * with one: the presigned URL. Once the storage POST goes out that request has
+ * answered, and this pause covers the client's own bookkeeping, so what the
+ * assertion sees afterwards is this guard and nothing else. Measured with the
+ * guard removed: the page stops preventing unload about a second after the POST
+ * is issued, leaving the rest of the transfer unprotected. That gap is the
+ * reason this feature exists.
+ */
+const CONVEX_UNLOAD_WARNING_SETTLE_MS = 2000;
+
+test.describe('Upload navigation guard', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/app/ai-chat');
+		await waitForAuthenticated(page);
+		await page.waitForURL(/\/app\/ai-chat\?thread=/, { timeout: 15000 });
+		await expect(page.locator('textarea')).toBeVisible({ timeout: 10000 });
+	});
+
+	test('leaving the page is announced while a file is transferring', async ({ page }) => {
+		const storagePost = page.waitForRequest(STORAGE_UPLOAD);
+		await stallUpload(page);
+
+		await attachNotes(page, 'in-flight.txt');
+		await expect(uploadInFlight(page)).toBeVisible({ timeout: 15000 });
+		await storagePost;
+		await page.waitForTimeout(CONVEX_UNLOAD_WARNING_SETTLE_MS);
+
+		expect(await wouldPromptOnUnload(page)).toBe(true);
+	});
+
+	test('leaving is not announced when nothing is transferring', async ({ page }) => {
+		// The guard that matters. One that prompts on every departure would be
+		// worse than none: users learn to click through it.
+		await page.locator('textarea').fill('No attachment here');
+
+		// Polled rather than asserted once, because the page may still be settling
+		// the warm-thread mutation it opened on arrival.
+		await expect.poll(() => wouldPromptOnUnload(page), { timeout: 15000 }).toBe(false);
+	});
+
+	test('the announcement stops once the transfer settles', async ({ page }) => {
+		// A stale claim is the quiet failure mode: the prompt outlives the upload
+		// and the app nags for the rest of the session.
+		let failNext = true;
+		await page.route(STORAGE_UPLOAD, async (route: Route) => {
+			if (failNext) {
+				failNext = false;
+				await route.abort('connectionfailed');
+				return;
+			}
+			await route.continue();
+		});
+
+		await attachNotes(page, 'settled.txt');
+		await expect(page.locator('[data-upload-failed]')).toBeVisible({ timeout: 20000 });
+
+		await expect.poll(() => wouldPromptOnUnload(page), { timeout: 15000 }).toBe(false);
+	});
+
+	test('moving to another page is stopped and explained', async ({ page }) => {
+		await stallUpload(page);
+
+		await attachNotes(page, 'in-flight.txt');
+		await expect(uploadInFlight(page)).toBeVisible({ timeout: 15000 });
+
+		const urlBeforeClick = page.url();
+		await page.getByTestId('sidebar-nav-community-chat').click();
+
+		// Either the copy or its key: the dev server resolves translations from the
+		// Tolgee API, which does not know a key added in this change until it is
+		// pushed. Production and CI build from the checked-in JSON and show copy.
+		const notice = page.locator('[data-sonner-toast]').filter({
+			hasText: /still in progress|common\.upload_in_progress/i
+		});
+		await expect(notice).toBeVisible({ timeout: 10000 });
+		expect(page.url()).toBe(urlBeforeClick);
+	});
+
+	// Runs last: it ends the shared session.
+	test('signing out is not stopped by a transfer', async ({ page }) => {
+		// The session is destroyed before the redirect, so a guard that stopped
+		// this would leave the user signed out on a page they cannot use.
+		await stallUpload(page);
+
+		await attachNotes(page, 'in-flight.txt');
+		await expect(uploadInFlight(page)).toBeVisible({ timeout: 15000 });
+
+		await page.locator('#user-menu-trigger').click();
+		await page.getByTestId('logout-button').click();
+
+		await page.waitForURL(/.*\/[a-z]{2}(\/signin)?(\?.*)?$/, { timeout: 15000 });
+	});
+});

--- a/scripts/version-config.test.ts
+++ b/scripts/version-config.test.ts
@@ -31,7 +31,9 @@ describe('kit.version config', () => {
 		// updated must come from $app/state, not the deprecated $app/stores.
 		expect(layout).toMatch(/import \{[^}]*\bupdated\b[^}]*\} from '\$app\/state'/);
 		expect(layout).toContain('updated.current');
-		expect(layout).toContain('location.href = to.url.href');
+		// Structural match so the callback can name its argument freely; the
+		// upload guard shares this callback and needs the whole navigation.
+		expect(layout).toMatch(/location\.href = (?:\w+\.)?to\.url\.href/);
 	});
 
 	it('registers a vite:preloadError backstop that reloads once', () => {

--- a/scripts/version-config.test.ts
+++ b/scripts/version-config.test.ts
@@ -31,9 +31,11 @@ describe('kit.version config', () => {
 		// updated must come from $app/state, not the deprecated $app/stores.
 		expect(layout).toMatch(/import \{[^}]*\bupdated\b[^}]*\} from '\$app\/state'/);
 		expect(layout).toContain('updated.current');
-		// Structural match so the callback can name its argument freely; the
-		// upload guard shares this callback and needs the whole navigation.
-		expect(layout).toMatch(/location\.href = (?:\w+\.)?to\.url\.href/);
+		// The layout still hands the deploy signal to the decision and acts on the
+		// answer. Which navigations that answer covers is settled by
+		// deployReloadTarget's own tests, not by matching source text here.
+		expect(layout).toMatch(/deployReloadTarget\([^)]*updated\.current/);
+		expect(layout).toContain('location.href =');
 	});
 
 	it('registers a vite:preloadError backstop that reloads once', () => {

--- a/src/blocks/pricing/pricing-three.svelte
+++ b/src/blocks/pricing/pricing-three.svelte
@@ -19,6 +19,7 @@
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
 
 	const { customer, checkout, openBillingPortal } = useCustomer();
 	const upgradeOperation = useAutumnOperation(checkout);
@@ -36,6 +37,10 @@
 
 	// Get translation function
 	const { t } = getTranslate();
+
+	// Consulted before navigations this component starts on the user's behalf,
+	// so an in-flight upload elsewhere on the page cannot stop them.
+	const activeUploads = activeUploadsContext.getOr(null);
 
 	// Helper function to get non-empty feature keys for a tier.
 	// Hard-coded indices are intentional: a dynamic loop (incrementing until empty)
@@ -78,6 +83,8 @@
 		});
 
 		if (result?.url) {
+			// The checkout session already exists; see nav-user.svelte.
+			activeUploads?.suspendOnce();
 			window.location.href = result.url;
 		} else if (upgradeOperation.error) {
 			haptic.trigger('error');

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -551,6 +551,7 @@
 		"delete": "Löschen",
 		"error": "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.",
 		"load_error": "Daten konnten nicht geladen werden. Bitte versuchen Sie es später erneut.",
+		"upload_in_progress": "Upload läuft noch. Bitte warten, bis er fertig ist.",
 		"you": "Sie"
 	},
 	"connection": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -551,6 +551,7 @@
 		"delete": "Delete",
 		"error": "Something went wrong. Please try again.",
 		"load_error": "Failed to load data. Please try again later.",
+		"upload_in_progress": "Upload still in progress. Wait for it to finish.",
 		"you": "You"
 	},
 	"connection": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -551,6 +551,7 @@
 		"delete": "Eliminar",
 		"error": "Algo salió mal. Por favor, inténtalo de nuevo.",
 		"load_error": "No se pudieron cargar los datos. Por favor, inténtalo de nuevo más tarde.",
+		"upload_in_progress": "La subida sigue en curso. Espera a que termine.",
 		"you": "Tú"
 	},
 	"connection": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -551,6 +551,7 @@
 		"delete": "Supprimer",
 		"error": "Une erreur est survenue. Veuillez réessayer.",
 		"load_error": "Échec du chargement des données. Veuillez réessayer plus tard.",
+		"upload_in_progress": "Le téléversement est toujours en cours. Attendez la fin.",
 		"you": "Vous"
 	},
 	"connection": {

--- a/src/lib/chat/ui/ChatRoot.svelte
+++ b/src/lib/chat/ui/ChatRoot.svelte
@@ -22,6 +22,7 @@
 		type MessagesQueryResponse
 	} from './streaming-display.js';
 	import { syncReasoningAccordionState } from './reasoning-accordion-sync.js';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
 
 	/**
 	 * External core adapter interface
@@ -101,6 +102,19 @@
 	// URLs of unsent attachments). External contexts are owned by their creator.
 	onDestroy(() => {
 		if (!externalUIContext) uiContext.dispose();
+	});
+
+	// Let the root layout warn before a page unload discards a transfer. Keyed on
+	// the UI context rather than this component: the support widget hands its own
+	// context in, so keying on the component would register one upload twice and
+	// leave a stale claim behind when either instance goes away.
+	// Absent outside the app shell (isolated component tests, the standalone
+	// example), where there is no layout to warn.
+	const activeUploads = activeUploadsContext.getOr(null);
+	$effect(() => {
+		if (!activeUploads || !uiContext.hasUploadingFiles) return;
+		activeUploads.claim(uiContext);
+		return () => activeUploads.release(uiContext);
 	});
 
 	// Update core threadId when prop changes (only for internal core)

--- a/src/lib/chat/ui/ChatRoot.svelte
+++ b/src/lib/chat/ui/ChatRoot.svelte
@@ -95,26 +95,14 @@
 	// Context object is created once and placed in Svelte context.
 	// svelte-ignore state_referenced_locally
 	const uiContext =
-		externalUIContext ?? new ChatUIContext(core, client, uploadConfig, userAlignment);
+		externalUIContext ??
+		new ChatUIContext(core, client, uploadConfig, userAlignment, activeUploadsContext.getOr(null));
 	setChatUIContext(uiContext);
 
 	// Dispose the internally created context on unmount (revokes blob preview
 	// URLs of unsent attachments). External contexts are owned by their creator.
 	onDestroy(() => {
 		if (!externalUIContext) uiContext.dispose();
-	});
-
-	// Let the root layout warn before a page unload discards a transfer. Keyed on
-	// the UI context rather than this component: the support widget hands its own
-	// context in, so keying on the component would register one upload twice and
-	// leave a stale claim behind when either instance goes away.
-	// Absent outside the app shell (isolated component tests, the standalone
-	// example), where there is no layout to warn.
-	const activeUploads = activeUploadsContext.getOr(null);
-	$effect(() => {
-		if (!activeUploads || !uiContext.hasUploadingFiles) return;
-		activeUploads.claim(uiContext);
-		return () => activeUploads.release(uiContext);
 	});
 
 	// Update core threadId when prop changes (only for internal core)

--- a/src/lib/chat/ui/chat-context-upload-claims.test.ts
+++ b/src/lib/chat/ui/chat-context-upload-claims.test.ts
@@ -184,3 +184,79 @@ describe('ChatUIContext upload claims, removal paths', () => {
 		expect(uploads.any).toBe(false);
 	});
 });
+
+describe('ChatUIContext upload claims, before the bytes move', () => {
+	beforeEach(() => {
+		uploadFileWithProgress.mockReset();
+	});
+
+	it('claims while an image is still being converted', async () => {
+		// The tile shows progress from the moment the file is picked, and the
+		// encoder can run for seconds on a large photo. Losing the page there
+		// loses the pick, transfer started or not.
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		let finishEncoding!: () => void;
+		const encoded = new Promise<void>((resolve) => {
+			finishEncoding = resolve;
+		});
+		const transfer = pendingTransfer();
+
+		const upload = ctx.uploadFile(new Blob(['x'], { type: 'image/png' }), 'photo.png', {
+			preprocess: async (input) => {
+				await encoded;
+				// Dimensions supplied, so the transfer is the next thing to happen.
+				return {
+					blob: input,
+					mimeType: 'image/webp',
+					filename: 'photo.webp',
+					width: 10,
+					height: 10
+				};
+			}
+		});
+
+		// Nothing has been sent yet, and the guard already has to hold.
+		expect(uploads.any).toBe(true);
+		expect(uploadFileWithProgress).not.toHaveBeenCalled();
+
+		finishEncoding();
+		while (uploadFileWithProgress.mock.calls.length === 0) await Promise.resolve();
+
+		expect(uploads.any).toBe(true);
+		transfer.succeed();
+		await upload;
+		expect(uploads.any).toBe(false);
+	});
+
+	it('lets go when conversion fails before any transfer', async () => {
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		const upload = ctx.uploadFile(new Blob(['x'], { type: 'image/png' }), 'photo.png', {
+			preprocess: async () => {
+				throw new Error('too large to compress');
+			}
+		});
+
+		expect(uploads.any).toBe(true);
+		await upload;
+		expect(uploads.any).toBe(false);
+	});
+
+	it('lets go the moment a discarded attachment is removed, not when its request unwinds', async () => {
+		// Aborting cannot stop a Convex mutation that is already out, so waiting
+		// for the attempt to unwind would keep asking about a discarded file for
+		// as long as that request hangs.
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		pendingTransfer();
+		void ctx.uploadScreenshot(shot(), 'shot.png');
+		expect(uploads.any).toBe(true);
+
+		ctx.removeAttachment(0);
+		expect(uploads.any).toBe(false);
+	});
+});

--- a/src/lib/chat/ui/chat-context-upload-claims.test.ts
+++ b/src/lib/chat/ui/chat-context-upload-claims.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The context, not the component, reports a transfer in progress.
+ *
+ * Closing the support panel unmounts the chat while its context and the bytes
+ * on the wire survive, so a claim scoped to the component would be given up
+ * mid-transfer and the page would stop asking before a reload. These tests pin
+ * the claim to the context's own view of what is still running.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ConvexClient } from 'convex/browser';
+import type { ChatCore } from '../core/chat-core.svelte.ts';
+
+const uploadFileWithProgress = vi.fn();
+
+vi.mock('svelte-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('../core/file-uploader.js', () => ({
+	uploadFileWithProgress: (...args: unknown[]) => uploadFileWithProgress(...args),
+	UploadError: class UploadError extends Error {}
+}));
+
+const { ChatUIContext } = await import('./chat-context.svelte.ts');
+const { ActiveUploads } = await import('$lib/hooks/active-uploads.svelte.ts');
+
+const uploadConfig = {
+	generateUploadUrl: 'storage:generateUploadUrl',
+	saveUploadedFile: 'storage:saveUploadedFile'
+} as unknown as ConstructorParameters<typeof ChatUIContext>[2];
+
+function context(uploads: InstanceType<typeof ActiveUploads> | null = null) {
+	return new ChatUIContext({} as ChatCore, {} as ConvexClient, uploadConfig, 'right', uploads);
+}
+
+/** A transfer the test decides the outcome of. */
+function pendingTransfer() {
+	let settle!: (result: { url: string; fileId: string }) => void;
+	let fail!: (error: unknown) => void;
+	uploadFileWithProgress.mockImplementationOnce(
+		() =>
+			new Promise((resolve, reject) => {
+				settle = resolve;
+				fail = reject;
+			})
+	);
+	return {
+		succeed: () => settle({ url: 'https://example.test/f', fileId: 'file-1' }),
+		reject: (error: unknown) => fail(error)
+	};
+}
+
+const shot = () => new Blob(['x'], { type: 'image/png' });
+
+describe('ChatUIContext upload claims', () => {
+	beforeEach(() => {
+		uploadFileWithProgress.mockReset();
+	});
+
+	it('claims while a transfer runs and lets go once it lands', async () => {
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		const transfer = pendingTransfer();
+		const upload = ctx.uploadScreenshot(shot(), 'shot.png');
+		expect(uploads.any).toBe(true);
+
+		transfer.succeed();
+		await upload;
+		expect(uploads.any).toBe(false);
+	});
+
+	it('lets go when the transfer fails, not only when it succeeds', async () => {
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		const transfer = pendingTransfer();
+		const upload = ctx.uploadScreenshot(shot(), 'shot.png');
+		transfer.reject(new Error('network'));
+		await upload;
+
+		// A failed upload is recoverable, but it is not on the wire any more, so
+		// leaving the page costs nothing.
+		expect(uploads.any).toBe(false);
+	});
+
+	it('keeps the claim while a second transfer is still running', async () => {
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		const first = pendingTransfer();
+		const second = pendingTransfer();
+		const firstUpload = ctx.uploadScreenshot(shot(), 'one.png');
+		const secondUpload = ctx.uploadScreenshot(shot(), 'two.png');
+
+		first.succeed();
+		await firstUpload;
+		expect(uploads.any).toBe(true);
+
+		second.succeed();
+		await secondUpload;
+		expect(uploads.any).toBe(false);
+	});
+
+	it('lets go when the context is disposed mid-transfer', async () => {
+		// The surface is gone for good here, unlike an unmounted chat whose
+		// context lives on; nothing is left that could report the outcome.
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		pendingTransfer();
+		void ctx.uploadScreenshot(shot(), 'shot.png');
+		expect(uploads.any).toBe(true);
+
+		ctx.dispose();
+		expect(uploads.any).toBe(false);
+	});
+
+	it('works without a registry, for a chat rendered outside the app shell', async () => {
+		const ctx = context();
+		const transfer = pendingTransfer();
+
+		const upload = ctx.uploadScreenshot(shot(), 'shot.png');
+		transfer.succeed();
+		await expect(upload).resolves.toBeUndefined();
+	});
+});
+
+describe('ChatUIContext upload claims, removal paths', () => {
+	beforeEach(() => {
+		uploadFileWithProgress.mockReset();
+	});
+
+	it('lets go after the only uploading attachment is removed', async () => {
+		// removeAttachment drops the aborter synchronously; the claim can only be
+		// given up once the aborted attempt actually unwinds.
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		const transfer = pendingTransfer();
+		const upload = ctx.uploadScreenshot(shot(), 'shot.png');
+		expect(uploads.any).toBe(true);
+
+		ctx.removeAttachment(0);
+		transfer.reject(new DOMException('aborted', 'AbortError'));
+		await upload;
+
+		expect(uploads.any).toBe(false);
+	});
+
+	it('holds on when one of two attachments is removed', async () => {
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		const first = pendingTransfer();
+		const second = pendingTransfer();
+		const firstUpload = ctx.uploadScreenshot(shot(), 'one.png');
+		const secondUpload = ctx.uploadScreenshot(shot(), 'two.png');
+
+		ctx.removeAttachment(0);
+		first.reject(new DOMException('aborted', 'AbortError'));
+		await firstUpload;
+		expect(uploads.any).toBe(true);
+
+		second.succeed();
+		await secondUpload;
+		expect(uploads.any).toBe(false);
+	});
+
+	it('a superseded attempt does not let go while its replacement runs', async () => {
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		const first = pendingTransfer();
+		const upload = ctx.uploadScreenshot(shot(), 'shot.png');
+		first.reject(new Error('network'));
+		await upload;
+
+		const retry = pendingTransfer();
+		ctx.retryUpload(0);
+		expect(uploads.any).toBe(true);
+
+		retry.succeed();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(uploads.any).toBe(false);
+	});
+});

--- a/src/lib/chat/ui/chat-context-upload-claims.test.ts
+++ b/src/lib/chat/ui/chat-context-upload-claims.test.ts
@@ -260,3 +260,111 @@ describe('ChatUIContext upload claims, before the bytes move', () => {
 		expect(uploads.any).toBe(false);
 	});
 });
+
+describe('ChatUIContext upload claims, adversarial sequences', () => {
+	beforeEach(() => {
+		uploadFileWithProgress.mockReset();
+	});
+
+	it('lets go when an attachment is discarded while its image is converting', async () => {
+		// Preprocessing cannot be cancelled, so it resolves into a context that no
+		// longer has the attachment. Nothing after that point settles the key, so
+		// the exit taken here has to.
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		let finishEncoding!: () => void;
+		const encoded = new Promise<void>((resolve) => {
+			finishEncoding = resolve;
+		});
+
+		const upload = ctx.uploadFile(new Blob(['x'], { type: 'image/png' }), 'photo.png', {
+			preprocess: async (input) => {
+				await encoded;
+				return { blob: input, mimeType: 'image/webp', width: 10, height: 10 };
+			}
+		});
+		expect(uploads.any).toBe(true);
+
+		ctx.removeAttachment(0);
+		expect(uploads.any).toBe(false);
+
+		finishEncoding();
+		await upload;
+		expect(uploads.any).toBe(false);
+		expect(uploadFileWithProgress).not.toHaveBeenCalled();
+	});
+
+	it('holds on for the other attachment when one is discarded mid-encode', async () => {
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		let finishEncoding!: () => void;
+		const encoded = new Promise<void>((resolve) => {
+			finishEncoding = resolve;
+		});
+		const encoding = ctx.uploadFile(new Blob(['x'], { type: 'image/png' }), 'photo.png', {
+			preprocess: async (input) => {
+				await encoded;
+				return { blob: input, mimeType: 'image/webp', width: 10, height: 10 };
+			}
+		});
+
+		const transfer = pendingTransfer();
+		const sending = ctx.uploadScreenshot(shot(), 'shot.png');
+
+		ctx.removeAttachment(0);
+		expect(uploads.any).toBe(true);
+
+		finishEncoding();
+		await encoding;
+		expect(uploads.any).toBe(true);
+
+		transfer.succeed();
+		await sending;
+		expect(uploads.any).toBe(false);
+	});
+
+	it('claims again when a failed attachment is retried', async () => {
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		const failing = pendingTransfer();
+		const upload = ctx.uploadScreenshot(shot(), 'shot.png');
+		failing.reject(new Error('network'));
+		await upload;
+		expect(uploads.any).toBe(false);
+
+		const retry = pendingTransfer();
+		ctx.retryUpload(0);
+		expect(uploads.any).toBe(true);
+
+		retry.succeed();
+		while (uploads.any) await Promise.resolve();
+		expect(uploads.any).toBe(false);
+	});
+
+	it('lets go when the context is disposed while an image is converting', async () => {
+		const uploads = new ActiveUploads();
+		const ctx = context(uploads);
+
+		let finishEncoding!: () => void;
+		const encoded = new Promise<void>((resolve) => {
+			finishEncoding = resolve;
+		});
+		const upload = ctx.uploadFile(new Blob(['x'], { type: 'image/png' }), 'photo.png', {
+			preprocess: async (input) => {
+				await encoded;
+				return { blob: input, mimeType: 'image/webp', width: 10, height: 10 };
+			}
+		});
+		expect(uploads.any).toBe(true);
+
+		ctx.dispose();
+		expect(uploads.any).toBe(false);
+
+		finishEncoding();
+		await upload;
+		expect(uploads.any).toBe(false);
+	});
+});

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -65,6 +65,15 @@ export interface UploadConfig {
 }
 
 /**
+ * The part of the app's in-flight upload registry this context reports to.
+ * Structural on purpose, so the chat module stays independent of the app hook.
+ */
+export interface ActiveUploadsRegistry {
+	claim(owner: object): void;
+	release(owner: object): void;
+}
+
+/**
  * Chat UI Context class
  *
  * Holds both the core state and UI-specific state like reasoning accordion states.
@@ -112,6 +121,17 @@ export class ChatUIContext {
 	private readonly uploadAborters = new SvelteMap<string, AbortController>();
 
 	/**
+	 * Where to report a transfer in progress, so navigating away asks first.
+	 *
+	 * Reported from here rather than watched from a component: this context
+	 * outlives the chat rendering it. Closing the support panel unmounts the chat
+	 * while the transfer keeps running, and the screenshot flow uploads through
+	 * this context with no chat mounted at all, so a component-scoped claim would
+	 * be given up, or never taken, while the file is on the wire.
+	 */
+	private readonly activeUploads: ActiveUploadsRegistry | null;
+
+	/**
 	 * The exact payload each failed attachment would need to try again. Held
 	 * because retrying from the picked file is not equivalent: images are
 	 * re-encoded before upload, and screenshots never had a File to begin with.
@@ -132,12 +152,14 @@ export class ChatUIContext {
 		core: ChatCore,
 		client: ConvexClient,
 		uploadConfig?: UploadConfig,
-		userAlignment: ChatAlignment = 'right'
+		userAlignment: ChatAlignment = 'right',
+		activeUploads: ActiveUploadsRegistry | null = null
 	) {
 		this.core = core;
 		this.client = client;
 		this.uploadConfig = uploadConfig;
 		this.userAlignment = userAlignment;
+		this.activeUploads = activeUploads;
 	}
 
 	/**
@@ -357,6 +379,9 @@ export class ChatUIContext {
 	 */
 	dispose(): void {
 		this.clearAttachments();
+		// clearAttachments aborts the transfers, but their handlers run later; the
+		// context is going away, so it cannot be the thing that lets go.
+		this.activeUploads?.release(this);
 	}
 
 	/**
@@ -544,6 +569,7 @@ export class ChatUIContext {
 		const aborter = new AbortController();
 		this.uploadAborters.set(key, aborter);
 		this.retryJobs.set(key, job);
+		this.activeUploads?.claim(this);
 		this.patchAttachment(key, { uploadState: { status: 'uploading', progress: 0 } });
 
 		/**
@@ -592,6 +618,9 @@ export class ChatUIContext {
 			});
 		} finally {
 			if (isCurrent()) this.uploadAborters.delete(key);
+			// Unconditional: a superseded attempt still has to let go, and by now
+			// the map holds only whatever is genuinely still on the wire.
+			if (this.uploadAborters.size === 0) this.activeUploads?.release(this);
 		}
 	}
 

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -121,15 +121,26 @@ export class ChatUIContext {
 	private readonly uploadAborters = new SvelteMap<string, AbortController>();
 
 	/**
-	 * Where to report a transfer in progress, so navigating away asks first.
+	 * Where to report work in progress, so navigating away asks first.
 	 *
 	 * Reported from here rather than watched from a component: this context
 	 * outlives the chat rendering it. Closing the support panel unmounts the chat
-	 * while the transfer keeps running, and the screenshot flow uploads through
-	 * this context with no chat mounted at all, so a component-scoped claim would
-	 * be given up, or never taken, while the file is on the wire.
+	 * while the work keeps running, and the screenshot flow uploads through this
+	 * context with no chat mounted at all, so a component-scoped claim would be
+	 * given up, or never taken, while the file is still going somewhere.
 	 */
 	private readonly activeUploads: ActiveUploadsRegistry | null;
+
+	/**
+	 * Attachments the user is still waiting on, by key.
+	 *
+	 * Wider than `uploadAborters`, which only covers the transfer. An image
+	 * spends a visible stretch in the WebP encoder first, with the tile already
+	 * showing progress, and losing the page there loses the pick just the same.
+	 * Also narrower where it matters: a discarded attachment leaves this set at
+	 * once, even though the request it started may take a while to unwind.
+	 */
+	private readonly pendingUploads = new SvelteSet<string>();
 
 	/**
 	 * The exact payload each failed attachment would need to try again. Held
@@ -347,6 +358,22 @@ export class ChatUIContext {
 		this.uploadAborters.get(key)?.abort();
 		this.uploadAborters.delete(key);
 		this.retryJobs.delete(key);
+		// Straight away, not when the aborted attempt unwinds: an abort cannot
+		// stop a Convex mutation already in flight, so waiting for it would keep
+		// asking about a file the user has already thrown away.
+		this.settlePending(key);
+	}
+
+	/** Start counting an attachment as work in progress. Idempotent. */
+	private markPending(key: string): void {
+		this.pendingUploads.add(key);
+		this.activeUploads?.claim(this);
+	}
+
+	/** Stop counting it, and let go once nothing is left. Idempotent. */
+	private settlePending(key: string): void {
+		this.pendingUploads.delete(key);
+		if (this.pendingUploads.size === 0) this.activeUploads?.release(this);
 	}
 
 	/**
@@ -379,8 +406,9 @@ export class ChatUIContext {
 	 */
 	dispose(): void {
 		this.clearAttachments();
-		// clearAttachments aborts the transfers, but their handlers run later; the
-		// context is going away, so it cannot be the thing that lets go.
+		// The surface is gone for good, so nothing is left that could report an
+		// outcome, whatever is still unwinding.
+		this.pendingUploads.clear();
 		this.activeUploads?.release(this);
 	}
 
@@ -477,6 +505,9 @@ export class ChatUIContext {
 			sourceSize: file.size
 		};
 		this.attachments = [...this.attachments, placeholder];
+		// Before the first await: the tile already shows progress, so leaving now
+		// costs the user the same file whether or not the transfer has started.
+		this.markPending(key);
 
 		try {
 			let uploadBlob: File | Blob = file;
@@ -549,6 +580,11 @@ export class ChatUIContext {
 					`Failed to upload "${initialName}"`,
 				{ description: error instanceof Error ? error.message : undefined }
 			);
+		} finally {
+			// Every exit above already settles this key one way or another; saying
+			// so here too keeps the claim from outliving the attempt if a path is
+			// ever added that forgets.
+			this.settlePending(key);
 		}
 	}
 
@@ -569,7 +605,8 @@ export class ChatUIContext {
 		const aborter = new AbortController();
 		this.uploadAborters.set(key, aborter);
 		this.retryJobs.set(key, job);
-		this.activeUploads?.claim(this);
+		// Also for a retry, which starts here rather than in uploadFile.
+		this.markPending(key);
 		this.patchAttachment(key, { uploadState: { status: 'uploading', progress: 0 } });
 
 		/**
@@ -617,10 +654,12 @@ export class ChatUIContext {
 				}
 			});
 		} finally {
-			if (isCurrent()) this.uploadAborters.delete(key);
-			// Unconditional: a superseded attempt still has to let go, and by now
-			// the map holds only whatever is genuinely still on the wire.
-			if (this.uploadAborters.size === 0) this.activeUploads?.release(this);
+			// Only the live attempt settles the attachment: a superseded one is
+			// finishing behind a newer transfer that is still running.
+			if (isCurrent()) {
+				this.uploadAborters.delete(key);
+				this.settlePending(key);
+			}
 		}
 	}
 

--- a/src/lib/components/customer-support/customer-support.svelte
+++ b/src/lib/components/customer-support/customer-support.svelte
@@ -20,6 +20,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { getLegalEmailAddress } from '$lib/config/legal';
 	import { buildMailto } from '$lib/utils/mailto';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
 
 	const { t } = getTranslate();
 
@@ -98,7 +99,16 @@
 
 	// Create ChatUIContext at this level so we can handle screenshot uploads
 	// Cast threadContext to ChatCore since it implements the required interface
-	const chatUIContext = new ChatUIContext(threadContext as any, client, uploadConfig);
+	// Report transfers to the app so a navigation that would kill one asks first.
+	// Absent outside the app shell (isolated tests, the standalone example), where
+	// there is no layout to ask.
+	const chatUIContext = new ChatUIContext(
+		threadContext as any,
+		client,
+		uploadConfig,
+		'right',
+		activeUploadsContext.getOr(null)
+	);
 
 	// Revoke blob preview URLs of unsent attachments when the widget unmounts
 	onDestroy(() => chatUIContext.dispose());

--- a/src/lib/components/customer-support/customer-support.svelte
+++ b/src/lib/components/customer-support/customer-support.svelte
@@ -240,15 +240,25 @@
 <AIChatbar isFeedbackOpen={!shouldShowAIChatbar} />
 <FeedbackButton {isFeedbackOpen} onToggle={setWidgetOpen} bind:isScreenshotMode {chatUIContext} />
 
-{#if isScreenshotMode}
-	{#await import('./screenshot-editor/ScreenshotEditor.svelte') then { default: ScreenshotEditor }}
-		<ScreenshotEditor
-			onCancel={handleScreenshotCancel}
-			onScreenshotSaved={handleScreenshotSaved}
-			onCaptureError={handleScreenshotCaptureError}
-		/>
-	{/await}
-{/if}
+<!--
+	The editor is loaded on demand, and an await block with no catch rethrows a
+	rejected import (svelte/src/internal/client/dom/blocks/await.js). A deploy can
+	delete the chunk under a page that is still open, and the reload that would
+	normally rescue it waits for confirmation while a file is uploading — so this
+	failure is reachable, and without a boundary it takes the whole page down.
+	Routed to the same place a failed capture goes: overlay down, retry offered.
+-->
+<svelte:boundary onerror={handleScreenshotCaptureError}>
+	{#if isScreenshotMode}
+		{#await import('./screenshot-editor/ScreenshotEditor.svelte') then { default: ScreenshotEditor }}
+			<ScreenshotEditor
+				onCancel={handleScreenshotCancel}
+				onScreenshotSaved={handleScreenshotSaved}
+				onCaptureError={handleScreenshotCaptureError}
+			/>
+		{/await}
+	{/if}
+</svelte:boundary>
 
 <AlertDialog.Root bind:open={captureErrorOpen}>
 	<AlertDialog.Content>

--- a/src/lib/components/customer-support/lazy-editor-boundary.test.ts
+++ b/src/lib/components/customer-support/lazy-editor-boundary.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The screenshot editor is imported on demand. An await block with no catch
+ * rethrows a rejected import (svelte/src/internal/client/dom/blocks/await.js
+ * "Rethrow the error if no catch block exists"), which takes the page down
+ * rather than the overlay.
+ *
+ * That was unreachable while a failed chunk load always won its race with the
+ * reload in app.html. It stopped being unreachable once an upload in progress
+ * could hold that reload back for confirmation, so the import needs a boundary.
+ *
+ * Asserted structurally rather than through the browser: reaching the camera
+ * means opening the widget, then a thread, then an overflow menu, and none of
+ * that is what breaks. What breaks is someone removing the boundary.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+	path.resolve('src/lib/components/customer-support/customer-support.svelte'),
+	'utf8'
+);
+
+describe('lazy screenshot editor', () => {
+	it('loads inside an error boundary', () => {
+		const boundaryStart = source.indexOf('<svelte:boundary');
+		const boundaryEnd = source.indexOf('</svelte:boundary>');
+		const lazyImport = source.indexOf(
+			"{#await import('./screenshot-editor/ScreenshotEditor.svelte')"
+		);
+
+		expect(lazyImport, 'the lazy import moved or was renamed').toBeGreaterThan(-1);
+		expect(boundaryStart, 'no <svelte:boundary> around the lazy import').toBeGreaterThan(-1);
+		expect(boundaryStart).toBeLessThan(lazyImport);
+		expect(boundaryEnd).toBeGreaterThan(lazyImport);
+	});
+
+	it('routes a failure to the existing capture-error path', () => {
+		// Not a bare boundary: the overlay has to come down and offer a way on,
+		// which is what a failed capture already does.
+		expect(source).toMatch(/<svelte:boundary\s+onerror=\{handleScreenshotCaptureError\}/);
+	});
+});

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -17,8 +17,13 @@
 	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { LEGAL_CONFIG } from '$lib/config/legal';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
 
 	const { t } = getTranslate();
+
+	// Consulted before navigations this component starts on the user's behalf,
+	// so an in-flight upload elsewhere on the page cannot stop them.
+	const activeUploads = activeUploadsContext.getOr(null);
 	const auth = useAuth();
 	let signingOut = $state(false);
 	const isAuthenticated = $derived(auth.isAuthenticated && !signingOut);
@@ -55,6 +60,8 @@
 		signingOut = true;
 		const result = await authClient.signOut();
 		if (!result.error) {
+			// The session is already gone; see nav-user.svelte.
+			activeUploads?.suspendOnce();
 			await goto(resolve(localizedHref('/')));
 		} else {
 			signingOut = false;

--- a/src/lib/components/marketing/marketing-header.svelte
+++ b/src/lib/components/marketing/marketing-header.svelte
@@ -182,7 +182,7 @@
 											variant="outline"
 											size="icon"
 											class="size-8 text-warning hover:text-warning"
-											onclick={() => impersonation.stop($t)}
+											onclick={() => impersonation.stop($t, activeUploads)}
 											aria-label={$t('app.user_menu.stop_impersonating')}
 											data-testid="marketing-nav-stop-impersonating"
 										>

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -22,8 +22,13 @@
 	import { ImpersonationState } from '$lib/hooks/use-impersonation.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { useCustomer, useAutumnOperation } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
 
 	const { t } = getTranslate();
+
+	// Consulted before navigations this component starts on the user's behalf,
+	// so an in-flight upload elsewhere on the page cannot stop them.
+	const activeUploads = activeUploadsContext.getOr(null);
 
 	interface Props {
 		user: { name: string; email: string; avatar: string };
@@ -63,6 +68,9 @@
 			successUrl: successUrl.href
 		});
 		if (result?.url) {
+			// The checkout session already exists; prompting about an upload here
+			// would only leave the user on a page waiting for a redirect.
+			activeUploads?.suspendOnce();
 			window.location.href = result.url;
 		} else if (upgradeOperation.error) {
 			haptic.trigger('error');
@@ -89,6 +97,9 @@
 			console.error('Sign out error:', result.error);
 			toast.error($t('common.error'));
 		} else {
+			// The session is already gone. Stopping this would strand the user on a
+			// signed-out page, so an upload does not get a say.
+			activeUploads?.suspendOnce();
 			await goto(resolve(localizedHref('/')));
 		}
 	}

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -201,7 +201,7 @@
 				     unresolved session. -->
 				{#if impersonation.isImpersonating}
 					<DropdownMenu.Item
-						onclick={() => impersonation.stop($t)}
+						onclick={() => impersonation.stop($t, activeUploads)}
 						class="text-warning"
 						data-testid="app-user-menu-stop-impersonating"
 					>

--- a/src/lib/components/upload-guard-notice.svelte
+++ b/src/lib/components/upload-guard-notice.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { getTranslate } from '@tolgee/svelte';
+	import { watch } from 'runed';
+	import { toast } from 'svelte-sonner';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
+
+	// Renders nothing. It exists because the navigation guard lives in the root
+	// layout's script, which runs outside TolgeeProvider and so has no $t.
+	const { t } = getTranslate();
+	const activeUploads = activeUploadsContext.get();
+
+	// Safe to miss: nothing was lost, the upload is still visibly running, and the
+	// page has not moved. The user can simply click again once it finishes.
+	watch(
+		() => activeUploads.blockedCount,
+		(count) => {
+			if (count === 0) return;
+			toast.info($t('common.upload_in_progress'));
+		}
+	);
+</script>

--- a/src/lib/hooks/active-uploads.svelte.ts
+++ b/src/lib/hooks/active-uploads.svelte.ts
@@ -1,0 +1,91 @@
+import { Context } from 'runed';
+import { SvelteSet } from 'svelte/reactivity';
+
+/** The parts of SvelteKit's `BeforeNavigate` the guard reads. */
+export interface GuardedNavigation {
+	from: { url: URL } | null;
+	to: { url: URL } | null;
+}
+
+/**
+ * Whether a navigation would destroy a file that is still transferring.
+ *
+ * Leaving the document has no `to` at all, so that case has to be answered
+ * first: comparing `to?.url.pathname` against `from` would give the right
+ * answer there only by accident, and would flip silently once either side of
+ * the comparison changes.
+ */
+export function shouldBlockNavigation(nav: GuardedNavigation, hasActiveUploads: boolean): boolean {
+	if (!hasActiveUploads) return false;
+	// Reload, tab close, external link: the document goes away, the transfer with it.
+	if (!nav.to) return true;
+	// Same page, different search params (opening the support panel, switching a
+	// chat thread): the document survives, so the page-level answer is "not my
+	// call". A surface that drops its own upload on such a change owns that.
+	if (nav.to.url.pathname === nav.from?.url.pathname) return false;
+	return true;
+}
+
+/**
+ * Which surfaces currently have a file in flight, shared via context.
+ *
+ * A transfer that dies with the document is invisible: the progress bar simply
+ * disappears and the user assumes the file arrived. One shared answer is needed
+ * because uploads run in several places at once — the page's chat, the floating
+ * support chat, and the avatar picker are separate owners.
+ *
+ * Instantiated per request in the root layout — never a module-level singleton,
+ * which would leak across SSR requests.
+ */
+export class ActiveUploads {
+	// Owner identities rather than a count: a count that misses one release (a
+	// surface torn down mid-upload) stays wrong for the rest of the session, and
+	// a guard that asks for no reason is worse than no guard at all. Claiming and
+	// releasing twice is harmless here.
+	readonly #owners = new SvelteSet<object>();
+	#suspended = false;
+
+	get any(): boolean {
+		return this.#owners.size > 0;
+	}
+
+	claim(owner: object): void {
+		this.#owners.add(owner);
+	}
+
+	release(owner: object): void {
+		this.#owners.delete(owner);
+	}
+
+	/**
+	 * Let the next navigation through without asking.
+	 *
+	 * For navigations the app itself starts, where stopping would strand the
+	 * user: signing out has already destroyed the session, a checkout redirect
+	 * follows an operation that already happened. Call it immediately before
+	 * navigating — the next navigation of any kind consumes it.
+	 */
+	suspendOnce(): void {
+		this.#suspended = true;
+	}
+
+	/** Reads and clears the suspension. The guard calls this once per navigation. */
+	consumeSuspension(): boolean {
+		const suspended = this.#suspended;
+		this.#suspended = false;
+		return suspended;
+	}
+
+	/**
+	 * Bumped whenever a navigation inside the app was stopped, so the UI can
+	 * explain why the click did nothing. Leaving the document needs no such
+	 * signal: the browser shows its own prompt.
+	 */
+	blockedCount = $state(0);
+
+	noteBlocked(): void {
+		this.blockedCount++;
+	}
+}
+
+export const activeUploadsContext = new Context<ActiveUploads>('active-uploads');

--- a/src/lib/hooks/active-uploads.svelte.ts
+++ b/src/lib/hooks/active-uploads.svelte.ts
@@ -35,6 +35,11 @@ export function shouldBlockNavigation(nav: GuardedNavigation, hasActiveUploads: 
  * this would turn that very navigation into a full load that does not. Nothing
  * would ask either, because SvelteKit skips the callbacks while a navigation is
  * already under way. The stale chunks survive one more click; the file would not.
+ *
+ * Deferring is cheap here specifically: the navigations that reach this line
+ * while a file is going out are the same-page ones, which reuse the route that
+ * is already loaded rather than importing a chunk that a deploy may have
+ * deleted. The vite:preloadError backstop in app.html covers the rest.
  */
 export function deployReloadTarget(
 	nav: GuardedNavigation,

--- a/src/lib/hooks/active-uploads.svelte.ts
+++ b/src/lib/hooks/active-uploads.svelte.ts
@@ -30,9 +30,10 @@ export function shouldBlockNavigation(nav: GuardedNavigation, hasActiveUploads: 
  * Which surfaces currently have a file in flight, shared via context.
  *
  * A transfer that dies with the document is invisible: the progress bar simply
- * disappears and the user assumes the file arrived. One shared answer is needed
- * because uploads run in several places at once — the page's chat, the floating
- * support chat, and the avatar picker are separate owners.
+ * disappears and the user assumes the file arrived. The root layout has to ask
+ * before that happens, and it cannot see into the surfaces that transfer files,
+ * so they report here instead: the page's chat, the support chat, the avatar
+ * picker.
  *
  * Instantiated per request in the root layout — never a module-level singleton,
  * which would leak across SSR requests.

--- a/src/lib/hooks/active-uploads.svelte.ts
+++ b/src/lib/hooks/active-uploads.svelte.ts
@@ -1,10 +1,11 @@
 import { Context } from 'runed';
 import { SvelteSet } from 'svelte/reactivity';
 
-/** The parts of SvelteKit's `BeforeNavigate` the guard reads. */
+/** The parts of SvelteKit's `BeforeNavigate` the root layout reads. */
 export interface GuardedNavigation {
 	from: { url: URL } | null;
 	to: { url: URL } | null;
+	willUnload?: boolean;
 }
 
 /**
@@ -24,6 +25,25 @@ export function shouldBlockNavigation(nav: GuardedNavigation, hasActiveUploads: 
 	// call". A surface that drops its own upload on such a change owns that.
 	if (nav.to.url.pathname === nav.from?.url.pathname) return false;
 	return true;
+}
+
+/**
+ * Where to reload to when a detected deploy should be taken now, or null.
+ *
+ * The upload answer has to be part of this one, not a separate hook: a
+ * same-page navigation is let through above because it keeps the document, and
+ * this would turn that very navigation into a full load that does not. Nothing
+ * would ask either, because SvelteKit skips the callbacks while a navigation is
+ * already under way. The stale chunks survive one more click; the file would not.
+ */
+export function deployReloadTarget(
+	nav: GuardedNavigation,
+	deployDetected: boolean,
+	hasActiveUploads: boolean
+): URL | null {
+	if (!deployDetected || nav.willUnload || !nav.to) return null;
+	if (hasActiveUploads) return null;
+	return nav.to.url;
 }
 
 /**

--- a/src/lib/hooks/active-uploads.test.ts
+++ b/src/lib/hooks/active-uploads.test.ts
@@ -7,7 +7,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ActiveUploads, shouldBlockNavigation } from './active-uploads.svelte.ts';
+import {
+	ActiveUploads,
+	deployReloadTarget,
+	shouldBlockNavigation
+} from './active-uploads.svelte.ts';
 
 function nav(from: string | null, to: string | null) {
 	return {
@@ -101,5 +105,29 @@ describe('shouldBlockNavigation', () => {
 
 	it('blocks a first navigation that has no origin', () => {
 		expect(shouldBlockNavigation(nav(null, '/app/settings'), true)).toBe(true);
+	});
+});
+
+describe('deployReloadTarget', () => {
+	const target = nav('/app/ai-chat?thread=a', '/app/ai-chat?thread=b');
+
+	it('reloads on the next navigation once a deploy is detected', () => {
+		expect(deployReloadTarget(target, true, false)?.pathname).toBe('/app/ai-chat');
+	});
+
+	it('stays put while nothing has been deployed', () => {
+		expect(deployReloadTarget(target, false, false)).toBeNull();
+	});
+
+	it('waits while a file is transferring', () => {
+		// The navigation itself is allowed through, because a search-param change
+		// keeps the document. Turning it into a full load would not, and SvelteKit
+		// runs no callback during a navigation, so nothing would ask first.
+		expect(shouldBlockNavigation(target, true)).toBe(false);
+		expect(deployReloadTarget(target, true, true)).toBeNull();
+	});
+
+	it('leaves a departure alone, since the document is going anyway', () => {
+		expect(deployReloadTarget({ ...nav('/app', null), willUnload: true }, true, false)).toBeNull();
 	});
 });

--- a/src/lib/hooks/active-uploads.test.ts
+++ b/src/lib/hooks/active-uploads.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the in-flight upload registry and the navigation predicate.
+ *
+ * Two failure modes matter more than the happy path: a stale claim makes the
+ * app prompt forever for an upload that finished, and a predicate that answers
+ * "block" for ordinary navigation makes the app feel broken.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ActiveUploads, shouldBlockNavigation } from './active-uploads.svelte.ts';
+
+function nav(from: string | null, to: string | null) {
+	return {
+		from: from === null ? null : { url: new URL(from, 'https://example.test') },
+		to: to === null ? null : { url: new URL(to, 'https://example.test') }
+	};
+}
+
+describe('ActiveUploads', () => {
+	it('reports nothing in flight until a surface claims', () => {
+		const uploads = new ActiveUploads();
+		expect(uploads.any).toBe(false);
+	});
+
+	it('survives a doubled claim and a doubled release', () => {
+		const uploads = new ActiveUploads();
+		const owner = {};
+
+		uploads.claim(owner);
+		uploads.claim(owner);
+		expect(uploads.any).toBe(true);
+
+		uploads.release(owner);
+		uploads.release(owner);
+		expect(uploads.any).toBe(false);
+	});
+
+	it('keeps reporting in flight while a second surface still uploads', () => {
+		const uploads = new ActiveUploads();
+		const pageChat = {};
+		const supportChat = {};
+
+		uploads.claim(pageChat);
+		uploads.claim(supportChat);
+		uploads.release(pageChat);
+
+		expect(uploads.any).toBe(true);
+		uploads.release(supportChat);
+		expect(uploads.any).toBe(false);
+	});
+
+	it('releasing a surface that never claimed leaves the others alone', () => {
+		const uploads = new ActiveUploads();
+		const uploading = {};
+
+		uploads.claim(uploading);
+		uploads.release({});
+
+		expect(uploads.any).toBe(true);
+	});
+
+	it('spends a suspension on the very next navigation', () => {
+		const uploads = new ActiveUploads();
+
+		uploads.suspendOnce();
+		expect(uploads.consumeSuspension()).toBe(true);
+		expect(uploads.consumeSuspension()).toBe(false);
+	});
+
+	it('counts stopped in-app navigations so the UI can explain them', () => {
+		const uploads = new ActiveUploads();
+
+		expect(uploads.blockedCount).toBe(0);
+		uploads.noteBlocked();
+		uploads.noteBlocked();
+		expect(uploads.blockedCount).toBe(2);
+	});
+});
+
+describe('shouldBlockNavigation', () => {
+	it('never blocks while nothing is uploading', () => {
+		expect(shouldBlockNavigation(nav('/app/ai-chat', '/app/settings'), false)).toBe(false);
+		expect(shouldBlockNavigation(nav('/app/ai-chat', null), false)).toBe(false);
+	});
+
+	it('blocks leaving the document, where `to` is absent', () => {
+		// Reload, tab close and external links all arrive without a target.
+		expect(shouldBlockNavigation(nav('/app/ai-chat', null), true)).toBe(true);
+	});
+
+	it('blocks moving to another page', () => {
+		expect(shouldBlockNavigation(nav('/app/ai-chat', '/app/settings'), true)).toBe(true);
+	});
+
+	it('allows a search-param change on the same page', () => {
+		// Opening the support panel and switching a chat thread both look like this.
+		expect(shouldBlockNavigation(nav('/app/ai-chat?thread=a', '/app/ai-chat?thread=b'), true)).toBe(
+			false
+		);
+	});
+
+	it('blocks a first navigation that has no origin', () => {
+		expect(shouldBlockNavigation(nav(null, '/app/settings'), true)).toBe(true);
+	});
+});

--- a/src/lib/hooks/use-impersonation.svelte.ts
+++ b/src/lib/hooks/use-impersonation.svelte.ts
@@ -85,7 +85,15 @@ export class ImpersonationState {
 	 *
 	 * @param t - Tolgee translate function ($t from getTranslate())
 	 */
-	async stop(t: (key: string) => string): Promise<void> {
+	async stop(
+		t: (key: string) => string,
+		/**
+		 * Consulted immediately before the redirect. By then the session and the
+		 * JWT already belong to the admin again, so an upload that stopped this
+		 * would leave the target's page on screen under the admin's identity.
+		 */
+		activeUploads?: { suspendOnce(): void } | null
+	): Promise<void> {
 		haptic.trigger('warning');
 		try {
 			const result = await authClient.admin.stopImpersonating();
@@ -118,6 +126,7 @@ export class ImpersonationState {
 			toast.success(t('app.user_menu.impersonation_stopped'));
 			// Full document navigation, not a client-side goto: the app must boot with
 			// the fresh JWT and new Convex subscriptions bound to the admin identity.
+			activeUploads?.suspendOnce();
 			window.location.assign(localizedHref('/admin/users'));
 		} catch {
 			toast.error(t('app.user_menu.impersonation_stop_failed'));

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,7 +14,8 @@
 	import {
 		ActiveUploads,
 		activeUploadsContext,
-		shouldBlockNavigation
+		shouldBlockNavigation,
+		deployReloadTarget
 	} from '$lib/hooks/active-uploads.svelte.ts';
 	import UploadGuardNotice from '$lib/components/upload-guard-notice.svelte';
 	import { setGlobalSearchContext } from '$lib/components/global-search/context.svelte.ts';
@@ -56,8 +57,9 @@
 			if (nav.to) activeUploads.noteBlocked();
 			return;
 		}
-		if (updated.current && !nav.willUnload && nav.to?.url) {
-			location.href = nav.to.url.href;
+		const reloadTarget = deployReloadTarget(nav, updated.current, activeUploads.any);
+		if (reloadTarget) {
+			location.href = reloadTarget.href;
 		}
 	});
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,6 +11,12 @@
 	import AppPostHogBootstrap from '$lib/components/app/app-posthog-bootstrap.svelte';
 	import ClockSkewBanner from '$lib/components/clock-skew-banner.svelte';
 	import { ClockSkewState, clockSkewContext } from '$lib/hooks/clock-skew.svelte.ts';
+	import {
+		ActiveUploads,
+		activeUploadsContext,
+		shouldBlockNavigation
+	} from '$lib/hooks/active-uploads.svelte.ts';
+	import UploadGuardNotice from '$lib/components/upload-guard-notice.svelte';
 	import { setGlobalSearchContext } from '$lib/components/global-search/context.svelte.ts';
 	import GlobalSearchShell from '$lib/components/global-search/global-search-shell.svelte';
 	import { languageContext } from '$lib/i18n/context';
@@ -27,13 +33,31 @@
 
 	let { children } = $props();
 
+	// A file still transferring dies with the page, and silently: the progress bar
+	// disappears and the user assumes it arrived. Ask first.
+	//
+	// This shares the deploy hook's callback on purpose. Cancelling a navigation
+	// does not stop the other beforeNavigate callbacks, so a separate hook would
+	// still let the reload below tear the upload down.
+	const activeUploads = new ActiveUploads();
+	activeUploadsContext.set(activeUploads);
+
 	// After a new deploy is detected (version.json poll flips updated.current),
 	// turn the next client navigation into a full document load so fresh chunk
 	// hashes are fetched instead of importing a now-deleted hash and blanking
 	// the page. Covers goto() and back/forward, unlike data-sveltekit-reload.
-	beforeNavigate(({ willUnload, to }) => {
-		if (updated.current && !willUnload && to?.url) {
-			location.href = to.url.href;
+	beforeNavigate((nav) => {
+		const exempt = activeUploads.consumeSuspension();
+		if (!exempt && shouldBlockNavigation(nav, activeUploads.any)) {
+			nav.cancel();
+			// Leaving the document: SvelteKit turns the cancel into the browser's own
+			// prompt, which says everything there is to say. Only a stopped in-app
+			// navigation needs explaining, because nothing visibly happened.
+			if (nav.to) activeUploads.noteBlocked();
+			return;
+		}
+		if (updated.current && !nav.willUnload && nav.to?.url) {
+			location.href = nav.to.url.href;
 		}
 	});
 
@@ -148,6 +172,7 @@
 					<T keyName="a11y.skip_to_content" />
 				</a>
 				<ClockSkewBanner />
+				<UploadGuardNotice />
 				<GlobalSearchShell />
 				{@render children()}
 			</TolgeeProvider>

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -23,6 +23,7 @@
 	import { adminSupportUIContext } from '$lib/hooks/admin-support-ui.svelte.ts';
 	import { getTranslate } from '@tolgee/svelte';
 	import { page } from '$app/state';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
 
 	const { t } = getTranslate();
 
@@ -74,7 +75,16 @@
 	});
 
 	// Create ChatUIContext with upload support (userAlignment 'left' for admin view)
-	const chatUIContext = new ChatUIContext(chatCore, client, uploadConfig, 'left');
+	// Report transfers to the app so a navigation that would kill one asks first.
+	// Absent outside the app shell (isolated tests, the standalone example), where
+	// there is no layout to ask.
+	const chatUIContext = new ChatUIContext(
+		chatCore,
+		client,
+		uploadConfig,
+		'left',
+		activeUploadsContext.getOr(null)
+	);
 
 	// Revoke blob preview URLs of unsent attachments when this thread view unmounts
 	onDestroy(() => chatUIContext.dispose());

--- a/src/routes/[[lang]]/app/ai-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/+page.svelte
@@ -13,8 +13,13 @@
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import ThreadChat from './thread-chat.svelte';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
 
 	const { t } = getTranslate();
+
+	// Consulted before navigations this component starts on the user's behalf,
+	// so an in-flight upload elsewhere on the page cannot stop them.
+	const activeUploads = activeUploadsContext.getOr(null);
 
 	let { data } = $props();
 
@@ -99,6 +104,8 @@
 			successUrl: successUrl.href
 		});
 		if (result?.url) {
+			// The checkout session already exists; see nav-user.svelte.
+			activeUploads?.suspendOnce();
 			window.location.href = result.url;
 		} else if (upgradeOperation.error) {
 			haptic.trigger('error');

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -14,6 +14,7 @@
 	import { getTranslate } from '@tolgee/svelte';
 	import { page } from '$app/state';
 	import { onDestroy, tick } from 'svelte';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
 
 	const { t } = getTranslate();
 
@@ -71,7 +72,16 @@
 		}
 	});
 
-	const chatUIContext = new ChatUIContext(chatCore, client, uploadConfig, 'right');
+	// Report transfers to the app so a navigation that would kill one asks first.
+	// Absent outside the app shell (isolated tests, the standalone example), where
+	// there is no layout to ask.
+	const chatUIContext = new ChatUIContext(
+		chatCore,
+		client,
+		uploadConfig,
+		'right',
+		activeUploadsContext.getOr(null)
+	);
 
 	// Revoke blob preview URLs of unsent attachments when this thread view unmounts
 	onDestroy(() => chatUIContext.dispose());

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -34,8 +34,13 @@
 	import type { OptimisticLocalStore } from 'convex/browser';
 	import { ConvexError } from 'convex/values';
 	import type { Id } from '$lib/convex/_generated/dataModel';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
 
 	const { t } = getTranslate();
+
+	// Consulted before navigations this component starts on the user's behalf,
+	// so an in-flight upload elsewhere on the page cannot stop them.
+	const activeUploads = activeUploadsContext.getOr(null);
 
 	let { data } = $props();
 
@@ -207,6 +212,8 @@
 			successUrl: successUrl.href
 		});
 		if (result?.url) {
+			// The checkout session already exists; see nav-user.svelte.
+			activeUploads?.suspendOnce();
 			window.location.href = result.url;
 		} else if (upgradeOperation.error) {
 			haptic.trigger('error');

--- a/src/routes/[[lang]]/app/settings/account-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/account-settings.svelte
@@ -9,6 +9,7 @@
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import { uploadToStorage, UploadError } from '$lib/chat';
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
 	import { toast } from 'svelte-sonner';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { useConvexClient } from 'convex-svelte';
@@ -46,6 +47,15 @@
 	// Field errors
 	let errors = $state<Record<string, string[]>>({});
 	const hasNameError = $derived((errors.name?.length ?? 0) > 0);
+
+	// Let the root layout warn before a page unload discards the transfer.
+	const activeUploads = activeUploadsContext.getOr(null);
+	const uploadOwner = {};
+	$effect(() => {
+		if (!activeUploads || !isUploading) return;
+		activeUploads.claim(uploadOwner);
+		return () => activeUploads.release(uploadOwner);
+	});
 
 	async function handleFileSelect(e: Event) {
 		const target = e.target as HTMLInputElement;


### PR DESCRIPTION
A file that is still uploading dies with the page, and dies quietly: the progress bar disappears and the user assumes the file arrived. #760 and #761 fixed what a *failed* upload leaves behind. This closes the case that caused that report in the first place, a reload at 96%.

Surfaces that transfer a file register with a small shared registry, and the root layout's existing `beforeNavigate` callback stops a departure while any of them is busy. It shares that callback rather than adding a second one: cancelling a navigation does not stop the other callbacks, so the deploy reload would otherwise tear the transfer down anyway. Leaving the document becomes the browser's own prompt; an in-app navigation is stopped with a note, because nothing visibly happens otherwise. Navigations the app starts after an irreversible step, signing out and the checkout redirects, opt out explicitly instead of being matched against a list of paths that would rot.

Worth recording: the Convex client already warns for its own outstanding requests, so this looked partly solved. Measured with the guard removed, that covers roughly the first second of an upload, the presigned URL request. The bytes themselves were unprotected, which is the whole gap.

Two things the tests had to be built around. `page.close({ runBeforeUnload: true })` raises a dialog for the mere presence of a listener and SvelteKit always registers one, so that assertion passes with the guard deleted; the specs dispatch a synthetic `beforeunload` and read `defaultPrevented` instead. And the in-flight assertion waits for the storage POST plus a settle window so it cannot be satisfied by Convex's own warning.

Where the claim lives turned out to matter. It started as a `$effect` in ChatRoot, which is wrong: the chat's context is created by the surface around it and outlives it. Closing the support panel unmounts the chat while the transfer keeps running, so the cleanup gave up the claim mid-flight, and the screenshot flow uploads through that same context with no chat mounted at all. The context now reports its own transfers and takes the registry as a constructor argument, so there is no part of its life where it is unset.

A cross-model review of the branch turned up five more holes, each verified against the code before fixing: an image sits in the WebP encoder before any bytes move and was unclaimed; discarding an attachment could not recall a Convex mutation already sent, so the claim outlived the file; the deploy recovery could turn a permitted same-page navigation into the full load the guard had just avoided; stopping impersonation swaps the session before it redirects and needed the same exemption as sign-out; and the sign-out test sat in the shared browser project, where its logout would revoke the session every later test reuses.

One knock-on effect is worth recording. Holding the reload back makes a previously unreachable failure reachable: a lazy import whose chunk a deploy deleted. `{#await import(...)}` with no catch rethrows, which takes the page down. Cancelling the event in the preloadError handler looks like the fix and is not: Vite then resolves the import to `undefined`, which destructures into the same crash and removes the rejection SvelteKit relies on for its own route recovery. A boundary around the screenshot editor routes it to the capture-error path instead.

Verified by removing each piece and watching the matching test go red: without the guard, both the unload and the in-app cases fail; without the sign-out exemption, signing out mid-upload hangs. Checked visually at 1280px and 390px, English and German.

Regression guard: added `src/lib/hooks/active-uploads.test.ts`, `src/lib/chat/ui/chat-context-upload-claims.test.ts`, `src/lib/components/customer-support/lazy-editor-boundary.test.ts` and `e2e/upload-navigation-guard.spec.ts`
