### PR TITLE
feat(support): Disclose AI chat interaction

### DIFF
--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -252,7 +252,10 @@
 		</div>
 
 		<!-- EU AI Act Art. 50(1): disclose AI interaction at the latest at first
-			 interaction. Sits under the bar so it reads with the input, not the page. -->
+			 interaction. Visually shown on focus, when the interaction starts, so
+			 the idle pill stays quiet; stays in the accessibility tree throughout
+			 because it is only opacity-hidden. Sits under the bar so it reads
+			 with the input, not the page. -->
 		<p
 			class="ai-chatbar-disclosure pointer-events-none absolute top-full right-0 left-0 mt-1.5 text-center"
 		>
@@ -344,8 +347,11 @@
 		transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 	}
 	:global(.ai-chatbar-disclosure) {
-		opacity: 1;
+		opacity: 0;
 		transition: opacity 0.25s cubic-bezier(0.23, 1, 0.32, 1);
+	}
+	:global(.group:focus-within .ai-chatbar-disclosure) {
+		opacity: 1;
 	}
 	:global(.ai-chatbar.fade-out .ai-chatbar-content),
 	:global(.ai-chatbar.fade-out .ai-chatbar-disclosure),
@@ -377,6 +383,9 @@
 			transition: none;
 		}
 		:global(.ai-chatbar-content) {
+			transition: none;
+		}
+		:global(.ai-chatbar-disclosure) {
 			transition: none;
 		}
 		:global(.ai-pill-bg) {

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -344,6 +344,17 @@
 						}
 					}}
 				/>
+
+				{#if !threadContext.isHandedOff}
+					<!-- EU AI Act Art. 50(1): the widget is the second entry point into
+						 the same AI thread, so it carries the same disclosure. Dropped
+						 once a human takes over the thread. -->
+					<p
+						class="pointer-events-none -mt-2 px-4 pb-2 text-center text-[11px] text-balance text-muted-foreground"
+					>
+						{$t('support.chatbar.disclosure')}
+					</p>
+				{/if}
 			</ChatRoot>
 		</SlidingPanel>
 	</div>


### PR DESCRIPTION
The support chat is an AI conversation, but neither entry point disclosed that. EU AI Act Art. 50(1) requires the disclosure at the latest at first interaction.

The floating chatbar shows "AI can make mistakes. Check important info." under the pill while the input is focused, so the idle pill stays quiet; the text is only opacity-hidden and stays available to screen readers throughout. The support widget renders the same disclosure under its chat input and drops it once a human takes over the thread.

<!-- pr-media:start -->
| Chatbar focused | Widget chat |
| --- | --- |
| <img width="900" alt="Chatbar focused" src="https://github.com/user-attachments/assets/6c6f602f-7aaf-40f9-ad37-35d3ce26b4c4" /> | <img width="900" alt="Widget chat" src="https://github.com/user-attachments/assets/cadec05e-bdac-4ebc-95be-826edde0b7dd" /> |
<!-- pr-media:end -->

Verified in the browser on the marketing page: hidden while idle, fades in on focus and out on blur, and rendered under the widget chat input.
