### PR TITLE
fix(seo): Bust preview caches when the OG image changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Marketing pages return structured markdown when an AI agent sends `Accept: text/
 
 ### SEO
 
-Every page includes a `<SEOHead>` component that outputs OpenGraph tags, Twitter Cards, canonical URLs, and `hreflang` alternates for all languages plus `x-default`. An OG image is included at `static/og-image.png` (1200x630).
+Every page includes a `<SEOHead>` component that outputs OpenGraph tags, Twitter Cards, canonical URLs, and `hreflang` alternates for all languages plus `x-default`. An OG image is included at `static/og-image.png` (1200x630). Replace it with your own and run `bun run generate:og-image-url`: the meta tags carry the image's content hash, which is what makes social platforms fetch the new card instead of the cached one for links that were already shared.
 
 ### Accessibility
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"postbuild": "bun scripts/patch-cf-worker.ts",
 		"start": "node build",
 		"generate:logos": "bun scripts/generate-logos.ts",
+		"generate:og-image-url": "bun scripts/generate-og-image-url.ts",
 		"build:emails": "bun run generate:logos && bun scripts/build-emails.ts",
 		"preview": "vite preview",
 		"prepare": "husky",

--- a/scripts/generate-og-image-url.ts
+++ b/scripts/generate-og-image-url.ts
@@ -1,0 +1,41 @@
+/**
+ * Stamp the OG image's content hash into the URL SEOHead advertises.
+ *
+ * Social platforms cache the preview image separately from the page it belongs
+ * to, keyed on the image URL. Replacing static/og-image.png therefore does not
+ * reach anywhere the link was already shared: re-scraping the page refreshes
+ * the title and description and keeps serving the previously fetched bytes.
+ * Moving the URL with the file is what invalidates those caches.
+ *
+ * Run after replacing static/og-image.png:
+ *   bun run generate:og-image-url
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const IMAGE_PATH = resolve(import.meta.dirname!, '../static/og-image.png');
+const OUTPUT_PATH = resolve(
+	import.meta.dirname!,
+	'../src/lib/components/og-image-url.generated.ts'
+);
+
+export const hashImage = (bytes: Buffer): string =>
+	createHash('sha256').update(bytes).digest('hex').slice(0, 8);
+
+export const renderModule = (hash: string): string => `// GENERATED FILE — do not edit manually.
+// Run \`bun run generate:og-image-url\` after replacing static/og-image.png.
+// Source: scripts/generate-og-image-url.ts
+
+// The query string is the image's content hash. Social platforms cache the
+// preview image under its URL, so an unchanged URL keeps serving the old card
+// everywhere the link was already shared.
+export const OG_IMAGE_URL = '/og-image.png?v=${hash}';
+`;
+
+if (import.meta.main) {
+	const hash = hashImage(readFileSync(IMAGE_PATH));
+	writeFileSync(OUTPUT_PATH, renderModule(hash));
+	console.log(`✓ /og-image.png?v=${hash} → ${OUTPUT_PATH}`);
+}

--- a/scripts/og-image-url.test.ts
+++ b/scripts/og-image-url.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { hashImage, renderModule } from './generate-og-image-url';
+import { OG_IMAGE_URL } from '../src/lib/components/og-image-url.generated';
+
+const root = resolve(import.meta.dirname, '..');
+const image = readFileSync(resolve(root, 'static/og-image.png'));
+const generated = readFileSync(
+	resolve(root, 'src/lib/components/og-image-url.generated.ts'),
+	'utf8'
+);
+
+// Replacing the image without regenerating the URL is invisible while
+// developing — the meta tag still resolves to the new file — and only shows up
+// as an unchanged preview card in every chat the link was ever pasted into.
+describe('og-image URL', () => {
+	it('carries the current image content hash', () => {
+		expect(OG_IMAGE_URL).toBe(`/og-image.png?v=${hashImage(image)}`);
+	});
+
+	it('matches what the generator would write', () => {
+		expect(generated).toBe(renderModule(hashImage(image)));
+	});
+});

--- a/src/lib/components/SEOHead.svelte
+++ b/src/lib/components/SEOHead.svelte
@@ -3,6 +3,7 @@
 	import { PUBLIC_SITE_URL } from '$env/static/public';
 	import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE, getLanguage } from '$lib/i18n/languages';
 	import { LEGAL_CONFIG } from '$lib/config/legal';
+	import { OG_IMAGE_URL } from './og-image-url.generated';
 
 	// During prerendering page.url.origin is SvelteKit's placeholder
 	// http://sveltekit-prerender, so absolute SEO URLs must come from the
@@ -21,7 +22,8 @@
 		ogType?: string;
 		/** OG/Twitter image path relative to static/ (e.g. "/og-image.png").
 		 * Will be converted to an absolute URL using the current origin.
-		 * Defaults to /og-image.png (1200x630). */
+		 * Defaults to the bundled og-image.png (1200x630), carrying the content
+		 * hash that busts the social platforms' image caches. */
 		image?: string;
 		/** OG image width in pixels (defaults to 1200 for the default image only) */
 		imageWidth?: number;
@@ -39,7 +41,7 @@
 		description,
 		canonicalUrl,
 		ogType = 'website',
-		image = '/og-image.png',
+		image = OG_IMAGE_URL,
 		imageWidth,
 		imageHeight,
 		imageAlt,
@@ -69,7 +71,7 @@
 
 	// Only the bundled default og-image has known dimensions (1200x630).
 	// Custom images keep dimensions undefined unless explicitly provided.
-	const isDefaultImage = $derived(image === '/og-image.png');
+	const isDefaultImage = $derived(image === OG_IMAGE_URL);
 	const ogImageWidth = $derived(imageWidth ?? (isDefaultImage ? 1200 : undefined));
 	const ogImageHeight = $derived(imageHeight ?? (isDefaultImage ? 630 : undefined));
 </script>

--- a/src/lib/components/og-image-url.generated.ts
+++ b/src/lib/components/og-image-url.generated.ts
@@ -1,0 +1,8 @@
+// GENERATED FILE — do not edit manually.
+// Run `bun run generate:og-image-url` after replacing static/og-image.png.
+// Source: scripts/generate-og-image-url.ts
+
+// The query string is the image's content hash. Social platforms cache the
+// preview image under its URL, so an unchanged URL keeps serving the old card
+// everywhere the link was already shared.
+export const OG_IMAGE_URL = '/og-image.png?v=e0769f93';


### PR DESCRIPTION
Closes #779

`SEOHead` pointed `og:image` at `/og-image.png`, a path that survives replacing the file. Social platforms cache the preview image under that URL separately from the page, so a fork that swapped in its own image kept showing the template's card everywhere a link had already been shared — re-scraping refreshed the title and description and served the old bytes.

The advertised URL now carries the image's content hash. `bun run generate:og-image-url` writes it into `og-image-url.generated.ts` after the image is replaced, and a test fails when that hash drifts from the committed file, which is otherwise invisible: the meta tag keeps resolving to the right image while every chat keeps the stale card. The README says to run it.

Regression guard: added scripts/og-image-url.test.ts
Verified with the new test, `bun scripts/static-checks.ts` over the changed files, and against a live deployment of a fork carrying the same change, where re-scraping picked up the new card only once the URL moved.