### PR TITLE
fix(support): Lift the chatbar on focus

### DIFF
--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -201,21 +201,23 @@
 
 <!-- Glow container with group hover/focus behavior -->
 <div
-	class="ai-chatbar fixed bottom-10 left-1/2 z-40 w-full -translate-x-1/2 pr-19 pl-5 md:mb-0 md:p-0 {!mounted.current ||
+	class="ai-chatbar fixed bottom-5 left-1/2 z-40 w-full -translate-x-1/2 pr-19 pl-5 md:mb-0 md:p-0 {!mounted.current ||
 	delayedFeedbackOpen
 		? 'fade-out'
 		: ''}"
 >
+	<!-- Idle keeps the original bottom-5 offset; focus lifts the bar so the
+		 disclosure fades into the freed space below it. -->
 	<div
-		class="group relative mx-auto motion-safe:transition-[max-width] motion-safe:duration-300 motion-safe:ease-in-out {isFocused
+		class="group relative mx-auto focus-within:-translate-y-5 motion-safe:transition-[max-width,translate] motion-safe:duration-300 motion-safe:ease-in-out {isFocused
 			? 'max-w-[430px]'
 			: 'max-w-[280px]'}"
 	>
 		<!-- Gradient glow layers (behind) - not affected by fade animation -->
-		<div class="ai-gradient-wrapper-glow pointer-events-none rounded-3xl"></div>
-		<div class="ai-gradient-wrapper pointer-events-none rounded-3xl"></div>
+		<div class="ai-gradient-wrapper-glow pointer-events-none rounded-full"></div>
+		<div class="ai-gradient-wrapper pointer-events-none rounded-full"></div>
 		<!-- Pill background layer - outside content wrapper to stay aligned with gradients -->
-		<div class="ai-pill-bg pointer-events-none rounded-3xl"></div>
+		<div class="ai-pill-bg pointer-events-none rounded-full"></div>
 
 		<!-- Content wrapper with separate opacity animation -->
 		<div class="ai-chatbar-content">
@@ -227,7 +229,7 @@
 				class="relative z-[1] mb-1 flex w-full flex-row items-center border-0 bg-transparent !p-1 shadow-none"
 			>
 				<PromptInputTextarea
-					class="!h-auto !min-h-auto rounded-3xl bg-transparent !py-0 "
+					class="!h-auto !min-h-auto rounded-full bg-transparent !py-0 "
 					placeholder={$t('support.chatbar.placeholder')}
 					onfocus={handleFocus}
 					onblur={handleBlur}
@@ -274,8 +276,10 @@
 		position: absolute;
 		inset: -2px;
 		overflow: hidden;
+		/* Inset matches the group's 300ms width/lift transition so every
+			 focus-driven change settles together */
 		transition:
-			inset 0.2s ease-in-out,
+			inset 0.3s cubic-bezier(0.4, 0, 0.2, 1),
 			opacity 0.3s cubic-bezier(0.23, 1, 0.32, 1);
 	}
 	:global(.ai-gradient-wrapper-glow) {
@@ -346,9 +350,11 @@
 		transform: translateY(20px);
 		transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 	}
+	/* Fade duration and curve mirror the group's width/lift transition so the
+		 label lands exactly when the bar settles */
 	:global(.ai-chatbar-disclosure) {
 		opacity: 0;
-		transition: opacity 0.25s cubic-bezier(0.23, 1, 0.32, 1);
+		transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 	}
 	:global(.group:focus-within .ai-chatbar-disclosure) {
 		opacity: 1;

--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -17,7 +17,6 @@
 	const { t } = getTranslate();
 
 	let input = $state('');
-	let isFocused = $state(false);
 	const { isFeedbackOpen = false } = $props<{ isFeedbackOpen?: boolean }>();
 
 	// Get thread context
@@ -188,15 +187,9 @@
 		}
 	}
 
-	function handleFocus() {
-		isFocused = true;
-	}
-
-	function handleBlur() {
-		isFocused = false;
-		// Don't delete pending thread on blur - automatic cleanup handles unused threads
-		// Query subscription stays active for faster optimistic updates on re-focus
-	}
+	// On blur, the pending warm thread is intentionally kept - automatic cleanup
+	// handles unused threads, and the query subscription stays active for faster
+	// optimistic updates on re-focus.
 </script>
 
 <!-- Glow container with group hover/focus behavior -->
@@ -209,9 +202,7 @@
 	<!-- Idle keeps the original bottom-5 offset; focus lifts the bar so the
 		 disclosure fades into the freed space below it. -->
 	<div
-		class="group relative mx-auto focus-within:-translate-y-5 motion-safe:transition-[max-width,translate] motion-safe:duration-300 motion-safe:ease-in-out {isFocused
-			? 'max-w-[430px]'
-			: 'max-w-[280px]'}"
+		class="group relative mx-auto max-w-[280px] focus-within:max-w-[430px] focus-within:-translate-y-5 motion-safe:transition-[max-width,translate] motion-safe:duration-300 motion-safe:ease-in-out"
 	>
 		<!-- Gradient glow layers (behind) - not affected by fade animation -->
 		<div class="ai-gradient-wrapper-glow pointer-events-none rounded-full"></div>
@@ -231,8 +222,6 @@
 				<PromptInputTextarea
 					class="!h-auto !min-h-auto rounded-full bg-transparent !py-0 "
 					placeholder={$t('support.chatbar.placeholder')}
-					onfocus={handleFocus}
-					onblur={handleBlur}
 					maxlength={MAX_MESSAGE_LENGTH}
 				/>
 


### PR DESCRIPTION
The disclosure feature had pushed the idle chatbar up to bottom-10 to reserve room for its label, so the resting bar floated higher than before the feature existed.

The bar sits at the original bottom-5 again. Focus lifts the pill 20px while the disclosure fades into the freed space below it, and every focus-driven transition (input width, lift, glow inset, label fade) shares the same 300ms ease-in-out so they settle in the same frame. The lift transitions the translate property, which Tailwind v4 uses for its translate utilities and which a transform-only transition list silently skips. The pill layers also switch from rounded-3xl to rounded-full so the ends stay true semicircles at any pill height.

<!-- pr-media:start -->
| Idle (bottom-5, no label) | Focused (lifted, label below) | Pill ends (rounded-full) |
| --- | --- | --- |
| <img width="600" alt="Idle (bottom-5, no label)" src="https://github.com/user-attachments/assets/7cf7cf45-76f4-4357-b6c1-b1846db4479f" /> | <img width="600" alt="Focused (lifted, label below)" src="https://github.com/user-attachments/assets/492a37c0-8b70-48b0-b422-0d4719bd8179" /> | <img width="600" alt="Pill ends (rounded-full)" src="https://github.com/user-attachments/assets/c8b6d4a1-f4c9-4f3b-a744-fed5f5f1d1ef" /> |
<!-- pr-media:end -->

Regression guard: not warranted, animation-and-shape-only polish with no functional invariant to assert

Verified in the browser: idle gap back at the pre-disclosure 24px, the focus lift interpolates through 27 positions over 300ms instead of jumping, all focus transitions report the same duration and curve, and the pill radius clamps to a perfect semicircle.
