### PR TITLE
fix(chat): Park attachments on a thread switch

### DIFF
--- a/src/lib/chat/ui/chat-context-parked-attachments.test.ts
+++ b/src/lib/chat/ui/chat-context-parked-attachments.test.ts
@@ -1,0 +1,378 @@
+/**
+ * An attachment survives the switch to another thread.
+ *
+ * Picking a different thread mid-transfer used to cancel the upload and remove
+ * the attachment without a word, so a file the user was still waiting on looked
+ * sent. The composer is still emptied, because attachments belong to the thread
+ * they were picked in, but the transfer keeps running and the tile is back where
+ * it belongs on the way back.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import type { ConvexClient } from 'convex/browser';
+import type { ChatCore } from '../core/chat-core.svelte.ts';
+
+const uploadFileWithProgress = vi.fn();
+
+vi.mock('svelte-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('../core/file-uploader.js', () => ({
+	uploadFileWithProgress: (...args: unknown[]) => uploadFileWithProgress(...args),
+	UploadError: class UploadError extends Error {}
+}));
+
+const { ChatUIContext } = await import('./chat-context.svelte.ts');
+const { ActiveUploads } = await import('$lib/hooks/active-uploads.svelte.ts');
+
+const uploadConfig = {
+	generateUploadUrl: 'storage:generateUploadUrl',
+	saveUploadedFile: 'storage:saveUploadedFile'
+} as unknown as ConstructorParameters<typeof ChatUIContext>[2];
+
+/** A transfer the test decides the outcome of, plus the signal that cancels it. */
+function pendingTransfer() {
+	let settle!: (result: { url: string; fileId: string }) => void;
+	let fail!: (error: unknown) => void;
+	let signal: AbortSignal | undefined;
+	let report: ((progress: number) => void) | undefined;
+	uploadFileWithProgress.mockImplementationOnce(
+		(...args: unknown[]) =>
+			new Promise((resolve, reject) => {
+				report = args[3] as (progress: number) => void;
+				signal = args[7] as AbortSignal;
+				settle = resolve;
+				fail = reject;
+			})
+	);
+	return {
+		succeed: (fileId = 'file-1') => settle({ url: `https://example.test/${fileId}`, fileId }),
+		reject: (error: unknown) => fail(error),
+		progress: (percent: number) => report?.(percent),
+		get canceled() {
+			return signal?.aborted ?? false;
+		}
+	};
+}
+
+/** A chat sitting in one thread, able to move to another. */
+function threadedChat(threadId: string, uploads: InstanceType<typeof ActiveUploads> | null = null) {
+	const core = { threadId } as unknown as ChatCore;
+	const ctx = new ChatUIContext(core, {} as ConvexClient, uploadConfig, 'right', uploads);
+	// The first call is what gives the context a thread to compare against.
+	ctx.setDisplayMessages([]);
+	return {
+		ctx,
+		switchTo(next: string | null) {
+			(core as { threadId: string | null }).threadId = next;
+			ctx.setDisplayMessages([]);
+		}
+	};
+}
+
+const shot = () => new Blob(['x'], { type: 'image/png' });
+
+function uploadState(ctx: InstanceType<typeof ChatUIContext>, index = 0) {
+	const attachment = ctx.attachments[index];
+	return attachment && 'uploadState' in attachment ? attachment.uploadState : undefined;
+}
+
+/** Only picked files carry a name; plain image attachments have none. */
+function names(ctx: InstanceType<typeof ChatUIContext>) {
+	return ctx.attachments.map((a) => ('name' in a ? a.name : undefined));
+}
+
+describe('ChatUIContext parked attachments', () => {
+	beforeAll(() => {
+		// jsdom does not implement revokeObjectURL
+		if (!('revokeObjectURL' in URL)) {
+			Object.defineProperty(URL, 'revokeObjectURL', {
+				value: () => {},
+				writable: true,
+				configurable: true
+			});
+		}
+	});
+
+	beforeEach(() => {
+		uploadFileWithProgress.mockReset();
+	});
+
+	it('brings the attachment back when the user returns to its thread', () => {
+		const transfer = pendingTransfer();
+		const chat = threadedChat('thread-a');
+		void chat.ctx.uploadScreenshot(shot(), 'shot.png');
+
+		chat.switchTo('thread-b');
+		expect(chat.ctx.attachments).toHaveLength(0);
+		expect(transfer.canceled).toBe(false);
+
+		chat.switchTo('thread-a');
+		expect(chat.ctx.attachments).toHaveLength(1);
+		expect(transfer.canceled).toBe(false);
+	});
+
+	it('shows a thread its own attachments, not the ones left behind', () => {
+		pendingTransfer();
+		const chat = threadedChat('thread-a');
+		void chat.ctx.uploadScreenshot(shot(), 'from-a.png');
+
+		pendingTransfer();
+		chat.switchTo('thread-b');
+		void chat.ctx.uploadScreenshot(shot(), 'from-b.png');
+		expect(names(chat.ctx)).toEqual(['from-b.png']);
+
+		chat.switchTo('thread-a');
+		expect(names(chat.ctx)).toEqual(['from-a.png']);
+	});
+
+	it('records the result of a transfer that lands while its thread is parked', async () => {
+		// The write has to find the attachment where it actually is. Through the
+		// composer alone it would go nowhere, and the user would come back to a
+		// tile loading forever for a file that is already stored.
+		const transfer = pendingTransfer();
+		const chat = threadedChat('thread-a');
+		const upload = chat.ctx.uploadScreenshot(shot(), 'shot.png');
+
+		chat.switchTo('thread-b');
+		transfer.succeed('file-parked');
+		await upload;
+
+		chat.switchTo('thread-a');
+		expect(uploadState(chat.ctx)).toMatchObject({ status: 'success', fileId: 'file-parked' });
+	});
+
+	it('keeps a failure that happened while parked recoverable', async () => {
+		const transfer = pendingTransfer();
+		const chat = threadedChat('thread-a');
+		const upload = chat.ctx.uploadScreenshot(shot(), 'shot.png');
+
+		chat.switchTo('thread-b');
+		transfer.reject(new Error('network'));
+		await upload;
+
+		chat.switchTo('thread-a');
+		expect(uploadState(chat.ctx)).toMatchObject({ status: 'error' });
+
+		const retry = pendingTransfer();
+		chat.ctx.retryUpload(0);
+		expect(uploadFileWithProgress).toHaveBeenCalledTimes(2);
+		retry.succeed('file-retried');
+		await vi.waitFor(() =>
+			expect(uploadState(chat.ctx)).toMatchObject({ status: 'success', fileId: 'file-retried' })
+		);
+	});
+
+	it('starts the transfer for an image parked while it was still encoding', async () => {
+		// The encoder runs for seconds on a large photo, and the switch can land
+		// in the middle of it. Looking for the attachment in the composer alone
+		// would read the park as a discard and drop the file before it moved.
+		const chat = threadedChat('thread-a');
+
+		let finishEncoding!: () => void;
+		const encoded = new Promise<void>((resolve) => {
+			finishEncoding = resolve;
+		});
+		const transfer = pendingTransfer();
+
+		const upload = chat.ctx.uploadFile(new Blob(['x'], { type: 'image/png' }), 'photo.png', {
+			preprocess: async (input) => {
+				await encoded;
+				// Dimensions supplied, so the transfer is the next thing to happen.
+				return {
+					blob: input,
+					mimeType: 'image/webp',
+					filename: 'photo.webp',
+					width: 10,
+					height: 10
+				};
+			}
+		});
+
+		await vi.waitFor(() => expect(chat.ctx.attachments).toHaveLength(1));
+		chat.switchTo('thread-b');
+		finishEncoding();
+		await vi.waitFor(() => expect(uploadFileWithProgress).toHaveBeenCalledTimes(1));
+		transfer.succeed('file-encoded');
+		await upload;
+
+		chat.switchTo('thread-a');
+		expect(uploadState(chat.ctx)).toMatchObject({ status: 'success', fileId: 'file-encoded' });
+	});
+
+	it('takes the attachment back when a warm thread is handed out again', () => {
+		// Asking for a new conversation drops the thread id and then gets the same
+		// unused warm thread back. Treating that return as thread creation and
+		// nothing else would leave the attachment parked under the id the user is
+		// standing in: gone from the composer, still transferring.
+		const transfer = pendingTransfer();
+		const chat = threadedChat('warm-thread');
+		void chat.ctx.uploadScreenshot(shot(), 'shot.png');
+
+		chat.switchTo(null);
+		expect(chat.ctx.attachments).toHaveLength(0);
+
+		chat.switchTo('warm-thread');
+		expect(names(chat.ctx)).toEqual(['shot.png']);
+		expect(transfer.canceled).toBe(false);
+	});
+
+	it('keeps what the composer holds when a new thread gets its id', () => {
+		// The other half of the same transition: a file picked while the thread was
+		// still being created belongs to it, so nothing may displace it.
+		pendingTransfer();
+		const chat = threadedChat('warm-thread');
+		chat.switchTo(null);
+		void chat.ctx.uploadScreenshot(shot(), 'picked-while-new.png');
+
+		chat.switchTo('fresh-thread');
+		expect(names(chat.ctx)).toEqual(['picked-while-new.png']);
+	});
+
+	it('merges both sides when a warm thread comes back to a busy composer', () => {
+		// Both belong to the thread now: one was picked before stepping out, the
+		// other while it had no id yet. Neither may displace the other.
+		pendingTransfer();
+		const chat = threadedChat('warm-thread');
+		void chat.ctx.uploadScreenshot(shot(), 'before.png');
+
+		pendingTransfer();
+		chat.switchTo(null);
+		void chat.ctx.uploadScreenshot(shot(), 'while-new.png');
+
+		chat.switchTo('warm-thread');
+		expect(names(chat.ctx)).toEqual(['before.png', 'while-new.png']);
+	});
+
+	it('does not end up with the same file twice after the merge', () => {
+		// The composer's duplicate check only ever saw the live list, so the same
+		// file can be picked again while the other copy sits parked.
+		const first = pendingTransfer();
+		const chat = threadedChat('warm-thread');
+		void chat.ctx.uploadFile(new Blob(['x'], { type: 'text/plain' }), 'notes.txt');
+
+		const second = pendingTransfer();
+		chat.switchTo(null);
+		void chat.ctx.uploadFile(new Blob(['x'], { type: 'text/plain' }), 'notes.txt');
+
+		chat.switchTo('warm-thread');
+		expect(names(chat.ctx)).toEqual(['notes.txt']);
+		// The kept copy is the one already on the wire, and the other is called off.
+		expect(first.canceled).toBe(false);
+		expect(second.canceled).toBe(true);
+	});
+
+	it('keeps the copy that got further, not the one that was parked', () => {
+		// The parked copy usually has the head start, but not when it failed. The
+		// user would be handed back a tile to retry while the working transfer it
+		// replaced was cancelled.
+		const failing = pendingTransfer();
+		const chat = threadedChat('warm-thread');
+		const failed = chat.ctx.uploadFile(new Blob(['x'], { type: 'text/plain' }), 'notes.txt');
+		failing.reject(new Error('network'));
+
+		return failed.then(async () => {
+			const fresh = pendingTransfer();
+			chat.switchTo(null);
+			void chat.ctx.uploadFile(new Blob(['x'], { type: 'text/plain' }), 'notes.txt');
+			await vi.waitFor(() => expect(chat.ctx.attachments).toHaveLength(1));
+
+			chat.switchTo('warm-thread');
+			expect(names(chat.ctx)).toEqual(['notes.txt']);
+			expect(uploadState(chat.ctx)).toMatchObject({ status: 'uploading' });
+			expect(fresh.canceled).toBe(false);
+		});
+	});
+
+	it('keeps the copy that is further along, not the one that waited longer', async () => {
+		// Both are still moving, so the head start is only an assumption: the
+		// parked transfer can be stalled at the start while the one picked again
+		// is nearly done. Cancelling that one would throw away the better attempt.
+		const stalled = pendingTransfer();
+		const chat = threadedChat('warm-thread');
+		void chat.ctx.uploadFile(new Blob(['x'], { type: 'text/plain' }), 'notes.txt');
+		await vi.waitFor(() => expect(chat.ctx.attachments).toHaveLength(1));
+
+		const nearlyDone = pendingTransfer();
+		chat.switchTo(null);
+		void chat.ctx.uploadFile(new Blob(['x'], { type: 'text/plain' }), 'notes.txt');
+		await vi.waitFor(() => expect(uploadFileWithProgress).toHaveBeenCalledTimes(2));
+		nearlyDone.progress(99);
+
+		chat.switchTo('warm-thread');
+		expect(names(chat.ctx)).toEqual(['notes.txt']);
+		expect(uploadState(chat.ctx)).toMatchObject({ progress: 99 });
+		expect(nearlyDone.canceled).toBe(false);
+		expect(stalled.canceled).toBe(true);
+	});
+
+	it('files a parked upload under the thread it was picked in', () => {
+		// Every surface derives the access key from the thread on screen, and the
+		// key is what the stored file is filed under. Reading it when the encoder
+		// finally hands over would file the image in the thread the user moved to.
+		const transfer = pendingTransfer();
+		const core = { threadId: 'thread-a' } as unknown as ChatCore;
+		const keyedConfig = {
+			...uploadConfig,
+			getAccessKey: () => core.threadId ?? undefined
+		} as ConstructorParameters<typeof ChatUIContext>[2];
+		const ctx = new ChatUIContext(core, {} as ConvexClient, keyedConfig, 'right', null);
+		ctx.setDisplayMessages([]);
+
+		let finishEncoding!: () => void;
+		const encoded = new Promise<void>((resolve) => {
+			finishEncoding = resolve;
+		});
+		const upload = ctx.uploadFile(new Blob(['x'], { type: 'image/png' }), 'photo.png', {
+			preprocess: async (input) => {
+				await encoded;
+				return {
+					blob: input,
+					mimeType: 'image/webp',
+					filename: 'photo.webp',
+					width: 10,
+					height: 10
+				};
+			}
+		});
+
+		return vi
+			.waitFor(() => expect(ctx.attachments).toHaveLength(1))
+			.then(async () => {
+				(core as { threadId: string }).threadId = 'thread-b';
+				ctx.setDisplayMessages([]);
+				finishEncoding();
+				await vi.waitFor(() => expect(uploadFileWithProgress).toHaveBeenCalledTimes(1));
+
+				expect(uploadFileWithProgress.mock.calls[0]?.[6]).toBe('thread-a');
+				transfer.succeed();
+				await upload;
+			});
+	});
+
+	it('cancels parked transfers when the surface goes away', () => {
+		// Nothing is coming back to pick them up, and the claim has to end with the
+		// context or the page keeps asking about a file nobody can finish.
+		const uploads = new ActiveUploads();
+		const transfer = pendingTransfer();
+		const chat = threadedChat('thread-a', uploads);
+		void chat.ctx.uploadScreenshot(shot(), 'shot.png');
+		chat.switchTo('thread-b');
+
+		chat.ctx.dispose();
+
+		expect(transfer.canceled).toBe(true);
+		expect(uploads.any).toBe(false);
+	});
+
+	it('keeps asking before a reload while a parked transfer runs', () => {
+		// The bytes still die with the document, whichever thread is on screen.
+		const uploads = new ActiveUploads();
+		const transfer = pendingTransfer();
+		const chat = threadedChat('thread-a', uploads);
+		void chat.ctx.uploadScreenshot(shot(), 'shot.png');
+
+		chat.switchTo('thread-b');
+		expect(uploads.any).toBe(true);
+
+		transfer.succeed();
+	});
+});

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -29,7 +29,21 @@ type UploadJob = {
 	blob: File | Blob;
 	filename: string;
 	dimensions?: { width: number; height: number };
+	/**
+	 * Who the stored file belongs to, read when the file was picked.
+	 *
+	 * Every surface derives this from the thread it is showing, and the transfer
+	 * can start long after the pick: an image spends its encoding time first, and
+	 * a retry happens whenever the user gets to it. Reading it at that point would
+	 * file the attachment under whatever thread is on screen by then.
+	 */
+	accessKey?: string;
 };
+
+/** Ranks for a transfer that is over, and one that has to start again, against
+ * the 0-100 progress of any still running. */
+const SETTLED_RANK = 101;
+const FAILED_RANK = -1;
 
 /** A canceled upload, which the user caused and does not need to be told about. */
 function isAbortError(error: unknown): boolean {
@@ -116,6 +130,16 @@ export class ChatUIContext {
 	 * used by upload methods to apply progress/success/error updates by value
 	 * rather than by array index. */
 	attachments = $state<Attachment[]>([]);
+
+	/**
+	 * Attachments of threads the user stepped away from, by thread id.
+	 *
+	 * Deliberately unbounded: evicting one would be the silent loss this exists
+	 * to prevent. What it can grow to is bounded by the user's own picking, one
+	 * file dialog at a time, and a retry payload is only retained while its
+	 * attachment can still fail. Everything here is released on dispose.
+	 */
+	private readonly parked = new SvelteMap<string, Attachment[]>();
 
 	/** Cancels the in-flight upload of an attachment, keyed by its stable `key`. */
 	private readonly uploadAborters = new SvelteMap<string, AbortController>();
@@ -263,19 +287,14 @@ export class ChatUIContext {
 
 		// Reset only on actual navigation between threads
 		// NOT on null → threadId (thread creation) or during brief empty states
-		if (
-			this._lastThreadId !== undefined &&
-			currentThreadId !== this._lastThreadId &&
-			this._lastThreadId !== null // Don't reset when creating new thread
-		) {
-			this.messagesFade.reset();
-			this._hasEverDisplayedMessages = false;
-			// Attachments belong to the thread they were picked in. Every surface
-			// reuses one context across threads and swaps only the text draft, so
-			// without this a file follows the user and is sent in the wrong
-			// conversation — and a failed one blocks sending there. Also cancels
-			// any transfer still running for the thread being left.
-			this.clearAttachments();
+		if (this._lastThreadId !== undefined && currentThreadId !== this._lastThreadId) {
+			if (this._lastThreadId === null) {
+				this.adoptParked(currentThreadId);
+			} else {
+				this.messagesFade.reset();
+				this._hasEverDisplayedMessages = false;
+				this.parkAttachments(this._lastThreadId, currentThreadId);
+			}
 		}
 		this._lastThreadId = currentThreadId;
 
@@ -400,11 +419,95 @@ export class ChatUIContext {
 	}
 
 	/**
+	 * Hand the composer over from one thread to another.
+	 *
+	 * Attachments belong to the thread they were picked in. Every surface reuses
+	 * one context across threads and swaps only the text draft, so a file left
+	 * in place would be sent in the wrong conversation, and a failed one would
+	 * block sending there. Set aside rather than thrown away: the transfer keeps
+	 * running, and the composer looks the same on the way back, so a switch mid
+	 * transfer no longer costs the file.
+	 */
+	private parkAttachments(leaving: string, entering: string | null): void {
+		if (this.attachments.length > 0) this.parked.set(leaving, this.attachments);
+		// A thread that has none is a thread with an empty composer, so the
+		// lookup miss is the answer rather than a case to handle. Threads with no
+		// id yet share the empty key, which no real thread can collide with.
+		const key = entering ?? '';
+		this.attachments = this.parked.get(key) ?? [];
+		this.parked.delete(key);
+	}
+
+	/**
+	 * Take back what was parked for a thread that is only now getting its id.
+	 *
+	 * Starting a conversation is not a move to another one, so the composer keeps
+	 * what it holds. It can still land on a thread with something parked: leaving
+	 * an unused warm thread parks under its id, and asking for a new conversation
+	 * hands the very same warm thread back out. Without this the attachment would
+	 * be stranded under an id the user is standing in, invisible and still
+	 * transferring.
+	 */
+	private adoptParked(threadId: string | null): void {
+		const key = threadId ?? '';
+		const parked = this.parked.get(key);
+		if (!parked) return;
+		this.parked.delete(key);
+
+		// The composer's own duplicate check could only see the live list while
+		// this was parked, so the same file can be in both. Whichever copy got
+		// further stays, because the loser costs the user a retry it did not need.
+		// Indices rather than identities: reading `attachments` hands out proxies,
+		// so comparing the objects would not reliably match.
+		const supersededLive = this.attachments.map(() => false);
+		const adopted: Attachment[] = [];
+		for (const candidate of parked) {
+			const rivalIndex = this.attachments.findIndex(
+				(live, index) => !supersededLive[index] && ChatUIContext.isSameFile(candidate, live)
+			);
+			const rival = rivalIndex === -1 ? undefined : this.attachments[rivalIndex];
+			if (!rival) {
+				adopted.push(candidate);
+				continue;
+			}
+			// Ties go to the parked copy, which has the head start on its transfer.
+			if (ChatUIContext.uploadProgressRank(candidate) >= ChatUIContext.uploadProgressRank(rival)) {
+				supersededLive[rivalIndex] = true;
+				this.releaseUpload(rival);
+				this.revokePreview(rival);
+				adopted.push(candidate);
+			} else {
+				this.releaseUpload(candidate);
+				this.revokePreview(candidate);
+			}
+		}
+
+		// Adopted first: they were picked before whatever is in the composer now.
+		// The result can sit above the pick-time attachment cap, which is the
+		// lesser evil. The cap keeps one pick reasonable; dropping a file the user
+		// picked, to hold a number they never see, is the loss this path exists to
+		// avoid. They are all destined for this thread, and any one can be removed.
+		this.attachments = [
+			...adopted,
+			...this.attachments.filter((_, index) => !supersededLive[index])
+		];
+	}
+
+	/**
 	 * Release resources held by this context. Call on unmount of the owning
 	 * component so blob preview URLs of unsent attachments do not leak until
 	 * the document unloads.
 	 */
 	dispose(): void {
+		// Parked attachments hold aborters and blob previews just like live ones,
+		// and no thread switch is coming to pick them up any more.
+		for (const attachments of this.parked.values()) {
+			for (const attachment of attachments) {
+				this.releaseUpload(attachment);
+				this.revokePreview(attachment);
+			}
+		}
+		this.parked.clear();
 		this.clearAttachments();
 		// The surface is gone for good, so nothing is left that could report an
 		// outcome, whatever is still unwinding.
@@ -413,18 +516,49 @@ export class ChatUIContext {
 	}
 
 	/**
+	 * How an attachment answers "is this the same file", as name and size.
+	 *
+	 * Two answers, because preprocessing renames an image to .webp and changes
+	 * its bytes: without the pre-preprocessing pair, re-pasting the same source
+	 * image would slip past dedup and upload twice.
+	 */
+	private static fileIdentity(attachment: Attachment): string[] {
+		if (attachment.type !== 'file' && attachment.type !== 'screenshot') return [];
+		const identities = [`${attachment.name}:${attachment.size}`];
+		if (attachment.sourceName !== undefined && attachment.sourceSize !== undefined) {
+			identities.push(`${attachment.sourceName}:${attachment.sourceSize}`);
+		}
+		return identities;
+	}
+
+	/** Whether two attachments are the same picked file. */
+	private static isSameFile(a: Attachment, b: Attachment): boolean {
+		const other = ChatUIContext.fileIdentity(b);
+		return ChatUIContext.fileIdentity(a).some((identity) => other.includes(identity));
+	}
+
+	/**
+	 * How far an attachment got, so the better of two copies of one file wins.
+	 *
+	 * A stored file beats one still moving, which beats a failure the user would
+	 * have to retry. Between two that are still moving the percentage decides:
+	 * ranking them equal would let a stalled transfer cancel one at 99%. An
+	 * attachment handed in from outside has no upload state and nothing pending,
+	 * so it counts as settled.
+	 */
+	private static uploadProgressRank(attachment: Attachment): number {
+		const state = 'uploadState' in attachment ? attachment.uploadState : undefined;
+		if (!state || state.status === 'success') return SETTLED_RANK;
+		if (state.status === 'error') return FAILED_RANK;
+		return state.progress;
+	}
+
+	/**
 	 * Check if a file with the same name and size already exists
 	 */
 	hasFile(name: string, size: number): boolean {
-		// Match either current name+size OR the pre-preprocessing source values.
-		// Without the second branch, image attachments would lose dedup after
-		// they're renamed to .webp on upload — the user could re-paste the same
-		// source image and get duplicate uploads.
-		return this.attachments.some(
-			(a) =>
-				(a.type === 'file' || a.type === 'screenshot') &&
-				((a.name === name && a.size === size) || (a.sourceName === name && a.sourceSize === size))
-		);
+		const picked = `${name}:${size}`;
+		return this.attachments.some((a) => ChatUIContext.fileIdentity(a).includes(picked));
 	}
 
 	/**
@@ -508,6 +642,9 @@ export class ChatUIContext {
 		// Before the first await: the tile already shows progress, so leaving now
 		// costs the user the same file whether or not the transfer has started.
 		this.markPending(key);
+		// Read here too, for the same reason: this is the thread the file was
+		// picked in, and encoding can outlast the user's stay in it.
+		const accessKey = this.uploadConfig.getAccessKey?.();
 
 		try {
 			let uploadBlob: File | Blob = file;
@@ -525,11 +662,11 @@ export class ChatUIContext {
 				height = processed.height;
 				// Reflect post-process metadata on the placeholder so the UI shows
 				// the final size and name during the actual upload.
-				this.attachments = this.attachments.map((a) =>
-					'key' in a && a.key === key
-						? { ...a, name: uploadName, mimeType: uploadMime, size: uploadBlob.size }
-						: a
-				);
+				this.patchAttachment(key, {
+					name: uploadName,
+					mimeType: uploadMime,
+					size: uploadBlob.size
+				});
 			}
 
 			// Read dimensions only when preprocess didn't supply them. Image-typed
@@ -543,16 +680,14 @@ export class ChatUIContext {
 				}
 			}
 			if (width && height) {
-				this.attachments = this.attachments.map((a) =>
-					'key' in a && a.key === key ? { ...a, width, height } : a
-				);
+				this.patchAttachment(key, { width, height });
 			}
 
 			// Preprocessing and dimension reading are awaited above and cannot be
 			// canceled, so the user may have discarded the attachment by now.
 			// Starting the transfer would upload a file nothing references and
 			// leave map entries behind for a key that is gone.
-			if (!this.attachments.some((a) => 'key' in a && a.key === key)) {
+			if (!this.findAttachment(key)) {
 				this.retryJobs.delete(key);
 				return;
 			}
@@ -560,7 +695,8 @@ export class ChatUIContext {
 			await this.runUpload(key, {
 				blob: uploadBlob,
 				filename: uploadName,
-				dimensions: width && height ? { width, height } : undefined
+				dimensions: width && height ? { width, height } : undefined,
+				accessKey
 			});
 		} catch (error) {
 			// A failure before the transfer (image preprocessing, dimension
@@ -571,7 +707,7 @@ export class ChatUIContext {
 			// Unless the user got there first: preprocessing cannot be canceled,
 			// so it may still reject long after the chip was discarded, and
 			// reporting a failure for a file nobody is waiting on is noise.
-			const stillPresent = this.attachments.some((a) => 'key' in a && a.key === key);
+			const stillPresent = this.findAttachment(key) !== undefined;
 			this.discardAttachment(key);
 			if (isAbortError(error) || !stillPresent) return;
 			const translate = this.uploadConfig?.translate;
@@ -626,7 +762,7 @@ export class ChatUIContext {
 				},
 				this.uploadConfig,
 				job.dimensions,
-				this.uploadConfig.getAccessKey?.(),
+				job.accessKey,
 				aborter.signal
 			);
 
@@ -676,30 +812,67 @@ export class ChatUIContext {
 		void this.runUpload(attachment.key, job);
 	}
 
+	/**
+	 * Rewrite every list holding this attachment, the live one and any parked.
+	 *
+	 * An upload outlives the composer showing it: switching threads parks its
+	 * attachment while the transfer keeps running. Writing only through the live
+	 * list would drop the outcome of a transfer that lands while its thread is
+	 * parked, leaving a tile loading forever for a file that is already stored.
+	 */
+	private rewriteLists(key: string, rewrite: (list: Attachment[]) => Attachment[]): void {
+		const holds = (list: Attachment[]) => list.some((a) => 'key' in a && a.key === key);
+		if (holds(this.attachments)) this.attachments = rewrite(this.attachments);
+		// Bounded by the threads the user stepped away from with something open.
+		for (const [threadId, list] of this.parked) {
+			if (!holds(list)) continue;
+			const next = rewrite(list);
+			if (next.length > 0) this.parked.set(threadId, next);
+			else this.parked.delete(threadId);
+		}
+	}
+
+	/** The attachment with this key, live or parked. */
+	private findAttachment(key: string): Attachment | undefined {
+		const match = (a: Attachment) => 'key' in a && a.key === key;
+		const live = this.attachments.find(match);
+		if (live) return live;
+		for (const list of this.parked.values()) {
+			const found = list.find(match);
+			if (found) return found;
+		}
+		return undefined;
+	}
+
 	/** Apply a partial update to the attachment with this key. */
 	private patchAttachment(key: string, patch: Partial<Attachment>): void {
-		this.attachments = this.attachments.map((a) =>
-			'key' in a && a.key === key ? ({ ...a, ...patch } as Attachment) : a
+		this.rewriteLists(key, (list) =>
+			list.map((a) => ('key' in a && a.key === key ? ({ ...a, ...patch } as Attachment) : a))
 		);
 	}
 
 	/** Update the upload state of the attachment with this key, if it has one. */
 	private patchUploadState(key: string, next: (state: UploadState) => UploadState): void {
-		this.attachments = this.attachments.map((a) =>
-			'key' in a && a.key === key && (a.type === 'file' || a.type === 'screenshot') && a.uploadState
-				? { ...a, uploadState: next(a.uploadState) }
-				: a
+		this.rewriteLists(key, (list) =>
+			list.map((a) =>
+				'key' in a &&
+				a.key === key &&
+				(a.type === 'file' || a.type === 'screenshot') &&
+				a.uploadState
+					? { ...a, uploadState: next(a.uploadState) }
+					: a
+			)
 		);
 	}
 
 	/** Remove an attachment by key and release everything held for it. */
 	private discardAttachment(key: string): void {
-		const attachment = this.attachments.find((a) => 'key' in a && a.key === key);
+		const attachment = this.findAttachment(key);
 		if (attachment) {
 			this.releaseUpload(attachment);
 			this.revokePreview(attachment);
 		}
-		this.attachments = this.attachments.filter((a) => !('key' in a) || a.key !== key);
+		this.rewriteLists(key, (list) => list.filter((a) => !('key' in a) || a.key !== key));
 	}
 
 	/**
@@ -733,7 +906,12 @@ export class ChatUIContext {
 
 		// No preprocessing here: the blob and its dimensions are already what
 		// gets uploaded, so they double as the retry payload unchanged.
-		await this.runUpload(key, { blob, filename, dimensions });
+		await this.runUpload(key, {
+			blob,
+			filename,
+			dimensions,
+			accessKey: this.uploadConfig.getAccessKey?.()
+		});
 	}
 
 	/**

--- a/src/lib/chat/ui/chat-context.test.ts
+++ b/src/lib/chat/ui/chat-context.test.ts
@@ -301,9 +301,9 @@ describe('ChatUIContext upload failures', () => {
 		expect(client.mutation).not.toHaveBeenCalled();
 	});
 
-	it('drops attachments when navigating between threads', () => {
+	it('takes attachments out of the composer when navigating between threads', () => {
 		// Every surface reuses one context across threads and swaps only the text
-		// draft, so an attachment would otherwise be sent in the wrong thread —
+		// draft, so an attachment left in place would be sent in the wrong thread —
 		// and a failed one would block sending there.
 		const core = { threadId: 'thread-a' } as unknown as ChatCore;
 		const ctx = new ChatUIContext(core, succeedingClient(), uploadConfig);


### PR DESCRIPTION
Closes #763

Attaching a file and picking another thread before it finishes cancelled the upload and removed the attachment with no notice, so the file looked sent. #762 guards the navigations that genuinely kill a transfer; this one never needed to. A thread switch leaves the document standing, the context survives, and the request keeps running until `clearAttachments` cancels it on the way out.

So the attachments of the thread being left are set aside instead of thrown away, and the ones belonging to the thread being entered are restored. The composer is still emptied, because attachments belong to the thread they were picked in and a file that followed the user would be sent in the wrong conversation. The transfer finishes in the background, and the tile is there again on the way back, uploaded or still in progress. Nothing to tell the user, because nothing is lost.

The load-bearing part is that an upload has to survive being out of sight. Attachment writes previously went through the live composer list alone, so a transfer that finished off-screen would have dropped its `url` and `fileId` and left a tile loading forever for a file that was already stored. The check that reads a missing attachment as a discard needed the same treatment, or an image parked mid-encode would be dropped before it ever moved. And which thread a stored file belongs to is now read when the file is picked rather than when the transfer starts, since encoding, parking, and a retry all sit between the two.

One thread can be left and re-entered without ever being switched away from: leaving an unused warm thread parks under its id, and asking for a new conversation hands that same warm thread back out. That return takes the parked list back and merges it with whatever the composer picked up meanwhile, since both belong to the thread now. Of two copies of one file the one that got further stays, by upload state and then by percentage, so a stalled transfer cannot cancel one that is nearly done.

The guard from #762 is unchanged. A route change still unmounts the surface and disposes the context, so blocking it with a notice stays right, and reload and tab close still raise the native dialog, which is why a parked transfer keeps its claim. The admin support view has the same symptom from a different cause and is tracked in #765.

Regression guard: added src/lib/chat/ui/chat-context-parked-attachments.test.ts

Verified with the full unit suite and static checks on the final tree, and every behaviour this adds was mutation-checked by removing it and confirming its own test goes red; no Playwright spec, because the AI chat exposes a single warm thread with no way to reach a second one, and the support widget, which does have a thread list, would need an anonymous multi-thread fixture and new testids for a flow with no visual change.

A related pre-existing rollback hole is tracked separately in #766.
