### PR TITLE
fix(dev): Close the fourth Convex secret leak

### DIFF
--- a/patches/convex-vite-plugin@0.4.0.patch
+++ b/patches/convex-vite-plugin@0.4.0.patch
@@ -1,8 +1,24 @@
+diff --git a/node_modules/convex-vite-plugin/.bun-tag-3cb0ae79d7081430 b/.bun-tag-3cb0ae79d7081430
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/convex-vite-plugin/.bun-tag-f7bcc5c18e81cda6 b/.bun-tag-f7bcc5c18e81cda6
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/backend-CgypcZjo.mjs b/dist/backend-CgypcZjo.mjs
-index a2446d37d147b021fb5315b9d3ffbd9e5f0e8ca0..62876c1ca5f1a10a3299e02777649aa35fb0a77b 100644
+index a2446d37d147b021fb5315b9d3ffbd9e5f0e8ca0..8c8db83dcd5c3aa93a3bdcc8544d8927691a66e4 100644
 --- a/dist/backend-CgypcZjo.mjs
 +++ b/dist/backend-CgypcZjo.mjs
-@@ -576,8 +576,8 @@ var ConvexBackend = class {
+@@ -565,6 +565,9 @@ var ConvexBackend = class {
+ 			cwd: backendDir,
+ 			stdio: this.stdio
+ 		});
++		this.process.on("error", (error) => {
++			this.logger.error(`Convex backend process failed to start: ${error instanceof Error ? error.message : String(error)}`, { timestamp: true });
++		});
+ 		if (!this.process.pid) throw new Error("Convex process failed to start - no PID assigned");
+ 		this.logger.info(`Backend spawned on port ${this.port} (waiting for ready...)`, { timestamp: true });
+ 	}
+@@ -576,8 +579,8 @@ var ConvexBackend = class {
  		await this.healthCheck();
  		this.logger.info("Backend ready", { timestamp: true });
  		this.logger.info(`  Instance name:   ${this.instanceName}`, { timestamp: true });
@@ -27,10 +43,29 @@ index 9fae259bd780fd2cb930f4c9f74eef80b3a73b88..0d377d80ae7648b9f12158dec1adce3d
  						}
  						deploy();
 diff --git a/src/backend.ts b/src/backend.ts
-index 27271554f6ed8c2c8aba185bbb62f8a16c7e8c7d..2909ebcf02ab245f3bd095a8d96f96e9cc686eb1 100644
+index 27271554f6ed8c2c8aba185bbb62f8a16c7e8c7d..15fedc76750edfbfb8960d2e7a398114dcb10ff6 100644
 --- a/src/backend.ts
 +++ b/src/backend.ts
-@@ -198,8 +198,8 @@ export class ConvexBackend {
+@@ -180,6 +180,18 @@ export class ConvexBackend {
+       },
+     );
+ 
++    // A failed exec leaves pid undefined, so the check below already rejects
++    // spawn() and reports the failure. What it does not stop is the 'error'
++    // event that lands afterwards: with no listener Node prints the whole error
++    // object, and its spawnargs carry --instance-secret. This listener exists
++    // only to keep that print sanitized.
++    this.process.on("error", (error) => {
++      this.logger.error(
++        `Convex backend process failed to start: ${error instanceof Error ? error.message : String(error)}`,
++        { timestamp: true },
++      );
++    });
++
+     if (!this.process.pid) {
+       throw new Error("Convex process failed to start - no PID assigned");
+     }
+@@ -198,8 +210,8 @@ export class ConvexBackend {
  
      this.logger.info("Backend ready", { timestamp: true });
      this.logger.info(`  Instance name:   ${this.instanceName}`, { timestamp: true });

--- a/scripts/convex-vite-secret-logging.test.ts
+++ b/scripts/convex-vite-secret-logging.test.ts
@@ -1,31 +1,154 @@
 // convex-vite-plugin prints every value it hands the local Convex backend, plus
 // the backend's generated instance secret and admin key, straight to the dev
-// console (upstream: juliusmarminge/agent-tools#24). We redact all three at the
-// source with patches/convex-vite-plugin@0.4.0.patch.
+// console (upstream: juliusmarminge/agent-tools#24). It also passes
+// --instance-secret in argv with no 'error' listener on the child, so a failed
+// exec makes Node print the whole error object, spawnargs included. All four are
+// closed by patches/convex-vite-plugin@0.4.0.patch.
 //
-// This asserts the *installed* artifacts rather than the patch file, because
-// three things can go wrong silently: the patch is not registered, it fails to
-// apply on install, or a dependency upgrade moves the code out from under it.
-// The plugin's `exports["."]` resolves to dist/index.mjs and it has no `main`,
-// so a patch that only touched src/ would change nothing at runtime — reading
-// what the resolver actually reaches is what makes that case fail here.
+// These assertions read the *installed* artifacts rather than the patch file,
+// because three things can go wrong silently: the patch is not registered, it
+// fails to apply on install, or a dependency upgrade moves the code out from
+// under it. The plugin's `exports["."]` resolves to dist/index.mjs and it has no
+// `main`, so a patch that only touched src/ would change nothing at runtime.
+//
+// The bundles are parsed rather than pattern-matched. Substring and line-wise
+// checks pass against a reworded log, a call whose argument sits on the next
+// line, and forms like `logger.info(name + value)` — exactly the drift a guard
+// on a patched dependency exists to catch.
+//
+// It is a syntactic guard, not taint analysis, and the difference is worth
+// knowing before trusting it further than it goes. It recognises a logger by
+// shape (`<something ending in logger>.info|warn|error`), so an alias, a
+// destructured `const { info } = logger`, a computed `logger['info']` or a
+// bundler rename would slip past, and it matches identifier names rather than
+// values, so `const s = this.instanceSecret; logger.info(s)` would too. That is
+// acceptable here only because the dependency is pinned to an exact version and
+// this guards a patch against it: the realistic failure is that patch decaying,
+// not the package growing a laundering path.
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const entry = require.resolve('convex-vite-plugin');
 
-/** The backend chunk's filename is content-hashed, so find it rather than pin it. */
+/**
+ * The backend chunk's filename is content-hashed, so it is followed from the
+ * entry's own import rather than matched by prefix. Picking the first
+ * `backend-*.mjs` in the directory would inspect a stale or secondary chunk if a
+ * release ever shipped two, and pass while the imported one stayed unpatched.
+ */
 function backendChunk(): string {
-	const dir = path.dirname(entry);
-	const match = fs
-		.readdirSync(dir)
-		.find((file) => file.startsWith('backend-') && file.endsWith('.mjs'));
-	expect(match, `no backend-*.mjs chunk beside ${entry}`).toBeDefined();
-	return path.join(dir, match!);
+	const imported = fs
+		.readFileSync(entry, 'utf-8')
+		.match(/from\s+["'](\.\/backend-[^"']+\.mjs)["']/);
+	expect(imported?.[1], `no backend chunk imported by ${entry}`).toBeDefined();
+	return path.resolve(path.dirname(entry), imported![1]!);
+}
+
+function parse(file: string): ts.SourceFile {
+	return ts.createSourceFile(
+		file,
+		fs.readFileSync(file, 'utf-8'),
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.JS
+	);
+}
+
+function findCalls(node: ts.Node, keep: (call: ts.CallExpression) => boolean): ts.CallExpression[] {
+	const found: ts.CallExpression[] = [];
+	const visit = (current: ts.Node): void => {
+		if (ts.isCallExpression(current) && keep(current)) found.push(current);
+		ts.forEachChild(current, visit);
+	};
+	visit(node);
+	return found;
+}
+
+/** `logger.info(...)`, `this.logger.warn(...)`, and friends. */
+function isLoggerCall(call: ts.CallExpression): boolean {
+	const callee = call.expression;
+	return (
+		ts.isPropertyAccessExpression(callee) &&
+		['info', 'warn', 'error'].includes(callee.name.text) &&
+		callee.expression.getText().endsWith('logger')
+	);
+}
+
+/** Every identifier named anywhere inside a node, however it is composed. */
+function identifiersIn(node: ts.Node): Set<string> {
+	const names = new Set<string>();
+	const visit = (current: ts.Node): void => {
+		if (ts.isIdentifier(current)) names.add(current.text);
+		ts.forEachChild(current, visit);
+	};
+	visit(node);
+	return names;
+}
+
+/**
+ * Every use of the binding `name` inside `scope`, excluding its declaration.
+ *
+ * Member and key positions are not uses of the binding: in `this.logger.error`
+ * and `{ error: x }` the identifier merely happens to share the name. Shorthand
+ * (`{ error }`) is a real use and is deliberately kept, since that is one of the
+ * ways the object escapes.
+ */
+function referencesTo(scope: ts.Node, declaration: ts.Node, name: string): ts.Identifier[] {
+	const uses: ts.Identifier[] = [];
+	const visit = (current: ts.Node): void => {
+		if (ts.isIdentifier(current) && current.text === name && current !== declaration) {
+			const parent = current.parent;
+			const isMemberName = ts.isPropertyAccessExpression(parent) && parent.name === current;
+			const isKey =
+				(ts.isPropertyAssignment(parent) || ts.isMethodDeclaration(parent)) &&
+				parent.name === current;
+			if (!isMemberName && !isKey) uses.push(current);
+		}
+		ts.forEachChild(current, visit);
+	};
+	visit(scope);
+	return uses;
+}
+
+/**
+ * Whether a reference to the spawn error is one of the reductions that provably
+ * cannot carry `spawnargs`: reading `.message`, `String()` (which goes through
+ * `Error.prototype.toString`, i.e. name plus message), or an `instanceof` test.
+ * Anything else — a bare argument, object shorthand, `JSON.stringify` — hands on
+ * the object itself and has to fail.
+ */
+function isSafeErrorReduction(reference: ts.Identifier): boolean {
+	const parent = reference.parent;
+	if (ts.isPropertyAccessExpression(parent) && parent.expression === reference) {
+		return parent.name.text === 'message';
+	}
+	if (
+		ts.isBinaryExpression(parent) &&
+		parent.operatorToken.kind === ts.SyntaxKind.InstanceOfKeyword
+	) {
+		return parent.left === reference;
+	}
+	if (ts.isCallExpression(parent) && parent.expression.getText() === 'String') {
+		return parent.arguments.length === 1 && parent.arguments[0] === reference;
+	}
+	return false;
+}
+
+/** Logger calls whose arguments mention any of `banned`, as printable text. */
+function loggedSecrets(file: string, banned: string[]): string[] {
+	return findCalls(parse(file), isLoggerCall)
+		.filter((call) =>
+			call.arguments.some((argument) => {
+				const names = identifiersIn(argument);
+				return banned.some((name) => names.has(name));
+			})
+		)
+		.map((call) => call.getText().replace(/\s+/g, ' ').slice(0, 120));
 }
 
 describe('convex-vite-plugin secret logging', () => {
@@ -34,19 +157,71 @@ describe('convex-vite-plugin secret logging', () => {
 	});
 
 	it('logs env var names without their values', () => {
-		const source = fs.readFileSync(entry, 'utf-8');
-		expect(source).toContain('Set environment variable: ${name} = [REDACTED]');
-		expect(source).not.toContain('Set environment variable: ${name} = ${value}');
+		expect(fs.readFileSync(entry, 'utf-8')).toContain(
+			'Set environment variable: ${name} = [REDACTED]'
+		);
+		// Not just the statement we patched: any logger call that reaches the
+		// loop's `value` binding, in any form, has to fail here.
+		expect(loggedSecrets(entry, ['value'])).toEqual([]);
 	});
 
-	// Scoped to the banner strings on purpose: the admin key legitimately appears
-	// in this chunk as an Authorization header, so banning the interpolation
-	// outright would fail against correct code.
 	it('logs the backend banner without the instance secret or admin key', () => {
-		const source = fs.readFileSync(backendChunk(), 'utf-8');
+		const chunk = backendChunk();
+		const source = fs.readFileSync(chunk, 'utf-8');
 		expect(source).toContain('Instance secret: [REDACTED]');
 		expect(source).toContain('Admin key:       [REDACTED]');
-		expect(source).not.toContain('Instance secret: ${this.instanceSecret}');
-		expect(source).not.toContain('Admin key:       ${this.adminKey}');
+		// Scoped to logger arguments, so the admin key's legitimate use in an
+		// Authorization header stays allowed.
+		expect(loggedSecrets(chunk, ['instanceSecret', 'adminKey'])).toEqual([]);
+	});
+
+	// The spawn carries --instance-secret in argv. Without a listener Node treats
+	// a failed exec as an unhandled 'error' event and prints the whole error
+	// object, spawnargs included — a leak no logger patch can reach.
+	it('handles the backend spawn error without forwarding the error object', () => {
+		const source = parse(backendChunk());
+		const listeners = findCalls(source, (call) => {
+			const callee = call.expression;
+			const first = call.arguments[0];
+			return (
+				ts.isPropertyAccessExpression(callee) &&
+				callee.name.text === 'on' &&
+				callee.expression.getText().endsWith('this.process') &&
+				!!first &&
+				ts.isStringLiteralLike(first) &&
+				first.text === 'error'
+			);
+		});
+		expect(listeners.length, 'no error listener on the spawned backend process').toBeGreaterThan(0);
+
+		// Every listener, not just the one this patch adds. A second one appearing
+		// is not itself a problem, but it would be a new place for the error object
+		// to escape, and pinning the count instead would fail on it for no reason.
+		for (const listener of listeners) {
+			const callback = listener.arguments[1]!;
+			expect(ts.isArrowFunction(callback) || ts.isFunctionExpression(callback)).toBe(true);
+			const parameterNode = (callback as ts.ArrowFunction).parameters[0]!.name;
+			const parameter = parameterNode.getText();
+
+			// Every reference to the error, not just the ones handed to a logger.
+			// Checking logger arguments alone lets the object escape by the side
+			// door: `{ timestamp: true, error }` reaches the package's default
+			// logger as `console.error(formatted, options.error)`, and a bare
+			// `console.error(JSON.stringify(error))` is not a logger call at all.
+			// So each reference must be one of the reductions proven not to carry
+			// argv: `.message`, `String()` (Error.prototype.toString is name plus
+			// message), or an `instanceof` test, which stringifies nothing.
+			const unsafe = referencesTo(callback, parameterNode, parameter).filter(
+				(reference) => !isSafeErrorReduction(reference)
+			);
+			expect(
+				unsafe.map((reference) => reference.parent.getText().replace(/\s+/g, ' ').slice(0, 120)),
+				'the error object escapes the listener instead of being reduced'
+			).toEqual([]);
+
+			const logs = findCalls(callback, isLoggerCall);
+			expect(logs.length, 'listener logs nothing, so the failure is silent').toBeGreaterThan(0);
+			expect(callback.getText()).toContain(`${parameter}.message`);
+		}
 	});
 });

--- a/scripts/env-schema-parity.test.ts
+++ b/scripts/env-schema-parity.test.ts
@@ -7,9 +7,10 @@ import { TEST_ONLY_ENV_PLACEHOLDERS } from './local-convex-env';
  * The Convex `env` block in `src/lib/convex/convex.config.ts` and the varlock
  * `.env-convex.schema` are two declarations of the same variable set. The env
  * block drives Convex's push-time validation and the generated typed `env`
- * object; the schema drives varlock typegen, deploy-time validation and the
- * `@type=url`/`@type=boolean` coercion. They must agree on which vars exist
- * and which are required, or one source silently drifts from the other.
+ * object; the schema drives varlock typegen and the deploy-time presence check.
+ * Its `@type=*` decorators coerce nothing on this path — no value here is loaded
+ * by varlock — so they are documentation. The two must still agree on which vars
+ * exist and which are required, or one source silently drifts from the other.
  *
  * Validator types intentionally differ (the schema's url/boolean vars are plain
  * strings in the env block, because Convex env values are always strings), so

--- a/scripts/local-convex-env.ts
+++ b/scripts/local-convex-env.ts
@@ -20,3 +20,20 @@ export const TEST_ONLY_ENV_PLACEHOLDERS = {
 	AUTUMN_SECRET_KEY: 'am_sk_local_e2e_dummy',
 	OPENROUTER_API_KEY: 'sk-or-local-e2e-dummy'
 } as const;
+
+/**
+ * The origin of a developer-supplied URL, for logging.
+ *
+ * `.env.convex.local` holds secrets, and a URL a developer typed can carry
+ * userinfo or a query token. The one place such a value still reaches the
+ * console is the warning about an ignored `SITE_URL`, so it is reduced to
+ * scheme, host and port — enough to say which stale value is being ignored,
+ * without the credential-bearing parts.
+ */
+export function logSafeOrigin(value: string): string {
+	try {
+		return new URL(value).origin;
+	} catch {
+		return '<unparseable>';
+	}
+}

--- a/scripts/log-safe-origin.test.ts
+++ b/scripts/log-safe-origin.test.ts
@@ -1,0 +1,24 @@
+// The ignored-SITE_URL warning is the one place a `.env.convex.local` value
+// still reaches the console, and that file holds secrets. A URL a developer
+// typed can carry userinfo or a query token, so only the origin is logged.
+
+import { describe, expect, it } from 'vitest';
+import { logSafeOrigin } from './local-convex-env';
+
+describe('logSafeOrigin', () => {
+	it('drops userinfo, path, query and fragment', () => {
+		expect(logSafeOrigin('https://user:pw@example.com:8443/p?token=abc#f')).toBe(
+			'https://example.com:8443'
+		);
+		expect(logSafeOrigin('https://example.com/x?k=secret')).toBe('https://example.com');
+	});
+
+	it('keeps the ordinary local case intact, so the warning stays useful', () => {
+		expect(logSafeOrigin('http://localhost:5173')).toBe('http://localhost:5173');
+	});
+
+	// parseEnvFile accepts any non-empty string, so a malformed value reaches here.
+	it('does not echo a value it cannot parse', () => {
+		expect(logSafeOrigin('not a url with a secret in it')).toBe('<unparseable>');
+	});
+});

--- a/src/lib/convex/convex.config.ts
+++ b/src/lib/convex/convex.config.ts
@@ -13,8 +13,9 @@ import convexFilesControl from '@gilhrpenner/convex-files-control/convex.config'
  * Convex validates these at push time (missing required vars or values that
  * fail their validator reject the deploy) and emits a typed `env` object into
  * `_generated/server`. This mirrors `.env-convex.schema`, which stays the
- * canonical superset: varlock still owns log redaction, leak scanning, the
- * `@type=url`/`@type=boolean` coercion, and the SvelteKit runtime side.
+ * canonical superset for typegen and for the scripts that read variable names
+ * and requiredness. Its `@type=*` decorators do not coerce or validate anything
+ * here, and it drives no redaction: no value on this path is loaded by varlock.
  *
  * Env values are always strings, so only string-like validators are allowed
  * (`v.string()`, string `v.literal()`/`v.union()`, and `v.optional()`).
@@ -24,10 +25,10 @@ const app = defineApp({
 	env: {
 		// Required, string-like (deploy-time presence + value guard)
 		BETTER_AUTH_SECRET: v.string(),
-		SITE_URL: v.string(), // @type=url stays enforced by varlock
+		SITE_URL: v.string(), // @type=url in the schema documents intent only
 		RESEND_API_KEY: v.string(),
 		AUTH_EMAIL: v.string(),
-		EMAIL_ASSET_URL: v.string(), // @type=url stays enforced by varlock
+		EMAIL_ASSET_URL: v.string(), // @type=url in the schema documents intent only
 		AUTUMN_SECRET_KEY: v.string(),
 		OPENROUTER_API_KEY: v.string(),
 		// Optional
@@ -38,7 +39,7 @@ const app = defineApp({
 		AUTH_GITHUB_SECRET: v.optional(v.string()),
 		AUTH_E2E_TEST_SECRET: v.optional(v.string()),
 		PREVIEW_ADMIN_PASSWORD: v.optional(v.string()),
-		// @type=boolean cannot be expressed here; varlock keeps the boolean type,
+		// @type=boolean cannot be expressed here either, and nothing coerces it:
 		// runtime code compares the raw 'true' string.
 		LOCAL_CONVEX_DEV: v.optional(v.string()),
 		LOCAL_SEEDED_ADMIN_EMAIL: v.optional(v.string()),

--- a/src/lib/convex/env.ts
+++ b/src/lib/convex/env.ts
@@ -7,11 +7,16 @@
  * required/optional split comes for free: required vars type as `string`,
  * optional vars as `string | undefined`.
  *
- * varlock (.env-convex.schema) stays canonical for typegen, deploy-time
- * validation, `@type=url`/`@type=boolean` coercion, and the SvelteKit runtime
- * side; `scripts/env-schema-parity.test.ts` keeps the two declarations in sync.
- * It does not drive redaction of the local dev server's own output — varlock
- * only redacts values it loaded itself, and these are the Convex backend's.
+ * varlock (.env-convex.schema) stays canonical for typegen and for the scripts
+ * that check which vars exist and which are required;
+ * `scripts/env-schema-parity.test.ts` keeps the two declarations in sync.
+ *
+ * What it does NOT do, despite what the decorators suggest: no value ever
+ * passes through varlock on this path. `.env.convex.local` is read by a
+ * hand-written parser in vite.config.ts and deployed values live in the Convex
+ * deployment, so `@type=url` and `@type=boolean` are documentation here, not
+ * validation. Redaction is likewise not driven from this schema — varlock only
+ * redacts values it loaded itself.
  */
 
 import { env } from './_generated/server';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import { varlockLoadedEnv, varlockVitePlugin } from '@varlock/vite-integration';
 import { convexLocal } from 'convex-vite-plugin';
 import { DEV_FEATURES, type DevFeature } from './src/lib/dev/features';
 import { findAvailablePort, portlessOwnsPort } from './scripts/dev-ports';
-import { TEST_ONLY_ENV_PLACEHOLDERS } from './scripts/local-convex-env';
+import { TEST_ONLY_ENV_PLACEHOLDERS, logSafeOrigin } from './scripts/local-convex-env';
 import { stripSensitiveManifestValues } from './scripts/strip-varlock-secrets';
 import { sentrySvelteKit } from '@sentry/sveltekit';
 import devtoolsJson from 'vite-plugin-devtools-json';
@@ -245,7 +245,7 @@ export default defineConfig(async ({ mode }) => {
 						: (resolvedUrls?.local[0] ?? `http://localhost:${vitePort}`);
 					if (ignoredLocalSiteUrl && ignoredLocalSiteUrl !== siteUrl) {
 						console.warn(
-							`[convex] Ignoring SITE_URL=${ignoredLocalSiteUrl} from .env.convex.local; ` +
+							`[convex] Ignoring SITE_URL (${logSafeOrigin(ignoredLocalSiteUrl)}) from .env.convex.local; ` +
 								`using ${siteUrl} (derived from the running dev server) so local sign-in keeps working. ` +
 								`Remove SITE_URL from .env.convex.local to silence this warning.`
 						);


### PR DESCRIPTION
Follow-up to #769, from a cross-model review of that change. Redacting the three logger sites turned out to leave one path open, and the guard that was supposed to hold the line was weaker than it read.

`ConvexBackend.spawn` passes `--instance-secret` in argv and the class attaches no `error` listener anywhere. A failed exec — corrupted binary cache, EACCES, quarantine — therefore emits an unhandled `'error'` event, and Node prints the whole error object with `spawnargs` in it. Confirmed with a sentinel: `util.inspect(err)` contains the argument, `err.message` does not. The patch now attaches a listener that logs only the message. It does not hide the failure: `pid` is `undefined` on a failed exec, so the existing check already rejects `spawn()` and reports it; the listener exists purely to keep the asynchronous print sanitized.

Three weaknesses in the guard itself, all found by the review rather than by me:

It matched the backend chunk by filename prefix instead of following the entry's import, so a release shipping two `backend-*.mjs` files could leave the imported one unpatched while the test happily inspected the other. It now parses the import out of the resolved `dist/index.mjs`.

It pinned exact literals, so a reworded or newly added statement logging the same secret would pass. Two replacements later — a line-wise filter that missed arguments on the following line, then a hand-rolled paren matcher that a `)` in a regex or comment could close early — it parses the bundles and inspects logger call expressions instead. A banned identifier reaching a logger argument fails whether it is interpolated, concatenated or nested, while the admin key's legitimate use in an Authorization header stays allowed.

And asserting that an error listener *exists* said nothing about what it does with the error. Checking only the arguments handed to a logger was not enough either: `{ timestamp: true, error }` reaches the package's default logger as `console.error(formatted, options.error)`, and a bare `console.error(JSON.stringify(error))` is not a logger call at all. Every reference to the error must now be a reduction that provably cannot carry argv — `.message`, `String()`, an `instanceof` test — so both of those fail.

Each bypass was counter-checked by injection, and every earlier version of this guard passed them. It is worth being plain about what it still is not: a syntactic guard, not taint analysis. An aliased or destructured logger, or a secret copied into a local variable first, would pass. That is acceptable only because the dependency is pinned to an exact version and this guards a patch against it, so the realistic failure is that patch decaying rather than the package growing a laundering path. The test says as much in its header.

Two smaller things. The ignored-`SITE_URL` warning printed a raw value from `.env.convex.local`, bypassing the patched sink entirely; it logs the origin now, so userinfo and query tokens stay out of scrollback; the label changes from `SITE_URL=...` to `SITE_URL (...)` and the ordinary `http://localhost:5173` case keeps its value intact. And the comments claiming varlock enforces `@type=url`/`@type=boolean` on this path are corrected — no value here is ever loaded by varlock, so a malformed `EMAIL_ASSET_URL` passes `v.string()` and is returned raw.

Not addressed here, and reported upstream on juliusmarminge/agent-tools#24 instead, because they need changes inside the package rather than around it: the instance secret and admin key sitting in argv where a process listing can read them, and `keys.json` plus the backend SQLite being written `0644`.

Regression guard: added scripts/log-safe-origin.test.ts and extended scripts/convex-vite-secret-logging.test.ts

Verified with the full suite at 119 files / 986 tests, plus static checks and types. Each new assertion was counter-checked by reverting the thing it guards.

