### PR TITLE
fix(billing): Complete Autumn checkout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@openrouter/ai-sdk-provider": "^2.9.0",
         "@rive-app/canvas": "^2.32.0",
         "@sentry/sveltekit": "^10.47.0",
-        "@stickerdaniel/convex-autumn-svelte": "^0.3.0",
+        "@stickerdaniel/convex-autumn-svelte": "^0.4.0",
         "@svelte-put/lockscroll": "^2.0.1",
         "@tolgee/format-icu": "^7.0.0",
         "@tolgee/svelte": "^7.0.0",
@@ -1204,7 +1204,7 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@stickerdaniel/convex-autumn-svelte": ["@stickerdaniel/convex-autumn-svelte@0.3.0", "", { "dependencies": { "@useautumn/convex": "^0.0.23", "atmn": "^0.0.36", "autumn-js": "^0.1.82", "cookie": "^1.0.2", "is-network-error": "^1.1.0", "jwt-decode": "^4.0.0", "path-to-regexp": "^8.2.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "convex": "^1.24.3", "convex-svelte": ">=0.13.0", "svelte": "^5.38.5" } }, "sha512-My00pvA9uYe7iWWcQ4zfQSL0gLY4J4SHu+pGzrV7a7r3wuuuH1WEHYj98FmBZ323mXTBIMYnI/2JtNq36UTq5g=="],
+    "@stickerdaniel/convex-autumn-svelte": ["@stickerdaniel/convex-autumn-svelte@0.4.0", "", { "dependencies": { "@useautumn/convex": "^0.0.23", "atmn": "^0.0.36", "autumn-js": "^0.1.82", "cookie": "^1.0.2", "is-network-error": "^1.1.0", "jwt-decode": "^4.0.0", "path-to-regexp": "^8.2.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "convex": "^1.24.3", "convex-svelte": ">=0.13.0", "svelte": "^5.38.5" } }, "sha512-PkHmwsop5qVX4dgNxmVtXC3KJB4bQZD3FRaVewRvod1hLuSgN/JRd0bO9qnTq1IlyWLBON2+ow9bxg9I/ce3rA=="],
 
     "@stomp/stompjs": ["@stomp/stompjs@7.3.0", "", {}, "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ=="],
 

--- a/e2e/upgrade-checkout-confirmation.spec.ts
+++ b/e2e/upgrade-checkout-confirmation.spec.ts
@@ -1,0 +1,211 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Regression guard for the silent-upgrade defect: Autumn answers a checkout
+// either with a hosted Stripe session or with a purchase preview that has to be
+// confirmed in the app and completed with `attach`. The app only handled the
+// first, so an answer without a URL left the button idle with no Stripe, no
+// error and no explanation.
+//
+// Both specs intercept the Convex WebSocket the same way
+// `upgrade-checkout-failure.spec.ts` does: everything is forwarded except the
+// checkout and attach actions, which are answered synthetically so no real
+// billing operation happens. The success envelope has to nest the Autumn
+// response inside the Convex one — a bare preview is rejected as NO_DATA by the
+// client wrapper.
+
+const PRO = {
+	id: 'pro',
+	name: 'Pro',
+	created_at: 1735689600000,
+	env: 'sandbox',
+	is_add_on: false,
+	is_default: false,
+	group: 'main',
+	version: 1,
+	items: [],
+	free_trial: null,
+	base_variant_id: null,
+	properties: {
+		is_free: false,
+		is_one_off: false,
+		interval_group: 'month',
+		has_trial: false,
+		updateable: true
+	}
+};
+
+const FREE = { ...PRO, id: 'free', name: 'Free', is_default: true };
+
+const CHECKOUT_PREVIEW = {
+	url: null,
+	customer_id: 'e2e-customer',
+	has_prorations: false,
+	lines: [{ description: 'Pro - $10 / month', amount: 10, item: {} }],
+	total: 10,
+	currency: 'usd',
+	options: [],
+	product: PRO,
+	current_product: FREE
+};
+
+type ActionFrame = { type?: string; udfPath?: string; requestId?: number; args?: unknown[] };
+
+type Intercept = {
+	/** Resolves once the attach action has been requested. */
+	attachRequested: Promise<{ args: unknown[] }>;
+	/** Answers the held attach request. */
+	resolveAttach: (payload: { data?: unknown; error?: unknown }) => void;
+};
+
+function actionResponse(requestId: number, data: unknown, error: unknown = null) {
+	return JSON.stringify({
+		type: 'ActionResponse',
+		requestId,
+		success: true,
+		result: { data, error, statusCode: error ? 400 : 200 },
+		logLines: []
+	});
+}
+
+/**
+ * Answer checkout immediately, hold attach until the test releases it.
+ *
+ * Holding attach is what makes the in-flight assertions possible: while the
+ * purchase is being charged the dialog has to stay open and its buttons
+ * disabled, including against Escape.
+ */
+async function interceptBilling(page: Page): Promise<Intercept> {
+	let onAttachRequested: (value: { args: unknown[] }) => void;
+	const attachRequested = new Promise<{ args: unknown[] }>((resolve) => {
+		onAttachRequested = resolve;
+	});
+
+	let respond: ((payload: { data?: unknown; error?: unknown }) => void) | null = null;
+
+	await page.routeWebSocket(/\/api\/[^/]+\/sync/, (ws) => {
+		const server = ws.connectToServer();
+
+		ws.onMessage((raw) => {
+			if (typeof raw !== 'string') {
+				server.send(raw);
+				return;
+			}
+
+			let parsed: ActionFrame | null = null;
+			try {
+				parsed = JSON.parse(raw) as ActionFrame;
+			} catch {
+				/* not JSON — forward verbatim */
+			}
+
+			if (
+				parsed?.type === 'Action' &&
+				typeof parsed.udfPath === 'string' &&
+				typeof parsed.requestId === 'number'
+			) {
+				if (parsed.udfPath.includes('checkout')) {
+					ws.send(actionResponse(parsed.requestId, CHECKOUT_PREVIEW));
+					return;
+				}
+
+				if (parsed.udfPath.includes('attach')) {
+					const requestId = parsed.requestId;
+					respond = (payload) => ws.send(actionResponse(requestId, payload.data, payload.error));
+					onAttachRequested({ args: parsed.args ?? [] });
+					return;
+				}
+			}
+
+			server.send(raw);
+		});
+
+		server.onMessage((raw) => ws.send(raw));
+	});
+
+	return {
+		attachRequested,
+		resolveAttach: (payload) => respond?.(payload)
+	};
+}
+
+test('a checkout without a hosted session is confirmed in a dialog', async ({ page }) => {
+	const billing = await interceptBilling(page);
+
+	await page.goto(`/en/pricing?cb=${Date.now()}`);
+	await page.waitForLoadState('networkidle');
+
+	const checkoutButton = page.getByTestId('pricing-checkout-pro');
+	await expect(checkoutButton).toBeEnabled();
+	await checkoutButton.click();
+
+	// No URL to follow, so the purchase has to surface as a confirmation.
+	const dialog = page.getByRole('alertdialog');
+	await expect(dialog).toBeVisible({ timeout: 10000 });
+	await expect(dialog).toContainText('Pro');
+	await expect(page.getByTestId('billing-checkout-total')).toHaveText('$10.00');
+	await expect(page).toHaveURL(/\/en\/pricing\?/);
+
+	const confirm = page.getByTestId('billing-checkout-confirm');
+	await confirm.click();
+
+	const { args } = await billing.attachRequested;
+	expect(args?.[0]).toMatchObject({
+		productId: 'pro',
+		successUrl: expect.stringContaining('upgraded=true')
+	});
+
+	// While the charge is in flight the dialog must hold: both buttons locked
+	// and Escape ignored, so a second click cannot double-charge.
+	await expect(confirm).toBeDisabled();
+	// bits-ui refuses the click but never renders the attribute, so the state
+	// is asserted the way assistive tech reads it.
+	await expect(page.getByTestId('billing-checkout-cancel')).toHaveAttribute(
+		'aria-disabled',
+		'true'
+	);
+	await page.keyboard.press('Escape');
+	await expect(dialog).toBeVisible();
+
+	billing.resolveAttach({
+		data: {
+			customer_id: 'e2e-customer',
+			product_ids: ['pro'],
+			code: 'attached',
+			message: 'Product attached'
+		}
+	});
+
+	await expect(dialog).toBeHidden({ timeout: 10000 });
+	await expect(page).toHaveURL(/\/en\/pricing\?/);
+});
+
+test('a failed confirmation reports the error and keeps the dialog open', async ({ page }) => {
+	const billing = await interceptBilling(page);
+
+	await page.goto('/en/app/community-chat');
+	await page.waitForLoadState('networkidle');
+
+	// Started from the user menu on purpose: the dialog is mounted in the root
+	// layout, so it has to survive the dropdown closing underneath it. The quota
+	// banner CTA is not usable here because a fresh test user still has messages.
+	await page.getByRole('button', { name: /E2E Test User/i }).click();
+	await page.getByRole('menuitem', { name: /Upgrade to Pro/i }).click();
+
+	const dialog = page.getByRole('alertdialog');
+	await expect(dialog).toBeVisible({ timeout: 10000 });
+
+	await page.getByTestId('billing-checkout-confirm').click();
+	await billing.attachRequested;
+
+	billing.resolveAttach({
+		error: { message: 'Card declined', code: 'card_declined' }
+	});
+
+	await expect(
+		page.locator('[data-sonner-toast]').filter({ hasText: /Could not complete the purchase/i })
+	).toBeVisible({ timeout: 10000 });
+
+	// The purchase never happened, so the customer has to be able to retry it.
+	await expect(dialog).toBeVisible();
+	await expect(page.getByTestId('billing-checkout-confirm')).toBeEnabled();
+});

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"@openrouter/ai-sdk-provider": "^2.9.0",
 		"@rive-app/canvas": "^2.32.0",
 		"@sentry/sveltekit": "^10.47.0",
-		"@stickerdaniel/convex-autumn-svelte": "^0.3.0",
+		"@stickerdaniel/convex-autumn-svelte": "^0.4.0",
 		"@svelte-put/lockscroll": "^2.0.1",
 		"@tolgee/format-icu": "^7.0.0",
 		"@tolgee/svelte": "^7.0.0",

--- a/src/blocks/pricing/pricing-three.svelte
+++ b/src/blocks/pricing/pricing-three.svelte
@@ -19,10 +19,10 @@
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
-	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
+	import { useBillingCheckout } from '$lib/components/billing';
 
-	const { customer, checkout, openBillingPortal } = useCustomer();
-	const upgradeOperation = useAutumnOperation(checkout);
+	const { customer, openBillingPortal } = useCustomer();
+	const billingCheckout = useBillingCheckout();
 	const portalOperation = useAutumnOperation(openBillingPortal);
 	const { isAuthenticated } = useAuth();
 
@@ -37,10 +37,6 @@
 
 	// Get translation function
 	const { t } = getTranslate();
-
-	// Consulted before navigations this component starts on the user's behalf,
-	// so an in-flight upload elsewhere on the page cannot stop them.
-	const activeUploads = activeUploadsContext.getOr(null);
 
 	// Helper function to get non-empty feature keys for a tier.
 	// Hard-coded indices are intentional: a dynamic loop (incrementing until empty)
@@ -77,20 +73,7 @@
 		// Proceed with checkout for authenticated users
 		const successUrl = new URL(localizedHref('/app/community-chat'), page.url.origin);
 		successUrl.searchParams.set('upgraded', 'true');
-		const result = await upgradeOperation.execute({
-			productId,
-			successUrl: successUrl.href
-		});
-
-		if (result?.url) {
-			// The checkout session already exists; see nav-user.svelte.
-			activeUploads?.suspendOnce();
-			window.location.href = result.url;
-		} else if (upgradeOperation.error) {
-			haptic.trigger('error');
-			toast.error($t('billing.checkout_failed'));
-			console.error('Checkout failed:', upgradeOperation.error);
-		}
+		await billingCheckout.start({ productId, successUrl: successUrl.href });
 	}
 
 	async function handleManageBilling() {
@@ -211,9 +194,9 @@
 							data-testid="pricing-checkout-pro"
 							class="mt-4 w-full"
 							onclick={() => handleCheckout('pro')}
-							disabled={upgradeOperation.isLoading}
+							disabled={billingCheckout.isLoading}
 						>
-							{#if upgradeOperation.isLoading}
+							{#if billingCheckout.isLoading}
 								<T keyName="pricing.tiers.pro.button_loading" />
 							{:else}
 								<T keyName="pricing.tiers.pro.button" />

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -462,7 +462,17 @@
 	},
 	"billing": {
 		"checkout_failed": "Bezahlvorgang fehlgeschlagen. Bitte versuchen Sie es erneut.",
-		"portal_failed": "Abrechnungsportal konnte nicht geöffnet werden. Bitte versuchen Sie es erneut."
+		"portal_failed": "Abrechnungsportal konnte nicht geöffnet werden. Bitte versuchen Sie es erneut.",
+		"attach_failed": "Kauf konnte nicht abgeschlossen werden. Bitte versuchen Sie es erneut.",
+		"confirmation": {
+			"title": "Kauf bestätigen",
+			"description": "Prüfen Sie die Kosten für {planName}, bevor Sie bestätigen.",
+			"product": "Tarif",
+			"quantity": "{featureId} enthalten",
+			"due_today": "Heute fällig",
+			"due_next_cycle": "Fällig am {date}",
+			"proration_details": "Der Betrag ist anteilig für den Rest des laufenden Abrechnungszeitraums berechnet."
+		}
 	},
 	"chat": {
 		"action": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -462,7 +462,17 @@
 	},
 	"billing": {
 		"checkout_failed": "Checkout failed. Please try again.",
-		"portal_failed": "Could not open billing portal. Please try again."
+		"portal_failed": "Could not open billing portal. Please try again.",
+		"attach_failed": "Could not complete the purchase. Please try again.",
+		"confirmation": {
+			"title": "Confirm your purchase",
+			"description": "Review the charges for {planName} before confirming.",
+			"product": "Plan",
+			"quantity": "{featureId} included",
+			"due_today": "Due today",
+			"due_next_cycle": "Due on {date}",
+			"proration_details": "The amount is prorated for the rest of the current billing period."
+		}
 	},
 	"chat": {
 		"action": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -462,7 +462,17 @@
 	},
 	"billing": {
 		"checkout_failed": "Error en el pago. Por favor, inténtalo de nuevo.",
-		"portal_failed": "No se pudo abrir el portal de facturación. Por favor, inténtalo de nuevo."
+		"portal_failed": "No se pudo abrir el portal de facturación. Por favor, inténtalo de nuevo.",
+		"attach_failed": "No se pudo completar la compra. Por favor, inténtalo de nuevo.",
+		"confirmation": {
+			"title": "Confirma tu compra",
+			"description": "Revisa los cargos de {planName} antes de confirmar.",
+			"product": "Plan",
+			"quantity": "{featureId} incluidos",
+			"due_today": "A pagar hoy",
+			"due_next_cycle": "A pagar el {date}",
+			"proration_details": "El importe se prorratea por el resto del periodo de facturación actual."
+		}
 	},
 	"chat": {
 		"action": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -462,7 +462,17 @@
 	},
 	"billing": {
 		"checkout_failed": "Échec du paiement. Veuillez réessayer.",
-		"portal_failed": "Impossible d'ouvrir le portail de facturation. Veuillez réessayer."
+		"portal_failed": "Impossible d'ouvrir le portail de facturation. Veuillez réessayer.",
+		"attach_failed": "Impossible de finaliser l'achat. Veuillez réessayer.",
+		"confirmation": {
+			"title": "Confirmez votre achat",
+			"description": "Vérifiez les frais pour {planName} avant de confirmer.",
+			"product": "Formule",
+			"quantity": "{featureId} inclus",
+			"due_today": "À payer aujourd'hui",
+			"due_next_cycle": "À payer le {date}",
+			"proration_details": "Le montant est calculé au prorata du reste de la période de facturation en cours."
+		}
 	},
 	"chat": {
 		"action": {

--- a/src/lib/billing/checkout-result.test.ts
+++ b/src/lib/billing/checkout-result.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import type { CheckoutResult } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
+import { getAttachCheckoutUrl, getCheckoutOutcome } from './checkout-result';
+
+function product(id: string, usageModel?: 'prepaid' | 'pay_per_use') {
+	return {
+		id,
+		name: id === 'pro' ? 'Pro' : 'Free',
+		created_at: 1_735_689_600_000,
+		env: 'sandbox',
+		is_add_on: false,
+		is_default: id === 'free',
+		group: 'main',
+		version: 1,
+		items: usageModel ? [{ feature_id: 'seats', usage_model: usageModel }] : [],
+		free_trial: null,
+		base_variant_id: null,
+		properties: {
+			is_free: id === 'free',
+			is_one_off: false,
+			interval_group: 'month',
+			has_trial: false,
+			updateable: true
+		}
+	};
+}
+
+function preview(overrides: Partial<CheckoutResult> = {}): CheckoutResult {
+	return {
+		url: null,
+		customer_id: 'customer_1',
+		has_prorations: false,
+		lines: [{ description: 'Pro - $10 / month', amount: 10, item: {} }],
+		total: 10,
+		currency: 'usd',
+		options: [],
+		product: product('pro'),
+		current_product: product('free'),
+		...overrides
+	} as CheckoutResult;
+}
+
+describe('getCheckoutOutcome', () => {
+	it('redirects when Autumn hands back a hosted session', () => {
+		expect(
+			getCheckoutOutcome(preview({ url: 'https://checkout.stripe.com/c/pay/cs_test' }))
+		).toEqual({ kind: 'redirect', url: 'https://checkout.stripe.com/c/pay/cs_test' });
+	});
+
+	// The live API answers null here while the installed types promise
+	// string | undefined. Both spellings, and an empty string, mean the same
+	// thing: there is nothing to redirect to, so confirm the preview instead.
+	it.each([
+		['null', null],
+		['undefined', undefined],
+		['an empty string', '']
+	])('asks for confirmation when the url is %s', (_label, url) => {
+		const result = preview({ url: url as CheckoutResult['url'] });
+		expect(getCheckoutOutcome(result)).toEqual({
+			kind: 'confirm',
+			preview: result,
+			options: []
+		});
+	});
+
+	// Autumn's own client shows its dialog whenever prepaid items are involved:
+	// the customer has to see the quantities before they are charged.
+	it('asks for confirmation for prepaid purchases even with a url', () => {
+		const result = preview({
+			url: 'https://checkout.stripe.com/c/pay/cs_test',
+			product: product('pro', 'prepaid') as CheckoutResult['product'],
+			options: [{ feature_id: 'seats', quantity: 5 }]
+		});
+
+		expect(getCheckoutOutcome(result)).toMatchObject({ kind: 'confirm' });
+	});
+
+	it('carries prepaid quantities over in the shape attach expects', () => {
+		const result = preview({
+			options: [
+				{ feature_id: 'seats', quantity: 5 },
+				{ feature_id: 'credits', quantity: 100 }
+			]
+		});
+
+		expect(getCheckoutOutcome(result)).toMatchObject({
+			options: [
+				{ featureId: 'seats', quantity: 5 },
+				{ featureId: 'credits', quantity: 100 }
+			]
+		});
+	});
+
+	// A half-formed answer used to fall through every branch and leave the
+	// button idle with no explanation. It has to be a visible failure now.
+	it.each([
+		['no product', { product: undefined }],
+		['no lines', { lines: undefined }]
+	])('reports failure for a preview with %s', (_label, overrides) => {
+		expect(getCheckoutOutcome(preview(overrides as Partial<CheckoutResult>))).toEqual({
+			kind: 'failed'
+		});
+	});
+});
+
+describe('getAttachCheckoutUrl', () => {
+	it('surfaces the hosted page when the stored card could not be charged', () => {
+		expect(getAttachCheckoutUrl({ checkout_url: 'https://checkout.test/x' } as never)).toBe(
+			'https://checkout.test/x'
+		);
+	});
+
+	it.each([
+		['null', null],
+		['undefined', undefined],
+		['an empty string', '']
+	])('returns null when checkout_url is %s', (_label, value) => {
+		expect(getAttachCheckoutUrl({ checkout_url: value } as never)).toBeNull();
+	});
+});

--- a/src/lib/billing/checkout-result.ts
+++ b/src/lib/billing/checkout-result.ts
@@ -1,0 +1,75 @@
+import type { AttachResult, CheckoutResult } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
+
+/** A prepaid feature quantity, in the camelCase form the attach action wants. */
+export type CheckoutAttachOption = { featureId: string; quantity: number };
+
+/**
+ * What to do with an Autumn checkout answer.
+ *
+ * `confirm` carries the preview untouched so the dialog can render it and the
+ * attach call can reuse the same quantities.
+ */
+export type CheckoutOutcome =
+	| { kind: 'redirect'; url: string }
+	| { kind: 'confirm'; preview: CheckoutResult; options: CheckoutAttachOption[] }
+	| { kind: 'failed' };
+
+/**
+ * The one place that reconciles the declared URL type with the live one.
+ *
+ * Autumn declares `url` as `string | undefined`, but the API answers `null`
+ * whenever the purchase needs an in-app confirmation instead of a hosted
+ * session. Treating anything that is not a usable string as absent keeps that
+ * discrepancy from leaking into the call sites, where it previously turned
+ * into a button that did nothing at all.
+ */
+function normalizeUrl(value: unknown): string | null {
+	return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** Whether a purchase charges prepaid quantities the customer has to confirm. */
+function hasPrepaidItem(preview: CheckoutResult): boolean {
+	return (preview.product?.items ?? []).some((item) => item.usage_model === 'prepaid');
+}
+
+/**
+ * Decide how to complete a checkout.
+ *
+ * Autumn has two success shapes and the difference is not an error: a hosted
+ * Stripe session to redirect to, or a preview to confirm in the app and
+ * complete with `attach`. Prepaid purchases always take the confirmation path,
+ * even when a URL is present, because the customer has to see the quantities
+ * being charged — this mirrors Autumn's own React client, which opens its
+ * dialog whenever a prepaid item is involved and a dialog is available.
+ *
+ * A preview missing the fields the dialog and the attach call depend on is
+ * reported as `failed` rather than rendered half-empty.
+ */
+export function getCheckoutOutcome(result: CheckoutResult): CheckoutOutcome {
+	if (!result?.product?.id || !Array.isArray(result.lines)) {
+		return { kind: 'failed' };
+	}
+
+	const url = normalizeUrl(result.url);
+	if (url && !hasPrepaidItem(result)) {
+		return { kind: 'redirect', url };
+	}
+
+	const options = (result.options ?? []).map((option) => ({
+		featureId: option.feature_id,
+		quantity: option.quantity
+	}));
+
+	return { kind: 'confirm', preview: result, options };
+}
+
+/**
+ * The hosted page an attach still needs, if any.
+ *
+ * Autumn returns `checkout_url` when the stored payment method could not be
+ * charged after all. Ignoring it would leave the purchase unfinished and
+ * silent, which is the failure this whole flow exists to remove.
+ */
+export function getAttachCheckoutUrl(result: AttachResult): string | null {
+	return normalizeUrl(result?.checkout_url);
+}

--- a/src/lib/components/billing/checkout-context.svelte.ts
+++ b/src/lib/components/billing/checkout-context.svelte.ts
@@ -1,0 +1,238 @@
+import { Context } from 'runed';
+import type { AttachResult, CheckoutResult } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
+import {
+	getAttachCheckoutUrl,
+	getCheckoutOutcome,
+	type CheckoutAttachOption
+} from '$lib/billing/checkout-result';
+
+/** Everything a call site knows about the purchase it wants to start. */
+export type CheckoutStartParams = {
+	productId: string;
+	successUrl?: string;
+	[key: string]: unknown;
+};
+
+/**
+ * The two Autumn calls, as `useAutumnOperation` exposes them.
+ *
+ * Typed structurally rather than against the wrapper so the manager can be
+ * driven by fakes in tests: `execute` resolves to `null` when the underlying
+ * action throws, and the matching `error` holds the reason.
+ */
+type Operation<TParams, TResult> = {
+	readonly isLoading: boolean;
+	readonly error: Error | null;
+	execute: (params: TParams) => Promise<TResult | null>;
+};
+
+export type BillingCheckoutDeps = {
+	checkout: Operation<CheckoutStartParams, CheckoutResult>;
+	attach: Operation<CheckoutStartParams, AttachResult>;
+	/** Leaves the document. Suspends the upload guard first. */
+	redirect: (url: string) => void;
+	onError: (stage: 'checkout' | 'confirm', error: Error | null) => void;
+};
+
+/**
+ * Drives Autumn's two-step purchase across every upgrade button in the app.
+ *
+ * Autumn answers a checkout either with a hosted Stripe session or with a
+ * preview that has to be confirmed in the app and completed with `attach`.
+ * Both endings live here so no call site can handle one and forget the other,
+ * which is exactly how the upgrade button used to fail: silently.
+ */
+export class BillingCheckoutManager {
+	#deps: BillingCheckoutDeps;
+	#open = $state(false);
+	#preview = $state.raw<CheckoutResult | null>(null);
+	#options = $state.raw<CheckoutAttachOption[]>([]);
+	#updating = $state(false);
+	// A purchase is money: two overlapping calls must not both go through, and
+	// an answer that arrives after the user moved on must not be applied.
+	// `useAutumnOperation` only toggles a boolean around its call, so the
+	// serialisation lives here. #inFlight is set before the first await;
+	// #generation invalidates anything a cancel or a newer start superseded.
+	#inFlight = false;
+	#generation = 0;
+	// The parameters the purchase started with. Confirming reuses them so
+	// successUrl and any caller-specific extras survive into the attach call.
+	#params: CheckoutStartParams | null = null;
+
+	constructor(deps: BillingCheckoutDeps) {
+		this.#deps = deps;
+	}
+
+	get open(): boolean {
+		return this.#open;
+	}
+
+	get preview(): CheckoutResult | null {
+		return this.#preview;
+	}
+
+	get options(): CheckoutAttachOption[] {
+		return this.#options;
+	}
+
+	get isAttaching(): boolean {
+		return this.#deps.attach.isLoading;
+	}
+
+	/** True while an open preview is being re-priced for new quantities. */
+	get isUpdating(): boolean {
+		return this.#updating;
+	}
+
+	/**
+	 * True while a call is in flight, false while the open dialog waits for the
+	 * user. Upgrade buttons bind to this, and a spinner behind a modal that is
+	 * waiting on a decision would be a lie.
+	 */
+	get isLoading(): boolean {
+		return this.#deps.checkout.isLoading || this.#deps.attach.isLoading;
+	}
+
+	async start(params: CheckoutStartParams): Promise<void> {
+		if (this.#inFlight) return;
+
+		this.#clear();
+		const generation = this.#generation;
+		this.#inFlight = true;
+
+		try {
+			const result = await this.#deps.checkout.execute(params);
+			if (generation !== this.#generation) return;
+
+			if (!result) {
+				this.#deps.onError('checkout', this.#deps.checkout.error);
+				return;
+			}
+
+			const outcome = getCheckoutOutcome(result);
+			if (outcome.kind === 'failed') {
+				this.#deps.onError('checkout', new Error('Checkout returned an unusable preview'));
+				return;
+			}
+
+			if (outcome.kind === 'redirect') {
+				this.#deps.redirect(outcome.url);
+				return;
+			}
+
+			this.#params = params;
+			this.#preview = outcome.preview;
+			this.#options = outcome.options;
+			this.#open = true;
+		} finally {
+			this.#inFlight = false;
+		}
+	}
+
+	async confirm(): Promise<void> {
+		const preview = this.#preview;
+		const params = this.#params;
+		if (!preview || !params || this.#inFlight) return;
+
+		const generation = this.#generation;
+		this.#inFlight = true;
+
+		try {
+			const result = await this.#deps.attach.execute({
+				...params,
+				productId: preview.product.id,
+				options: this.#options
+			});
+			if (generation !== this.#generation) return;
+
+			if (!result) {
+				// Keep the dialog and its preview so the purchase can be retried.
+				this.#deps.onError('confirm', this.#deps.attach.error);
+				return;
+			}
+
+			const checkoutUrl = getAttachCheckoutUrl(result);
+			if (checkoutUrl) {
+				this.#deps.redirect(checkoutUrl);
+				return;
+			}
+
+			this.#clear();
+		} finally {
+			this.#inFlight = false;
+		}
+	}
+
+	/**
+	 * Re-price the open preview for different prepaid quantities.
+	 *
+	 * Nothing in this template renders quantity inputs, because none of its
+	 * plans sell prepaid items. Forks that do can wire an editor to this
+	 * without touching the shared flow.
+	 */
+	async updateOptions(options: CheckoutAttachOption[]): Promise<void> {
+		const params = this.#params;
+		if (!params || this.#inFlight) return;
+
+		const generation = this.#generation;
+		this.#inFlight = true;
+		this.#updating = true;
+
+		try {
+			const result = await this.#deps.checkout.execute({ ...params, options });
+			if (generation !== this.#generation) return;
+
+			if (!result) {
+				this.#deps.onError('checkout', this.#deps.checkout.error);
+				return;
+			}
+
+			const outcome = getCheckoutOutcome(result);
+			if (outcome.kind !== 'confirm') return;
+
+			this.#preview = outcome.preview;
+			this.#options = outcome.options;
+		} finally {
+			this.#inFlight = false;
+			this.#updating = false;
+		}
+	}
+
+	cancel(): void {
+		this.setOpen(false);
+	}
+
+	/**
+	 * Closing is refused while the purchase is being charged.
+	 *
+	 * Escape and the cancel button both land here, and the dialog is bound
+	 * through a function so the child cannot close itself past this guard.
+	 */
+	setOpen(open: boolean): void {
+		if (open) {
+			this.#open = true;
+			return;
+		}
+		if (this.isAttaching) return;
+		this.#clear();
+	}
+
+	#clear(): void {
+		// Anything still in flight belongs to a purchase the user left behind.
+		this.#generation += 1;
+		this.#open = false;
+		this.#preview = null;
+		this.#options = [];
+		this.#params = null;
+	}
+}
+
+const billingCheckoutContext = new Context<BillingCheckoutManager>('billing-checkout');
+
+export function setBillingCheckoutContext(deps: BillingCheckoutDeps): BillingCheckoutManager {
+	return billingCheckoutContext.set(new BillingCheckoutManager(deps));
+}
+
+export function useBillingCheckout(): BillingCheckoutManager {
+	return billingCheckoutContext.get();
+}

--- a/src/lib/components/billing/checkout-context.test.ts
+++ b/src/lib/components/billing/checkout-context.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AttachResult, CheckoutResult } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
+import { BillingCheckoutManager, type BillingCheckoutDeps } from './checkout-context.svelte.ts';
+
+function product(id: string) {
+	return {
+		id,
+		name: id === 'pro' ? 'Pro' : 'Free',
+		created_at: 1_735_689_600_000,
+		env: 'sandbox',
+		is_add_on: false,
+		is_default: id === 'free',
+		group: 'main',
+		version: 1,
+		items: [],
+		free_trial: null,
+		base_variant_id: null,
+		properties: {
+			is_free: id === 'free',
+			is_one_off: false,
+			interval_group: 'month',
+			has_trial: false,
+			updateable: true
+		}
+	};
+}
+
+function preview(overrides: Partial<CheckoutResult> = {}): CheckoutResult {
+	return {
+		url: null,
+		customer_id: 'customer_1',
+		has_prorations: false,
+		lines: [{ description: 'Pro - $10 / month', amount: 10, item: {} }],
+		total: 10,
+		currency: 'usd',
+		options: [],
+		product: product('pro'),
+		current_product: product('free'),
+		...overrides
+	} as CheckoutResult;
+}
+
+/** A stand-in for `useAutumnOperation`: resolves to null when it "throws". */
+function operation<T>(result: T | null, error: Error | null = null) {
+	const state = {
+		isLoading: false,
+		error,
+		execute: vi.fn(async () => {
+			state.isLoading = true;
+			try {
+				return result;
+			} finally {
+				state.isLoading = false;
+			}
+		})
+	};
+	return state;
+}
+
+/** An operation whose call can be released by the test, one await at a time. */
+function deferredOperation<T>(result: T | null, error: Error | null = null) {
+	const releases: Array<() => void> = [];
+	const state = {
+		isLoading: false,
+		error,
+		calls: 0,
+		execute: vi.fn(async () => {
+			state.calls += 1;
+			state.isLoading = true;
+			await new Promise<void>((resolve) => releases.push(resolve));
+			state.isLoading = false;
+			return result;
+		}),
+		releaseAll: () => releases.splice(0).forEach((release) => release())
+	};
+	return state;
+}
+
+function setup(overrides: Partial<BillingCheckoutDeps> = {}) {
+	const deps = {
+		checkout: operation<CheckoutResult>(preview()),
+		attach: operation<AttachResult>({
+			customer_id: 'customer_1',
+			product_ids: ['pro'],
+			code: 'attached',
+			message: 'ok'
+		} as AttachResult),
+		redirect: vi.fn(),
+		onError: vi.fn(),
+		...overrides
+	} as unknown as BillingCheckoutDeps & {
+		checkout: ReturnType<typeof operation<CheckoutResult>>;
+		attach: ReturnType<typeof operation<AttachResult>>;
+		redirect: ReturnType<typeof vi.fn>;
+		onError: ReturnType<typeof vi.fn>;
+	};
+
+	return { deps, manager: new BillingCheckoutManager(deps) };
+}
+
+describe('BillingCheckoutManager.start', () => {
+	it('reports a thrown checkout instead of leaving the button silent', async () => {
+		const boom = new Error('network');
+		const { deps, manager } = setup({ checkout: operation<CheckoutResult>(null, boom) as never });
+
+		await manager.start({ productId: 'pro' });
+
+		expect(deps.onError).toHaveBeenCalledWith('checkout', boom);
+		expect(manager.open).toBe(false);
+		expect(deps.redirect).not.toHaveBeenCalled();
+	});
+
+	it('reports an unusable preview rather than opening an empty dialog', async () => {
+		const { deps, manager } = setup({
+			checkout: operation<CheckoutResult>(preview({ product: undefined })) as never
+		});
+
+		await manager.start({ productId: 'pro' });
+
+		expect(deps.onError).toHaveBeenCalledWith('checkout', expect.any(Error));
+		expect(manager.open).toBe(false);
+	});
+
+	it('redirects to a hosted session without opening the dialog', async () => {
+		const url = 'https://checkout.stripe.com/c/pay/cs_test';
+		const { deps, manager } = setup({
+			checkout: operation<CheckoutResult>(preview({ url })) as never
+		});
+
+		await manager.start({ productId: 'pro' });
+
+		expect(deps.redirect).toHaveBeenCalledWith(url);
+		expect(manager.open).toBe(false);
+	});
+
+	it('opens the dialog with the preview when there is no hosted session', async () => {
+		const { manager } = setup({
+			checkout: operation<CheckoutResult>(
+				preview({ options: [{ feature_id: 'seats', quantity: 3 }] })
+			) as never
+		});
+
+		await manager.start({ productId: 'pro' });
+
+		expect(manager.open).toBe(true);
+		expect(manager.preview?.product.id).toBe('pro');
+		expect(manager.options).toEqual([{ featureId: 'seats', quantity: 3 }]);
+		// Nothing is in flight while the dialog waits for a decision, so the
+		// buttons behind it must not sit there spinning.
+		expect(manager.isLoading).toBe(false);
+	});
+});
+
+describe('BillingCheckoutManager.confirm', () => {
+	it('attaches the previewed product with the original parameters', async () => {
+		const { deps, manager } = setup({
+			checkout: operation<CheckoutResult>(
+				preview({ options: [{ feature_id: 'seats', quantity: 3 }] })
+			) as never
+		});
+
+		await manager.start({ productId: 'pro', successUrl: 'https://app.test/done' });
+		await manager.confirm();
+
+		expect(deps.attach.execute).toHaveBeenCalledWith({
+			productId: 'pro',
+			successUrl: 'https://app.test/done',
+			options: [{ featureId: 'seats', quantity: 3 }]
+		});
+		expect(manager.open).toBe(false);
+	});
+
+	it('follows the hosted page when the stored card could not be charged', async () => {
+		const { deps, manager } = setup({
+			attach: operation<AttachResult>({
+				customer_id: 'customer_1',
+				product_ids: ['pro'],
+				code: 'checkout_created',
+				message: 'Payment required',
+				checkout_url: 'https://checkout.test/attach'
+			} as AttachResult) as never
+		});
+
+		await manager.start({ productId: 'pro' });
+		await manager.confirm();
+
+		expect(deps.redirect).toHaveBeenCalledWith('https://checkout.test/attach');
+	});
+
+	it('keeps the dialog open so a failed purchase can be retried', async () => {
+		const boom = new Error('declined');
+		const { deps, manager } = setup({ attach: operation<AttachResult>(null, boom) as never });
+
+		await manager.start({ productId: 'pro' });
+		await manager.confirm();
+
+		expect(deps.onError).toHaveBeenCalledWith('confirm', boom);
+		expect(manager.open).toBe(true);
+		expect(manager.preview).not.toBeNull();
+	});
+});
+
+describe('BillingCheckoutManager closing', () => {
+	it('refuses to close while the purchase is being charged', async () => {
+		const { deps, manager } = setup();
+		await manager.start({ productId: 'pro' });
+
+		deps.attach.isLoading = true;
+		manager.setOpen(false);
+
+		expect(manager.open).toBe(true);
+	});
+
+	it('closes and forgets the preview once nothing is in flight', async () => {
+		const { manager } = setup();
+		await manager.start({ productId: 'pro' });
+
+		manager.cancel();
+
+		expect(manager.open).toBe(false);
+		expect(manager.preview).toBeNull();
+	});
+});
+
+describe('BillingCheckoutManager.updateOptions', () => {
+	it('re-prices the open preview for new quantities', async () => {
+		const first = preview({ options: [{ feature_id: 'seats', quantity: 3 }] });
+		const second = preview({ total: 20, options: [{ feature_id: 'seats', quantity: 6 }] });
+		const checkout = operation<CheckoutResult>(first);
+		const { deps, manager } = setup({ checkout: checkout as never });
+
+		await manager.start({ productId: 'pro' });
+		checkout.execute.mockResolvedValueOnce(second);
+		await manager.updateOptions([{ featureId: 'seats', quantity: 6 }]);
+
+		expect(deps.checkout.execute).toHaveBeenLastCalledWith({
+			productId: 'pro',
+			options: [{ featureId: 'seats', quantity: 6 }]
+		});
+		expect(manager.preview?.total).toBe(20);
+		expect(manager.options).toEqual([{ featureId: 'seats', quantity: 6 }]);
+		expect(manager.open).toBe(true);
+	});
+});
+
+describe('BillingCheckoutManager concurrency', () => {
+	// A purchase is money. Two clicks that slip through before the button
+	// disables must not turn into two charges.
+	it('charges once when confirm is invoked twice', async () => {
+		const attach = deferredOperation<AttachResult>({
+			customer_id: 'customer_1',
+			product_ids: ['pro'],
+			code: 'attached',
+			message: 'ok'
+		} as AttachResult);
+		const { manager } = setup({ attach: attach as never });
+
+		await manager.start({ productId: 'pro' });
+		const first = manager.confirm();
+		const second = manager.confirm();
+		attach.releaseAll();
+		await Promise.all([first, second]);
+
+		expect(attach.calls).toBe(1);
+	});
+
+	it('ignores a second start while the first is still running', async () => {
+		const checkout = deferredOperation<CheckoutResult>(preview());
+		const { manager } = setup({ checkout: checkout as never });
+
+		const first = manager.start({ productId: 'pro' });
+		const second = manager.start({ productId: 'pro' });
+		checkout.releaseAll();
+		await Promise.all([first, second]);
+
+		expect(checkout.calls).toBe(1);
+	});
+
+	// Closing the dialog abandons the purchase; an answer that lands afterwards
+	// must not resurrect it.
+	it('discards a checkout answer the user already walked away from', async () => {
+		const checkout = deferredOperation<CheckoutResult>(preview());
+		const { manager } = setup({ checkout: checkout as never });
+
+		const pending = manager.start({ productId: 'pro' });
+		manager.cancel();
+		checkout.releaseAll();
+		await pending;
+
+		expect(manager.open).toBe(false);
+		expect(manager.preview).toBeNull();
+	});
+
+	it('refuses to confirm stale quantities while a re-price is in flight', async () => {
+		const checkout = deferredOperation<CheckoutResult>(preview());
+		const { deps, manager } = setup({ checkout: checkout as never });
+
+		const started = manager.start({ productId: 'pro' });
+		checkout.releaseAll();
+		await started;
+
+		const updating = manager.updateOptions([{ featureId: 'seats', quantity: 6 }]);
+		expect(manager.isUpdating).toBe(true);
+		await manager.confirm();
+		expect(deps.attach.execute).not.toHaveBeenCalled();
+
+		checkout.releaseAll();
+		await updating;
+		expect(manager.isUpdating).toBe(false);
+	});
+});

--- a/src/lib/components/billing/checkout-dialog.svelte
+++ b/src/lib/components/billing/checkout-dialog.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+	import * as AlertDialog from '$lib/components/ui/alert-dialog';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
+	import { getTranslate } from '@tolgee/svelte';
+	import { languageContext } from '$lib/i18n/context';
+	import { DEFAULT_LANGUAGE } from '$lib/i18n/languages';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+	import { useBillingCheckout } from './checkout-context.svelte.ts';
+
+	const checkout = useBillingCheckout();
+	const { t } = getTranslate();
+
+	// The context holds a getter, not a snapshot: this dialog is mounted once in
+	// the root layout and outlives language switches, so reading it eagerly
+	// would pin currency and date formatting to whatever locale loaded first.
+	const getLang = languageContext.getOr(() => DEFAULT_LANGUAGE);
+	const locale = $derived(getLang());
+
+	const preview = $derived(checkout.preview);
+
+	function money(amount: number, currency: string): string {
+		return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(amount);
+	}
+
+	function cycleStart(startsAt: number): string {
+		return new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(new Date(startsAt));
+	}
+</script>
+
+<AlertDialog.Root bind:open={() => checkout.open, (open) => checkout.setOpen(open)}>
+	<AlertDialog.Content>
+		{#if preview}
+			<AlertDialog.Header>
+				<AlertDialog.Title>{$t('billing.confirmation.title')}</AlertDialog.Title>
+				<AlertDialog.Description>
+					{$t('billing.confirmation.description', { planName: preview.product.name })}
+				</AlertDialog.Description>
+			</AlertDialog.Header>
+
+			<dl class="flex flex-col gap-2 text-sm">
+				<div class="flex items-center justify-between gap-4">
+					<dt class="text-muted-foreground">{$t('billing.confirmation.product')}</dt>
+					<dd class="font-medium">{preview.product.name}</dd>
+				</div>
+
+				{#each checkout.options as option (option.featureId)}
+					<div class="flex items-center justify-between gap-4">
+						<dt class="text-muted-foreground">
+							{$t('billing.confirmation.quantity', { featureId: option.featureId })}
+						</dt>
+						<dd>{option.quantity}</dd>
+					</div>
+				{/each}
+
+				<!-- Keyed by object identity: two lines can carry the same wording, and a
+				     duplicate key is a runtime crash. -->
+				{#each preview.lines as line (line)}
+					<div class="flex items-start justify-between gap-4">
+						<dt class="text-muted-foreground">{line.description}</dt>
+						<dd>{money(line.amount, preview.currency)}</dd>
+					</div>
+				{/each}
+
+				<div class="flex items-center justify-between gap-4 border-t pt-2 font-medium">
+					<dt>{$t('billing.confirmation.due_today')}</dt>
+					<dd data-testid="billing-checkout-total">{money(preview.total, preview.currency)}</dd>
+				</div>
+
+				{#if preview.next_cycle}
+					<div class="flex items-center justify-between gap-4">
+						<dt class="text-muted-foreground">
+							{$t('billing.confirmation.due_next_cycle', {
+								date: cycleStart(preview.next_cycle.starts_at)
+							})}
+						</dt>
+						<dd>{money(preview.next_cycle.total, preview.currency)}</dd>
+					</div>
+				{/if}
+			</dl>
+
+			{#if preview.has_prorations}
+				<p class="text-sm text-muted-foreground">
+					{$t('billing.confirmation.proration_details')}
+				</p>
+			{/if}
+
+			<AlertDialog.Footer>
+				<AlertDialog.Cancel
+					type="button"
+					disabled={checkout.isAttaching}
+					aria-disabled={checkout.isAttaching}
+					class="aria-disabled:pointer-events-none aria-disabled:opacity-50"
+					onclick={() => {
+						haptic.trigger('light');
+						checkout.cancel();
+					}}
+					data-testid="billing-checkout-cancel"
+				>
+					{$t('common.cancel')}
+				</AlertDialog.Cancel>
+				<AlertDialog.Action
+					type="button"
+					disabled={checkout.isAttaching || checkout.isUpdating}
+					onclick={() => {
+						haptic.trigger('light');
+						checkout.confirm();
+					}}
+					data-testid="billing-checkout-confirm"
+				>
+					{#if checkout.isAttaching}
+						<LoaderCircleIcon class="size-4 motion-safe:animate-spin" />
+					{/if}
+					{$t('common.confirm')}
+				</AlertDialog.Action>
+			</AlertDialog.Footer>
+		{/if}
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/lib/components/billing/checkout-provider.svelte
+++ b/src/lib/components/billing/checkout-provider.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { useCustomer, useAutumnOperation } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
+	import { getTranslate } from '@tolgee/svelte';
+	import { toast } from 'svelte-sonner';
+	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
+	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+	import CheckoutDialog from './checkout-dialog.svelte';
+	import { setBillingCheckoutContext } from './checkout-context.svelte.ts';
+
+	let { children } = $props();
+
+	const autumn = useCustomer();
+	const checkoutOperation = useAutumnOperation(autumn.checkout);
+	const attachOperation = useAutumnOperation(autumn.attach);
+	const activeUploads = activeUploadsContext.getOr(null);
+	const { t } = getTranslate();
+
+	setBillingCheckoutContext({
+		checkout: checkoutOperation,
+		attach: attachOperation,
+		redirect: (url) => {
+			// Leaving the document would otherwise trip the upload guard and
+			// strand the user on a purchase that already happened. Both the
+			// hosted checkout session and the attach fallback go through here.
+			activeUploads?.suspendOnce();
+			window.location.href = url;
+		},
+		onError: (stage, error) => {
+			haptic.trigger('error');
+			toast.error(
+				stage === 'confirm' ? $t('billing.attach_failed') : $t('billing.checkout_failed')
+			);
+			console.error(`[billing] ${stage} failed:`, error);
+		}
+	});
+</script>
+
+{@render children()}
+
+<CheckoutDialog />

--- a/src/lib/components/billing/index.ts
+++ b/src/lib/components/billing/index.ts
@@ -1,0 +1,3 @@
+export { default as CheckoutProvider } from './checkout-provider.svelte';
+export { useBillingCheckout, BillingCheckoutManager } from './checkout-context.svelte.ts';
+export type { BillingCheckoutDeps, CheckoutStartParams } from './checkout-context.svelte.ts';

--- a/src/lib/components/nav-user.svelte
+++ b/src/lib/components/nav-user.svelte
@@ -23,6 +23,7 @@
 	import { toast } from 'svelte-sonner';
 	import { useCustomer, useAutumnOperation } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
 	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
+	import { useBillingCheckout } from '$lib/components/billing';
 
 	const { t } = getTranslate();
 
@@ -44,7 +45,7 @@
 
 	// Autumn subscription state
 	const autumn = useCustomer();
-	const upgradeOperation = useAutumnOperation(autumn.checkout);
+	const billingCheckout = useBillingCheckout();
 	const portalOperation = useAutumnOperation(autumn.openBillingPortal);
 	const isPro = $derived(autumn.customer?.products?.some((p) => p.id === 'pro') ?? false);
 
@@ -63,20 +64,7 @@
 		haptic.trigger('light');
 		const successUrl = new URL(localizedHref('/app/community-chat'), page.url.origin);
 		successUrl.searchParams.set('upgraded', 'true');
-		const result = await upgradeOperation.execute({
-			productId: 'pro',
-			successUrl: successUrl.href
-		});
-		if (result?.url) {
-			// The checkout session already exists; prompting about an upload here
-			// would only leave the user on a page waiting for a redirect.
-			activeUploads?.suspendOnce();
-			window.location.href = result.url;
-		} else if (upgradeOperation.error) {
-			haptic.trigger('error');
-			toast.error($t('billing.checkout_failed'));
-			console.error('Checkout failed:', upgradeOperation.error);
-		}
+		await billingCheckout.start({ productId: 'pro', successUrl: successUrl.href });
 	}
 
 	async function handleBilling() {
@@ -167,8 +155,8 @@
 				<DropdownMenu.Separator />
 				{#if !isPro}
 					<DropdownMenu.Group>
-						<DropdownMenu.Item onclick={handleUpgrade} disabled={upgradeOperation.isLoading}>
-							{#if upgradeOperation.isLoading}
+						<DropdownMenu.Item onclick={handleUpgrade} disabled={billingCheckout.isLoading}>
+							{#if billingCheckout.isLoading}
 								<LoaderCircleIcon class="motion-safe:animate-spin" />
 							{:else}
 								<SparklesIcon />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
 		deployReloadTarget
 	} from '$lib/hooks/active-uploads.svelte.ts';
 	import UploadGuardNotice from '$lib/components/upload-guard-notice.svelte';
+	import CheckoutProvider from '$lib/components/billing/checkout-provider.svelte';
 	import { setGlobalSearchContext } from '$lib/components/global-search/context.svelte.ts';
 	import GlobalSearchShell from '$lib/components/global-search/global-search-shell.svelte';
 	import { languageContext } from '$lib/i18n/context';
@@ -176,7 +177,9 @@
 				<ClockSkewBanner />
 				<UploadGuardNotice />
 				<GlobalSearchShell />
-				{@render children()}
+				<CheckoutProvider>
+					{@render children()}
+				</CheckoutProvider>
 			</TolgeeProvider>
 		</Tooltip.Provider>
 	</AppAutumnProvider>

--- a/src/routes/[[lang]]/app/ai-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/+page.svelte
@@ -7,19 +7,14 @@
 	import { useQuery, useConvexClient } from 'convex-svelte';
 	import { api } from '$lib/convex/_generated/api';
 	import { ConvexError } from 'convex/values';
-	import { useCustomer, useAutumnOperation } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
+	import { useCustomer } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
 	import { getTranslate } from '@tolgee/svelte';
-	import { toast } from 'svelte-sonner';
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import ThreadChat from './thread-chat.svelte';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
-	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
+	import { useBillingCheckout } from '$lib/components/billing';
 
 	const { t } = getTranslate();
-
-	// Consulted before navigations this component starts on the user's behalf,
-	// so an in-flight upload elsewhere on the page cannot stop them.
-	const activeUploads = activeUploadsContext.getOr(null);
 
 	let { data } = $props();
 
@@ -30,7 +25,7 @@
 
 	// Pro check
 	const autumn = useCustomer();
-	const upgradeOperation = useAutumnOperation(autumn.checkout);
+	const billingCheckout = useBillingCheckout();
 	const isPro = $derived(autumn.customer?.products?.some((p) => p.id === 'pro') ?? false);
 	const aiChatFeature = $derived(autumn.customer?.features?.ai_chat_messages);
 	const remainingMessages = $derived(aiChatFeature?.balance ?? 0);
@@ -99,19 +94,7 @@
 		const successUrl = new URL(page.url.href);
 		successUrl.searchParams.delete('thread');
 		successUrl.searchParams.set('upgraded', 'true');
-		const result = await upgradeOperation.execute({
-			productId: 'pro',
-			successUrl: successUrl.href
-		});
-		if (result?.url) {
-			// The checkout session already exists; see nav-user.svelte.
-			activeUploads?.suspendOnce();
-			window.location.href = result.url;
-		} else if (upgradeOperation.error) {
-			haptic.trigger('error');
-			toast.error($t('billing.checkout_failed'));
-			console.error('Checkout failed:', upgradeOperation.error);
-		}
+		await billingCheckout.start({ productId: 'pro', successUrl: successUrl.href });
 	}
 </script>
 
@@ -131,7 +114,7 @@
 				{remainingMessages}
 				{totalMessages}
 				onUpgrade={handleUpgrade}
-				isUpgrading={upgradeOperation.isLoading}
+				isUpgrading={billingCheckout.isLoading}
 				onMessageSent={() => autumn.refetch()}
 			/>
 		{:else}

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -2,7 +2,7 @@
 	import { api } from '$lib/convex/_generated/api';
 	import SEOHead from '$lib/components/SEOHead.svelte';
 	import { useQuery, useConvexClient } from 'convex-svelte';
-	import { useCustomer, useAutumnOperation } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
+	import { useCustomer } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import {
 		PromptInput,
@@ -34,13 +34,9 @@
 	import type { OptimisticLocalStore } from 'convex/browser';
 	import { ConvexError } from 'convex/values';
 	import type { Id } from '$lib/convex/_generated/dataModel';
-	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
+	import { useBillingCheckout } from '$lib/components/billing';
 
 	const { t } = getTranslate();
-
-	// Consulted before navigations this component starts on the user's behalf,
-	// so an in-flight upload elsewhere on the page cannot stop them.
-	const activeUploads = activeUploadsContext.getOr(null);
 
 	let { data } = $props();
 
@@ -56,7 +52,7 @@
 
 	// Billing
 	const autumn = useCustomer();
-	const upgradeOperation = useAutumnOperation(autumn.checkout);
+	const billingCheckout = useBillingCheckout();
 	const isPro = $derived(autumn.customer?.products?.some((p) => p.id === 'pro') ?? false);
 	const messagesFeature = $derived(autumn.customer?.features?.messages);
 	const hasMessagesAvailable = $derived(isPro || (messagesFeature?.balance ?? 0) > 0);
@@ -207,19 +203,7 @@
 		haptic.trigger('light');
 		const successUrl = new URL(page.url.href);
 		successUrl.searchParams.set('upgraded', 'true');
-		const result = await upgradeOperation.execute({
-			productId: 'pro',
-			successUrl: successUrl.href
-		});
-		if (result?.url) {
-			// The checkout session already exists; see nav-user.svelte.
-			activeUploads?.suspendOnce();
-			window.location.href = result.url;
-		} else if (upgradeOperation.error) {
-			haptic.trigger('error');
-			toast.error($t('billing.checkout_failed'));
-			console.error('Checkout failed:', upgradeOperation.error);
-		}
+		await billingCheckout.start({ productId: 'pro', successUrl: successUrl.href });
 	}
 </script>
 
@@ -330,7 +314,7 @@
 				remaining={remainingMessages}
 				total={totalMessages}
 				onUpgrade={handleUpgrade}
-				isUpgrading={upgradeOperation.isLoading}
+				isUpgrading={billingCheckout.isLoading}
 			/>
 
 			<PromptInput


### PR DESCRIPTION
An upgrade could end in nothing at all. Autumn answers a checkout in one of two ways: with a hosted Stripe session, or with a purchase preview that has to be confirmed in the app and completed with `attach`. Every call site handled only the first and treated the second as neither success nor failure, so the button returned to idle with no Stripe, no error and no explanation. Reproduced in production against `saas.daniel.sticker.name` with a real session, and confirmed against the Autumn API: fresh customers get a `cs_test_…` URL, while one existing customer gets `"url": null` with an otherwise complete preview.

A shared flow now owns both endings. `getCheckoutOutcome` decides between redirecting, confirming and failing, and is the only place that reconciles the declared `url` type with the `null` the live API sends. `BillingCheckoutManager` runs the purchase and holds the preview; one dialog mounted in the root layout renders it and completes it with `attach`, following attach's own `checkout_url` when the stored card turns out not to be chargeable. Failures are reported instead of swallowed, and state transitions are serialised so two clicks cannot become two charges. Prepaid purchases take the confirmation path even when a URL is present, matching Autumn's own client, and the preview quantities are carried through to `attach` — this template sells none, but the seam is what forks with per-seat plans need. The upload guard is suspended centrally now, once for both the checkout redirect and the attach fallback.

Reading the preview at all needs `@stickerdaniel/convex-autumn-svelte` 0.4.0, which returns the full `CheckoutResult` from `checkout` and the `AttachResult` from `attach` (stickerdaniel/convex-autumn-svelte#39). That is published and required here.

Regression guard: added e2e/upgrade-checkout-confirmation.spec.ts

Verified with the full unit suite (1012 passing, 26 of them new), the full Playwright suite, and `bun scripts/static-checks.ts` on the changed files and `--scope types`.