### PR TITLE
fix(support): Keep unread conversations reachable

### DIFF
--- a/src/lib/components/customer-support/thread-activity.test.ts
+++ b/src/lib/components/customer-support/thread-activity.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { hasConversationActivity } from './thread-activity';
+
+describe('hasConversationActivity', () => {
+	it('keeps a conversation whose only reply is an attachment', () => {
+		// An attachment-only admin reply is valid (sendAdminReply accepts an empty
+		// prompt alongside fileIds) and leaves the denormalized preview text empty.
+		expect(hasConversationActivity({ lastMessageAt: 1_700_000_000_000 })).toBe(true);
+	});
+
+	it('hides a conversation that never carried a message', () => {
+		expect(hasConversationActivity({})).toBe(false);
+	});
+});

--- a/src/lib/components/customer-support/thread-activity.test.ts
+++ b/src/lib/components/customer-support/thread-activity.test.ts
@@ -8,6 +8,12 @@ describe('hasConversationActivity', () => {
 		expect(hasConversationActivity({ lastMessageAt: 1_700_000_000_000 })).toBe(true);
 	});
 
+	it('keeps a conversation stored before the timestamp was denormalized', () => {
+		// Those rows carry only the preview text until the backfill mutation is
+		// run by hand, which upgrading an installation does not do on its own.
+		expect(hasConversationActivity({ lastMessage: 'Older stored preview' })).toBe(true);
+	});
+
 	it('hides a conversation that never carried a message', () => {
 		expect(hasConversationActivity({})).toBe(false);
 	});

--- a/src/lib/components/customer-support/thread-activity.ts
+++ b/src/lib/components/customer-support/thread-activity.ts
@@ -2,13 +2,20 @@
  * Whether a support conversation has actually been used.
  *
  * The overview hides conversations that were created but never carried a
- * message. Activity is decided on the timestamp rather than on the preview
- * text: an admin may answer with an attachment and no words, which leaves the
- * denormalized `lastMessage` empty while the conversation is real and, with an
- * unread reply, is the one the visitor is being pointed at. Deciding on the
- * text would hide exactly that conversation behind a launcher that keeps
- * claiming an unread answer.
+ * message. Either denormalized trace of a message counts, because neither one
+ * alone covers every stored conversation:
+ *
+ * - An admin may answer with an attachment and no words, which leaves the
+ *   preview text empty while the timestamp is written. Requiring the text
+ *   would hide exactly that conversation behind a launcher that keeps
+ *   claiming an unread answer.
+ * - Conversations stored before the timestamp was denormalized carry only the
+ *   text until the backfill mutation is run by hand, which no upgrade does for
+ *   the operator. Requiring the timestamp would take those away on upgrade.
  */
-export function hasConversationActivity(thread: { lastMessageAt?: number }): boolean {
-	return thread.lastMessageAt !== undefined;
+export function hasConversationActivity(thread: {
+	lastMessage?: string;
+	lastMessageAt?: number;
+}): boolean {
+	return thread.lastMessageAt !== undefined || Boolean(thread.lastMessage);
 }

--- a/src/lib/components/customer-support/thread-activity.ts
+++ b/src/lib/components/customer-support/thread-activity.ts
@@ -1,0 +1,14 @@
+/**
+ * Whether a support conversation has actually been used.
+ *
+ * The overview hides conversations that were created but never carried a
+ * message. Activity is decided on the timestamp rather than on the preview
+ * text: an admin may answer with an attachment and no words, which leaves the
+ * denormalized `lastMessage` empty while the conversation is real and, with an
+ * unread reply, is the one the visitor is being pointed at. Deciding on the
+ * text would hide exactly that conversation behind a launcher that keeps
+ * claiming an unread answer.
+ */
+export function hasConversationActivity(thread: { lastMessageAt?: number }): boolean {
+	return thread.lastMessageAt !== undefined;
+}

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -47,24 +47,37 @@
 	// Filter out threads with no messages (e.g., eagerly created but never used threads)
 	const threads = $derived(threadsQuery.results.filter(hasConversationActivity));
 	const isLoading = $derived(!ctx.userId ? true : threadsQuery.isLoading);
-	// Query error: without this branch the greeting/empty state would swallow it
-	// (self-heals when the live Convex subscription recovers). Only while nothing
-	// is on screen: a failed page keeps the results already delivered, and taking
-	// the whole list away would cost the visitor conversations they were reading.
 	const loadError = $derived(threadsQuery.error);
-	// An explicit control rather than infinite scroll: the widget's unread signal
-	// covers every conversation the owner has, so an older one carrying an unread
-	// reply has to stay reachable without depending on scroll position.
-	const canLoadMore = $derived(threadsQuery.status === 'CanLoadMore');
-	const isLoadingMore = $derived(threadsQuery.status === 'LoadingMore');
-	const hasInitialError = $derived(Boolean(loadError) && threads.length === 0);
-	// Nothing to show is only an empty inbox once there is nothing left to fetch.
-	// A page can filter down to nothing on its own, and treating that as empty
-	// would show the greeting over conversations that are one page further back,
-	// with no control on that branch to reach them.
-	const showGreeting = $derived(
-		!isLoading && threads.length === 0 && !canLoadMore && !isLoadingMore
-	);
+
+	// One name per visible state, rather than conditions combined at each place
+	// that renders. Read as independent flags, the query's status, its error and
+	// the filtered count kept leaving a combination to no branch at all: a
+	// failure after the last page was already loaded belongs to no "there is
+	// more to fetch" condition, and went unreported.
+	//
+	// - waiting: the owner or the first page is still being resolved
+	// - initial-error: nothing was ever delivered, so the failure is the view
+	// - greeting: nothing to show and nothing left to fetch
+	// - list: anything is on screen, or another page could still bring some
+	const overviewState = $derived.by(() => {
+		if (loadError && threads.length === 0) return 'initial-error';
+		if (isLoading && threads.length === 0) return 'waiting';
+		if (threads.length === 0 && threadsQuery.status === 'Exhausted') return 'greeting';
+		return 'list';
+	});
+
+	// The list's footer, in precedence order. A failure comes first because it
+	// can arrive in any pagination status, including one that has nothing left
+	// to load. An explicit control rather than infinite scroll: the widget's
+	// unread signal covers every conversation the owner has, so an older one
+	// carrying an unread reply has to stay reachable without depending on
+	// scroll position.
+	const footerState = $derived.by(() => {
+		if (loadError) return 'error';
+		if (threadsQuery.status === 'LoadingMore') return 'loading-more';
+		if (threadsQuery.status === 'CanLoadMore') return 'can-load-more';
+		return 'none';
+	});
 
 	// Query admin avatars for the welcome screen
 	const adminAvatarsQuery = useQuery(api.support.threads.getAdminAvatars, {});
@@ -199,8 +212,8 @@
 		     would tell a screen reader that the conversations failed to load. The
 		     region has to outlive the message; a status container that appears
 		     already holding its text is not reliably read out. -->
-		<div role="status" class={hasInitialError ? 'h-full' : undefined}>
-			{#if hasInitialError}
+		<div role="status" class={overviewState === 'initial-error' ? 'h-full' : undefined}>
+			{#if overviewState === 'initial-error'}
 				<div
 					class="flex h-full items-center justify-center p-8 text-center text-balance text-destructive"
 					data-testid="support-threads-error"
@@ -209,9 +222,9 @@
 				</div>
 			{/if}
 		</div>
-		{#if hasInitialError}
+		{#if overviewState === 'initial-error'}
 			<!-- The message above stands in for the list. -->
-		{:else if showGreeting}
+		{:else if overviewState === 'greeting'}
 			<!-- Empty state with greeting (only shown after query completes) -->
 			<div class="flex h-full flex-col justify-start">
 				<div class="m-10 flex flex-col items-start">
@@ -344,9 +357,9 @@
 					</button>
 				{/each}
 
-				{#if canLoadMore || isLoadingMore}
+				{#if footerState !== 'none'}
 					<div class="p-4">
-						<!-- A failed page leaves the query reporting that it is still loading
+						<!-- A failed page leaves the query reporting whichever status it had
 						     and the hook exposes no reset, so nothing here can start another
 						     attempt: loadMore only acts while the status says more can load.
 						     Keeping the control visible would hand the visitor a button that
@@ -365,20 +378,20 @@
 						     to, so the debt outlived the situation and was collected by an
 						     unrelated control later. The announcement carries the outcome. -->
 						<div role="status">
-							{#if loadError}
+							{#if footerState === 'error'}
 								<p class="text-center text-sm text-balance text-destructive">
 									{$t('support.thread.load_error')}
 								</p>
 							{/if}
 						</div>
-						{#if !loadError}
+						{#if footerState !== 'error'}
 							<Button
 								variant="ghost"
 								class="w-full"
-								disabled={isLoadingMore}
+								disabled={footerState === 'loading-more'}
 								onclick={() => threadsQuery.loadMore(20)}
 							>
-								{#if isLoadingMore}
+								{#if footerState === 'loading-more'}
 									<Loader2Icon
 										class="size-4 text-muted-foreground motion-safe:animate-spin"
 										aria-hidden="true"

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -58,6 +58,14 @@
 	const canLoadMore = $derived(threadsQuery.status === 'CanLoadMore');
 	const isLoadingMore = $derived(threadsQuery.status === 'LoadingMore');
 
+	// Removing the control takes the focused element away with it, and the
+	// browser drops focus to the document. Only then does the message take it,
+	// so a failure that arrives on its own never pulls focus away from whatever
+	// the visitor was doing.
+	function claimLostFocus(node: HTMLElement) {
+		if (document.activeElement === document.body) node.focus();
+	}
+
 	// Query admin avatars for the welcome screen
 	const adminAvatarsQuery = useQuery(api.support.threads.getAdminAvatars, {});
 	const adminUsers = $derived(adminAvatarsQuery.data ?? []);
@@ -333,12 +341,24 @@
 						     attempt: loadMore only acts while the status says more can load.
 						     Keeping the control visible would hand the visitor a button that
 						     does nothing, so the failure is reported instead; the control
-						     returns by itself once the subscription recovers. -->
-						{#if loadError}
-							<p class="text-center text-sm text-balance text-destructive">
-								{$t('support.thread.load_error')}
-							</p>
-						{:else}
+						     returns by itself once the subscription recovers.
+
+						     The region is always present so that the message is announced
+						     when it appears. Filling a live region that mounts in the same
+						     update is unreliable, and the failure replaces the control the
+						     visitor just pressed, so it has to speak for itself. -->
+						<div role="status" aria-live="polite">
+							{#if loadError}
+								<p
+									{@attach claimLostFocus}
+									tabindex="-1"
+									class="text-center text-sm text-balance text-destructive outline-none"
+								>
+									{$t('support.thread.load_error')}
+								</p>
+							{/if}
+						</div>
+						{#if !loadError}
 							<Button
 								variant="ghost"
 								class="w-full"

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -328,28 +328,32 @@
 
 				{#if canLoadMore || isLoadingMore}
 					<div class="p-4">
+						<!-- A failed page leaves the query reporting that it is still loading
+						     and the hook exposes no reset, so nothing here can start another
+						     attempt: loadMore only acts while the status says more can load.
+						     Keeping the control visible would hand the visitor a button that
+						     does nothing, so the failure is reported instead; the control
+						     returns by itself once the subscription recovers. -->
 						{#if loadError}
-							<p class="mb-2 text-center text-sm text-balance text-destructive">
+							<p class="text-center text-sm text-balance text-destructive">
 								{$t('support.thread.load_error')}
 							</p>
+						{:else}
+							<Button
+								variant="ghost"
+								class="w-full"
+								disabled={isLoadingMore}
+								onclick={() => threadsQuery.loadMore(20)}
+							>
+								{#if isLoadingMore}
+									<Loader2Icon
+										class="size-4 text-muted-foreground motion-safe:animate-spin"
+										aria-hidden="true"
+									/>
+								{/if}
+								{$t('support.button.show_older_conversations')}
+							</Button>
 						{/if}
-						<!-- A failed page leaves the query reporting that it is still loading,
-						     and the hook exposes no reset, so tying the disabled state to that
-						     alone would freeze the control on a spinner with no way back. -->
-						<Button
-							variant="ghost"
-							class="w-full"
-							disabled={isLoadingMore && !loadError}
-							onclick={() => threadsQuery.loadMore(20)}
-						>
-							{#if isLoadingMore && !loadError}
-								<Loader2Icon
-									class="size-4 text-muted-foreground motion-safe:animate-spin"
-									aria-hidden="true"
-								/>
-							{/if}
-							{$t('support.button.show_older_conversations')}
-						</Button>
 					</div>
 				{/if}
 			</div>

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -357,49 +357,48 @@
 					</button>
 				{/each}
 
-				{#if footerState !== 'none'}
+				<!-- The region outlives every message it carries, including the one that
+				     follows a list with nothing left to load: a status container that
+				     appears already holding its text is not reliably read out, and the
+				     failure can arrive from any pagination status. It stays empty, and so
+				     invisible, whenever there is nothing to report. -->
+				<div role="status">
+					{#if footerState === 'error'}
+						<p class="p-4 text-center text-sm text-balance text-destructive">
+							{$t('support.thread.load_error')}
+						</p>
+					{/if}
+				</div>
+
+				<!-- A failed page leaves the query reporting whichever status it had and
+				     the hook exposes no reset, so nothing here can start another attempt:
+				     loadMore only acts while the status says more can load. Keeping the
+				     control visible would hand the visitor a button that does nothing, so
+				     the message above stands in its place; the control returns by itself
+				     once the subscription recovers.
+
+				     Replacing the control does drop focus to the document. Moving it onto
+				     the message and back was tried and removed: every version had to
+				     remember across renders whether it owed focus back, and a recovery
+				     that ends the pagination leaves no control to return it to, so the
+				     debt outlived the situation and was collected by an unrelated control
+				     later. The announcement carries the outcome. -->
+				{#if footerState === 'loading-more' || footerState === 'can-load-more'}
 					<div class="p-4">
-						<!-- A failed page leaves the query reporting whichever status it had
-						     and the hook exposes no reset, so nothing here can start another
-						     attempt: loadMore only acts while the status says more can load.
-						     Keeping the control visible would hand the visitor a button that
-						     does nothing, so the failure is reported instead; the control
-						     returns by itself once the subscription recovers.
-
-						     The region is always present so that the message is announced
-						     when it appears. Filling a live region that mounts in the same
-						     update is unreliable, and the failure replaces the control the
-						     visitor just pressed, so it has to speak for itself.
-
-						     Replacing the control does drop focus to the document. Moving it
-						     onto the message and back was tried and removed: every version
-						     had to remember across renders whether it owed focus back, and a
-						     recovery that ends the pagination leaves no control to return it
-						     to, so the debt outlived the situation and was collected by an
-						     unrelated control later. The announcement carries the outcome. -->
-						<div role="status">
-							{#if footerState === 'error'}
-								<p class="text-center text-sm text-balance text-destructive">
-									{$t('support.thread.load_error')}
-								</p>
+						<Button
+							variant="ghost"
+							class="w-full"
+							disabled={footerState === 'loading-more'}
+							onclick={() => threadsQuery.loadMore(20)}
+						>
+							{#if footerState === 'loading-more'}
+								<Loader2Icon
+									class="size-4 text-muted-foreground motion-safe:animate-spin"
+									aria-hidden="true"
+								/>
 							{/if}
-						</div>
-						{#if footerState !== 'error'}
-							<Button
-								variant="ghost"
-								class="w-full"
-								disabled={footerState === 'loading-more'}
-								onclick={() => threadsQuery.loadMore(20)}
-							>
-								{#if footerState === 'loading-more'}
-									<Loader2Icon
-										class="size-4 text-muted-foreground motion-safe:animate-spin"
-										aria-hidden="true"
-									/>
-								{/if}
-								{$t('support.button.show_older_conversations')}
-							</Button>
-						{/if}
+							{$t('support.button.show_older_conversations')}
+						</Button>
 					</div>
 				{/if}
 			</div>

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -23,6 +23,7 @@
 	import { page } from '$app/state';
 	import { DEFAULT_LANGUAGE } from '$lib/i18n/languages';
 	import SupportUnreadIndicator from './support-unread-indicator.svelte';
+	import { hasConversationActivity } from './thread-activity';
 
 	const { t } = getTranslate();
 
@@ -44,7 +45,7 @@
 	);
 
 	// Filter out threads with no messages (e.g., eagerly created but never used threads)
-	const threads = $derived(threadsQuery.results.filter((thread) => thread.lastMessage));
+	const threads = $derived(threadsQuery.results.filter(hasConversationActivity));
 	const isLoading = $derived(!ctx.userId ? true : threadsQuery.isLoading);
 	// Query error: without this branch the greeting/empty state would swallow it
 	// (self-heals when the live Convex subscription recovers). Only while nothing
@@ -327,13 +328,21 @@
 
 				{#if canLoadMore || isLoadingMore}
 					<div class="p-4">
+						{#if loadError}
+							<p class="mb-2 text-center text-sm text-balance text-destructive">
+								{$t('support.thread.load_error')}
+							</p>
+						{/if}
+						<!-- A failed page leaves the query reporting that it is still loading,
+						     and the hook exposes no reset, so tying the disabled state to that
+						     alone would freeze the control on a spinner with no way back. -->
 						<Button
 							variant="ghost"
 							class="w-full"
-							disabled={isLoadingMore}
+							disabled={isLoadingMore && !loadError}
 							onclick={() => threadsQuery.loadMore(20)}
 						>
-							{#if isLoadingMore}
+							{#if isLoadingMore && !loadError}
 								<Loader2Icon
 									class="size-4 text-muted-foreground motion-safe:animate-spin"
 									aria-hidden="true"

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -57,6 +57,14 @@
 	// reply has to stay reachable without depending on scroll position.
 	const canLoadMore = $derived(threadsQuery.status === 'CanLoadMore');
 	const isLoadingMore = $derived(threadsQuery.status === 'LoadingMore');
+	const hasInitialError = $derived(Boolean(loadError) && threads.length === 0);
+	// Nothing to show is only an empty inbox once there is nothing left to fetch.
+	// A page can filter down to nothing on its own, and treating that as empty
+	// would show the greeting over conversations that are one page further back,
+	// with no control on that branch to reach them.
+	const showGreeting = $derived(
+		!isLoading && threads.length === 0 && !canLoadMore && !isLoadingMore
+	);
 
 	// Query admin avatars for the welcome screen
 	const adminAvatarsQuery = useQuery(api.support.threads.getAdminAvatars, {});
@@ -186,18 +194,24 @@
 <div class="flex h-full flex-col" inert={ctx.currentView !== 'overview' ? true : undefined}>
 	<!-- Thread List -->
 	<div class="min-h-0 flex-1 overflow-y-auto">
-		{#if loadError && threads.length === 0}
-			<!-- Announced for the same reason as the paging failure below: it arrives
-			     after the view is already open, without moving focus, so nothing else
-			     would tell a screen reader that the conversations failed to load. -->
-			<div
-				role="status"
-				class="flex h-full items-center justify-center p-8 text-center text-balance text-destructive"
-				data-testid="support-threads-error"
-			>
-				{$t('support.thread.load_error')}
-			</div>
-		{:else if !isLoading && threads.length === 0}
+		<!-- Announced for the same reason as the paging failure below: it arrives
+		     after the view is already open, without moving focus, so nothing else
+		     would tell a screen reader that the conversations failed to load. The
+		     region has to outlive the message; a status container that appears
+		     already holding its text is not reliably read out. -->
+		<div role="status" class={hasInitialError ? 'h-full' : undefined}>
+			{#if hasInitialError}
+				<div
+					class="flex h-full items-center justify-center p-8 text-center text-balance text-destructive"
+					data-testid="support-threads-error"
+				>
+					{$t('support.thread.load_error')}
+				</div>
+			{/if}
+		</div>
+		{#if hasInitialError}
+			<!-- The message above stands in for the list. -->
+		{:else if showGreeting}
 			<!-- Empty state with greeting (only shown after query completes) -->
 			<div class="flex h-full flex-col justify-start">
 				<div class="m-10 flex flex-col items-start">

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -187,7 +187,11 @@
 	<!-- Thread List -->
 	<div class="min-h-0 flex-1 overflow-y-auto">
 		{#if loadError && threads.length === 0}
+			<!-- Announced for the same reason as the paging failure below: it arrives
+			     after the view is already open, without moving focus, so nothing else
+			     would tell a screen reader that the conversations failed to load. -->
 			<div
+				role="status"
 				class="flex h-full items-center justify-center p-8 text-center text-balance text-destructive"
 				data-testid="support-threads-error"
 			>
@@ -346,7 +350,7 @@
 						     recovery that ends the pagination leaves no control to return it
 						     to, so the debt outlived the situation and was collected by an
 						     unrelated control later. The announcement carries the outcome. -->
-						<div role="status" aria-live="polite">
+						<div role="status">
 							{#if loadError}
 								<p class="text-center text-sm text-balance text-destructive">
 									{$t('support.thread.load_error')}

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -58,25 +58,6 @@
 	const canLoadMore = $derived(threadsQuery.status === 'CanLoadMore');
 	const isLoadingMore = $derived(threadsQuery.status === 'LoadingMore');
 
-	// Swapping the control for the message and back takes the focused element
-	// away with it each time, and the browser drops focus to the document. Both
-	// sides of the swap pick it up again, but only when it was actually lost, so
-	// a failure or a recovery that arrives on its own never pulls focus away
-	// from whatever the visitor was doing. A recovery that ends the pagination
-	// altogether has nothing left to hand focus to.
-	let messageTookFocus = false;
-
-	function claimLostFocus(node: HTMLElement) {
-		messageTookFocus = document.activeElement === document.body;
-		if (messageTookFocus) node.focus();
-	}
-
-	function returnLostFocus(node: HTMLElement) {
-		if (!messageTookFocus) return;
-		messageTookFocus = false;
-		if (document.activeElement === document.body) node.focus();
-	}
-
 	// Query admin avatars for the welcome screen
 	const adminAvatarsQuery = useQuery(api.support.threads.getAdminAvatars, {});
 	const adminUsers = $derived(adminAvatarsQuery.data ?? []);
@@ -357,14 +338,17 @@
 						     The region is always present so that the message is announced
 						     when it appears. Filling a live region that mounts in the same
 						     update is unreliable, and the failure replaces the control the
-						     visitor just pressed, so it has to speak for itself. -->
+						     visitor just pressed, so it has to speak for itself.
+
+						     Replacing the control does drop focus to the document. Moving it
+						     onto the message and back was tried and removed: every version
+						     had to remember across renders whether it owed focus back, and a
+						     recovery that ends the pagination leaves no control to return it
+						     to, so the debt outlived the situation and was collected by an
+						     unrelated control later. The announcement carries the outcome. -->
 						<div role="status" aria-live="polite">
 							{#if loadError}
-								<p
-									{@attach claimLostFocus}
-									tabindex="-1"
-									class="text-center text-sm text-balance text-destructive outline-none"
-								>
+								<p class="text-center text-sm text-balance text-destructive">
 									{$t('support.thread.load_error')}
 								</p>
 							{/if}
@@ -375,7 +359,6 @@
 								class="w-full"
 								disabled={isLoadingMore}
 								onclick={() => threadsQuery.loadMore(20)}
-								{@attach returnLostFocus}
 							>
 								{#if isLoadingMore}
 									<Loader2Icon

--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -58,11 +58,22 @@
 	const canLoadMore = $derived(threadsQuery.status === 'CanLoadMore');
 	const isLoadingMore = $derived(threadsQuery.status === 'LoadingMore');
 
-	// Removing the control takes the focused element away with it, and the
-	// browser drops focus to the document. Only then does the message take it,
-	// so a failure that arrives on its own never pulls focus away from whatever
-	// the visitor was doing.
+	// Swapping the control for the message and back takes the focused element
+	// away with it each time, and the browser drops focus to the document. Both
+	// sides of the swap pick it up again, but only when it was actually lost, so
+	// a failure or a recovery that arrives on its own never pulls focus away
+	// from whatever the visitor was doing. A recovery that ends the pagination
+	// altogether has nothing left to hand focus to.
+	let messageTookFocus = false;
+
 	function claimLostFocus(node: HTMLElement) {
+		messageTookFocus = document.activeElement === document.body;
+		if (messageTookFocus) node.focus();
+	}
+
+	function returnLostFocus(node: HTMLElement) {
+		if (!messageTookFocus) return;
+		messageTookFocus = false;
 		if (document.activeElement === document.body) node.focus();
 	}
 
@@ -364,6 +375,7 @@
 								class="w-full"
 								disabled={isLoadingMore}
 								onclick={() => threadsQuery.loadMore(20)}
+								{@attach returnLostFocus}
 							>
 								{#if isLoadingMore}
 									<Loader2Icon


### PR DESCRIPTION
Two ways the customer inbox could keep an unread indicator lit with no way to act on it.

The conversation list hid any thread without preview text, but an admin reply may be an attachment with no words, which `sendAdminReply` accepts by contract. Such a reply leaves the denormalized `lastMessage` empty while `lastMessageAt` is set, so the conversation dropped out of the list while still counting as unread: the launcher kept its indicator, no row existed to open, and the receipt could never be recorded. Visibility now accepts either denormalized trace of a message, because the timestamp alone would take away conversations stored before it was denormalized, which only a hand-run backfill repairs.

A page that filtered down to nothing was also read as an empty inbox, which showed the greeting over conversations one page further back and withheld the only control that could reach them. That decision now waits until there is nothing left to fetch.

The control that loads older conversations could freeze. A failed page leaves the paginated query reporting whichever status it had, and the hook exposes no reset, so a disabled state derived from that stranded the control on a spinner, while nothing in the component could start another attempt. The failure is now reported in place of the control rather than behind a button that would do nothing, and the control returns once the subscription recovers.

Holding the view together from separate booleans is what let those states slip through, so the overview now derives one name for what it shows and one for its footer, with a failure taking precedence over pagination. That closes a case where a failure arriving after the last page had loaded belonged to no condition at all and went unreported. Both failures are announced from status regions that outlive their messages, since a live region that appears already holding its text is not reliably read out.

Regression guard: added `src/lib/components/customer-support/thread-activity.test.ts`, which pins the visibility rule to both traces of a message. It guards the rule, not its use: this repository has no component-test layer that could follow a query result without preview text through to a rendered, clickable row. The failure states have no guard either, since reproducing them needs a transport failure between two pages of a live subscription.

Verified with static checks, the Svelte autofixer, and the unit suite.
