### PR TITLE
fix(lint): Ban control and bidi characters written as raw bytes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,9 +49,16 @@ const localPlugin = {
 
 export default defineConfig(
 	includeIgnoreFile(gitignorePath),
-	// Ignore auto-generated files
+	// Convex codegen and varlock both emit a file-level `/* eslint-disable */`, which
+	// switches off every rule from inside the file. Ignoring those paths here changes
+	// nothing they would otherwise be checked for, so the entry stays.
+	//
+	// `src/env.d.ts` carries no such directive, so ignoring it was the only thing
+	// keeping it out of ESLint's reach. It is written from environment values, which
+	// come from outside this repository, which makes it the generated file most
+	// exposed to a character nobody typed. It is linted below instead.
 	{
-		ignores: ['**/_generated/**', 'src/env.d.ts', 'src/lib/convex/convex-env.d.ts']
+		ignores: ['**/_generated/**', 'src/lib/convex/convex-env.d.ts']
 	},
 	js.configs.recommended,
 	...ts.configs.recommended,
@@ -323,6 +330,15 @@ export default defineConfig(
 		},
 		rules: {
 			'local/no-literal-control-char': 'error'
+		}
+	},
+	// The only rule `src/env.d.ts` trips, and it trips it by construction: varlock
+	// writes the directive into every generated header. Everything else, including the
+	// control-character rule above, applies to it.
+	{
+		files: ['src/env.d.ts'],
+		rules: {
+			'@typescript-eslint/ban-ts-comment': 'off'
 		}
 	},
 	// Convex best-practice rules — v2 ships ESLint 9 flat config natively

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ import requireGuardedServerConvexClientRule from './eslint/rules/require-guarded
 import noFrozenAuthPageDataRule from './eslint/rules/no-frozen-auth-page-data.js';
 import requireSvelteModuleExtensionRule from './eslint/rules/require-svelte-module-extension.js';
 import noAnimatedPixelPressRule from './eslint/rules/no-animated-pixel-press.js';
+import safeSvelteParser from './eslint/parsers/safe-svelte-parser.js';
 import noLiteralControlCharRule from './eslint/rules/no-literal-control-char.js';
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
@@ -345,6 +346,15 @@ export default defineConfig(
 		},
 		rules: {
 			'local/no-literal-control-char': 'error'
+		}
+	},
+	// Valid Svelte files keep the ordinary parser and rule lifecycle. The wrapper
+	// changes only a thrown parser message, which is the path that happens before a
+	// Program visitor can sanitize the invalid token itself.
+	{
+		files: ['**/*.svelte'],
+		languageOptions: {
+			parser: safeSvelteParser
 		}
 	},
 	// Varlock puts a file-wide ESLint disable and empty marker interfaces in this

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ import requireGuardedServerConvexClientRule from './eslint/rules/require-guarded
 import noFrozenAuthPageDataRule from './eslint/rules/no-frozen-auth-page-data.js';
 import requireSvelteModuleExtensionRule from './eslint/rules/require-svelte-module-extension.js';
 import noAnimatedPixelPressRule from './eslint/rules/no-animated-pixel-press.js';
+import noLiteralControlCharRule from './eslint/rules/no-literal-control-char.js';
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
 const localPlugin = {
@@ -41,7 +42,8 @@ const localPlugin = {
 		'require-guarded-server-convex-client': requireGuardedServerConvexClientRule,
 		'no-frozen-auth-page-data': noFrozenAuthPageDataRule,
 		'require-svelte-module-extension': requireSvelteModuleExtensionRule,
-		'no-animated-pixel-press': noAnimatedPixelPressRule
+		'no-animated-pixel-press': noAnimatedPixelPressRule,
+		'no-literal-control-char': noLiteralControlCharRule
 	}
 };
 
@@ -308,6 +310,19 @@ export default defineConfig(
 		},
 		rules: {
 			'local/no-animated-pixel-press': 'error'
+		}
+	},
+	// A control or bidirectional character written as itself is invisible in review
+	// and turns the file binary for git, so this has to reach every file ESLint
+	// parses. Scoping it to src/ would leave scripts/, config and the guard itself
+	// unchecked, which is where an unreviewable byte does the most damage.
+	{
+		files: ['**/*.{js,ts,svelte}'],
+		plugins: {
+			local: localPlugin
+		},
+		rules: {
+			'local/no-literal-control-char': 'error'
 		}
 	},
 	// Convex best-practice rules — v2 ships ESLint 9 flat config natively

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,20 @@ import noLiteralControlCharRule from './eslint/rules/no-literal-control-char.js'
 
 const gitignorePath = path.resolve(import.meta.dirname, '.gitignore');
 const localPlugin = {
+	processors: {
+		// Varlock writes a file-wide disable into generated environment types. Blank
+		// that exact directive without changing its length, so ESLint still reports
+		// the right locations and the generated file cannot switch this plugin off.
+		'strip-generated-eslint-disable': {
+			preprocess(text) {
+				return [text.replace('/* eslint-disable */', (directive) => ' '.repeat(directive.length))];
+			},
+			postprocess(messageLists) {
+				return messageLists.flat();
+			},
+			supportsAutofix: true
+		}
+	},
 	rules: {
 		'require-marketing-markdown': requireMarketingMarkdownRule,
 		'require-marketing-route-registration': requireMarketingRouteRegistrationRule,
@@ -49,14 +63,15 @@ const localPlugin = {
 
 export default defineConfig(
 	includeIgnoreFile(gitignorePath),
-	// Convex codegen and varlock both emit a file-level `/* eslint-disable */`, which
-	// switches off every rule from inside the file. Ignoring those paths here changes
-	// nothing they would otherwise be checked for, so the entry stays.
+	// Convex codegen and varlock emit a file-level `/* eslint-disable */`, which
+	// switches off every rule from inside the generated file. The Convex and varlock
+	// Convex outputs stay ignored because reaching them would require overriding the
+	// generator's own directive and then exempting all of its generated style.
 	//
-	// `src/env.d.ts` carries no such directive, so ignoring it was the only thing
-	// keeping it out of ESLint's reach. It is written from environment values, which
-	// come from outside this repository, which makes it the generated file most
-	// exposed to a character nobody typed. It is linted below instead.
+	// `src/env.d.ts` carries the same directive, but it is written from environment
+	// values, which come from outside this repository. It is the generated file most
+	// exposed to a character nobody typed, so the later file block disables its inline
+	// directive and exempts only the generated style rules it then trips.
 	{
 		ignores: ['**/_generated/**', 'src/lib/convex/convex-env.d.ts']
 	},
@@ -319,10 +334,10 @@ export default defineConfig(
 			'local/no-animated-pixel-press': 'error'
 		}
 	},
-	// A control or bidirectional character written as itself is invisible in review
-	// and turns the file binary for git, so this has to reach every file ESLint
-	// parses. Scoping it to src/ would leave scripts/, config and the guard itself
-	// unchecked, which is where an unreviewable byte does the most damage.
+	// A control or bidirectional character written as itself can disappear in review,
+	// so this has to reach every file ESLint parses. Scoping it to src/ would leave
+	// scripts/, config and the guard itself unchecked, which is where an invisible
+	// character does the most damage.
 	{
 		files: ['**/*.{js,ts,svelte}'],
 		plugins: {
@@ -332,13 +347,19 @@ export default defineConfig(
 			'local/no-literal-control-char': 'error'
 		}
 	},
-	// The only rule `src/env.d.ts` trips, and it trips it by construction: varlock
-	// writes the directive into every generated header. Everything else, including the
-	// control-character rule above, applies to it.
+	// Varlock puts a file-wide ESLint disable and empty marker interfaces in this
+	// generated header. The processor blanks the directive without shifting source
+	// locations; the rules below exempt the generated TypeScript style and nothing
+	// else. The control-character rule therefore still runs on the real file text.
 	{
 		files: ['src/env.d.ts'],
+		plugins: {
+			local: localPlugin
+		},
+		processor: 'local/strip-generated-eslint-disable',
 		rules: {
-			'@typescript-eslint/ban-ts-comment': 'off'
+			'@typescript-eslint/ban-ts-comment': 'off',
+			'@typescript-eslint/no-empty-object-type': 'off'
 		}
 	},
 	// Convex best-practice rules — v2 ships ESLint 9 flat config natively

--- a/eslint/config-coverage.test.ts
+++ b/eslint/config-coverage.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { existsSync, readFileSync } from 'node:fs';
 import { ESLint } from 'eslint';
 import { describe, expect, it } from 'vitest';
 
@@ -7,37 +8,63 @@ import { describe, expect, it } from 'vitest';
  *
  * The rule replaced a scan in `scripts/static-checks.ts` whose route required a
  * `src/` prefix, so it reached neither `scripts/` nor the config files nor itself.
- * That claim is the whole reason the rule lives in ESLint, and nothing enforced it:
- * a `files` glob, an `ignores` entry, or a later config block can take a file back
- * out of reach without a single test failing.
+ * That claim is the whole reason the rule lives in ESLint, and a config calculation
+ * alone cannot prove it: a file-wide `/* eslint-disable *\/` still suppresses a rule
+ * whose calculated severity is `error`.
  *
- * A file can also be out of reach for a reason no config expresses. Convex codegen
- * and varlock write `/* eslint-disable *\/` into their output, which switches every
- * rule off from inside the file, so those paths stay in the global ignores and are
- * asserted here as unreachable rather than quietly assumed to be covered.
+ * Each positive case therefore reads an existing tracked file, adds a control
+ * character in a valid comment, and sends the result through the real ESLint API
+ * with that file's path. This covers config selection, parsers, processors, inline
+ * directives, and the final rule verdict in one assertion.
+ *
+ * Convex codegen and varlock's Convex generator write a file-wide disable into their
+ * output, so those paths stay globally ignored. `src/env.d.ts` gets different
+ * treatment: its processor blanks that directive without shifting source locations,
+ * because environment values come from outside the repository and are exactly where
+ * a character nobody typed can enter generated source.
  */
 const eslint = new ESLint();
+const offender = String.fromCharCode(0x1b);
 
-/** `calculateConfigForFile` normalizes severity to a number, where 2 is `error`. */
-async function ruleSeverity(file: string): Promise<unknown> {
-	const config = await eslint.calculateConfigForFile(file);
-	return config.rules?.['local/no-literal-control-char']?.[0];
+async function controlCharacterMessages(file: string) {
+	// Keep the real path, which selects the config, parser and processor. A minimal
+	// source makes this a coverage test rather than a second lint of six whole files.
+	// The generated env case deliberately keeps its real header, because its file-wide
+	// disable is the condition the processor exists to remove.
+	const source =
+		file === 'src/env.d.ts'
+			? readFileSync(file, 'utf-8')
+			: file.endsWith('.svelte')
+				? '<script>const value = true;</script>'
+				: 'export {};';
+	const withOffender = file.endsWith('.svelte')
+		? `${source}\n<!-- ${offender} -->\n`
+		: `${source}\n// ${offender}\n`;
+	const [result] = await eslint.lintText(withOffender, { filePath: file });
+	return result.messages.filter((message) => message.ruleId === 'local/no-literal-control-char');
 }
 
 describe('no-literal-control-char coverage', () => {
 	it.each([
-		['a source module', 'src/lib/utils/index.ts'],
+		['a source module', 'src/lib/utils.ts'],
 		['a Svelte component', 'src/routes/+layout.svelte'],
 		['a build script outside src/', 'scripts/static-checks.ts'],
 		['the ESLint config itself', 'eslint.config.js'],
 		['the rule implementation', 'eslint/rules/no-literal-control-char.js'],
-		['the generated env types', 'src/env.d.ts']
-	])('reaches %s', async (_label, file) => {
-		expect(await ruleSeverity(file)).toBe(2);
-	});
+		['the generated env types despite their file-wide disable', 'src/env.d.ts']
+	])(
+		'reaches %s',
+		async (_label, file) => {
+			expect(existsSync(file)).toBe(true);
+			const messages = await controlCharacterMessages(file);
+			expect(messages).toHaveLength(1);
+			expect(messages[0].severity).toBe(2);
+		},
+		15_000
+	);
 
-	// Not a gap this config can close. Both generators emit a file-level disable, so
-	// un-ignoring these paths would buy nothing and add unused-directive warnings.
+	// The generators for these paths disable ESLint inside every file. Un-ignoring
+	// them would buy no coverage and add only unused-directive warnings.
 	it.each([
 		['Convex codegen output', 'src/lib/convex/_generated/api.js'],
 		['the varlock Convex env types', 'src/lib/convex/convex-env.d.ts']

--- a/eslint/config-coverage.test.ts
+++ b/eslint/config-coverage.test.ts
@@ -60,8 +60,38 @@ describe('no-literal-control-char coverage', () => {
 			expect(messages).toHaveLength(1);
 			expect(messages[0].severity).toBe(2);
 		},
-		15_000
+		60_000
 	);
+
+	it.each([
+		['C0', 0x1b, 'U+001B'],
+		['DEL', 0x7f, 'U+007F'],
+		['C1', 0x85, 'U+0085'],
+		['bidi', 0x202e, 'U+202E']
+	])(
+		'sanitizes a fatal Svelte parser diagnostic carrying %s input',
+		async (_label, code, codepoint) => {
+			const value = String.fromCharCode(code);
+			const source = `<div>{${value}}</div>`;
+			const [result] = await eslint.lintText(source, { filePath: 'src/routes/+layout.svelte' });
+			const fatal = result.messages.filter((message) => message.fatal);
+			expect(fatal).toHaveLength(1);
+			expect(fatal[0].message).toContain(codepoint);
+			expect(fatal[0].message).not.toContain(value);
+			const formatter = await eslint.loadFormatter('stylish');
+			expect(await formatter.format([result])).not.toContain(value);
+		},
+		60_000
+	);
+
+	it('keeps ordinary Svelte rule suppression on the valid parse path', async () => {
+		const source = `<!-- eslint-disable local/no-literal-control-char -->
+<!-- ${offender} -->`;
+		const [result] = await eslint.lintText(source, { filePath: 'src/routes/+layout.svelte' });
+		expect(
+			result.messages.filter((message) => message.ruleId === 'local/no-literal-control-char')
+		).toEqual([]);
+	}, 60_000);
 
 	// The generators for these paths disable ESLint inside every file. Un-ignoring
 	// them would buy no coverage and add only unused-directive warnings.

--- a/eslint/config-coverage.test.ts
+++ b/eslint/config-coverage.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { ESLint } from 'eslint';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * What `no-literal-control-char` can actually see.
+ *
+ * The rule replaced a scan in `scripts/static-checks.ts` whose route required a
+ * `src/` prefix, so it reached neither `scripts/` nor the config files nor itself.
+ * That claim is the whole reason the rule lives in ESLint, and nothing enforced it:
+ * a `files` glob, an `ignores` entry, or a later config block can take a file back
+ * out of reach without a single test failing.
+ *
+ * A file can also be out of reach for a reason no config expresses. Convex codegen
+ * and varlock write `/* eslint-disable *\/` into their output, which switches every
+ * rule off from inside the file, so those paths stay in the global ignores and are
+ * asserted here as unreachable rather than quietly assumed to be covered.
+ */
+const eslint = new ESLint();
+
+/** `calculateConfigForFile` normalizes severity to a number, where 2 is `error`. */
+async function ruleSeverity(file: string): Promise<unknown> {
+	const config = await eslint.calculateConfigForFile(file);
+	return config.rules?.['local/no-literal-control-char']?.[0];
+}
+
+describe('no-literal-control-char coverage', () => {
+	it.each([
+		['a source module', 'src/lib/utils/index.ts'],
+		['a Svelte component', 'src/routes/+layout.svelte'],
+		['a build script outside src/', 'scripts/static-checks.ts'],
+		['the ESLint config itself', 'eslint.config.js'],
+		['the rule implementation', 'eslint/rules/no-literal-control-char.js'],
+		['the generated env types', 'src/env.d.ts']
+	])('reaches %s', async (_label, file) => {
+		expect(await ruleSeverity(file)).toBe(2);
+	});
+
+	// Not a gap this config can close. Both generators emit a file-level disable, so
+	// un-ignoring these paths would buy nothing and add unused-directive warnings.
+	it.each([
+		['Convex codegen output', 'src/lib/convex/_generated/api.js'],
+		['the varlock Convex env types', 'src/lib/convex/convex-env.d.ts']
+	])(
+		'leaves %s ignored, because its generator disables ESLint inside the file',
+		async (_label, file) => {
+			expect(await eslint.isPathIgnored(file)).toBe(true);
+		}
+	);
+});

--- a/eslint/config-coverage.test.ts
+++ b/eslint/config-coverage.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { existsSync, readFileSync } from 'node:fs';
 import { ESLint } from 'eslint';
+import stripAnsi from 'strip-ansi';
 import { describe, expect, it } from 'vitest';
 
 /**
@@ -79,7 +80,7 @@ describe('no-literal-control-char coverage', () => {
 			expect(fatal[0].message).toContain(codepoint);
 			expect(fatal[0].message).not.toContain(value);
 			const formatter = await eslint.loadFormatter('stylish');
-			expect(await formatter.format([result])).not.toContain(value);
+			expect(stripAnsi(await formatter.format([result]))).not.toContain(value);
 		},
 		60_000
 	);

--- a/eslint/parsers/safe-svelte-parser.js
+++ b/eslint/parsers/safe-svelte-parser.js
@@ -1,0 +1,31 @@
+import * as svelteParser from 'svelte-eslint-parser';
+import { sanitizeDiagnosticText } from '../rules/no-literal-control-char.js';
+
+/**
+ * Keep parser failures safe for terminal and CI output.
+ *
+ * A malformed Svelte expression can make `svelte-eslint-parser` quote its invalid
+ * token before any ESLint rule visitor runs. If that token is a control or bidi
+ * character, the normal rule has no chance to replace it with a codepoint before
+ * the formatter prints it. The wrapper changes only the thrown message and keeps
+ * every location and parser service on the original parser.
+ *
+ * Valid files take the direct path, so HTML and JavaScript ESLint directives,
+ * autofixes, source maps and the normal rule visitor all retain their native
+ * behavior.
+ */
+function parseForESLint(code, options) {
+	try {
+		return svelteParser.parseForESLint(code, options);
+	} catch (error) {
+		if (error && typeof error === 'object' && typeof error.message === 'string') {
+			error.message = sanitizeDiagnosticText(error.message);
+		}
+		throw error;
+	}
+}
+
+export default {
+	meta: svelteParser.meta,
+	parseForESLint
+};

--- a/eslint/rules/no-literal-control-char.js
+++ b/eslint/rules/no-literal-control-char.js
@@ -7,9 +7,11 @@
  * Why: the character is often the right one. NUL is a good separator for a
  * composite key, because it cannot occur in the parts being joined. Writing it as
  * the raw byte is what breaks. It renders as nothing, so a reader sees an empty
- * string where the code means a separator, a text search or scripted edit matches
- * nothing while appearing to succeed, and git calls the whole file binary, which
- * takes its diffs out of code review.
+ * string where the code means a separator, and a text search or scripted edit
+ * matches nothing while appearing to succeed. A NUL goes further and takes the
+ * file out of code review altogether, because git classifies a file holding one as
+ * binary and stops diffing it. The other characters here keep their text diffs and
+ * simply show nothing in them.
  *
  * The bidirectional characters are worse than invisible: they reorder how the
  * source displays without changing what it does, so a reviewer can read one
@@ -36,11 +38,13 @@
 // would flag every file, and a check that noisy gets switched off the same day.
 const STRUCTURAL = new Set([0x09, 0x0a, 0x0d]);
 
-// Bidirectional formatting characters. The embedding and override pair
-// (U+202A-U+202E) and the isolates (U+2066-U+2069) reorder a run of text; the
-// marks (U+200E, U+200F) set its direction.
+// Every character Unicode gives the Bidi_Control property: the marks (U+061C,
+// U+200E, U+200F) set a run's direction, the embeddings and overrides
+// (U+202A-U+202E) and the isolates (U+2066-U+2069) reorder it. Spelled out rather
+// than matched with `\p{Bidi_Control}`, so that adding a member is a visible edit
+// and a Unicode revision cannot silently widen what this rule rejects.
 const BIDI = new Set([
-	0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069
+	0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069
 ]);
 
 /** The category a banned codepoint belongs to, or null when it is legal. */
@@ -62,7 +66,7 @@ export default {
 		schema: [],
 		messages: {
 			literalControlChar:
-				'{{codepoint}} ({{category}}) is written as the character itself, so it is invisible in editors, diffs and text search, and it makes git treat this file as binary. Write it as an escape ({{escape}}).'
+				'{{codepoint}} ({{category}}) is written as the character itself, so it is invisible in editors, diffs and text search. Write it as an escape ({{escape}}).'
 		}
 	},
 	create(context) {
@@ -73,7 +77,17 @@ export default {
 				let column = 0;
 				for (let i = 0; i < text.length; i++) {
 					const code = text.charCodeAt(i);
-					if (code === 0x0a) {
+					// ESLint counts four line terminators, and a report that disagrees sends
+					// `eslint-disable-next-line` to the wrong line. CR is one of them, so a
+					// CRLF pair has to advance once rather than twice.
+					if (code === 0x0d) {
+						if (text.charCodeAt(i + 1) !== 0x0a) {
+							line++;
+							column = 0;
+						}
+						continue;
+					}
+					if (code === 0x0a || code === 0x2028 || code === 0x2029) {
 						line++;
 						column = 0;
 						continue;

--- a/eslint/rules/no-literal-control-char.js
+++ b/eslint/rules/no-literal-control-char.js
@@ -17,21 +17,20 @@
  * source displays without changing what it does, so a reviewer can read one
  * program while the compiler reads another (Trojan Source, CVE-2021-42574).
  *
- * A scan over the source text rather than an AST visit, because these characters
- * hide anywhere: string literals, template literals, comments, JSX text, and
- * identifiers. The categories are a closed set, so anything outside it passes
- * rather than being guessed at.
+ * A source-text scan reaches string literals, template literals, comments, JSX
+ * text and identifiers. The categories are a closed set, so anything outside it
+ * passes without guesswork.
  *
  * The report names the codepoint and never quotes the offending source. Printing
  * the line would show the reader nothing, and an escape sequence pasted into a
  * terminal reprograms it.
  *
- * The example is described rather than written out, because spelling the byte here
- * would put the character this rule bans into the rule that bans it. That is not
- * hypothetical: the first run of this rule over the repository flagged this file.
+ * The example is described instead of written out. Spelling the byte here would
+ * put the character this rule bans into the rule that bans it. The first run over
+ * the repository found exactly that in this file.
  *
- * ❌ a raw 0x01 byte between two interpolations, showing as nothing at all
- * ✅ the same separator written as the six characters of a unicode escape
+ * Bad: a raw 0x01 byte between two interpolations, showing as nothing at all.
+ * Good: the same separator written as the six characters of a unicode escape.
  */
 
 // Tab, line feed and carriage return are what source is made of. Flagging them
@@ -40,12 +39,15 @@ const STRUCTURAL = new Set([0x09, 0x0a, 0x0d]);
 
 // Every character Unicode gives the Bidi_Control property: the marks (U+061C,
 // U+200E, U+200F) set a run's direction, the embeddings and overrides
-// (U+202A-U+202E) and the isolates (U+2066-U+2069) reorder it. Spelled out rather
-// than matched with `\p{Bidi_Control}`, so that adding a member is a visible edit
-// and a Unicode revision cannot silently widen what this rule rejects.
+// (U+202A-U+202E) and the isolates (U+2066-U+2069) reorder it. Spelled out instead
+// of matched with `\p{Bidi_Control}`, so adding a member is a visible edit and a
+// Unicode revision cannot silently widen what this rule rejects.
 const BIDI = new Set([
 	0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069
 ]);
+
+const MESSAGE =
+	'{{codepoint}} ({{category}}) is written as the character itself, so it is invisible in editors, diffs and text search. Remove it or replace it with visible whitespace. If it belongs inside a string or template literal, write {{escape}}.';
 
 /** The category a banned codepoint belongs to, or null when it is legal. */
 function category(code) {
@@ -54,6 +56,50 @@ function category(code) {
 	if (code === 0x7f) return 'DEL';
 	if (code >= 0x80 && code <= 0x9f) return 'C1 control';
 	return BIDI.has(code) ? 'bidirectional formatting' : null;
+}
+
+function dataFor(code, kind) {
+	const hex = code.toString(16).padStart(4, '0').toUpperCase();
+	return { codepoint: `U+${hex}`, category: kind, escape: `\\u${hex}` };
+}
+
+/** Every banned character and its ESLint location in the supplied source. */
+export function findLiteralControlCharacters(text) {
+	const findings = [];
+	let line = 1;
+	let column = 0;
+	for (let index = 0; index < text.length; index++) {
+		const code = text.charCodeAt(index);
+		// ESLint counts four line terminators. CR is one of them, so a CRLF pair
+		// advances once when the following LF is processed.
+		if (code === 0x0d) {
+			if (text.charCodeAt(index + 1) !== 0x0a) {
+				line++;
+				column = 0;
+			}
+			continue;
+		}
+		if (code === 0x0a || code === 0x2028 || code === 0x2029) {
+			line++;
+			column = 0;
+			continue;
+		}
+		const kind = category(code);
+		if (kind !== null) findings.push({ line, column, data: dataFor(code, kind) });
+		column++;
+	}
+	return findings;
+}
+
+/** Remove banned characters from diagnostic prose before a formatter sees it. */
+export function sanitizeDiagnosticText(text) {
+	let safe = '';
+	for (let index = 0; index < text.length; index++) {
+		const code = text.charCodeAt(index);
+		const kind = category(code);
+		safe += kind === null ? text[index] : dataFor(code, kind).codepoint;
+	}
+	return safe;
 }
 
 export default {
@@ -65,43 +111,18 @@ export default {
 		},
 		schema: [],
 		messages: {
-			literalControlChar:
-				'{{codepoint}} ({{category}}) is written as the character itself, so it is invisible in editors, diffs and text search. Remove it or replace it with visible whitespace. If it belongs inside a string or template literal, write {{escape}}.'
+			literalControlChar: MESSAGE
 		}
 	},
 	create(context) {
 		return {
 			Program() {
-				const text = context.sourceCode.getText();
-				let line = 1;
-				let column = 0;
-				for (let i = 0; i < text.length; i++) {
-					const code = text.charCodeAt(i);
-					// ESLint counts four line terminators, and a report that disagrees sends
-					// `eslint-disable-next-line` to the wrong line. CR is one of them, so a
-					// CRLF pair has to advance once rather than twice.
-					if (code === 0x0d) {
-						if (text.charCodeAt(i + 1) !== 0x0a) {
-							line++;
-							column = 0;
-						}
-						continue;
-					}
-					if (code === 0x0a || code === 0x2028 || code === 0x2029) {
-						line++;
-						column = 0;
-						continue;
-					}
-					const kind = category(code);
-					if (kind !== null) {
-						const hex = code.toString(16).padStart(4, '0').toUpperCase();
-						context.report({
-							loc: { line, column },
-							messageId: 'literalControlChar',
-							data: { codepoint: `U+${hex}`, category: kind, escape: `\\u${hex}` }
-						});
-					}
-					column++;
+				for (const finding of findLiteralControlCharacters(context.sourceCode.getText())) {
+					context.report({
+						loc: { line: finding.line, column: finding.column },
+						messageId: 'literalControlChar',
+						data: finding.data
+					});
 				}
 			}
 		};

--- a/eslint/rules/no-literal-control-char.js
+++ b/eslint/rules/no-literal-control-char.js
@@ -66,7 +66,7 @@ export default {
 		schema: [],
 		messages: {
 			literalControlChar:
-				'{{codepoint}} ({{category}}) is written as the character itself, so it is invisible in editors, diffs and text search. Write it as an escape ({{escape}}).'
+				'{{codepoint}} ({{category}}) is written as the character itself, so it is invisible in editors, diffs and text search. Remove it or replace it with visible whitespace. If it belongs inside a string or template literal, write {{escape}}.'
 		}
 	},
 	create(context) {

--- a/eslint/rules/no-literal-control-char.js
+++ b/eslint/rules/no-literal-control-char.js
@@ -1,0 +1,95 @@
+/**
+ * ESLint rule: no-literal-control-char
+ *
+ * Flags a control or bidirectional-formatting character written as the character
+ * itself instead of an escape.
+ *
+ * Why: the character is often the right one. NUL is a good separator for a
+ * composite key, because it cannot occur in the parts being joined. Writing it as
+ * the raw byte is what breaks. It renders as nothing, so a reader sees an empty
+ * string where the code means a separator, a text search or scripted edit matches
+ * nothing while appearing to succeed, and git calls the whole file binary, which
+ * takes its diffs out of code review.
+ *
+ * The bidirectional characters are worse than invisible: they reorder how the
+ * source displays without changing what it does, so a reviewer can read one
+ * program while the compiler reads another (Trojan Source, CVE-2021-42574).
+ *
+ * A scan over the source text rather than an AST visit, because these characters
+ * hide anywhere: string literals, template literals, comments, JSX text, and
+ * identifiers. The categories are a closed set, so anything outside it passes
+ * rather than being guessed at.
+ *
+ * The report names the codepoint and never quotes the offending source. Printing
+ * the line would show the reader nothing, and an escape sequence pasted into a
+ * terminal reprograms it.
+ *
+ * The example is described rather than written out, because spelling the byte here
+ * would put the character this rule bans into the rule that bans it. That is not
+ * hypothetical: the first run of this rule over the repository flagged this file.
+ *
+ * ❌ a raw 0x01 byte between two interpolations, showing as nothing at all
+ * ✅ the same separator written as the six characters of a unicode escape
+ */
+
+// Tab, line feed and carriage return are what source is made of. Flagging them
+// would flag every file, and a check that noisy gets switched off the same day.
+const STRUCTURAL = new Set([0x09, 0x0a, 0x0d]);
+
+// Bidirectional formatting characters. The embedding and override pair
+// (U+202A-U+202E) and the isolates (U+2066-U+2069) reorder a run of text; the
+// marks (U+200E, U+200F) set its direction.
+const BIDI = new Set([
+	0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069
+]);
+
+/** The category a banned codepoint belongs to, or null when it is legal. */
+function category(code) {
+	if (STRUCTURAL.has(code)) return null;
+	if (code < 0x20) return 'C0 control';
+	if (code === 0x7f) return 'DEL';
+	if (code >= 0x80 && code <= 0x9f) return 'C1 control';
+	return BIDI.has(code) ? 'bidirectional formatting' : null;
+}
+
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Disallow control and bidirectional-formatting characters written as the character itself'
+		},
+		schema: [],
+		messages: {
+			literalControlChar:
+				'{{codepoint}} ({{category}}) is written as the character itself, so it is invisible in editors, diffs and text search, and it makes git treat this file as binary. Write it as an escape ({{escape}}).'
+		}
+	},
+	create(context) {
+		return {
+			Program() {
+				const text = context.sourceCode.getText();
+				let line = 1;
+				let column = 0;
+				for (let i = 0; i < text.length; i++) {
+					const code = text.charCodeAt(i);
+					if (code === 0x0a) {
+						line++;
+						column = 0;
+						continue;
+					}
+					const kind = category(code);
+					if (kind !== null) {
+						const hex = code.toString(16).padStart(4, '0').toUpperCase();
+						context.report({
+							loc: { line, column },
+							messageId: 'literalControlChar',
+							data: { codepoint: `U+${hex}`, category: kind, escape: `\\u${hex}` }
+						});
+					}
+					column++;
+				}
+			}
+		};
+	}
+};

--- a/eslint/rules/no-literal-control-char.test.ts
+++ b/eslint/rules/no-literal-control-char.test.ts
@@ -69,6 +69,7 @@ describe('no-literal-control-char', () => {
 	// These reorder how the source displays without changing what it runs, which is
 	// the Trojan Source attack (CVE-2021-42574). Invisibility is the lesser problem.
 	it.each([
+		['ALM', 0x061c],
 		['LRM', 0x200e],
 		['RLM', 0x200f],
 		['LRE', 0x202a],
@@ -81,7 +82,24 @@ describe('no-literal-control-char', () => {
 		expect(reports[0].data.category).toBe('bidirectional formatting');
 	});
 
+	it('flags exactly the characters Unicode gives the Bidi_Control property', () => {
+		const flagged: number[] = [];
+		for (let code = 0; code <= 0xffff; code++) {
+			if (lint(String.fromCharCode(code)).length > 0) flagged.push(code);
+		}
+		const bidi = flagged.filter((code) => /\p{Bidi_Control}/u.test(String.fromCharCode(code)));
+		const missing = [];
+		for (let code = 0; code <= 0xffff; code++) {
+			const char = String.fromCharCode(code);
+			if (/\p{Bidi_Control}/u.test(char) && !flagged.includes(code)) missing.push(code);
+		}
+		expect(missing).toEqual([]);
+		expect(bidi).toHaveLength(12);
+	});
+
 	it('leaves the printable characters either side of the bidi ranges alone', () => {
+		expect(lint(`a${char(0x061b)}b`)).toHaveLength(0);
+		expect(lint(`a${char(0x061d)}b`)).toHaveLength(0);
 		expect(lint(`a${char(0x200d)}b`)).toHaveLength(0);
 		expect(lint(`a${char(0x2010)}b`)).toHaveLength(0);
 		expect(lint(`a${char(0x2065)}b`)).toHaveLength(0);
@@ -118,9 +136,23 @@ describe('no-literal-control-char', () => {
 		expect(reports[0].loc).toEqual({ line: 2, column: 11 });
 	});
 
-	// A CRLF file must not shift every column on the following line by one.
+	// A CRLF file must not shift every column on the following line by one, and it
+	// must not count the pair as two lines either.
 	it('does not let a carriage return consume the newline', () => {
 		const reports = lint(`const a = 1;\r\n${char(0x1b)}`);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].loc).toEqual({ line: 2, column: 0 });
+	});
+
+	// ESLint treats all four of these as line terminators. Counting only the line
+	// feed reported the character a line early, and an `eslint-disable-next-line`
+	// written against the reported line then landed on the wrong one.
+	it.each([
+		['a lone carriage return', 0x0d],
+		['a line separator', 0x2028],
+		['a paragraph separator', 0x2029]
+	])('starts a new line after %s', (_label, terminator) => {
+		const reports = lint(`const a = 1;${char(terminator)}${char(0x1b)}`);
 		expect(reports).toHaveLength(1);
 		expect(reports[0].loc).toEqual({ line: 2, column: 0 });
 	});

--- a/eslint/rules/no-literal-control-char.test.ts
+++ b/eslint/rules/no-literal-control-char.test.ts
@@ -83,18 +83,17 @@ describe('no-literal-control-char', () => {
 	});
 
 	it('flags exactly the characters Unicode gives the Bidi_Control property', () => {
-		const flagged: number[] = [];
+		const reported: number[] = [];
+		const unicode: number[] = [];
 		for (let code = 0; code <= 0xffff; code++) {
-			if (lint(String.fromCharCode(code)).length > 0) flagged.push(code);
+			const value = String.fromCharCode(code);
+			if (lint(value).some((report) => report.data.category === 'bidirectional formatting')) {
+				reported.push(code);
+			}
+			if (/\p{Bidi_Control}/u.test(value)) unicode.push(code);
 		}
-		const bidi = flagged.filter((code) => /\p{Bidi_Control}/u.test(String.fromCharCode(code)));
-		const missing = [];
-		for (let code = 0; code <= 0xffff; code++) {
-			const char = String.fromCharCode(code);
-			if (/\p{Bidi_Control}/u.test(char) && !flagged.includes(code)) missing.push(code);
-		}
-		expect(missing).toEqual([]);
-		expect(bidi).toHaveLength(12);
+		expect(reported).toEqual(unicode);
+		expect(unicode).toHaveLength(12);
 	});
 
 	it('leaves the printable characters either side of the bidi ranges alone', () => {
@@ -106,8 +105,9 @@ describe('no-literal-control-char', () => {
 		expect(lint(`a${char(0x206a)}b`)).toHaveLength(0);
 	});
 
-	// The fix is to make the byte visible, never to change what the code does, so the
-	// same separator spelled as an escape has to stay legal.
+	// Inside a string or template literal an escape keeps the runtime value while making
+	// the source visible. Between tokens the right repair is ordinary whitespace, which
+	// is why the rule deliberately has no fixer.
 	it.each(['\\u0000', '\\u0001', '\\0', '\\x00', '\\u202E'])('allows the escape %s', (escape) => {
 		expect(lint(`const key = a + '${escape}' + b;`)).toHaveLength(0);
 	});
@@ -165,5 +165,7 @@ describe('no-literal-control-char', () => {
 		expect(reports[0].data.codepoint).toBe('U+001B');
 		expect(reports[0].data.escape).toBe('\\u001B');
 		expect(rule.meta.messages.literalControlChar).not.toContain('{{source}}');
+		expect(rule.meta.messages.literalControlChar).toContain('visible whitespace');
+		expect(rule.meta.messages.literalControlChar).toContain('inside a string or template literal');
 	});
 });

--- a/eslint/rules/no-literal-control-char.test.ts
+++ b/eslint/rules/no-literal-control-char.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import rule from './no-literal-control-char.js';
+
+/**
+ * Every offending character below is built with `fromCharCode`. Spelling one
+ * literally would put the very bytes this rule bans into its own guard, which is
+ * the mistake the rule exists to catch, and it would make this file's diffs
+ * unreviewable the moment the guard failed.
+ */
+const char = (code: number) => String.fromCharCode(code);
+
+interface Report {
+	loc: { line: number; column: number };
+	messageId: string;
+	data: { codepoint: string; category: string; escape: string };
+}
+
+function lint(code: string): Report[] {
+	const reports: Report[] = [];
+	const context = {
+		report: (opts: Report) => reports.push(opts),
+		sourceCode: { getText: () => code }
+	};
+	const listeners = rule.create(context) as Record<string, () => void>;
+	listeners.Program();
+	return reports;
+}
+
+describe('no-literal-control-char', () => {
+	it.each([
+		['NUL', 0x00, 'C0 control'],
+		['SOH', 0x01, 'C0 control'],
+		['VT', 0x0b, 'C0 control'],
+		['FF', 0x0c, 'C0 control'],
+		['ESC', 0x1b, 'C0 control'],
+		['DEL', 0x7f, 'DEL']
+	])('flags a literal %s and names its codepoint', (_label, code, category) => {
+		const reports = lint(`const key = a + '${char(code)}' + b;`);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].messageId).toBe('literalControlChar');
+		expect(reports[0].data.category).toBe(category);
+		expect(reports[0].loc).toEqual({ line: 1, column: 17 });
+	});
+
+	// U+001F is the last C0 control and U+0020 the first printable character, so a
+	// boundary written as `<` or `<=` lands here and nowhere else.
+	it('flags U+001F and leaves the space beside it alone', () => {
+		expect(lint(`a${char(0x1f)}b`)).toHaveLength(1);
+		expect(lint(`a${char(0x20)}b`)).toHaveLength(0);
+	});
+
+	// C1 controls are as invisible as C0 and survive a round trip through UTF-8, so a
+	// scan that stops at DEL passes them through.
+	it.each([
+		['U+0080', 0x80],
+		['U+0085', 0x85],
+		['U+009F', 0x9f]
+	])('flags the C1 control %s', (_label, code) => {
+		const reports = lint(`const a = '${char(code)}';`);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].data.category).toBe('C1 control');
+	});
+
+	it('leaves the printable characters either side of the C1 block alone', () => {
+		expect(lint(`a${char(0x7e)}b`)).toHaveLength(0);
+		expect(lint(`a${char(0xa0)}b`)).toHaveLength(0);
+	});
+
+	// These reorder how the source displays without changing what it runs, which is
+	// the Trojan Source attack (CVE-2021-42574). Invisibility is the lesser problem.
+	it.each([
+		['LRM', 0x200e],
+		['RLM', 0x200f],
+		['LRE', 0x202a],
+		['RLO', 0x202e],
+		['LRI', 0x2066],
+		['PDI', 0x2069]
+	])('flags the bidirectional character %s', (_label, code) => {
+		const reports = lint(`const a = '${char(code)}';`);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].data.category).toBe('bidirectional formatting');
+	});
+
+	it('leaves the printable characters either side of the bidi ranges alone', () => {
+		expect(lint(`a${char(0x200d)}b`)).toHaveLength(0);
+		expect(lint(`a${char(0x2010)}b`)).toHaveLength(0);
+		expect(lint(`a${char(0x2065)}b`)).toHaveLength(0);
+		expect(lint(`a${char(0x206a)}b`)).toHaveLength(0);
+	});
+
+	// The fix is to make the byte visible, never to change what the code does, so the
+	// same separator spelled as an escape has to stay legal.
+	it.each(['\\u0000', '\\u0001', '\\0', '\\x00', '\\u202E'])('allows the escape %s', (escape) => {
+		expect(lint(`const key = a + '${escape}' + b;`)).toHaveLength(0);
+	});
+
+	// Source is made of these. Flagging them would flag every file and the rule would
+	// be switched off the same day.
+	it.each([
+		['tab', 0x09],
+		['newline', 0x0a],
+		['carriage return', 0x0d]
+	])('leaves %s alone', (_label, code) => {
+		expect(lint(`const a = 1;${char(code)}const b = 2;`)).toHaveLength(0);
+	});
+
+	// One report per character, not one per file. A file that lost its escapes in a
+	// bad merge should name every place a fix is needed.
+	it('reports every offender rather than stopping at the first', () => {
+		expect(lint(`a${char(0x01)}b${char(0x00)}c`)).toHaveLength(2);
+	});
+
+	// The column is what makes the report actionable, since the character shows the
+	// reader nothing and the line looks correct.
+	it('counts lines and restarts the column after each newline', () => {
+		const reports = lint(`const a = 1;\nconst b = '${char(0x1b)}';`);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].loc).toEqual({ line: 2, column: 11 });
+	});
+
+	// A CRLF file must not shift every column on the following line by one.
+	it('does not let a carriage return consume the newline', () => {
+		const reports = lint(`const a = 1;\r\n${char(0x1b)}`);
+		expect(reports).toHaveLength(1);
+		expect(reports[0].loc).toEqual({ line: 2, column: 0 });
+	});
+
+	// The message carries the codepoint and the escape to write instead. It must
+	// never quote the source: the character would show nothing, and an ESC pasted
+	// into a terminal reprograms it.
+	it('names the codepoint and the escape without quoting the source', () => {
+		const reports = lint(`const a = '${char(0x1b)}';`);
+		expect(reports[0].data.codepoint).toBe('U+001B');
+		expect(reports[0].data.escape).toBe('\\u001B');
+		expect(rule.meta.messages.literalControlChar).not.toContain('{{source}}');
+	});
+});

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -19,7 +19,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
-import { ROUTES, resolveInputs } from './static-checks';
+import { findLiteralControlChar, ROUTES, resolveInputs } from './static-checks';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SCRIPT = path.join(ROOT, 'scripts', 'static-checks.ts');
@@ -87,5 +87,53 @@ describe('bad input dies at the boundary', () => {
 
 	it('still accepts a run with nothing staged', () => {
 		expect(run('--staged', '--scope', 'lint')).toBe(0);
+	});
+});
+
+/**
+ * A control character has to be written as an escape.
+ *
+ * The character itself is often right: NUL is the correct separator for a composite
+ * key, because it cannot occur in the parts being joined. Writing it as the raw byte
+ * is what breaks, since it renders as nothing. A reader sees an empty string where
+ * the code means a separator, a text search matches nothing while appearing to
+ * succeed, and git calls the file binary so its diffs stop being reviewable.
+ *
+ * The characters below are built with fromCharCode deliberately. Spelling them
+ * literally here would put the very bytes this rule bans into its own guard, and
+ * eslint's no-control-regex would reject a pattern containing them either way.
+ */
+describe('findLiteralControlChar', () => {
+	const char = (code: number) => String.fromCharCode(code);
+
+	it.each([
+		['NUL', 0x00],
+		['SOH', 0x01],
+		['VT', 0x0b],
+		['FF', 0x0c],
+		['ESC', 0x1b],
+		['DEL', 0x7f]
+	])('finds a literal %s and reports its column', (_label, code) => {
+		expect(findLiteralControlChar(`const key = a + '${char(code)}' + b;`)).toBe(17);
+	});
+
+	// The fix is to make the byte visible, never to change what the code does, so the
+	// same separator spelled as an escape has to stay legal.
+	it.each(['\\u0000', '\\u0001', '\\0', '\\x00'])('allows the escape %s', (escape) => {
+		expect(findLiteralControlChar(`const key = a + '${escape}' + b;`)).toBeNull();
+	});
+
+	// Source is made of these. Flagging them would flag every file and the check
+	// would be switched off the same day.
+	it.each([
+		['tab', 0x09],
+		['newline', 0x0a],
+		['carriage return', 0x0d]
+	])('leaves %s alone', (_label, code) => {
+		expect(findLiteralControlChar(`const a = 1;${char(code)}const b = 2;`)).toBeNull();
+	});
+
+	it('reports the FIRST offender when a line carries several', () => {
+		expect(findLiteralControlChar(`a${char(0x01)}b${char(0x00)}c`)).toBe(1);
 	});
 });

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -89,7 +89,8 @@ describe('bad input dies at the boundary', () => {
 	// or nothing pins that the guards above leave it alone.
 	//
 	// It reads the real git index, which is the developer's, so with anything staged
-	// it lints those files for real and blows the 5s timeout. The index cannot be
+	// it lints those files for real and outruns vitest's default per-test timeout,
+	// which nothing here raises. The index cannot be
 	// substituted from outside either: `sanitizedGitEnv` scrubs `GIT_INDEX_FILE`
 	// deliberately, because a pre-commit framework setting it points the run at the
 	// wrong worktree (#332). CI stages nothing, so the assertion always runs where it

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -19,7 +19,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
-import { findLiteralControlChar, ROUTES, resolveInputs } from './static-checks';
+import { ROUTES, resolveInputs } from './static-checks';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SCRIPT = path.join(ROOT, 'scripts', 'static-checks.ts');
@@ -85,55 +85,19 @@ describe('bad input dies at the boundary', () => {
 		expect(run(...args)).toBe(1);
 	});
 
-	it('still accepts a run with nothing staged', () => {
+	// `--staged` is the one case here that is not bad input, so it has to be asserted
+	// or nothing pins that the guards above leave it alone.
+	//
+	// It reads the real git index, which is the developer's, so with anything staged
+	// it lints those files for real and blows the 5s timeout. The index cannot be
+	// substituted from outside either: `sanitizedGitEnv` scrubs `GIT_INDEX_FILE`
+	// deliberately, because a pre-commit framework setting it points the run at the
+	// wrong worktree (#332). CI stages nothing, so the assertion always runs where it
+	// gates a merge, and a developer mid-commit gets a skip with the reason instead of
+	// a timeout that looks like a broken script.
+	const nothingStaged =
+		spawnSync('git', ['diff', '--cached', '--quiet'], { cwd: ROOT }).status === 0;
+	it.skipIf(!nothingStaged)('still accepts a run with nothing staged', () => {
 		expect(run('--staged', '--scope', 'lint')).toBe(0);
-	});
-});
-
-/**
- * A control character has to be written as an escape.
- *
- * The character itself is often right: NUL is the correct separator for a composite
- * key, because it cannot occur in the parts being joined. Writing it as the raw byte
- * is what breaks, since it renders as nothing. A reader sees an empty string where
- * the code means a separator, a text search matches nothing while appearing to
- * succeed, and git calls the file binary so its diffs stop being reviewable.
- *
- * The characters below are built with fromCharCode deliberately. Spelling them
- * literally here would put the very bytes this rule bans into its own guard, and
- * eslint's no-control-regex would reject a pattern containing them either way.
- */
-describe('findLiteralControlChar', () => {
-	const char = (code: number) => String.fromCharCode(code);
-
-	it.each([
-		['NUL', 0x00],
-		['SOH', 0x01],
-		['VT', 0x0b],
-		['FF', 0x0c],
-		['ESC', 0x1b],
-		['DEL', 0x7f]
-	])('finds a literal %s and reports its column', (_label, code) => {
-		expect(findLiteralControlChar(`const key = a + '${char(code)}' + b;`)).toBe(17);
-	});
-
-	// The fix is to make the byte visible, never to change what the code does, so the
-	// same separator spelled as an escape has to stay legal.
-	it.each(['\\u0000', '\\u0001', '\\0', '\\x00'])('allows the escape %s', (escape) => {
-		expect(findLiteralControlChar(`const key = a + '${escape}' + b;`)).toBeNull();
-	});
-
-	// Source is made of these. Flagging them would flag every file and the check
-	// would be switched off the same day.
-	it.each([
-		['tab', 0x09],
-		['newline', 0x0a],
-		['carriage return', 0x0d]
-	])('leaves %s alone', (_label, code) => {
-		expect(findLiteralControlChar(`const a = 1;${char(code)}const b = 2;`)).toBeNull();
-	});
-
-	it('reports the FIRST offender when a line carries several', () => {
-		expect(findLiteralControlChar(`a${char(0x01)}b${char(0x00)}c`)).toBe(1);
 	});
 });

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -19,6 +19,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
+import { sanitizedGitEnv } from './git-context';
 import { ROUTES, resolveInputs } from './static-checks';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -97,7 +98,10 @@ describe('bad input dies at the boundary', () => {
 	// gates a merge, and a developer mid-commit gets a skip with the reason instead of
 	// a timeout that looks like a broken script.
 	const nothingStaged =
-		spawnSync('git', ['diff', '--cached', '--quiet'], { cwd: ROOT }).status === 0;
+		spawnSync('git', ['diff', '--cached', '--quiet'], {
+			cwd: ROOT,
+			env: sanitizedGitEnv()
+		}).status === 0;
 	it.skipIf(!nothingStaged)('still accepts a run with nothing staged', () => {
 		expect(run('--staged', '--scope', 'lint')).toBe(0);
 	});

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -215,6 +215,32 @@ function readFilesFrom(source: string): string[] {
  * derived, so a check can no longer disagree with the ledger about its own scope, and
  * a new check has to declare a route to be accounted for.
  */
+/**
+ * The column of the first control character written as the byte itself, or null.
+ *
+ * The character is often the right one: NUL is the correct separator for a composite
+ * key, because it cannot occur in the parts being joined. Writing it as the raw byte
+ * is what breaks, since it renders as nothing. A reader sees an empty string where
+ * the code means a separator, a text search or scripted edit matches nothing while
+ * appearing to succeed, and git calls the whole file binary so its diffs stop being
+ * reviewable in a pull request.
+ *
+ * A codepoint scan rather than a regular expression, for two reasons: eslint's
+ * no-control-regex rejects a pattern containing these characters whatever the intent,
+ * and the column is needed for the message, since printing the offending line shows
+ * the reader nothing at all.
+ *
+ * Tab, newline and carriage return are structural in source and stay legal.
+ */
+export function findLiteralControlChar(line: string): number | null {
+	for (let i = 0; i < line.length; i++) {
+		const code = line.charCodeAt(i);
+		const structural = code === 0x09 || code === 0x0a || code === 0x0d;
+		if ((code < 0x20 && !structural) || code === 0x7f) return i;
+	}
+	return null;
+}
+
 export const ROUTES = {
 	misspell: (f: string) => !CONFIG.misspell.ignore.some((i) => f.includes(i)),
 	'banned-patterns': (f: string) => /\.(svelte|ts)$/.test(f) && f.startsWith('src/'),
@@ -594,6 +620,15 @@ async function main(): Promise<void> {
 					if (CONFIG.bannedPatterns.ungatedTolgeeApiKey.test(line)) {
 						violations.push(
 							`${file}:${i + 1}: ungated Tolgee apiKey (gate behind import.meta.env.DEV so it is stripped from production/preview bundles): ${line.trim()}`
+						);
+					}
+					const controlAt = findLiteralControlChar(line);
+					if (controlAt !== null) {
+						// Name the byte by codepoint and column. Printing the line alone would
+						// show the reader nothing, which is the whole problem with it.
+						const hex = line.charCodeAt(controlAt).toString(16).padStart(4, '0').toUpperCase();
+						violations.push(
+							`${file}:${i + 1}:${controlAt + 1}: literal control character U+${hex} (write it as an escape so it stays visible in editors, diffs and text search): ${line.trim()}`
 						);
 					}
 				}

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -215,32 +215,6 @@ function readFilesFrom(source: string): string[] {
  * derived, so a check can no longer disagree with the ledger about its own scope, and
  * a new check has to declare a route to be accounted for.
  */
-/**
- * The column of the first control character written as the byte itself, or null.
- *
- * The character is often the right one: NUL is the correct separator for a composite
- * key, because it cannot occur in the parts being joined. Writing it as the raw byte
- * is what breaks, since it renders as nothing. A reader sees an empty string where
- * the code means a separator, a text search or scripted edit matches nothing while
- * appearing to succeed, and git calls the whole file binary so its diffs stop being
- * reviewable in a pull request.
- *
- * A codepoint scan rather than a regular expression, for two reasons: eslint's
- * no-control-regex rejects a pattern containing these characters whatever the intent,
- * and the column is needed for the message, since printing the offending line shows
- * the reader nothing at all.
- *
- * Tab, newline and carriage return are structural in source and stay legal.
- */
-export function findLiteralControlChar(line: string): number | null {
-	for (let i = 0; i < line.length; i++) {
-		const code = line.charCodeAt(i);
-		const structural = code === 0x09 || code === 0x0a || code === 0x0d;
-		if ((code < 0x20 && !structural) || code === 0x7f) return i;
-	}
-	return null;
-}
-
 export const ROUTES = {
 	misspell: (f: string) => !CONFIG.misspell.ignore.some((i) => f.includes(i)),
 	'banned-patterns': (f: string) => /\.(svelte|ts)$/.test(f) && f.startsWith('src/'),
@@ -620,15 +594,6 @@ async function main(): Promise<void> {
 					if (CONFIG.bannedPatterns.ungatedTolgeeApiKey.test(line)) {
 						violations.push(
 							`${file}:${i + 1}: ungated Tolgee apiKey (gate behind import.meta.env.DEV so it is stripped from production/preview bundles): ${line.trim()}`
-						);
-					}
-					const controlAt = findLiteralControlChar(line);
-					if (controlAt !== null) {
-						// Name the byte by codepoint and column. Printing the line alone would
-						// show the reader nothing, which is the whole problem with it.
-						const hex = line.charCodeAt(controlAt).toString(16).padStart(4, '0').toUpperCase();
-						violations.push(
-							`${file}:${i + 1}:${controlAt + 1}: literal control character U+${hex} (write it as an escape so it stays visible in editors, diffs and text search): ${line.trim()}`
 						);
 					}
 				}

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -125,7 +125,7 @@
 	const rotatingPlaceholders = $derived(compact ? placeholders : []);
 	// Content-based key so the index only resets when the copy actually changes
 	// (locale or thread switch), not on every re-derivation of the same list.
-	const placeholderKey = $derived(rotatingPlaceholders.join(''));
+	const placeholderKey = $derived(rotatingPlaceholders.join('\u0001'));
 	const visiblePlaceholder = $derived(
 		rotatingPlaceholders.length > 0
 			? rotatingPlaceholders[placeholderIndex % rotatingPlaceholders.length]


### PR DESCRIPTION
`ChatInput.svelte` carried a raw U+0001 separator that looked like an empty string in source and could not be found reliably in review or text search. The guard lived in `static-checks.ts` and missed scripts, config, JavaScript and itself.

A local ESLint rule covers C0, C1, DEL and Unicode `Bidi_Control` characters across JavaScript, TypeScript and Svelte. It reports codepoint and location without quoting source and gives context-safe repair guidance. A parser wrapper sanitizes fatal Svelte errors before the formatter. A processor removes varlock's file-wide disable from `src/env.d.ts`, with real ESLint coverage proving the rule still runs there. The existing separator is escaped without changing its runtime value.

Regression guard: added 35 character/range tests plus 13 config coverage cases, mutation-verified; 188 focused tests and full static checks pass.

See also: #832
