### PR TITLE
ci(previews): Delete preview when its PR closes

### DIFF
--- a/.github/workflows/delete-convex-preview.yml
+++ b/.github/workflows/delete-convex-preview.yml
@@ -1,0 +1,39 @@
+name: Delete Convex Preview
+
+# A Convex preview deployment is created per PR branch and otherwise lives until
+# the platform TTL (5 days, 14 on Professional), holding one of the team's 40
+# preview slots the whole time and running whatever crons the app schedules. This
+# deletes the preview as soon as the PR closes (merged or not), so a median
+# ~20-minute PR does not occupy a slot for days. Resolves the preview by the
+# branch's canonical identifier; idempotent if it is already gone.
+#
+# Optional: without CONVEX_MANAGEMENT_TOKEN the script exits 0 and the platform
+# TTL remains the only cleanup.
+
+on:
+  pull_request:
+    types: [closed]
+
+# Only read access is needed; the delete uses the Convex management token.
+permissions:
+  contents: read
+
+concurrency:
+  group: delete-convex-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  delete-preview:
+    # Fork PRs never receive repository secrets; skip before any secret is referenced.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubicloud-standard-2
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Delete the preview deployment for the PR branch
+        env:
+          CONVEX_MANAGEMENT_TOKEN: ${{ secrets.CONVEX_MANAGEMENT_TOKEN }}
+          CONVEX_PROJECT_ID: ${{ vars.CONVEX_PROJECT_ID }}
+          PREVIEW_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: bun scripts/deploy/delete-preview.ts --branch "$PREVIEW_BRANCH"

--- a/README.md
+++ b/README.md
@@ -166,7 +166,18 @@ Push a branch and Vercel creates a preview deployment with its own Convex previe
 
 </details>
 
-Convex cleans up preview deployments after 5 days (14 days on Professional). If you hit `DeploymentQuotaReached` anyway (team quota is 40, counted across all projects), the deploy script can self-heal by pruning the oldest eligible preview, opt in by setting `CONVEX_MANAGEMENT_TOKEN` and `CONVEX_PROJECT_ID` (see the [env matrix](#environment-variables)).
+### Preview cleanup
+
+Convex expires preview deployments after 5 days (14 on Professional), and the team quota is 40 counted across all projects. An active repo reaches that ceiling well before the TTL frees anything, and once it does, creating a preview fails with `DeploymentQuotaReached`.
+
+Two optional mechanisms keep the count down:
+
+- **On PR close** (`.github/workflows/delete-convex-preview.yml`) deletes the branch's preview as soon as its PR is merged or closed, so a short-lived PR stops holding a slot for days. It resolves the deployment by the branch's canonical identifier, treats an already-deleted preview as success, and fails closed without deleting anything if two identifiers normalize to the same slug.
+- **On quota exhaustion** (`scripts/deploy/steps.ts`) prunes the oldest eligible preview and retries once when a build hits `DeploymentQuotaReached`. It never prunes the current branch, the newest preview, or a branch that still exists on the remote.
+
+Both read `CONVEX_MANAGEMENT_TOKEN` and `CONVEX_PROJECT_ID`, and they run in different environments, so the values have to be set in two places: GitHub Actions for the workflow, and the hosting platform's build settings for the deploy script (see the [env matrix](#environment-variables)). Configuring one leaves the other silently inactive, which is easy to miss because the deploy script only reports its half when a build is already failing.
+
+The token is team-scoped. Mint it on the team that owns this project: a token from another team you belong to is valid and authenticates fine, yet every call for this project returns `404` rather than an authorization error.
 
 ## Production Deployment
 
@@ -340,7 +351,7 @@ Set `PREVIEW_ADMIN_PASSWORD` once as a preview default (`bunx convex env default
 | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | :-----: | :--: |
 | `CONVEX_DEPLOY_KEY`         | Convex production deploy key                                                                                                             |    ✓    |  ✓   |
 | `CONVEX_PREVIEW_DEPLOY_KEY` | Convex preview deploy key                                                                                                                |    ✓    |      |
-| `CONVEX_MANAGEMENT_TOKEN`   | Convex Team Token for quota self-heal (mint at Team Settings > Access Tokens, Team ID shown on the same page)                            |    ○    |      |
+| `CONVEX_MANAGEMENT_TOKEN`   | Convex team token for quota self-heal (mint at Team Settings > Access Tokens, Team ID shown on the same page)                            |    ○    |      |
 | `CONVEX_PROJECT_ID`         | Numeric project id for quota self-heal (`curl -H "Authorization: Bearer $TOKEN" https://api.convex.dev/v1/teams/{teamId}/list_projects`) |    ○    |      |
 | `WORKERS_NAME`              | CF Workers only: worker name (matches `wrangler.toml`)                                                                                   |    ✓    |  ○   |
 | `WORKERS_SUBDOMAIN`         | CF Workers only: account's `workers.dev` subdomain                                                                                       |    ✓    |  ○   |
@@ -355,6 +366,15 @@ Set `PREVIEW_ADMIN_PASSWORD` once as a preview default (`bunx convex env default
 | `PRODUCTION_BRANCH`         | Cloudflare only: production branch name (default: `main`)                                                                                |    ○    |  ○   |
 
 `PUBLIC_CONVEX_URL` and `PUBLIC_CONVEX_SITE_URL` are intentionally not in this table. The build (`scripts/deploy.ts`) derives both from `CONVEX_DEPLOY_KEY` and overwrites any value you set on the hosting platform, so setting them there has no effect. To point production at a different Convex deployment, change the deploy key, not the URL.
+
+**GitHub Actions, preview cleanup** (repository Settings > Secrets and variables > Actions):
+
+| Variable                  |                                                                                   | Required |
+| ------------------------- | --------------------------------------------------------------------------------- | :------: |
+| `CONVEX_MANAGEMENT_TOKEN` | Secret. The same team token as above, used to delete a preview when its PR closes |    ○     |
+| `CONVEX_PROJECT_ID`       | Variable, not a secret. The same numeric project id                               |    ○     |
+
+These are the same two names the hosting platform needs, set a second time for CI. Without them the `Delete Convex Preview` workflow logs that it is skipping and exits successfully, which also keeps fork PRs green.
 
 </details>
 

--- a/scripts/deploy/delete-preview.ts
+++ b/scripts/deploy/delete-preview.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env bun
+/**
+ * Delete the Convex preview deployment for one git branch.
+ *
+ * Thin adapter over deletePreviewForBranch in prune-previews.ts, invoked by the
+ * delete-convex-preview.yml workflow on pull_request:closed. Reads the
+ * management token + project id from the environment (GitHub secret/variable);
+ * never logs them or any response body. Idempotent: a branch whose preview is
+ * already gone exits 0. Ambiguity or a list/delete error exits non-zero so the
+ * workflow surfaces it red rather than forcing an unsafe delete.
+ */
+import { parseArgs } from 'node:util';
+import { deletePreviewForBranch } from './prune-previews';
+
+const { values } = parseArgs({ options: { branch: { type: 'string' } }, strict: true });
+const branch = values.branch;
+if (!branch) {
+	console.error('delete-preview: --branch <gitRef> is required');
+	process.exit(2);
+}
+
+const token = process.env.CONVEX_MANAGEMENT_TOKEN;
+const projectId = process.env.CONVEX_PROJECT_ID;
+if (!token || !projectId) {
+	console.error(
+		'delete-preview: CONVEX_MANAGEMENT_TOKEN and CONVEX_PROJECT_ID must be set; skipping.'
+	);
+	// Not a failure of this PR: without credentials there is nothing to do, and a
+	// fork PR (no secrets) must not fail the workflow.
+	process.exit(0);
+}
+
+const result = await deletePreviewForBranch({ token, projectId, gitRef: branch });
+
+if (result.deleted) {
+	console.log(`Deleted preview deployment ${result.deleted} for branch ${branch}`);
+	process.exit(0);
+}
+if (result.reason === 'not_found') {
+	console.log(`No preview deployment for branch ${branch} (already gone) — nothing to do.`);
+	process.exit(0);
+}
+console.error(`delete-preview failed for branch ${branch}: ${result.reason}`);
+process.exit(1);

--- a/scripts/deploy/prune-previews.test.ts
+++ b/scripts/deploy/prune-previews.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+	deletePreviewForBranch,
 	normalizeIdentifier,
 	pruneOldestPreview,
 	selectPrunable,
-	type Preview
+	type Preview,
+	type PruneDeps
 } from './prune-previews';
 
 const NOW = 1_700_000_000_000;
@@ -235,5 +237,113 @@ describe('pruneOldestPreview', () => {
 			}
 		});
 		expect(result).toEqual({ pruned: null, reason: 'delete failed: 403 forbidden' });
+	});
+});
+
+describe('deletePreviewForBranch', () => {
+	function deps(previews: Preview[], remove = vi.fn(async () => {})): PruneDeps {
+		return { list: vi.fn(async () => previews), remove };
+	}
+
+	it('deletes exactly the preview whose identifier matches the branch', async () => {
+		const remove = vi.fn(async () => {});
+		const result = await deletePreviewForBranch({
+			token: 't',
+			projectId: 'p',
+			gitRef: 'Feature/Foo-Bar',
+			deps: deps(
+				[preview({ id: 'feature-foo-bar', ageMin: 5 }), preview({ id: 'other', ageMin: 5 })],
+				remove
+			)
+		});
+		expect(result).toEqual({ deleted: 'dep-feature-foo-bar' });
+		expect(remove).toHaveBeenCalledExactlyOnceWith('t', 'dep-feature-foo-bar');
+	});
+
+	it('never matches a prefix/suffix of another branch', async () => {
+		const remove = vi.fn(async () => {});
+		const result = await deletePreviewForBranch({
+			token: 't',
+			projectId: 'p',
+			gitRef: 'fix/auth',
+			deps: deps([preview({ id: 'fix-auth-2', ageMin: 5 })], remove)
+		});
+		expect(result).toEqual({ deleted: null, reason: 'not_found' });
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it('is an idempotent no-op when the preview is already gone', async () => {
+		const remove = vi.fn(async () => {});
+		const result = await deletePreviewForBranch({
+			token: 't',
+			projectId: 'p',
+			gitRef: 'merged/branch',
+			deps: deps([preview({ id: 'still-open', ageMin: 5 })], remove)
+		});
+		expect(result).toEqual({ deleted: null, reason: 'not_found' });
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it('rejects an empty/invalid branch without listing or deleting', async () => {
+		const remove = vi.fn(async () => {});
+		const list = vi.fn(async () => [] as Preview[]);
+		const result = await deletePreviewForBranch({
+			token: 't',
+			projectId: 'p',
+			gitRef: '///',
+			deps: { list, remove }
+		});
+		expect(result).toEqual({ deleted: null, reason: 'invalid_branch' });
+		expect(list).not.toHaveBeenCalled();
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it('fails closed on a normalization collision without deleting', async () => {
+		const remove = vi.fn(async () => {});
+		const result = await deletePreviewForBranch({
+			token: 't',
+			projectId: 'p',
+			gitRef: 'fix/auth',
+			// Two distinct identifiers that normalize to the same slug.
+			deps: deps(
+				[
+					preview({ id: 'fix/auth', name: 'dep-a', ageMin: 5 }),
+					preview({ id: 'fix-auth', name: 'dep-b', ageMin: 5 })
+				],
+				remove
+			)
+		});
+		expect(result).toEqual({ deleted: null, reason: 'ambiguous' });
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it('propagates a list failure', async () => {
+		const result = await deletePreviewForBranch({
+			token: 't',
+			projectId: 'p',
+			gitRef: 'feature/x',
+			deps: {
+				list: vi.fn(async () => {
+					throw new Error('500 boom');
+				}),
+				remove: vi.fn(async () => {})
+			}
+		});
+		expect(result).toEqual({ deleted: null, reason: 'list failed: 500 boom' });
+	});
+
+	it('propagates a delete failure', async () => {
+		const result = await deletePreviewForBranch({
+			token: 't',
+			projectId: 'p',
+			gitRef: 'feature/x',
+			deps: {
+				list: vi.fn(async () => [preview({ id: 'feature-x', ageMin: 5 })]),
+				remove: vi.fn(async () => {
+					throw new Error('403 forbidden');
+				})
+			}
+		});
+		expect(result).toEqual({ deleted: null, reason: 'delete failed: 403 forbidden' });
 	});
 });

--- a/scripts/deploy/prune-previews.ts
+++ b/scripts/deploy/prune-previews.ts
@@ -128,6 +128,65 @@ export async function pruneOldestPreview(args: {
 	return { pruned: target.name };
 }
 
+export type DeleteByBranchResult =
+	| { deleted: string }
+	| {
+			deleted: null;
+			reason: 'not_found' | 'ambiguous' | 'invalid_branch' | 'invalid_target' | string;
+	  };
+
+/**
+ * Delete the preview deployment that belongs to one git branch, resolved by its
+ * canonical (normalized) identifier. Used by the pull_request:closed workflow so
+ * a merged/closed PR's preview stops consuming a team quota slot within minutes
+ * instead of lingering to the platform TTL.
+ *
+ * Safety, in order:
+ *  - `list` only returns objects with a non-null previewIdentifier, so prod and
+ *    dev deployments can never enter the candidate set.
+ *  - Match is exact canonical equality, never prefix/substring, so a branch like
+ *    `fix/auth` cannot delete `fix/auth-2`.
+ *  - No match is a successful idempotent no-op (the preview already expired or
+ *    was deleted).
+ *  - Two matches after normalization is ambiguous and fails closed WITHOUT any
+ *    delete, so a collision never deletes the wrong backend.
+ */
+export async function deletePreviewForBranch(args: {
+	token: string;
+	projectId: string;
+	gitRef: string;
+	deps?: PruneDeps;
+}): Promise<DeleteByBranchResult> {
+	const deps = args.deps ?? defaultDeps;
+	const wanted = normalizeIdentifier(args.gitRef);
+	if (!wanted) return { deleted: null, reason: 'invalid_branch' };
+
+	let previews: Preview[];
+	try {
+		previews = await deps.list(args.token, args.projectId);
+	} catch (err) {
+		return { deleted: null, reason: `list failed: ${errMessage(err)}` };
+	}
+
+	const matches = previews.filter((p) => normalizeIdentifier(p.previewIdentifier) === wanted);
+	if (matches.length === 0) return { deleted: null, reason: 'not_found' };
+	if (matches.length > 1) return { deleted: null, reason: 'ambiguous' };
+
+	const target = matches[0];
+	// Re-assert the target came from the listed preview set and still carries a
+	// non-empty previewIdentifier immediately before the irreversible delete.
+	if (!target.previewIdentifier || !previews.some((p) => p.name === target.name)) {
+		return { deleted: null, reason: 'invalid_target' };
+	}
+
+	try {
+		await deps.remove(args.token, target.name);
+	} catch (err) {
+		return { deleted: null, reason: `delete failed: ${errMessage(err)}` };
+	}
+	return { deleted: target.name };
+}
+
 function errMessage(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
 }


### PR DESCRIPTION
Convex expires previews after 5 days (14 on Professional) and the team quota is 40 counted across all projects, so an active repo hits the ceiling long before the TTL frees anything. Today the template only cleans up reactively: `tryRecoverFromQuota` prunes the oldest eligible preview after a build has already failed with `DeploymentQuotaReached`. Nothing removes a preview when its PR closes, so slots accumulate until that failure path is the only thing standing between the repo and a blocked deploy. In my fork this ran to 46 orphaned previews from long-merged branches, at which point new previews were evicted to make room and E2E runs began 404ing against backends that no longer existed.

This adds the proactive half. `deletePreviewForBranch` resolves a branch's preview by its canonical identifier and deletes it, driven by a `pull_request:closed` workflow. Resolution is exact canonical equality, so `fix/auth` cannot delete `fix/auth-2`; a branch whose preview is already gone is an idempotent success; two identifiers that normalize to the same slug fail closed without deleting anything. Fork PRs are skipped before any secret is referenced and an unset token exits 0, so the workflow stays green for anyone who never configures it.

The README gains the part that is easy to get wrong. `CONVEX_MANAGEMENT_TOKEN` now has two consumers in different environments, so it has to be set both as a GitHub Actions secret and in the hosting platform's build settings, and configuring one leaves the other silently inactive. It also records that a token minted on the wrong team of a multi-team account authenticates fine and still returns `404` on every call for the project, so the symptom looks like a missing project.

Regression guard: added `deletePreviewForBranch` suite in `scripts/deploy/prune-previews.test.ts`

Verified by running the suite (27 pass), confirming the exact-match and ambiguity guards each fail their test when removed, and `actionlint` on the new workflow.