### PR TITLE
fix(support): Slide the disclosure out on handoff

### DIFF
--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -11,6 +11,9 @@
 	import { getTranslate } from '@tolgee/svelte';
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';
+	import { slide } from 'svelte/transition';
+	import { quintOut } from 'svelte/easing';
+	import { prefersReducedMotion } from 'svelte/motion';
 
 	// Import new chat components
 	import { ChatRoot, ChatMessages, ChatInput, type ChatUIContext } from '$lib/chat';
@@ -348,8 +351,13 @@
 				{#if !threadContext.isHandedOff}
 					<!-- EU AI Act Art. 50(1): the widget is the second entry point into
 						 the same AI thread, so it carries the same disclosure. Dropped
-						 once a human takes over the thread. -->
+						 once a human takes over the thread; the slide collapses its
+						 height so the composer settles instead of jumping. -->
 					<p
+						transition:slide={{
+							duration: prefersReducedMotion.current ? 0 : 200,
+							easing: quintOut
+						}}
 						class="pointer-events-none -mt-2 px-4 pb-2 text-center text-[11px] text-balance text-muted-foreground"
 					>
 						{$t('support.chatbar.disclosure')}


### PR DESCRIPTION
Clicking "Talk to a human" removed the AI disclosure in one frame, so the composer dropped 16px without warning.

The disclosure now leaves through a 200ms slide transition (quintOut, duration zero under reduced motion), collapsing its height so the composer settles into the freed space instead of jumping. Svelte compiles the slide to a CSS animation, so it stays smooth while the handoff mutation occupies the main thread.

Regression guard: not warranted, animation-only polish with no functional invariant to assert

Verified in the browser on the real handoff flow: the composer moves through eight distinct interpolated positions from 587.5px to 604px instead of one jump.
