### PR TITLE
fix(ui): Guard immediate pixel presses

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,7 @@ import requireFieldErrorAssociationRule from './eslint/rules/require-field-error
 import requireGuardedServerConvexClientRule from './eslint/rules/require-guarded-server-convex-client.js';
 import noFrozenAuthPageDataRule from './eslint/rules/no-frozen-auth-page-data.js';
 import requireSvelteModuleExtensionRule from './eslint/rules/require-svelte-module-extension.js';
+import noAnimatedPixelPressRule from './eslint/rules/no-animated-pixel-press.js';
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
 const localPlugin = {
@@ -39,7 +40,8 @@ const localPlugin = {
 		'require-field-error-association': requireFieldErrorAssociationRule,
 		'require-guarded-server-convex-client': requireGuardedServerConvexClientRule,
 		'no-frozen-auth-page-data': noFrozenAuthPageDataRule,
-		'require-svelte-module-extension': requireSvelteModuleExtensionRule
+		'require-svelte-module-extension': requireSvelteModuleExtensionRule,
+		'no-animated-pixel-press': noAnimatedPixelPressRule
 	}
 };
 
@@ -297,6 +299,15 @@ export default defineConfig(
 		},
 		rules: {
 			'local/require-guarded-server-convex-client': 'error'
+		}
+	},
+	{
+		files: ['src/**/*.svelte'],
+		plugins: {
+			local: localPlugin
+		},
+		rules: {
+			'local/no-animated-pixel-press': 'error'
 		}
 	},
 	// Convex best-practice rules — v2 ships ESLint 9 flat config natively

--- a/eslint/rules/no-animated-pixel-press.js
+++ b/eslint/rules/no-animated-pixel-press.js
@@ -1,0 +1,136 @@
+/**
+ * ESLint rule: no-animated-pixel-press
+ *
+ * One-pixel press offsets are tactile state changes. Animating them makes the
+ * control lag behind the pointer. This rule checks static Tailwind classes on
+ * Svelte class attributes, including literals split across cn() arguments, and
+ * the base classes of tailwind-variants definitions.
+ *
+ * Component class props need an explicit safe transition because their classes
+ * are merged with defaults the call site cannot see. Native elements without a
+ * transition are already safe.
+ *
+ * ❌ <button class="transition-all active:translate-y-px">
+ * ❌ <Widget class="active:translate-y-px">
+ * ✅ <button class="transition-colors active:translate-y-px">
+ * ✅ <Widget class="transition-colors active:translate-y-px">
+ * ✅ <button class="transition-transform active:scale-[0.97]">
+ */
+
+const CLASS_FACTORY_NAMES = new Set(['cva', 'tv']);
+
+function walk(node, visit) {
+	if (!node || typeof node !== 'object') return;
+	visit(node);
+	for (const [key, value] of Object.entries(node)) {
+		if (key === 'parent') continue;
+		if (Array.isArray(value)) value.forEach((child) => walk(child, visit));
+		else if (value && typeof value === 'object' && value.type) walk(value, visit);
+	}
+}
+
+function staticClassTokens(node) {
+	const tokens = [];
+	walk(node, (candidate) => {
+		let value;
+		if (
+			(candidate.type === 'Literal' || candidate.type === 'SvelteLiteral') &&
+			typeof candidate.value === 'string'
+		) {
+			value = candidate.value;
+		} else if (candidate.type === 'TemplateElement') {
+			value = candidate.value?.cooked ?? candidate.value?.raw;
+		}
+		if (value) tokens.push(...value.split(/\s+/u).filter(Boolean));
+	});
+	return tokens;
+}
+
+function isPixelPress(token) {
+	const isPressVariant =
+		/(?:^|:)active:/u.test(token) ||
+		/(?:^|:)(?:group|peer)-active(?:\/[^:]+)?:/u.test(token) ||
+		/:active\]/u.test(token);
+	return isPressVariant && /(?:^|:)!?-?translate-[xy]-px!?$/u.test(token);
+}
+
+function isUnsafeTransition(token) {
+	const animatesMovement =
+		/(?:^|:)!?transition(?:-(?:all|transform)|-\[[^\]]*(?:all|transform|translate)[^\]]*\])?!?$/u.test(
+			token
+		);
+	const hasUnknownProperties =
+		/(?:^|:)!?transition-(?:\[[^\]]*(?:var\(|--)[^\]]*\]|\(--[^)]*\))!?$/u.test(token);
+	return animatesMovement || hasUnknownProperties;
+}
+
+function isExplicitSafeTransition(token) {
+	if (!/^!?transition(?:-|$)/u.test(token)) return false;
+	return !isUnsafeTransition(token);
+}
+
+function isComponentClassAttribute(node) {
+	const element = node.parent?.parent;
+	const name = element?.name;
+	if (!name) return element?.type === 'SvelteComponent';
+	if (name.type === 'SvelteMemberExpressionName') return true;
+	return name.type === 'Identifier' && /^[A-Z]/u.test(name.name ?? '');
+}
+
+function propertyName(property) {
+	if (!property || property.type !== 'Property' || property.computed) return null;
+	if (property.key?.type === 'Identifier') return property.key.name;
+	return typeof property.key?.value === 'string' ? property.key.value : null;
+}
+
+function classFactoryBase(call) {
+	if (call.callee?.type !== 'Identifier' || !CLASS_FACTORY_NAMES.has(call.callee.name)) return null;
+	const first = call.arguments?.[0];
+	if (!first) return null;
+	if (call.callee.name === 'cva' && first.type !== 'ObjectExpression') return first;
+	if (first.type !== 'ObjectExpression') return null;
+	return first.properties.find((property) => propertyName(property) === 'base')?.value ?? null;
+}
+
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Keep one-pixel press translations out of transform transitions'
+		},
+		schema: [],
+		messages: {
+			animatedPixelPress:
+				'One-pixel press translation must be immediate. Restrict the transition to non-movement properties such as transition-colors.',
+			unprovenComponentPress:
+				'Component classes may inherit a movement transition. Add an explicit non-movement transition such as transition-colors beside the one-pixel press.'
+		}
+	},
+	create(context) {
+		function check(node, { component = false } = {}) {
+			const tokens = staticClassTokens(node);
+			if (!tokens.some(isPixelPress)) return;
+			if (tokens.some(isUnsafeTransition)) {
+				context.report({ node, messageId: 'animatedPixelPress' });
+				return;
+			}
+			if (component && !tokens.some(isExplicitSafeTransition)) {
+				context.report({ node, messageId: 'unprovenComponentPress' });
+			}
+		}
+
+		return {
+			SvelteAttribute(node) {
+				if (node.key?.name !== 'class') return;
+				check(node, { component: isComponentClassAttribute(node) });
+			},
+			Property(node) {
+				if (propertyName(node) === 'class') check(node.value);
+			},
+			CallExpression(node) {
+				const base = classFactoryBase(node);
+				if (base) check(base);
+			}
+		};
+	}
+};

--- a/eslint/rules/no-animated-pixel-press.test.ts
+++ b/eslint/rules/no-animated-pixel-press.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import parser from 'svelte-eslint-parser';
+import rule from './no-animated-pixel-press.js';
+
+function lint(template: string): Array<{ messageId: string }> {
+	const reports: Array<{ messageId: string }> = [];
+	const ast = parser.parseForESLint(template, {});
+	const context = {
+		report: (opts: { messageId: string }) => reports.push(opts),
+		getFilename: () => 'test.svelte',
+		filename: 'test.svelte'
+	};
+	const listeners = rule.create(context);
+
+	function walk(node: Record<string, unknown>) {
+		if (!node || typeof node !== 'object') return;
+		const type = node.type as string;
+		if (type && typeof listeners[type] === 'function') {
+			(listeners[type] as (candidate: unknown) => void)(node);
+		}
+		for (const [key, value] of Object.entries(node)) {
+			if (key === 'parent') continue;
+			if (Array.isArray(value)) value.forEach((child) => walk(child as Record<string, unknown>));
+			else if (value && typeof value === 'object' && (value as Record<string, unknown>).type) {
+				walk(value as Record<string, unknown>);
+			}
+		}
+	}
+
+	walk(ast.ast as unknown as Record<string, unknown>);
+	return reports;
+}
+
+describe('no-animated-pixel-press', () => {
+	it.each([
+		'transition active:translate-y-px',
+		'transition-all active:-translate-x-px',
+		'transition-transform sm:active:translate-y-px',
+		'transition-[color,translate] active:translate-y-px',
+		'transition-[opacity,transform] active:translate-y-px',
+		'transition-[var(--press-properties)] active:translate-y-px',
+		'transition-(--press-properties) active:translate-y-px'
+	])('flags an animated pixel press in %s', (classes) => {
+		const reports = lint(`<button class="${classes}"></button>`);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('animatedPixelPress');
+	});
+
+	it('combines static classes split across cn arguments', () => {
+		const reports = lint(
+			'<button class={cn("transition-transform", enabled && "active:translate-y-px")}></button>'
+		);
+		expect(reports).toHaveLength(1);
+	});
+
+	it('recognizes press propagation through an arbitrary group selector', () => {
+		const reports = lint(
+			'<span class="transition-all group-has-[[data-slot=trigger]:active]/row:translate-y-px"></span>'
+		);
+		expect(reports).toHaveLength(1);
+	});
+
+	it('recognizes press propagation through a group active variant', () => {
+		const reports = lint('<span class="transition-all group-active/link:translate-y-px"></span>');
+		expect(reports).toHaveLength(1);
+	});
+
+	it('checks class values assembled in a script object', () => {
+		const reports = lint(
+			'<script>const attrs = { class: cn("transition-[color,translate]", "active:translate-y-px") };</script>'
+		);
+		expect(reports).toHaveLength(1);
+	});
+
+	it('requires component call sites to override unknown default transitions', () => {
+		expect(lint('<Widget class="active:translate-y-px" />')[0].messageId).toBe(
+			'unprovenComponentPress'
+		);
+		expect(lint('<Sidebar.Action class="active:translate-y-px" />')[0].messageId).toBe(
+			'unprovenComponentPress'
+		);
+	});
+
+	it('checks the base class of a tailwind-variants definition', () => {
+		const reports = lint(
+			'<script>const button = tv({ base: "transition-all active:translate-y-px", variants: {} });</script>'
+		);
+		expect(reports).toHaveLength(1);
+	});
+
+	it('checks the base argument of a cva definition', () => {
+		const reports = lint(
+			'<script>const button = cva("transition-transform active:translate-y-px", {});</script>'
+		);
+		expect(reports).toHaveLength(1);
+	});
+
+	it.each([
+		'<button class="active:translate-y-px"></button>',
+		'<button class="transition-colors active:translate-y-px"></button>',
+		'<button class="transition-opacity active:translate-y-px"></button>',
+		'<button class="transition-[opacity] active:translate-y-px"></button>',
+		'<button class="transition-[width,height,padding] active:translate-y-px"></button>',
+		'<Widget class="transition-colors active:translate-y-px" />',
+		'<Widget class="transition-none active:translate-y-px" />',
+		'<button class="transition-transform active:scale-[0.97]"></button>',
+		'<div class="transition-all translate-y-px"></div>',
+		'<div class="transition-all data-active:translate-y-px"></div>'
+	])('allows %s', (template) => {
+		expect(lint(template)).toHaveLength(0);
+	});
+});

--- a/src/blocks/team/team-two.svelte
+++ b/src/blocks/team/team-two.svelte
@@ -89,9 +89,11 @@
 								<a
 									href="#"
 									draggable={false}
-									class="inline-block text-sm tracking-wide no-drag group-hover:translate-y-0 group-hover:text-primary group-hover:opacity-100 hover:underline active:translate-y-px motion-safe:translate-y-8 motion-safe:opacity-0 motion-safe:transition-all motion-safe:duration-300"
+									class="group/link inline-block text-sm tracking-wide no-drag group-hover:translate-y-0 group-hover:text-primary group-hover:opacity-100 hover:underline motion-safe:translate-y-8 motion-safe:opacity-0 motion-safe:transition-all motion-safe:duration-300"
 								>
-									<T keyName="team.linktree" />
+									<span class="inline-block group-active/link:translate-y-px">
+										<T keyName="team.linktree" />
+									</span>
 								</a>
 							</div>
 						</div>

--- a/src/lib/components/ai-elements/reasoning/ReasoningTrigger.svelte
+++ b/src/lib/components/ai-elements/reasoning/ReasoningTrigger.svelte
@@ -39,7 +39,7 @@
 <Accordion.Trigger
 	disabled={!hasContent}
 	class={cn(
-		'flex items-start justify-start gap-2 py-0 text-sm text-muted-foreground hover:no-underline active:translate-y-px',
+		'flex items-start justify-start gap-2 py-0 text-sm text-muted-foreground transition-colors hover:no-underline active:translate-y-px',
 		className
 	)}
 	{...props}

--- a/src/lib/components/authenticated/authenticated-sidebar.svelte
+++ b/src/lib/components/authenticated/authenticated-sidebar.svelte
@@ -170,7 +170,7 @@
 											{#snippet child({ props })}
 												<Sidebar.MenuAction
 													{...props}
-													class="group/threads-toggle active:translate-y-px"
+													class="group/threads-toggle transition-colors active:translate-y-px"
 												>
 													<ChevronRightIcon
 														class="transition-transform duration-200 group-data-[state=open]/threads-toggle:rotate-90"

--- a/src/lib/components/ui/breadcrumb/breadcrumb-link.svelte
+++ b/src/lib/components/ui/breadcrumb/breadcrumb-link.svelte
@@ -16,10 +16,7 @@
 
 	const attrs = $derived({
 		'data-slot': 'breadcrumb-link',
-		class: cn(
-			'hover:text-foreground transition-[color,translate] active:translate-y-px',
-			className
-		),
+		class: cn('hover:text-foreground transition-colors active:translate-y-px', className),
 		href,
 		...restProps
 	});


### PR DESCRIPTION
One-pixel press feedback can accidentally inherit movement transitions through Tailwind class composition or component defaults. Current main still had this in the breadcrumb, reasoning trigger, sidebar toggle, and a marketing link.

A local ESLint rule now checks Svelte class attributes, script-built class objects, classes split across `cn(...)`, `tv`/`cva` bases, propagated active selectors, and variable-backed transitions. Existing violations retain their color or entrance motion while the one-pixel press snaps immediately.

Regression guard: added 24 focused rule cases.

Verified with targeted static checks, 1,164 passing unit tests, and the production build.

See also: #802
