### PR TITLE
fix(auth): Stop overstating what password screens know

### DIFF
--- a/e2e/forgot-reset-password.spec.ts
+++ b/e2e/forgot-reset-password.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page, type Route } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 import 'varlock/auto-load';
@@ -112,6 +112,32 @@ test.describe('Forgot Password', () => {
 		// address has no account, and Better Auth swallows a failing send, so the
 		// screen can claim neither that an account exists nor that mail went out.
 		expect(known.toLowerCase()).toContain('if an account exists');
+	});
+
+	/**
+	 * The subtitle promises a mail outright, so it has to give way to any answer,
+	 * not only to a successful one. The failing request is faked because a real
+	 * backend failure is not reachable from a test.
+	 */
+	test('drops the delivery promise when the request fails', async ({ page }) => {
+		await page.route('**/request-password-reset', (route: Route) =>
+			route.fulfill({
+				status: 500,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'Internal Server Error' })
+			})
+		);
+		await page.goto('/en/forgot-password');
+		await page.waitForLoadState('domcontentloaded');
+		await expect(page.getByTestId('forgot-password-email-input')).toBeEnabled({ timeout: 30000 });
+		await expect(page.getByTestId('forgot-password-description')).toBeVisible();
+
+		await page.getByTestId('forgot-password-email-input').fill('someone@e2e.example.com');
+		await page.getByTestId('forgot-password-submit-button').click();
+
+		await expect(page.getByTestId('forgot-password-form-error')).toBeVisible({ timeout: 10000 });
+		await expect(page.getByTestId('forgot-password-description')).toHaveCount(0);
+		await expect(page.getByTestId('forgot-password-success-message')).toHaveCount(0);
 	});
 
 	test('navigates back to signin', async ({ page }) => {

--- a/e2e/forgot-reset-password.spec.ts
+++ b/e2e/forgot-reset-password.spec.ts
@@ -114,6 +114,18 @@ test.describe('Forgot Password', () => {
 		expect(known.toLowerCase()).toContain('if an account exists');
 	});
 
+	// The answer names the address it was given, so it must not outlive that
+	// address in the field. Nothing clears it on the next submit either, because a
+	// validation failure returns before the reset.
+	test('drops the answer when the address changes', async ({ page }) => {
+		await submitForgotPassword(page, `stale-${Date.now()}@e2e.example.com`);
+
+		await page.getByTestId('forgot-password-email-input').fill('not-an-email');
+
+		await expect(page.getByTestId('forgot-password-success-message')).toHaveCount(0);
+		await expect(page.getByTestId('forgot-password-description')).toBeVisible();
+	});
+
 	/**
 	 * The subtitle promises a mail outright, so it has to give way to any answer,
 	 * not only to a successful one. The failing request is faked because a real

--- a/e2e/forgot-reset-password.spec.ts
+++ b/e2e/forgot-reset-password.spec.ts
@@ -1,4 +1,6 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
 import 'varlock/auto-load';
 import { ConvexHttpClient } from 'convex/browser';
 import { api } from '../src/lib/convex/_generated/api';
@@ -14,7 +16,29 @@ test.use({ storageState: { cookies: [], origins: [] } });
 // e2e/upgrade-checkout-failure.spec.ts), which would serve translated copy
 // on non-English runners.
 
+import type { TestCredentials } from './utils/types';
+
 const testSecret = process.env.AUTH_E2E_TEST_SECRET!;
+
+function getSeededUserEmail(): string {
+	const credentialsPath = path.join(process.cwd(), 'e2e', '.auth', 'test-credentials.json');
+	if (!fs.existsSync(credentialsPath)) {
+		throw new Error('test-credentials.json not found. globalSetup may have failed.');
+	}
+	const credentials: TestCredentials = JSON.parse(fs.readFileSync(credentialsPath, 'utf-8'));
+	return credentials.user.email;
+}
+
+async function submitForgotPassword(page: Page, email: string) {
+	await page.goto('/en/forgot-password');
+	await page.waitForLoadState('domcontentloaded');
+	await expect(page.getByTestId('forgot-password-email-input')).toBeEnabled({ timeout: 30000 });
+	await page.getByTestId('forgot-password-email-input').fill(email);
+	await page.getByTestId('forgot-password-submit-button').click();
+	const message = page.getByTestId('forgot-password-success-message');
+	await expect(message).toBeVisible({ timeout: 10000 });
+	return (await message.innerText()).trim();
+}
 
 const getConvexClient = () => {
 	const convexUrl = resolveConvexUrl();
@@ -60,6 +84,27 @@ test.describe('Forgot Password', () => {
 		await expect(page.getByTestId('forgot-password-success-message')).toBeVisible({
 			timeout: 10000
 		});
+	});
+
+	/**
+	 * Account enumeration guard. Better Auth answers /request-password-reset
+	 * identically whether or not the address has an account, and the screen must
+	 * not undo that by rendering something the API never told it. Submitting a
+	 * seeded address and an address that cannot exist has to leave the user
+	 * looking at the same words.
+	 */
+	test('says the same thing for a known and an unknown address', async ({ page }) => {
+		const known = await submitForgotPassword(page, getSeededUserEmail());
+		const unknown = await submitForgotPassword(
+			page,
+			`definitely-not-registered-${Date.now()}@e2e.example.com`
+		);
+
+		expect(known).toBe(unknown);
+		// The wording stays conditional: the endpoint reports success even when the
+		// address has no account, and Better Auth swallows a failing send, so the
+		// screen can claim neither that an account exists nor that mail went out.
+		expect(known.toLowerCase()).toContain('if an account exists');
 	});
 
 	test('navigates back to signin', async ({ page }) => {

--- a/e2e/forgot-reset-password.spec.ts
+++ b/e2e/forgot-reset-password.spec.ts
@@ -33,10 +33,17 @@ async function submitForgotPassword(page: Page, email: string) {
 	await page.goto('/en/forgot-password');
 	await page.waitForLoadState('domcontentloaded');
 	await expect(page.getByTestId('forgot-password-email-input')).toBeEnabled({ timeout: 30000 });
+	// Asserted before the submit as well, so that the after-check below cannot pass
+	// by the element having never rendered.
+	await expect(page.getByTestId('forgot-password-description')).toBeVisible();
 	await page.getByTestId('forgot-password-email-input').fill(email);
 	await page.getByTestId('forgot-password-submit-button').click();
 	const message = page.getByTestId('forgot-password-success-message');
 	await expect(message).toBeVisible({ timeout: 10000 });
+	// The subtitle promises a mail outright. Leaving it up next to the conditional
+	// message would put both claims on screen at once, which is the overstatement
+	// the conditional wording exists to remove.
+	await expect(page.getByTestId('forgot-password-description')).toHaveCount(0);
 	return (await message.innerText()).trim();
 }
 

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -356,7 +356,7 @@
 		},
 		"messages": {
 			"auth_cancelled": "Authentifizierung abgebrochen",
-			"credential_account_not_found": "Kein Passwortkonto gefunden. Versuchen Sie die Anmeldung mit Ihrem sozialen Anbieter.",
+			"credential_account_not_found": "Für dieses Konto ist kein Passwort festgelegt.",
 			"email_change_failed": "E-Mail konnte nicht geändert werden",
 			"email_not_verified": "Bitte bestätigen Sie Ihre E-Mail-Adresse",
 			"email_same_as_current": "Neue E-Mail muss sich von der aktuellen E-Mail unterscheiden",
@@ -383,7 +383,7 @@
 			"rate_limited": "Zu viele Anfragen. Bitte versuchen Sie es später erneut.",
 			"request_reset_failed": "Passwort-Reset konnte nicht angefordert werden",
 			"reset_failed": "Passwort konnte nicht zurückgesetzt werden",
-			"reset_link_sent": "Bitte prüfen Sie Ihre E-Mail für den Reset-Link.",
+			"reset_link_sent": "Wenn ein Konto mit dieser Adresse existiert, prüfen Sie Ihre E-Mails auf einen Link zum Zurücksetzen.",
 			"signup_disabled": "Registrierung ist deaktiviert",
 			"signup_failed": "Konto konnte nicht erstellt werden",
 			"too_many_attempts": "Zu viele Versuche. Bitte versuchen Sie es später erneut.",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -351,7 +351,7 @@
 			"back_to_signin": "Zurück zur Anmeldung",
 			"button_loading": "Wird gesendet...",
 			"button_submit": "Link senden",
-			"description": "Wir senden Ihnen einen Link zum Zurücksetzen",
+			"description": "Geben Sie die E-Mail-Adresse Ihres Kontos ein",
 			"title": "Passwort vergessen"
 		},
 		"messages": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -351,7 +351,7 @@
 			"back_to_signin": "Back to sign in",
 			"button_loading": "Sending...",
 			"button_submit": "Send reset link",
-			"description": "We will email you a reset link",
+			"description": "Enter the email address for your account",
 			"title": "Forgot password"
 		},
 		"messages": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -356,7 +356,7 @@
 		},
 		"messages": {
 			"auth_cancelled": "Authentication was cancelled",
-			"credential_account_not_found": "No password account found. Try signing in with your social provider.",
+			"credential_account_not_found": "This account has no password set.",
 			"email_change_failed": "Failed to change email",
 			"email_not_verified": "Please verify your email address",
 			"email_same_as_current": "New email must be different from current email",
@@ -383,7 +383,7 @@
 			"rate_limited": "Too many requests. Please try again later.",
 			"request_reset_failed": "Failed to request password reset",
 			"reset_failed": "Failed to reset password",
-			"reset_link_sent": "Check your email for a reset link.",
+			"reset_link_sent": "If an account exists for that address, check your email for a reset link.",
 			"signup_disabled": "Sign up is disabled",
 			"signup_failed": "Failed to create account",
 			"too_many_attempts": "Too many attempts. Please try again later.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -351,7 +351,7 @@
 			"back_to_signin": "Volver a iniciar sesión",
 			"button_loading": "Enviando...",
 			"button_submit": "Enviar enlace",
-			"description": "Te enviaremos un enlace para restablecer",
+			"description": "Introduce la dirección de correo de tu cuenta",
 			"title": "¿Olvidaste tu contraseña?"
 		},
 		"messages": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -356,7 +356,7 @@
 		},
 		"messages": {
 			"auth_cancelled": "La autenticación fue cancelada",
-			"credential_account_not_found": "No se encontró cuenta con contraseña. Intenta iniciar sesión con tu proveedor social.",
+			"credential_account_not_found": "Esta cuenta no tiene ninguna contraseña establecida.",
 			"email_change_failed": "No se pudo cambiar el correo",
 			"email_not_verified": "Por favor verifica tu correo electrónico",
 			"email_same_as_current": "El nuevo correo debe ser diferente al actual",
@@ -383,7 +383,7 @@
 			"rate_limited": "Demasiadas solicitudes. Inténtalo más tarde.",
 			"request_reset_failed": "No se pudo solicitar el restablecimiento de contraseña",
 			"reset_failed": "No se pudo restablecer la contraseña",
-			"reset_link_sent": "Revisa tu correo para el enlace de restablecimiento.",
+			"reset_link_sent": "Si existe una cuenta con esa dirección, revisa tu correo para encontrar el enlace de restablecimiento.",
 			"signup_disabled": "El registro está deshabilitado",
 			"signup_failed": "No se pudo crear la cuenta",
 			"too_many_attempts": "Demasiados intentos. Inténtalo más tarde.",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -351,7 +351,7 @@
 			"back_to_signin": "Retour à la connexion",
 			"button_loading": "Envoi en cours...",
 			"button_submit": "Envoyer le lien",
-			"description": "Nous vous enverrons un lien de réinitialisation",
+			"description": "Saisissez l'adresse e-mail de votre compte",
 			"title": "Mot de passe oublié"
 		},
 		"messages": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -356,7 +356,7 @@
 		},
 		"messages": {
 			"auth_cancelled": "L'authentification a été annulée",
-			"credential_account_not_found": "Aucun compte avec mot de passe trouvé. Essayez de vous connecter avec votre fournisseur social.",
+			"credential_account_not_found": "Aucun mot de passe n'est défini pour ce compte.",
 			"email_change_failed": "Impossible de modifier l'e-mail",
 			"email_not_verified": "Veuillez vérifier votre adresse e-mail",
 			"email_same_as_current": "Le nouvel e-mail doit être différent de l'actuel",
@@ -383,7 +383,7 @@
 			"rate_limited": "Trop de requêtes. Réessayez plus tard.",
 			"request_reset_failed": "Impossible de demander la réinitialisation du mot de passe",
 			"reset_failed": "Impossible de réinitialiser le mot de passe",
-			"reset_link_sent": "Vérifiez votre e-mail pour le lien de réinitialisation.",
+			"reset_link_sent": "Si un compte est associé à cette adresse, vérifiez votre messagerie pour trouver le lien de réinitialisation.",
 			"signup_disabled": "L'inscription est désactivée",
 			"signup_failed": "Impossible de créer le compte",
 			"too_many_attempts": "Trop de tentatives. Réessayez plus tard.",

--- a/src/lib/convex/betterAuth/schema.ts
+++ b/src/lib/convex/betterAuth/schema.ts
@@ -13,6 +13,11 @@
  * Customizations preserved across regeneration:
  * - Admin-list indexes on the `user` table — generator drops them.
  * - `.index('updatedAt', ['updatedAt'])` on `session` for activity metrics.
+ * - `.index('value', ['value'])` on `verification` so E2E teardown can delete a
+ *   user's password-reset tokens, which are keyed by `reset-password:<token>`
+ *   and carry the user id in `value`. Without it that deletion is a table scan,
+ *   which shares the caller's transaction budget and fails the whole cleanup on
+ *   a long-lived backend.
  *
  * Custom-index pattern: https://labs.convex.dev/better-auth/features/local-install#adding-custom-indexes.
  */
@@ -84,7 +89,8 @@ export const tables = {
 		updatedAt: v.number()
 	})
 		.index('expiresAt', ['expiresAt'])
-		.index('identifier', ['identifier']),
+		.index('identifier', ['identifier'])
+		.index('value', ['value']),
 	jwks: defineTable({
 		publicKey: v.string(),
 		privateKey: v.string(),

--- a/src/lib/convex/tests.ts
+++ b/src/lib/convex/tests.ts
@@ -500,59 +500,64 @@ export const deleteTestUser = mutation({
 			return { success: false, error: 'User not found' };
 		}
 
-		// Delete ALL associated account records (loop until none remain)
-		let accountsDeleted = 0;
-		let hasMoreAccounts = true;
-		while (hasMoreAccounts) {
-			const result = await ctx.runMutation(components.betterAuth.adapter.deleteMany, {
-				input: {
-					model: 'account',
-					where: [{ field: 'userId', value: user._id }]
-				},
-				paginationOpts: { numItems: 100, cursor: null }
-			});
-			accountsDeleted += result?.deletedCount ?? 0;
-			hasMoreAccounts = (result?.deletedCount ?? 0) >= 100;
-		}
+		// Page through deletions with the component's own cursor. `deleteMany` reports
+		// `count` and `isDone`, and an unindexed `where` makes them diverge: the scan
+		// stops after a fixed number of source rows, so a page can match nothing and
+		// still not be the last one. Continuing on a zero count is what makes the
+		// unindexed pass below terminate at the right place instead of the first page.
+		// The page callback keeps its literal model at the call site, which is what lets
+		// the component's per-model `where` validator narrow.
+		const deleteAll = async (
+			deletePage: (
+				cursor: string | null
+			) => Promise<{ count: number; isDone: boolean; continueCursor: string }>
+		) => {
+			let deleted = 0;
+			let cursor: string | null = null;
+			let isDone = false;
+			while (!isDone) {
+				const result = await deletePage(cursor);
+				deleted += result.count;
+				isDone = result.isDone;
+				cursor = result.continueCursor;
+			}
+			return deleted;
+		};
 
-		// Delete ALL associated sessions (loop until none remain)
-		let sessionsDeleted = 0;
-		let hasMoreSessions = true;
-		while (hasMoreSessions) {
-			const result = await ctx.runMutation(components.betterAuth.adapter.deleteMany, {
-				input: {
-					model: 'session',
-					where: [{ field: 'userId', value: user._id }]
-				},
-				paginationOpts: { numItems: 100, cursor: null }
-			});
-			sessionsDeleted += result?.deletedCount ?? 0;
-			hasMoreSessions = (result?.deletedCount ?? 0) >= 100;
-		}
+		const accountsDeleted = await deleteAll((cursor) =>
+			ctx.runMutation(components.betterAuth.adapter.deleteMany, {
+				input: { model: 'account', where: [{ field: 'userId', value: user._id }] },
+				paginationOpts: { numItems: 100, cursor }
+			})
+		);
+		const sessionsDeleted = await deleteAll((cursor) =>
+			ctx.runMutation(components.betterAuth.adapter.deleteMany, {
+				input: { model: 'session', where: [{ field: 'userId', value: user._id }] },
+				paginationOpts: { numItems: 100, cursor }
+			})
+		);
 
-		// Delete ALL verification records. A password-reset request stores the token
-		// under `reset-password:<token>` with the user id as its value, and email
-		// verification stores it under the address, so neither is reachable by userId.
-		// Better Auth only clears them when the token is consumed or looked up after
-		// expiry, so a suite that requests a reset without completing it would leave
-		// them behind for the lifetime of the backend.
+		// A password-reset request stores its token under `reset-password:<token>` with
+		// the user id as the value, and email verification stores it under the address,
+		// so neither is reachable by userId. Better Auth only clears them when the token
+		// is consumed or looked up after expiry, so a suite that requests a reset without
+		// completing it would leave them behind for the lifetime of the backend.
 		// The component indexes `identifier` but not `value`, so the first pass is a
 		// table scan. That is affordable here and nowhere else: this mutation is
 		// test-only, gated on the test secret, and runs against a test backend.
-		let verificationsDeleted = 0;
-		const deleteVerifications = async (field: 'value' | 'identifier', value: string) => {
-			let hasMore = true;
-			while (hasMore) {
-				const result = await ctx.runMutation(components.betterAuth.adapter.deleteMany, {
-					input: { model: 'verification', where: [{ field, value }] },
-					paginationOpts: { numItems: 100, cursor: null }
-				});
-				verificationsDeleted += result?.deletedCount ?? 0;
-				hasMore = (result?.deletedCount ?? 0) >= 100;
-			}
-		};
-		await deleteVerifications('value', user._id);
-		await deleteVerifications('identifier', email);
+		const verificationsDeleted =
+			(await deleteAll((cursor) =>
+				ctx.runMutation(components.betterAuth.adapter.deleteMany, {
+					input: { model: 'verification', where: [{ field: 'value', value: user._id }] },
+					paginationOpts: { numItems: 100, cursor }
+				})
+			)) +
+			(await deleteAll((cursor) =>
+				ctx.runMutation(components.betterAuth.adapter.deleteMany, {
+					input: { model: 'verification', where: [{ field: 'identifier', value: email }] },
+					paginationOpts: { numItems: 100, cursor }
+				})
+			));
 
 		// Delete the user
 		await ctx.runMutation(components.betterAuth.adapter.deleteOne, {

--- a/src/lib/convex/tests.ts
+++ b/src/lib/convex/tests.ts
@@ -542,9 +542,10 @@ export const deleteTestUser = mutation({
 		// so neither is reachable by userId. Better Auth only clears them when the token
 		// is consumed or looked up after expiry, so a suite that requests a reset without
 		// completing it would leave them behind for the lifetime of the backend.
-		// The component indexes `identifier` but not `value`, so the first pass is a
-		// table scan. That is affordable here and nowhere else: this mutation is
-		// test-only, gated on the test secret, and runs against a test backend.
+		// Both passes are indexed: `value` carries a custom index in the local schema
+		// for this one, because an unindexed scan here shares the caller's
+		// transaction budget and would fail the whole cleanup on a backend that has
+		// collected enough rows.
 		const verificationsDeleted =
 			(await deleteAll((cursor) =>
 				ctx.runMutation(components.betterAuth.adapter.deleteMany, {

--- a/src/lib/convex/tests.ts
+++ b/src/lib/convex/tests.ts
@@ -484,7 +484,8 @@ export const deleteTestUser = mutation({
 		error: v.optional(v.string()),
 		deletedEmail: v.optional(v.string()),
 		accountsDeleted: v.optional(v.number()),
-		sessionsDeleted: v.optional(v.number())
+		sessionsDeleted: v.optional(v.number()),
+		verificationsDeleted: v.optional(v.number())
 	}),
 	handler: async (ctx, { email, secret }) => {
 		requireTestSecret(secret);
@@ -529,6 +530,30 @@ export const deleteTestUser = mutation({
 			hasMoreSessions = (result?.deletedCount ?? 0) >= 100;
 		}
 
+		// Delete ALL verification records. A password-reset request stores the token
+		// under `reset-password:<token>` with the user id as its value, and email
+		// verification stores it under the address, so neither is reachable by userId.
+		// Better Auth only clears them when the token is consumed or looked up after
+		// expiry, so a suite that requests a reset without completing it would leave
+		// them behind for the lifetime of the backend.
+		// The component indexes `identifier` but not `value`, so the first pass is a
+		// table scan. That is affordable here and nowhere else: this mutation is
+		// test-only, gated on the test secret, and runs against a test backend.
+		let verificationsDeleted = 0;
+		const deleteVerifications = async (field: 'value' | 'identifier', value: string) => {
+			let hasMore = true;
+			while (hasMore) {
+				const result = await ctx.runMutation(components.betterAuth.adapter.deleteMany, {
+					input: { model: 'verification', where: [{ field, value }] },
+					paginationOpts: { numItems: 100, cursor: null }
+				});
+				verificationsDeleted += result?.deletedCount ?? 0;
+				hasMore = (result?.deletedCount ?? 0) >= 100;
+			}
+		};
+		await deleteVerifications('value', user._id);
+		await deleteVerifications('identifier', email);
+
 		// Delete the user
 		await ctx.runMutation(components.betterAuth.adapter.deleteOne, {
 			input: {
@@ -537,7 +562,13 @@ export const deleteTestUser = mutation({
 			}
 		});
 
-		return { success: true, deletedEmail: email, accountsDeleted, sessionsDeleted };
+		return {
+			success: true,
+			deletedEmail: email,
+			accountsDeleted,
+			sessionsDeleted,
+			verificationsDeleted
+		};
 	}
 });
 

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -158,12 +158,21 @@
 								<h1 class="text-2xl font-bold">
 									<T keyName="auth.forgot_password.title" defaultValue="Forgot password" />
 								</h1>
-								<p class="text-balance text-muted-foreground">
-									<T
-										keyName="auth.forgot_password.description"
-										defaultValue="We will email you a reset link"
-									/>
-								</p>
+								<!-- The subtitle promises a mail outright, which is only true while the
+								     address is still unknown to the reader. Once the request has been
+								     answered, the conditional success message below is the accurate
+								     statement, so the promise gives way rather than contradicting it. -->
+								{#if !message}
+									<p
+										data-testid="forgot-password-description"
+										class="text-balance text-muted-foreground"
+									>
+										<T
+											keyName="auth.forgot_password.description"
+											defaultValue="We will email you a reset link"
+										/>
+									</p>
+								{/if}
 							</div>
 							{#if formError}
 								<div

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -159,10 +159,12 @@
 									<T keyName="auth.forgot_password.title" defaultValue="Forgot password" />
 								</h1>
 								<!-- The subtitle promises a mail outright, which is only true while the
-								     address is still unknown to the reader. Once the request has been
-								     answered, the conditional success message below is the accurate
-								     statement, so the promise gives way rather than contradicting it. -->
-								{#if !message}
+								     request is still unanswered. Once an answer exists, whether it is
+								     the conditional success message or an error, that answer is the
+								     accurate statement and the promise gives way instead of
+								     contradicting it. Field validation sets `errors.email` rather than
+								     `formError`, so an unsent form keeps its subtitle. -->
+								{#if !message && !formError}
 									<p
 										data-testid="forgot-password-description"
 										class="text-balance text-muted-foreground"

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -180,7 +180,7 @@
 									>
 										<T
 											keyName="auth.forgot_password.description"
-											defaultValue="We will email you a reset link"
+											defaultValue="Enter the email address for your account"
 										/>
 									</p>
 								{/if}

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -77,6 +77,15 @@
 		}
 	});
 
+	// An answer names the address it was given ("if an account exists for that
+	// address"). Once the field holds a different one, the answer is about
+	// something the user is no longer looking at, so it goes with the edit rather
+	// than waiting for the next submit, which a validation failure never reaches.
+	function clearAnswer() {
+		message = null;
+		formError = null;
+	}
+
 	function validate(): boolean {
 		const result = v.safeParse(forgotPasswordSchema, formData);
 		if (!result.success) {
@@ -158,12 +167,12 @@
 								<h1 class="text-2xl font-bold">
 									<T keyName="auth.forgot_password.title" defaultValue="Forgot password" />
 								</h1>
-								<!-- The subtitle promises a mail outright, which is only true while the
-								     request is still unanswered. Once an answer exists, whether it is
-								     the conditional success message or an error, that answer is the
-								     accurate statement and the promise gives way instead of
-								     contradicting it. Field validation sets `errors.email` rather than
-								     `formError`, so an unsent form keeps its subtitle. -->
+								<!-- An instruction rather than a promise: this screen cannot know
+								     whether a mail will be sent, and the answer below says so. Once
+								     an answer exists, whether success or error, the instruction has
+								     been carried out and gives way to it. Field validation sets
+								     `errors.email` rather than `formError`, so an unsent form keeps
+								     its subtitle. -->
 								{#if !message && !formError}
 									<p
 										data-testid="forgot-password-description"
@@ -209,6 +218,7 @@
 									aria-invalid={hasEmailError ? 'true' : undefined}
 									aria-describedby={hasEmailError ? `email-${id}-error` : undefined}
 									bind:value={formData.email}
+									oninput={clearAnswer}
 								/>
 								<Field.Error
 									id="email-{id}-error"


### PR DESCRIPTION
The password screens claimed more than the API had told them. The forgot-password page said a reset link had been sent, which it cannot know: Better Auth answers identically whether or not the address has an account, and it swallows a failing send. Its subtitle promised a mail outright before any request had been made, and kept promising it beside the answer afterwards. `credential_account_not_found` described a missing record rather than the situation the user is in.

The copy now states only what is known, in all four locales, and the subtitle asks for an address instead of promising a result. An answer names the address it was given, so editing the field clears it rather than leaving it above a different one.

Teardown was rewritten alongside, because the new enumeration test exposed two defects in it. The deletion loops read a `deletedCount` that `deleteMany` does not return, so every count was zero and every loop stopped after one page; they follow the component's cursor now. Reset tokens were never deleted at all, since Better Auth keys them by token with the user id in `value`, and `verification` gains an index on that field in the local schema so the new pass is a lookup rather than a table scan sharing the caller's transaction budget.

The residual timing difference between the hit and miss paths is filed as #812.

Regression guard: added e2e/forgot-reset-password.spec.ts, three tests covering identical answers for a known and an unknown address, a faked request failure, and an answer outliving its address
Verified by the E2E suite on the CF preview plus the unit and type checks.