### PR TITLE
chore(env): Migrate to varlock codegen API

### DIFF
--- a/.env-convex.schema
+++ b/.env-convex.schema
@@ -1,6 +1,6 @@
 # @defaultSensitive=inferFromPrefix(PUBLIC_)
 # @defaultRequired=infer
-# @generateTypes(lang=ts, path=src/lib/convex/convex-env.d.ts)
+# @generateTsTypes(path=src/lib/convex/convex-env.d.ts)
 # @redactLogs=true
 # @preventLeaks=true
 # ---

--- a/.env.schema
+++ b/.env.schema
@@ -1,7 +1,7 @@
 # @defaultSensitive=inferFromPrefix(PUBLIC_)
 # @defaultRequired=infer
 # @currentEnv=$VARLOCK_ENV
-# @generateTypes(lang=ts, path=./src/env.d.ts)
+# @generateTsTypes(path=./src/env.d.ts)
 # @redactLogs=true
 # @preventLeaks=true
 # ---

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"dev:cloud": "bun-tasks dev:frontend ::: dev:backend:cloud",
 		"dev:test": "VARLOCK_ENV=test bun scripts/dev-test.ts",
 		"generate": "bun scripts/generate-convex.ts",
-		"postinstall": "bun svelte-kit sync && varlock typegen && varlock typegen --path .env-convex.schema && bun run build:emails",
+		"postinstall": "bun svelte-kit sync && varlock codegen && varlock codegen --path .env-convex.schema && bun run build:emails",
 		"prebuild": "bun run build:emails",
 		"build": "vite build",
 		"postbuild": "bun scripts/patch-cf-worker.ts",

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -27,8 +27,8 @@ Cloudflare environment values are uploaded through `varlock-wrangler`. Never emb
 
 - `varlock load` validates resolved configuration.
 - `varlock run -- <cmd>` executes with validation and redaction.
-- `varlock typegen` regenerates SvelteKit environment types.
-- `varlock typegen --path .env-convex.schema` regenerates Convex environment types.
+- `varlock codegen` regenerates SvelteKit environment types.
+- `varlock codegen --path .env-convex.schema` regenerates Convex environment types.
 - `varlock scan` checks for leaked values.
 
 ## Generated assets

--- a/scripts/env-schema-parity.test.ts
+++ b/scripts/env-schema-parity.test.ts
@@ -7,7 +7,7 @@ import { TEST_ONLY_ENV_PLACEHOLDERS } from './local-convex-env';
  * The Convex `env` block in `src/lib/convex/convex.config.ts` and the varlock
  * `.env-convex.schema` are two declarations of the same variable set. The env
  * block drives Convex's push-time validation and the generated typed `env`
- * object; the schema drives varlock typegen and the deploy-time presence check.
+ * object; the schema drives varlock codegen and the deploy-time presence check.
  * Its `@type=*` decorators coerce nothing on this path — no value here is loaded
  * by varlock — so they are documentation. The two must still agree on which vars
  * exist and which are required, or one source silently drifts from the other.

--- a/src/lib/convex/convex.config.ts
+++ b/src/lib/convex/convex.config.ts
@@ -13,9 +13,10 @@ import convexFilesControl from '@gilhrpenner/convex-files-control/convex.config'
  * Convex validates these at push time (missing required vars or values that
  * fail their validator reject the deploy) and emits a typed `env` object into
  * `_generated/server`. This mirrors `.env-convex.schema`, which stays the
- * canonical superset for typegen and for the scripts that read variable names
- * and requiredness. Its `@type=*` decorators do not coerce or validate anything
- * here, and it drives no redaction: no value on this path is loaded by varlock.
+ * canonical superset for code generation and for the scripts that read
+ * variable names and requiredness. Its `@type=*` decorators do not coerce or
+ * validate anything here, and it drives no redaction: no value on this path is
+ * loaded by varlock.
  *
  * Env values are always strings, so only string-like validators are allowed
  * (`v.string()`, string `v.literal()`/`v.union()`, and `v.optional()`).

--- a/src/lib/convex/env.ts
+++ b/src/lib/convex/env.ts
@@ -7,8 +7,8 @@
  * required/optional split comes for free: required vars type as `string`,
  * optional vars as `string | undefined`.
  *
- * varlock (.env-convex.schema) stays canonical for typegen and for the scripts
- * that check which vars exist and which are required;
+ * varlock (.env-convex.schema) stays canonical for code generation and for the
+ * scripts that check which vars exist and which are required;
  * `scripts/env-schema-parity.test.ts` keeps the two declarations in sync.
  *
  * What it does NOT do, despite what the decorators suggest: no value ever


### PR DESCRIPTION
Every install prints a deprecation warning for `varlock typegen`, twice, including in Cloudflare build logs. varlock 1.10.0 renamed the command to `codegen` because it now emits more than TypeScript, and moved the TypeScript generator from `@generateTypes(lang=ts)` to a dedicated `@generateTsTypes` decorator. Both old names keep working as aliases, and only the command warns, so the decorator deprecation is silent.

The postinstall hook now calls `varlock codegen`, and both env schemas declare `@generateTsTypes`. That decorator additionally accepts `exposeEnv`, `processEnv`, and `importMetaEnv`; leaving them unset keeps the previous output.

Verified by regenerating both files and diffing against the previous output: `src/env.d.ts` and `src/lib/convex/convex-env.d.ts` are byte-identical, and the install no longer warns.