### PR TITLE
fix(support): Order threads by messages

### DIFF
--- a/src/lib/convex/admin/support/queries.ts
+++ b/src/lib/convex/admin/support/queries.ts
@@ -28,7 +28,7 @@ const vSupportMetadata = v.object({
  * - status (open, done)
  * - search (title, summary, or message content)
  *
- * Returns threads sorted by lastMessageAt (most recent first)
+ * Non-search results are ordered by updatedAt; search results use relevance order.
  */
 export const listThreadsForAdmin = adminQuery({
 	args: {

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -71,7 +71,7 @@ export default defineSchema({
 		.index('by_thread', ['threadId'])
 		.index('by_user', ['userId'])
 		.index('by_user_warm', ['userId', 'isWarm'])
-		.index('by_user_and_updated', ['userId', 'updatedAt'])
+		.index('by_user_and_last_message', ['userId', 'lastMessageAt'])
 		.index('by_user_and_unread_admin_reply', ['userId', 'hasUnreadAdminReply'])
 		.index('by_handed_off_updated', ['isHandedOff', 'updatedAt'])
 		.index('by_handed_off_assigned_updated', ['isHandedOff', 'assignedTo', 'updatedAt'])

--- a/src/lib/convex/support/__tests__/threads.test.ts
+++ b/src/lib/convex/support/__tests__/threads.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../ownership', () => ({
+	getSupportOwnerIdentity: vi.fn(),
+	requireSupportOwnerIdentity: vi.fn(),
+	requireSupportThreadAccess: vi.fn(),
+	requireSupportThreadRecord: vi.fn()
+}));
+
+vi.mock('../agent', () => ({
+	supportAgent: {}
+}));
+
+vi.mock('../rateLimit', () => ({
+	supportRateLimiter: {}
+}));
+
+vi.mock('../../_generated/api', () => ({
+	components: {
+		betterAuth: {
+			adapter: {
+				findOne: 'components.betterAuth.adapter.findOne'
+			}
+		},
+		agent: {
+			messages: {
+				listMessagesByThreadId: 'components.agent.messages.listMessagesByThreadId'
+			}
+		}
+	},
+	internal: {}
+}));
+
+import { getSupportOwnerIdentity } from '../ownership';
+import { listThreads } from '../threads';
+
+const getSupportOwnerIdentityMock = getSupportOwnerIdentity as unknown as ReturnType<typeof vi.fn>;
+
+type QueryHandler<TArgs, TResult> = {
+	_handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const listThreadsHandler = listThreads as unknown as QueryHandler<
+	{ anonymousUserId?: string; paginationOpts?: { numItems: number; cursor: string | null } },
+	{ page: Array<{ _id: string }>; isDone: boolean; continueCursor: string }
+>;
+
+describe('customer support thread ordering', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getSupportOwnerIdentityMock.mockResolvedValue({
+			ownerId: 'user_1',
+			isAnonymous: false
+		});
+	});
+
+	it('paginates and returns threads in last-message index order', async () => {
+		const paginationOpts = { numItems: 20, cursor: 'cursor_1' };
+		// Convex has already ordered this page by lastMessageAt. The conflicting
+		// updatedAt values catch any page-local re-sort before it reaches the UI.
+		const indexedThreads = [
+			{
+				_id: 'support_doc_1',
+				threadId: 'thread_first',
+				createdAt: 1,
+				userId: 'user_1',
+				status: 'open' as const,
+				updatedAt: 10,
+				lastMessageAt: 100,
+				isWarm: false
+			},
+			{
+				_id: 'support_doc_2',
+				threadId: 'thread_second',
+				createdAt: 2,
+				userId: 'user_1',
+				status: 'open' as const,
+				updatedAt: 100,
+				lastMessageAt: 10,
+				isWarm: false
+			}
+		];
+		const paginate = vi.fn().mockResolvedValue({
+			page: indexedThreads,
+			isDone: false,
+			continueCursor: 'cursor_2'
+		});
+		const order = vi.fn(() => ({ paginate }));
+		const withIndex = vi.fn((_indexName, indexQuery) => {
+			const eq = vi.fn(() => ({}));
+			indexQuery({ eq });
+			expect(eq).toHaveBeenCalledWith('userId', 'user_1');
+			return { order };
+		});
+		const ctx = {
+			db: {
+				query: vi.fn(() => ({ withIndex }))
+			},
+			runQuery: vi.fn()
+		};
+
+		const result = await listThreadsHandler._handler(ctx, { paginationOpts });
+
+		expect(withIndex).toHaveBeenCalledWith('by_user_and_last_message', expect.any(Function));
+		expect(order).toHaveBeenCalledWith('desc');
+		expect(paginate).toHaveBeenCalledWith(paginationOpts);
+		expect(result.page.map((thread) => thread._id)).toEqual(['thread_first', 'thread_second']);
+		expect(result).toMatchObject({ isDone: false, continueCursor: 'cursor_2' });
+	});
+});

--- a/src/lib/convex/support/threads.ts
+++ b/src/lib/convex/support/threads.ts
@@ -168,7 +168,7 @@ export const listThreads = query({
 
 		const supportThreadsPage = await ctx.db
 			.query('supportThreads')
-			.withIndex('by_user_and_updated', (q) => q.eq('userId', owner.ownerId))
+			.withIndex('by_user_and_last_message', (q) => q.eq('userId', owner.ownerId))
 			.order('desc')
 			.paginate(args.paginationOpts ?? { numItems: 20, cursor: null });
 		// Bounded: each owner has at most one pre-warmed thread.
@@ -198,7 +198,7 @@ export const listThreads = query({
 			})
 		);
 
-		const threadsWithLastMessage = supportThreads.map((supportThread) => {
+		const threads = supportThreads.map((supportThread) => {
 			const assignedAdmin = supportThread.assignedTo
 				? adminMap.get(supportThread.assignedTo)
 				: undefined;
@@ -221,11 +221,8 @@ export const listThreads = query({
 			};
 		});
 
-		// Sort by lastMessageAt in descending order (most recent first)
-		threadsWithLastMessage.sort((a, b) => (b.lastMessageAt ?? 0) - (a.lastMessageAt ?? 0));
-
 		return {
-			page: threadsWithLastMessage,
+			page: threads,
 			isDone: supportThreadsPage.isDone,
 			continueCursor: supportThreadsPage.continueCursor
 		};
@@ -514,7 +511,7 @@ export const updateLastMessage = internalMutation({
  *
  * Leaves notificationEmail untouched (explicit opt-in that may intentionally
  * differ from the account email) and does not bump updatedAt (a profile edit
- * is not thread activity and must not reorder by_user_and_updated listings).
+ * is not thread activity and must not reorder the admin inbox).
  */
 export const syncUserProfile = internalMutation({
 	args: {


### PR DESCRIPTION
Closes #796

The customer conversation list paginated by `updatedAt` and then sorted each page by `lastMessageAt`. Administrative changes can update the first timestamp without changing the second, so once older pages were appended, newer conversations could appear below older ones.

Customer pagination now uses a `userId + lastMessageAt` index and preserves the database order. Page boundaries and the activity timestamp rendered in each row therefore use the same key, while assignments, status changes, and other customer-invisible metadata updates no longer reorder the list. The admin inbox keeps its separate `updatedAt` ordering, and its query comment now documents the relevance-ordered search path as well.

The production metadata backfill completed before rollout: all 128 visible support threads now have `lastMessageAt`. A handler-level unit test pins the index, descending direction, cursor forwarding, and preservation of Convex's page order.

Regression guard: added `src/lib/convex/support/__tests__/threads.test.ts`

Verified with targeted static checks, Convex type checking, and 1,132 passing unit tests. The unrelated prerender sync test timed out once under host load and then passed three consecutive isolated runs.