### PR TITLE
test(i18n): Guard the served html lang per locale

### DIFF
--- a/e2e/public-language-redirect.spec.ts
+++ b/e2e/public-language-redirect.spec.ts
@@ -45,3 +45,25 @@ test.describe('bare-path language redirect', () => {
 		expect(response.headers()['location']).not.toMatch(/\/zz\//);
 	});
 });
+
+// The served <html lang> needs both the %lang% placeholder in app.html and the
+// handleHtmlLang hook that fills it. Either one going missing fails silently:
+// without the placeholder the replace is a no-op and every locale ships the
+// hard-coded fallback, without the hook the raw token reaches the browser. So
+// this asserts the rendered response rather than unit-testing the hook. The
+// marketing root is prerendered and /pricing is not, which covers both the
+// build-time and the runtime substitution.
+test.describe('SSR html lang', () => {
+	for (const lang of ['en', 'de', 'es', 'fr'] as const) {
+		test(`serves lang="${lang}" on prerendered and runtime routes`, async ({ request }) => {
+			for (const path of [`/${lang}`, `/${lang}/pricing`]) {
+				const response = await request.get(path);
+				expect(response.ok(), `${path} should be reachable`).toBe(true);
+
+				const html = await response.text();
+				expect(html, `${path} should declare lang="${lang}"`).toContain(`<html lang="${lang}"`);
+				expect(html, `${path} should not leak the placeholder`).not.toContain('%lang%');
+			}
+		});
+	}
+});


### PR DESCRIPTION
The served `<html lang>` depends on two pieces in different files: the `%lang%` placeholder in `app.html` and the `handleHtmlLang` hook that fills it. Either one going missing fails silently. Without the placeholder the replace is a no-op and every locale ships the fallback; without the hook the raw token reaches the browser. Nothing covered that pairing, and `hooks.server.test.ts` only exercises the redirect and resolution helpers.

This came up in a fork that had branched before `handleHtmlLang` landed. It served `lang="en"` for every locale, so screen readers announced German, Spanish and French copy with English phonetics, and no test noticed. Adding the guard here means a fork that drops either half finds out from its own suite.

The assertion runs against the rendered response rather than the hook, on a prerendered route and a runtime one so both the build-time and the request-time substitution are covered. Verified passing for all four locales, and failing on `de`, `es` and `fr` when the placeholder is reverted.