### PR TITLE
fix(auth): Pin the last-used badge to its button

### DIFF
--- a/e2e/signin-last-used-badge.spec.ts
+++ b/e2e/signin-last-used-badge.spec.ts
@@ -60,3 +60,63 @@ test('email/password signin clears stored last-used method', async ({ page }) =>
 	});
 	expect(lastMethodAfterSignIn).toBeNull();
 });
+
+/**
+ * The badge is positioned beside the button, not inside it, so nothing in the
+ * markup makes it follow the button's one-pixel press offset. That coupling is
+ * a CSS selector keyed to the button's own :active state, and it depends on
+ * browser hit testing: an earlier version keyed off the wrapper instead and
+ * moved the badge alone whenever the button underneath was disabled, because
+ * pointer-events-none sent the press to the wrapper. Neither failure is
+ * reachable from a static class assertion, so it is asserted here.
+ */
+test('last-used badge tracks the button through a press', async ({ page }) => {
+	await page.goto('/signin');
+	await page.evaluate(() => {
+		localStorage.setItem('auth:last-auth-method', JSON.stringify('passkey'));
+		sessionStorage.removeItem('auth:pending-oauth-provider');
+	});
+	await page.reload();
+	await expect(page.locator('[data-testid="email-input"]')).toBeEnabled({ timeout: 30000 });
+
+	const button = page.locator('[data-testid="signin-oauth-passkey-button"]');
+	const badge = page.locator('[data-testid="oauth-passkey-last-used-badge"]');
+	await expect(badge).toBeVisible();
+
+	const tops = async () => {
+		const b = await button.boundingBox();
+		const g = await badge.boundingBox();
+		if (!b || !g) throw new Error('button or badge is not laid out');
+		return { button: b.y, badge: g.y };
+	};
+
+	const box = await button.boundingBox();
+	if (!box) throw new Error('button is not laid out');
+	const centre = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+
+	const resting = await tops();
+	await page.mouse.move(centre.x, centre.y);
+	await page.mouse.down();
+	const pressed = await tops();
+	// Release away from the button so the press does not trigger the passkey flow.
+	await page.mouse.move(5, 5);
+	await page.mouse.up();
+
+	expect(pressed.button - resting.button).toBeCloseTo(1, 1);
+	expect(pressed.badge - resting.badge).toBeCloseTo(1, 1);
+	expect(pressed.badge - pressed.button).toBeCloseTo(resting.badge - resting.button, 1);
+
+	// A disabled button does not move, so neither may the badge.
+	await button.evaluate((el: HTMLButtonElement) => {
+		el.disabled = true;
+	});
+	const disabledResting = await tops();
+	await page.mouse.move(centre.x, centre.y);
+	await page.mouse.down();
+	const disabledPressed = await tops();
+	await page.mouse.move(5, 5);
+	await page.mouse.up();
+
+	expect(disabledPressed.button - disabledResting.button).toBeCloseTo(0, 1);
+	expect(disabledPressed.badge - disabledResting.badge).toBeCloseTo(0, 1);
+});

--- a/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
@@ -38,7 +38,7 @@
 	style="grid-template-columns: repeat({enabledProviderCount}, minmax(0, 1fr));"
 >
 	{#if providers?.google}
-		<div class="relative">
+		<div class="group relative">
 			<Button
 				class="w-full"
 				data-testid="{mode}-oauth-google-button"
@@ -58,7 +58,7 @@
 			{#if isLastUsedAuthMethod('google')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px"
 					data-testid="oauth-google-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />
@@ -67,7 +67,7 @@
 		</div>
 	{/if}
 	{#if providers?.github}
-		<div class="relative">
+		<div class="group relative">
 			<Button
 				class="w-full"
 				data-testid="{mode}-oauth-github-button"
@@ -87,7 +87,7 @@
 			{#if isLastUsedAuthMethod('github')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px"
 					data-testid="oauth-github-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />
@@ -96,7 +96,7 @@
 		</div>
 	{/if}
 	{#if showPasskey}
-		<div class="relative">
+		<div class="group relative">
 			<Button
 				class="w-full"
 				data-testid="{mode}-oauth-passkey-button"
@@ -113,7 +113,7 @@
 			{#if isLastUsedAuthMethod('passkey')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px"
 					data-testid="oauth-passkey-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />


### PR DESCRIPTION
The "Last used" badge sits beside the OAuth button inside a wrapper div. Pressing the button applies its one-pixel offset to the button alone, so the badge stays put and reads as floating free of the control it labels.

The badge now mirrors that offset, keyed off the button's own pressed state. Driving it from the wrapper's `:active` looked equivalent and is not: a disabled button carries `pointer-events-none`, so a press over it lands on the wrapper and would move the badge while the button stays still. Measured with a held pointer press, the wrapper-keyed version moved the badge alone on a disabled control. Matching the button's `data-slot` rather than its tag keeps the coupling if a provider button is ever rendered as a link, which the shared Button supports.

The explicit `transition-colors` is load-bearing rather than decorative. `no-animated-pixel-press` requires it on a component class attribute because the badge's own base class carries a broader transition the call site cannot see, and removing it still reproduces `unprovenComponentPress` on all three badges.

Regression guard: added e2e/signin-last-used-badge.spec.ts "last-used badge tracks the button through a press"

Verified in the browser by measuring both elements through a held press: enabled moves both by one pixel and holds the gap constant, disabled moves neither.

See also: #802