### PR TITLE
fix(auth): Dim disabled last-used badges

### DIFF
--- a/e2e/signin-last-used-badge.spec.ts
+++ b/e2e/signin-last-used-badge.spec.ts
@@ -106,10 +106,23 @@ test('last-used badge tracks the button through a press', async ({ page }) => {
 	expect(pressed.badge - resting.badge).toBeCloseTo(1, 1);
 	expect(pressed.badge - pressed.button).toBeCloseTo(resting.badge - resting.button, 1);
 
-	// A disabled button does not move, so neither may the badge.
+	// A disabled button does not move, so neither may the badge. The badge also
+	// uses opaque mixed colors instead of opacity: it overlaps the button edge,
+	// where transparency would let the edge show through.
+	const enabledBadgeStyle = await badge.evaluate((element) => {
+		const style = getComputedStyle(element);
+		return { backgroundColor: style.backgroundColor, color: style.color };
+	});
 	await button.evaluate((el: HTMLButtonElement) => {
 		el.disabled = true;
 	});
+	await expect
+		.poll(() => badge.evaluate((element) => getComputedStyle(element).backgroundColor))
+		.not.toBe(enabledBadgeStyle.backgroundColor);
+	await expect
+		.poll(() => badge.evaluate((element) => getComputedStyle(element).color))
+		.not.toBe(enabledBadgeStyle.color);
+	await expect.poll(() => badge.evaluate((element) => getComputedStyle(element).opacity)).toBe('1');
 	const disabledResting = await tops();
 	await page.mouse.move(centre.x, centre.y);
 	await page.mouse.down();

--- a/e2e/signin-last-used-badge.spec.ts
+++ b/e2e/signin-last-used-badge.spec.ts
@@ -109,6 +109,19 @@ test('last-used badge tracks the button through a press', async ({ page }) => {
 	// A disabled button does not move, so neither may the badge. The badge also
 	// uses opaque mixed colors instead of opacity: it overlaps the button edge,
 	// where transparency would let the edge show through.
+	const waitForBadgeTransitions = () =>
+		badge.evaluate(async (element) => {
+			await Promise.all(
+				element.getAnimations().map(async (animation) => {
+					try {
+						await animation.finished;
+					} catch {
+						// A superseded transition is expected to reject its finished promise.
+					}
+				})
+			);
+		});
+	await waitForBadgeTransitions();
 	const enabledBadgeStyle = await badge.evaluate((element) => {
 		const style = getComputedStyle(element);
 		return { backgroundColor: style.backgroundColor, color: style.color };
@@ -116,13 +129,22 @@ test('last-used badge tracks the button through a press', async ({ page }) => {
 	await button.evaluate((el: HTMLButtonElement) => {
 		el.disabled = true;
 	});
-	await expect
-		.poll(() => badge.evaluate((element) => getComputedStyle(element).backgroundColor))
-		.not.toBe(enabledBadgeStyle.backgroundColor);
-	await expect
-		.poll(() => badge.evaluate((element) => getComputedStyle(element).color))
-		.not.toBe(enabledBadgeStyle.color);
-	await expect.poll(() => badge.evaluate((element) => getComputedStyle(element).opacity)).toBe('1');
+	await waitForBadgeTransitions();
+	const disabledBadgeStyle = await badge.evaluate((element) => {
+		const style = getComputedStyle(element);
+		const alphaMatch = style.backgroundColor.match(/\/\s*([\d.]+)(%)?\s*\)$/);
+		const backgroundAlpha = alphaMatch ? Number(alphaMatch[1]) / (alphaMatch[2] ? 100 : 1) : 1;
+		return {
+			backgroundColor: style.backgroundColor,
+			color: style.color,
+			opacity: style.opacity,
+			backgroundAlpha
+		};
+	});
+	expect(disabledBadgeStyle.backgroundColor).not.toBe(enabledBadgeStyle.backgroundColor);
+	expect(disabledBadgeStyle.color).not.toBe(enabledBadgeStyle.color);
+	expect(disabledBadgeStyle.opacity).toBe('1');
+	expect(disabledBadgeStyle.backgroundAlpha).toBe(1);
 	const disabledResting = await tops();
 	await page.mouse.move(centre.x, centre.y);
 	await page.mouse.down();

--- a/e2e/signin-last-used-badge.spec.ts
+++ b/e2e/signin-last-used-badge.spec.ts
@@ -74,10 +74,12 @@ test('last-used badge tracks the button through a press', async ({ page }) => {
 	await page.goto('/signin');
 	await page.evaluate(() => {
 		localStorage.setItem('auth:last-auth-method', JSON.stringify('passkey'));
+		localStorage.setItem('mode-watcher-mode', 'dark');
 		sessionStorage.removeItem('auth:pending-oauth-provider');
 	});
 	await page.reload();
 	await expect(page.locator('[data-testid="email-input"]')).toBeEnabled({ timeout: 30000 });
+	await expect(page.locator('html')).toHaveClass(/\bdark\b/);
 
 	const button = page.locator('[data-testid="signin-oauth-passkey-button"]');
 	const badge = page.locator('[data-testid="oauth-passkey-last-used-badge"]');
@@ -132,17 +134,34 @@ test('last-used badge tracks the button through a press', async ({ page }) => {
 	await waitForBadgeTransitions();
 	const disabledBadgeStyle = await badge.evaluate((element) => {
 		const style = getComputedStyle(element);
-		const alphaMatch = style.backgroundColor.match(/\/\s*([\d.]+)(%)?\s*\)$/);
-		const backgroundAlpha = alphaMatch ? Number(alphaMatch[1]) / (alphaMatch[2] ? 100 : 1) : 1;
+		const probe = document.createElement('span');
+		probe.style.backgroundColor = 'color-mix(in srgb, var(--secondary) 50%, var(--card))';
+		probe.style.color = 'color-mix(in srgb, var(--secondary-foreground) 50%, var(--card))';
+		if (!element.parentElement) throw new Error('badge is detached');
+		element.parentElement.append(probe);
+		const probeStyle = getComputedStyle(probe);
+		const expectedBackgroundColor = probeStyle.backgroundColor;
+		const expectedColor = probeStyle.color;
+		probe.remove();
+
+		const slashAlpha = style.backgroundColor.match(/\/\s*([\d.]+)(%)?\s*\)$/);
+		const rgbaAlpha = style.backgroundColor.match(/rgba\([^,]+,[^,]+,[^,]+,\s*([\d.]+)(%)?\s*\)$/);
+		const alphaValue = slashAlpha?.[1] ?? rgbaAlpha?.[1];
+		const alphaIsPercent = slashAlpha?.[2] ?? rgbaAlpha?.[2];
+		const backgroundAlpha = alphaValue ? Number(alphaValue) / (alphaIsPercent ? 100 : 1) : 1;
 		return {
 			backgroundColor: style.backgroundColor,
 			color: style.color,
 			opacity: style.opacity,
-			backgroundAlpha
+			backgroundAlpha,
+			expectedBackgroundColor,
+			expectedColor
 		};
 	});
 	expect(disabledBadgeStyle.backgroundColor).not.toBe(enabledBadgeStyle.backgroundColor);
 	expect(disabledBadgeStyle.color).not.toBe(enabledBadgeStyle.color);
+	expect(disabledBadgeStyle.backgroundColor).toBe(disabledBadgeStyle.expectedBackgroundColor);
+	expect(disabledBadgeStyle.color).toBe(disabledBadgeStyle.expectedColor);
 	expect(disabledBadgeStyle.opacity).toBe('1');
 	expect(disabledBadgeStyle.backgroundAlpha).toBe(1);
 	const disabledResting = await tops();

--- a/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
@@ -58,7 +58,7 @@
 			{#if isLastUsedAuthMethod('google')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--background))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--background))]"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--card))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--card))]"
 					data-testid="oauth-google-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />
@@ -87,7 +87,7 @@
 			{#if isLastUsedAuthMethod('github')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--background))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--background))]"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--card))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--card))]"
 					data-testid="oauth-github-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />
@@ -113,7 +113,7 @@
 			{#if isLastUsedAuthMethod('passkey')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--background))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--background))]"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--card))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--card))]"
 					data-testid="oauth-passkey-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />

--- a/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
@@ -58,7 +58,7 @@
 			{#if isLastUsedAuthMethod('google')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--background))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--background))]"
 					data-testid="oauth-google-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />
@@ -87,7 +87,7 @@
 			{#if isLastUsedAuthMethod('github')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--background))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--background))]"
 					data-testid="oauth-github-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />
@@ -113,7 +113,7 @@
 			{#if isLastUsedAuthMethod('passkey')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--background))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--background))]"
 					data-testid="oauth-passkey-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />


### PR DESCRIPTION
When sign-in enters its loading state, the OAuth buttons dim to 50% while the sibling "Last used" badge keeps its enabled contrast. The badge reads as detached from the disabled control it labels.

The badge now derives opaque disabled background and foreground colors with `color-mix(in srgb, ...)`, using the same 50% blend as the button against the card surface. Keeping the mixed colors opaque matters because the badge crosses the button edge; transparency would reveal that edge through the badge. The selector follows the disabled state of the button's `data-slot`, the same coupling used for its press offset.

<!-- pr-media:start -->
| Enabled | Disabled |
| --- | --- |
| <img width="900" alt="Enabled" src="https://github.com/user-attachments/assets/749048b7-bdfe-4b91-891a-b65205b733ee" /> | <img width="900" alt="Disabled" src="https://github.com/user-attachments/assets/cf08ddca-5866-4b43-b9e7-ccdaf4cf57f8" /> |
<!-- pr-media:end -->

Regression guard: added `e2e/signin-last-used-badge.spec.ts` to assert the opaque disabled colors against the dark card surface and preserve the badge's press coupling.

Verified with the focused browser suite (4 green), static checks, and transparent and wrong-backdrop mutations that both fail the guard.