### PR TITLE
fix(chat): Inset progressive blur from scrollbar

### DIFF
--- a/src/lib/chat/ui/ChatMessages.svelte
+++ b/src/lib/chat/ui/ChatMessages.svelte
@@ -238,7 +238,7 @@
 	<!-- Blur pinned to chat viewport bottom, inset to avoid the scrollbar -->
 	{#if ctx.displayMessages.length > 0}
 		<div
-			class="pointer-events-none absolute right-[calc(var(--scrollbar-w)+0.25rem)] bottom-0 left-0 z-10 h-20 md:right-[calc(var(--scrollbar-w)+0.75rem)]"
+			class="pointer-events-none absolute right-[calc(var(--scrollbar-w,0px)+0.25rem)] bottom-0 left-0 z-10 h-20 md:right-[calc(var(--scrollbar-w,0px)+0.75rem)]"
 		>
 			<ProgressiveBlur class="absolute inset-0" direction="bottom" blurIntensity={1} />
 			<!-- Gradient overlay: fades from transparent to parent background over the tucked-under portion -->

--- a/src/lib/chat/ui/ChatMessages.svelte
+++ b/src/lib/chat/ui/ChatMessages.svelte
@@ -238,8 +238,7 @@
 	<!-- Blur pinned to chat viewport bottom, inset to avoid the scrollbar -->
 	{#if ctx.displayMessages.length > 0}
 		<div
-			class="pointer-events-none absolute bottom-0 left-0 z-10"
-			style="right: var(--scrollbar-w, 0px); height: 5rem;"
+			class="pointer-events-none absolute right-[calc(var(--scrollbar-w)+0.25rem)] bottom-0 left-0 z-10 h-20 md:right-[calc(var(--scrollbar-w)+0.75rem)]"
 		>
 			<ProgressiveBlur class="absolute inset-0" direction="bottom" blurIntensity={1} />
 			<!-- Gradient overlay: fades from transparent to parent background over the tucked-under portion -->

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -290,7 +290,7 @@
 			<!-- Progressive blur at bottom -->
 			{#if messages.data && messages.data.length > 0}
 				<div
-					class="pointer-events-none absolute right-[calc(var(--scrollbar-w)+0.25rem)] bottom-0 left-0 z-10 h-20 md:right-[calc(var(--scrollbar-w)+0.75rem)]"
+					class="pointer-events-none absolute right-[calc(var(--scrollbar-w,0px)+0.25rem)] bottom-0 left-0 z-10 h-20 md:right-[calc(var(--scrollbar-w,0px)+0.75rem)]"
 				>
 					<ProgressiveBlur class="absolute inset-0" direction="bottom" blurIntensity={1} />
 					{#if resolvedBg}

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -290,8 +290,7 @@
 			<!-- Progressive blur at bottom -->
 			{#if messages.data && messages.data.length > 0}
 				<div
-					class="pointer-events-none absolute bottom-0 left-0 z-10"
-					style="right: var(--scrollbar-w, 0px); height: 5rem;"
+					class="pointer-events-none absolute right-[calc(var(--scrollbar-w)+0.25rem)] bottom-0 left-0 z-10 h-20 md:right-[calc(var(--scrollbar-w)+0.75rem)]"
 				>
 					<ProgressiveBlur class="absolute inset-0" direction="bottom" blurIntensity={1} />
 					{#if resolvedBg}


### PR DESCRIPTION
The progressive blur at the bottom of both chat views ended flush against the scrollbar edge, so it ran right into the border of the viewport. It is now inset by 4px, and by 12px from the `md` breakpoint up.

Carrying a breakpoint is something an inline style cannot do, so the positioning and height move to utility classes in the same step. `h-20` is the same 5rem the inline style set, and the blur stays `pointer-events-none`. The `, 0px` fallback on `--scrollbar-w` is kept: the variable is defined on `:root` in this repo, but forks replace `layout.css`, and without the fallback `calc()` would invalidate the whole declaration and collapse the overlay.

Applies to `ChatMessages.svelte` and the community chat page, which share the overlay markup.

Regression guard: not warranted, a purely visual offset on a decorative overlay with no behavior to assert
Verified against the built CSS that Tailwind emits both arbitrary `right` utilities including the fallback, so the overlay keeps an explicit width instead of falling back to `auto`.