### PR TITLE
fix(button): Make press translation immediate

### DIFF
--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -91,7 +91,7 @@
 							{#snippet child({ props })}
 								<Button
 									variant="ghost"
-									class="w-full justify-start gap-2 px-1.5 !transition-transform data-[state=open]:bg-muted"
+									class="w-full justify-start gap-2 px-1.5 data-[state=open]:bg-muted"
 									{...props}
 								>
 									<config.header.icon class="!size-5" />
@@ -120,7 +120,7 @@
 					<Button
 						variant="ghost"
 						href={resolve(config.header.href)}
-						class="w-full justify-start gap-2 px-1.5 !transition-transform"
+						class="w-full justify-start gap-2 px-1.5"
 					>
 						<config.header.icon class="!size-5" />
 						<span class="text-base font-semibold">
@@ -152,7 +152,7 @@
 									<Sidebar.MenuItem {...props}>
 										<Sidebar.MenuButton
 											isActive={item.isActive}
-											class="relative !transition-transform"
+											class="relative"
 											onclick={() => haptic.trigger('light')}
 										>
 											{#snippet child({ props })}
@@ -170,9 +170,11 @@
 											{#snippet child({ props })}
 												<Sidebar.MenuAction
 													{...props}
-													class="transition-transform duration-200 active:translate-y-px data-[state=open]:rotate-90"
+													class="group/threads-toggle active:translate-y-px"
 												>
-													<ChevronRightIcon />
+													<ChevronRightIcon
+														class="transition-transform duration-200 group-data-[state=open]/threads-toggle:rotate-90"
+													/>
 													<span class="sr-only"><T keyName="aria.toggle_threads" /></span>
 												</Sidebar.MenuAction>
 											{/snippet}
@@ -185,7 +187,7 @@
 							<Sidebar.MenuItem>
 								<Sidebar.MenuButton
 									isActive={item.isActive}
-									class="relative !transition-transform"
+									class="relative"
 									onclick={() => {
 										haptic.trigger('light');
 										item.onSelect?.();
@@ -227,10 +229,7 @@
 				{#each config.footerLinks as link (link.translationKey)}
 					{#if link.condition !== false}
 						<Sidebar.MenuItem>
-							<Sidebar.MenuButton
-								class="relative !transition-transform"
-								onclick={() => haptic.trigger('light')}
-							>
+							<Sidebar.MenuButton class="relative" onclick={() => haptic.trigger('light')}>
 								{#snippet child({ props })}
 									<a href={resolve(link.url)} {...props}>
 										<link.icon />

--- a/src/lib/components/customer-support/feedback-button.svelte
+++ b/src/lib/components/customer-support/feedback-button.svelte
@@ -54,7 +54,7 @@
 				: unread.hasUnread
 					? $t('aria.feedback_open_unread')
 					: $t('aria.feedback_open')}
-			class="relative size-12 rounded-xl transition-transform duration-150 ease-out active:scale-[0.97]"
+			class="relative size-12 rounded-xl transition-transform duration-150 ease-out active:not-aria-[haspopup]:translate-y-0 active:scale-[0.97]"
 		>
 			<div class="relative size-6">
 				<ChevronDownIcon

--- a/src/lib/components/customer-support/lazy-customer-support.svelte
+++ b/src/lib/components/customer-support/lazy-customer-support.svelte
@@ -101,7 +101,7 @@
 			disabled={isLoading}
 			onclick={openSupport}
 			aria-label={unread.hasUnread ? $t('aria.feedback_open_unread') : $t('aria.feedback_open')}
-			class="relative h-12 w-12 rounded-xl transition-[color,background-color,border-color,transform] duration-200 ease-out hover:scale-105 hover:bg-primary active:scale-[0.97]"
+			class="relative h-12 w-12 rounded-xl transition-[color,background-color,border-color,transform] duration-200 ease-out hover:scale-105 hover:bg-primary active:not-aria-[haspopup]:translate-y-0 active:scale-[0.97]"
 		>
 			<LauncherIcon />
 			{#if unread.hasUnread}

--- a/src/lib/components/prompt-kit/scroll-button/ScrollButton.svelte
+++ b/src/lib/components/prompt-kit/scroll-button/ScrollButton.svelte
@@ -53,7 +53,7 @@
 	{size}
 	aria-label={$t('aria.scroll_to_bottom')}
 	class={cn(
-		'h-10 w-10 rounded-full transition-all duration-150 ease-out',
+		'h-10 w-10 rounded-full transition-all duration-150 ease-out active:not-aria-[haspopup]:translate-y-0',
 		!resolvedIsAtBottom
 			? 'translate-y-0 scale-100 opacity-100'
 			: 'pointer-events-none translate-y-4 scale-95 opacity-0',

--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -4,7 +4,7 @@
 	import { type VariantProps, tv } from 'tailwind-variants';
 
 	export const buttonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-[color,background-color,border-color,box-shadow] outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default: 'bg-primary text-primary-foreground hover:bg-primary/80',

--- a/src/lib/components/ui/button/button.test.ts
+++ b/src/lib/components/ui/button/button.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { cn } from '$lib/utils.js';
+import { buttonVariants } from './button.svelte';
+
+describe('buttonVariants', () => {
+	it('keeps the one-pixel press immediate', () => {
+		const classes = buttonVariants();
+
+		expect(classes).toContain('active:not-aria-[haspopup]:translate-y-px');
+		expect(classes).toContain('transition-[color,background-color,border-color,box-shadow]');
+		expect(classes).not.toContain('transition-all');
+	});
+
+	it('lets intentional transform animations suppress the translate', () => {
+		const classes = cn(
+			buttonVariants(),
+			'active:not-aria-[haspopup]:translate-y-0 active:scale-[0.97]'
+		);
+
+		expect(classes).not.toContain('active:not-aria-[haspopup]:translate-y-px');
+		expect(classes).toContain('active:not-aria-[haspopup]:translate-y-0');
+		expect(classes).toContain('active:scale-[0.97]');
+	});
+});

--- a/src/lib/components/ui/sidebar/sidebar-menu-action.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-action.svelte
@@ -17,7 +17,7 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 aspect-square w-5 rounded-md p-0 peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 focus-visible:ring-2 [&>svg]:size-4 flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0',
+			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 aspect-square w-5 rounded-md p-0 peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 focus-visible:ring-2 [&>svg]:size-4 flex items-center justify-center outline-hidden group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0',
 			showOnHover &&
 				'peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-open:opacity-100 md:opacity-0',
 			className


### PR DESCRIPTION
Closes #802

The shared button animated its one-pixel press because `transition-all` included transform, and sidebar overrides extended the same delay. The standard press now translates immediately while hover colors, chevron rotation, visibility motion, and intentional scale feedback retain their transitions.

Regression guard: added buttonVariants press-transition tests

Verified with file-scoped static checks and the full unit suite (132 files, 1,140 tests).