### PR TITLE
fix(settings): Check the avatar bytes that actually upload

### DIFF
--- a/src/lib/uploads/profiles.test.ts
+++ b/src/lib/uploads/profiles.test.ts
@@ -2,16 +2,18 @@ import { describe, expect, it } from 'vitest';
 import {
 	acceptAttribute,
 	acceptsMimeType,
+	acceptsSource,
 	allowedMimeTypes,
 	UPLOAD_PROFILES,
+	type UploadProfile,
 	type UploadProfileName
 } from './profiles';
 import { canConsume, PROFILE_CONSUMERS, type Consumer } from './consumers';
 import { mediaCategoryOf, MODEL_INPUT_MODALITIES } from './model-capabilities';
 
-const PROFILES = Object.entries(UPLOAD_PROFILES) as Array<
-	[UploadProfileName, (typeof UPLOAD_PROFILES)[UploadProfileName]]
->;
+// Widened to UploadProfile so the loops can read optional fields like
+// sourceMimePrefixes, which the const assertion narrows away per profile.
+const PROFILES = Object.entries(UPLOAD_PROFILES) as Array<[UploadProfileName, UploadProfile]>;
 
 describe('mediaCategoryOf', () => {
 	it('maps top-level types to modality names', () => {
@@ -36,7 +38,12 @@ describe('profile derivations', () => {
 		const mimes = allowedMimeTypes(profile);
 		const entries = Object.entries(profile.extensions);
 
-		expect(acceptAttribute(profile).split(',')).toEqual(entries.map(([ext]) => ext));
+		// A transcoding surface offers its input families instead of extensions,
+		// because what may be picked is wider than what may be stored.
+		const expectedAccept = profile.sourceMimePrefixes?.length
+			? profile.sourceMimePrefixes.map((prefix) => `${prefix}*`)
+			: entries.map(([ext]) => ext);
+		expect(acceptAttribute(profile).split(',')).toEqual(expectedAccept);
 		expect(mimes.length).toBeGreaterThan(0);
 		// Every extension resolves to a listed mime type, so the picker and the
 		// server validator cannot disagree about a format.
@@ -49,6 +56,38 @@ describe('profile derivations', () => {
 		const profile = UPLOAD_PROFILES.chatAttachment;
 		expect(acceptsMimeType(profile, 'text/plain; charset=utf-8')).toBe(true);
 		expect(acceptsMimeType(profile, 'application/zip')).toBe(false);
+	});
+});
+
+describe('picking versus storing', () => {
+	// The regression this exists for: checking the PICKED file against the
+	// stored list rejected HEIC, which is the iOS camera default, before
+	// downscaleImage could turn it into the WebP the server does accept.
+	it('lets the avatar accept an input it will never store', () => {
+		const profile = UPLOAD_PROFILES.profileImage;
+		expect(acceptsSource(profile, 'image/heic')).toBe(true);
+		expect(acceptsMimeType(profile, 'image/heic')).toBe(false);
+	});
+
+	it('offers the input family to the picker, not the stored extensions', () => {
+		expect(acceptAttribute(UPLOAD_PROFILES.profileImage)).toBe('image/*');
+	});
+
+	// Everything the transcoder can hand back unchanged has to fail the storage
+	// check, or the drift this whole structure closes would reopen: GIF is passed
+	// through by design, and SVG survives whenever the decode fails.
+	it('still refuses to store what the transcoder passes through', () => {
+		const profile = UPLOAD_PROFILES.profileImage;
+		expect(acceptsSource(profile, 'image/svg+xml')).toBe(true);
+		expect(acceptsMimeType(profile, 'image/svg+xml')).toBe(false);
+	});
+
+	it('treats picking and storing alike where no transcoder sits in between', () => {
+		const profile: UploadProfile = UPLOAD_PROFILES.chatAttachment;
+		expect(profile.sourceMimePrefixes).toBeUndefined();
+		for (const mime of [...allowedMimeTypes(profile), 'application/zip', 'image/heic']) {
+			expect(acceptsSource(profile, mime)).toBe(acceptsMimeType(profile, mime));
+		}
 	});
 });
 

--- a/src/lib/uploads/profiles.ts
+++ b/src/lib/uploads/profiles.ts
@@ -13,8 +13,18 @@
  */
 
 export type UploadProfile = {
-	/** Extension to mime type. The source of truth both derivations read. */
+	/** Extension to mime type. What may be STORED, and what the server enforces. */
 	extensions: Readonly<Record<string, string>>;
+	/**
+	 * Mime families a user may PICK, where that is wider than what is stored.
+	 *
+	 * Only meaningful on a surface with a transcoder in between. The avatar
+	 * re-encodes to WebP before upload, so an iPhone's HEIC is a perfectly good
+	 * input even though HEIC is never stored. Checking the picked file against
+	 * the stored list would reject the platform default before the transcoder
+	 * ever ran.
+	 */
+	sourceMimePrefixes?: readonly string[];
 	maxBytes: number;
 	maxBytesLabel: string;
 	maxFiles: number;
@@ -53,6 +63,7 @@ export const UPLOAD_PROFILES = {
 			'.webp': 'image/webp',
 			'.gif': 'image/gif'
 		},
+		sourceMimePrefixes: ['image/'],
 		maxBytes: 2 * 1024 * 1024,
 		maxBytesLabel: '2MB',
 		maxFiles: 1
@@ -66,13 +77,40 @@ export function allowedMimeTypes(profile: UploadProfile): string[] {
 	return Array.from(new Set(Object.values(profile.extensions)));
 }
 
-/** Value for a file input's `accept` attribute. */
+/**
+ * Value for a file input's `accept` attribute.
+ *
+ * Offers the input families where the surface has a transcoder, so the picker
+ * is not narrower than what the surface can actually take.
+ */
 export function acceptAttribute(profile: UploadProfile): string {
+	const families = (profile.sourceMimePrefixes ?? []).map((prefix) => `${prefix}*`);
+	if (families.length) return families.join(',');
 	return Object.keys(profile.extensions).join(',');
 }
 
-/** Whether a profile accepts this mime type, ignoring any charset parameter. */
+/**
+ * Whether a profile accepts this mime type for STORAGE, ignoring any charset
+ * parameter. This is the answer the server enforces.
+ */
 export function acceptsMimeType(profile: UploadProfile, mimeType: string): boolean {
 	const essence = mimeType.split(';')[0]!.trim().toLowerCase();
 	return allowedMimeTypes(profile).includes(essence);
+}
+
+/**
+ * Whether a user may pick this file, which on a transcoding surface is wider
+ * than what may be stored. Falls back to the storage answer where no input
+ * family is declared, so a surface without a transcoder behaves as before.
+ *
+ * A surface that uses this must re-check the transcoder's OUTPUT with
+ * acceptsMimeType: the avatar transcoder is not total (it passes GIFs through,
+ * keeps the original when the re-encode is larger, and falls back on a decode
+ * failure), so picking is not a promise that the result is storable.
+ */
+export function acceptsSource(profile: UploadProfile, mimeType: string): boolean {
+	const essence = mimeType.split(';')[0]!.trim().toLowerCase();
+	const families = profile.sourceMimePrefixes ?? [];
+	if (!families.length) return acceptsMimeType(profile, essence);
+	return families.some((prefix) => essence.startsWith(prefix));
 }

--- a/src/routes/[[lang]]/app/settings/account-settings.svelte
+++ b/src/routes/[[lang]]/app/settings/account-settings.svelte
@@ -16,7 +16,12 @@
 	import { api } from '$lib/convex/_generated/api.js';
 	import { ConvexError } from 'convex/values';
 	import { PROFILE_IMAGE_MAX_SIZE, PROFILE_IMAGE_MAX_SIZE_LABEL } from '$lib/convex/constants.js';
-	import { acceptAttribute, acceptsMimeType, UPLOAD_PROFILES } from '$lib/uploads/profiles.js';
+	import {
+		acceptAttribute,
+		acceptsMimeType,
+		acceptsSource,
+		UPLOAD_PROFILES
+	} from '$lib/uploads/profiles.js';
 	import { downscaleImage } from '$lib/utils/downscale-image.js';
 	import { translateValidationErrors } from '$lib/utils/validation-i18n.js';
 
@@ -66,11 +71,12 @@
 
 		haptic.trigger('medium');
 
-		// Validate against the same profile the server enforces. A broader
-		// `image/*` check would accept HEIC and SVG, which downscaleImage hands
-		// back untouched whenever the decode fails or the WebP re-encode is not
-		// smaller — so the file would reach a server that rejects it.
-		if (!acceptsMimeType(UPLOAD_PROFILES.profileImage, file.type)) {
+		// Picked, not stored: the transcoder below turns most images into WebP, so
+		// an iPhone's HEIC is a fine input even though HEIC is never stored.
+		// Checking the picked file against the stored list would reject the iOS
+		// default before the transcoder ever ran. The result is checked instead,
+		// after downscaleImage.
+		if (!acceptsSource(UPLOAD_PROFILES.profileImage, file.type)) {
 			toast.error($t('settings.account.avatar.select_error'));
 			target.value = '';
 			return;
@@ -96,6 +102,16 @@
 			// every later avatar load stays small (falls back to the original
 			// file on any decode/encode failure).
 			const upload = await downscaleImage(file);
+
+			// downscaleImage is not total: it passes GIFs through, keeps the
+			// original when the re-encode is larger, and falls back to it on a
+			// decode failure. So the only reliable moment to check the type is
+			// here, on the bytes that are about to be sent.
+			if (!acceptsMimeType(UPLOAD_PROFILES.profileImage, upload.type)) {
+				toast.error($t('settings.account.avatar.select_error'));
+				target.value = '';
+				return;
+			}
 
 			// XHR transport for progress events, so the avatar shows live
 			// upload feedback instead of a silently disabled input.


### PR DESCRIPTION
Follow-up to #783, which moved the avatar type check to the wrong side of the transcoder.

The check runs on the picked file, but `downscaleImage` runs afterwards and re-encodes to WebP. Because it scales to 512px first, that re-encode is far smaller than a camera photo, so the conversion reliably wins the `blob.size < file.size` comparison. A HEIC picked in Safari therefore reached the server as a valid `image/webp` before #783 — and is now rejected up front. HEIC is the iOS camera default, so this is the normal case on iPhone.

The narrowing was still right in substance: `downscaleImage` is not total. It passes GIFs through, keeps the original when the re-encode is larger, and falls back to it on any decode failure, so an unsupported type can still arrive at the server. The mistake was checking the wrong bytes.

A profile now distinguishes what may be **stored** from what may be **picked**, which only differ where a transcoder sits in between. The avatar declares `image/*` as its input family, so the picker offers what the surface can genuinely take, and the type is verified again on the transcoder's output immediately before upload. Surfaces without a transcoder declare no input family and behave exactly as before — `acceptsSource` falls through to `acceptsMimeType` for them, which a test pins.

Regression guard: added `picking versus storing` in `src/lib/uploads/profiles.test.ts`

Verified with the unit suite and a project-wide type check. The new tests cover the distinction directly: HEIC and SVG are pickable but not storable, chat attachments answer identically to both questions, and the accept attribute offers the family rather than the stored extensions. One unrelated test (`prerender-sync`) timed out on a machine at load average 136 and passes on its own.