### PR TITLE
refactor(theme): Settle the color-mix space for flattened colours

### DIFF
--- a/e2e/signin-last-used-badge.spec.ts
+++ b/e2e/signin-last-used-badge.spec.ts
@@ -164,6 +164,27 @@ test('last-used badge tracks the button through a press', async ({ page }) => {
 	expect(disabledBadgeStyle.color).toBe(disabledBadgeStyle.expectedColor);
 	expect(disabledBadgeStyle.opacity).toBe('1');
 	expect(disabledBadgeStyle.backgroundAlpha).toBe(1);
+
+	// The mix has to resolve on the badge, not once at :root. Custom properties
+	// declared there compute their color-mix() at the root and inherit only the
+	// result, which passes every assertion above while silently ignoring a card or
+	// shell that scopes the theme. Overriding the inputs nearby is what tells the
+	// two implementations apart.
+	await badge.evaluate((element) => {
+		const wrapper = element.closest('.group');
+		if (!(wrapper instanceof HTMLElement)) throw new Error('badge has no group wrapper');
+		wrapper.style.setProperty('--secondary', 'rgb(0 128 0)');
+		wrapper.style.setProperty('--card', 'rgb(0 0 0)');
+	});
+	// The badge carries transition-colors, so a computed read before the transition
+	// settles would return an interpolated value rather than the new one.
+	await waitForBadgeTransitions();
+	const scopedBadgeStyle = await badge.evaluate((element) => {
+		const style = getComputedStyle(element);
+		return { backgroundColor: style.backgroundColor, color: style.color };
+	});
+	expect(scopedBadgeStyle.backgroundColor).not.toBe(disabledBadgeStyle.backgroundColor);
+	expect(scopedBadgeStyle.color).not.toBe(disabledBadgeStyle.color);
 	const disabledResting = await tops();
 	await page.mouse.move(centre.x, centre.y);
 	await page.mouse.down();

--- a/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
@@ -58,7 +58,7 @@
 			{#if isLastUsedAuthMethod('google')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--card))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--card))]"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-badge-secondary-disabled group-has-[[data-slot=button]:disabled]:text-badge-secondary-disabled-foreground"
 					data-testid="oauth-google-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />
@@ -87,7 +87,7 @@
 			{#if isLastUsedAuthMethod('github')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--card))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--card))]"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-badge-secondary-disabled group-has-[[data-slot=button]:disabled]:text-badge-secondary-disabled-foreground"
 					data-testid="oauth-github-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />
@@ -113,7 +113,7 @@
 			{#if isLastUsedAuthMethod('passkey')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-[color-mix(in_srgb,var(--secondary)_50%,var(--card))] group-has-[[data-slot=button]:disabled]:text-[color-mix(in_srgb,var(--secondary-foreground)_50%,var(--card))]"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-badge-secondary-disabled group-has-[[data-slot=button]:disabled]:text-badge-secondary-disabled-foreground"
 					data-testid="oauth-passkey-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />

--- a/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/OAuthButtons.svelte
@@ -58,7 +58,7 @@
 			{#if isLastUsedAuthMethod('google')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-badge-secondary-disabled group-has-[[data-slot=button]:disabled]:text-badge-secondary-disabled-foreground"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:badge-secondary-disabled"
 					data-testid="oauth-google-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />
@@ -87,7 +87,7 @@
 			{#if isLastUsedAuthMethod('github')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-badge-secondary-disabled group-has-[[data-slot=button]:disabled]:text-badge-secondary-disabled-foreground"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:badge-secondary-disabled"
 					data-testid="oauth-github-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />
@@ -113,7 +113,7 @@
 			{#if isLastUsedAuthMethod('passkey')}
 				<Badge
 					variant="secondary"
-					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:bg-badge-secondary-disabled group-has-[[data-slot=button]:disabled]:text-badge-secondary-disabled-foreground"
+					class="pointer-events-none absolute -top-2 -right-2 px-1.5 py-0 text-[10px] whitespace-nowrap transition-colors group-has-[[data-slot=button]:active:not([aria-haspopup])]:translate-y-px group-has-[[data-slot=button]:disabled]:badge-secondary-disabled"
 					data-testid="oauth-passkey-last-used-badge"
 				>
 					<T keyName="auth.signin.oauth_last_used" defaultValue="Last used" />

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -76,22 +76,15 @@
 	--sidebar-accent-foreground: oklch(0.21 0.006 285.885);
 	/* Opaque match for the row hover background, used by the shortcut/timestamp
 	   reveal overlay. Flatten the /65 hover to an opaque colour so the overlay matches the row.
-	   Every flattening mix in this file interpolates in srgb, because that is the space the
-	   browser composites a translucent layer in. oklab and oklch reach a different colour, and
-	   the gap grows with saturation, so a themed build would drift where this one looks fine. */
+	   Flattening mixes interpolate in srgb: measured in Chrome, it is the only space that
+	   reproduces the composited pixel for a colour inside the output gamut, exactly for
+	   these greys and within 1/255 for a saturated one, where oklab and oklch land up to
+	   34/255 away. Outside the output gamut no space reproduces it, because the translucent
+	   path is gamut-mapped before compositing and color-mix() is not, so a wide-gamut theme
+	   needs the flattened value checked by eye whichever space it names. */
 	--sidebar-accent-hover: color-mix(in srgb, var(--sidebar-accent) 65%, var(--sidebar));
 	--sidebar-border: oklch(0.92 0.004 286.32);
 	--sidebar-ring: oklch(0.705 0.015 286.067);
-	/* Opaque half-strength secondary for a badge whose button is disabled. The button
-	   fades itself with disabled:opacity-50, and the badge overlaps its edge, so a
-	   second opacity layer would let that edge show through. Flattened against
-	   --card because these badges sit on the auth card. */
-	--badge-secondary-disabled: color-mix(in srgb, var(--secondary) 50%, var(--card));
-	--badge-secondary-disabled-foreground: color-mix(
-		in srgb,
-		var(--secondary-foreground) 50%,
-		var(--card)
-	);
 	/* Status tokens are mode-aware like --destructive: dark 600/700 shades here keep
 	   text-success/warning/info readable on light backgrounds; .dark uses the
 	   brighter 500 shades. */
@@ -139,16 +132,6 @@
 	--sidebar-accent-hover: color-mix(in srgb, var(--sidebar-accent) 65%, var(--sidebar));
 	--sidebar-border: oklch(1 0 0 / 10%);
 	--sidebar-ring: oklch(0.552 0.016 285.938);
-	/* Opaque half-strength secondary for a badge whose button is disabled. The button
-	   fades itself with disabled:opacity-50, and the badge overlaps its edge, so a
-	   second opacity layer would let that edge show through. Flattened against
-	   --card because these badges sit on the auth card. */
-	--badge-secondary-disabled: color-mix(in srgb, var(--secondary) 50%, var(--card));
-	--badge-secondary-disabled-foreground: color-mix(
-		in srgb,
-		var(--secondary-foreground) 50%,
-		var(--card)
-	);
 	--success: oklch(0.723 0.191 149.579);
 	--success-foreground: oklch(1 0 0);
 	--warning: oklch(0.795 0.184 86.047);
@@ -197,8 +180,6 @@
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-ring: var(--sidebar-ring);
-	--color-badge-secondary-disabled: var(--badge-secondary-disabled);
-	--color-badge-secondary-disabled-foreground: var(--badge-secondary-disabled-foreground);
 	--color-success: var(--success);
 	--color-success-foreground: var(--success-foreground);
 	--color-warning: var(--warning);
@@ -482,6 +463,21 @@
 
 :where(.dark) .composer-elevation {
 	box-shadow: none;
+}
+
+/* Opaque half-strength secondary for a badge whose button is disabled. The button
+   fades itself with disabled:opacity-50, and the badge overlaps its edge, so a second
+   opacity layer would let that edge show through. Flattened against --card because
+   these badges sit on the auth card.
+
+   A utility rather than a pair of tokens: a custom property declared on :root computes
+   its color-mix() there and inherits the result, so it would keep the root theme even
+   where a card or shell scopes --secondary and --card. Measured in Chrome, a scoped
+   override moves the inline mix and leaves the root-declared token behind. Here the
+   var() lookups resolve on the badge itself. */
+@utility badge-secondary-disabled {
+	background-color: color-mix(in srgb, var(--secondary) 50%, var(--card));
+	color: color-mix(in srgb, var(--secondary-foreground) 50%, var(--card));
 }
 
 @utility marketing-shell-panel {

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -76,12 +76,13 @@
 	--sidebar-accent-foreground: oklch(0.21 0.006 285.885);
 	/* Opaque match for the row hover background, used by the shortcut/timestamp
 	   reveal overlay. Flatten the /65 hover to an opaque colour so the overlay matches the row.
-	   Flattening mixes interpolate in srgb: measured in Chrome, it is the only space that
-	   reproduces the composited pixel for a colour inside the output gamut, exactly for
-	   these greys and within 1/255 for a saturated one, where oklab and oklch land up to
-	   34/255 away. Outside the output gamut no space reproduces it, because the translucent
-	   path is gamut-mapped before compositing and color-mix() is not, so a wide-gamut theme
-	   needs the flattened value checked by eye whichever space it names. */
+	   Flattening mixes interpolate in srgb. Measured in Chrome, it was the only space that
+	   ever reproduced the composited pixel: exact for these greys, and within 1/255 for
+	   every in-gamut colour tried, where oklab and oklch were far off even for plain red
+	   (41 and 45 of 255 at /65 over --sidebar). Wide-gamut sources were not uniform:
+	   srgb matched display-p3 green over black exactly and missed display-p3 red over
+	   white by about 30, so a theme that reaches outside the output gamut wants its
+	   flattened value checked by eye whichever space it names. */
 	--sidebar-accent-hover: color-mix(in srgb, var(--sidebar-accent) 65%, var(--sidebar));
 	--sidebar-border: oklch(0.92 0.004 286.32);
 	--sidebar-ring: oklch(0.705 0.015 286.067);

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -75,10 +75,23 @@
 	--sidebar-accent: oklch(0.967 0.001 286.375);
 	--sidebar-accent-foreground: oklch(0.21 0.006 285.885);
 	/* Opaque match for the row hover background, used by the shortcut/timestamp
-	   reveal overlay. Flatten the /65 hover to an opaque colour so the overlay matches the row. */
+	   reveal overlay. Flatten the /65 hover to an opaque colour so the overlay matches the row.
+	   Every flattening mix in this file interpolates in srgb, because that is the space the
+	   browser composites a translucent layer in. oklab and oklch reach a different colour, and
+	   the gap grows with saturation, so a themed build would drift where this one looks fine. */
 	--sidebar-accent-hover: color-mix(in srgb, var(--sidebar-accent) 65%, var(--sidebar));
 	--sidebar-border: oklch(0.92 0.004 286.32);
 	--sidebar-ring: oklch(0.705 0.015 286.067);
+	/* Opaque half-strength secondary for a badge whose button is disabled. The button
+	   fades itself with disabled:opacity-50, and the badge overlaps its edge, so a
+	   second opacity layer would let that edge show through. Flattened against
+	   --card because these badges sit on the auth card. */
+	--badge-secondary-disabled: color-mix(in srgb, var(--secondary) 50%, var(--card));
+	--badge-secondary-disabled-foreground: color-mix(
+		in srgb,
+		var(--secondary-foreground) 50%,
+		var(--card)
+	);
 	/* Status tokens are mode-aware like --destructive: dark 600/700 shades here keep
 	   text-success/warning/info readable on light backgrounds; .dark uses the
 	   brighter 500 shades. */
@@ -121,11 +134,21 @@
 	--sidebar-accent: oklch(0.274 0.006 286.033);
 	--sidebar-accent-foreground: oklch(0.985 0 0);
 	/* Dark hover is bg-sidebar-accent/65 over the sidebar; flatten it to an opaque
-	   colour in srgb (the space the browser composites the /50 layer in) so the
+	   colour in srgb (the space the browser composites the /65 layer in) so the
 	   reveal overlay matches the row exactly. */
 	--sidebar-accent-hover: color-mix(in srgb, var(--sidebar-accent) 65%, var(--sidebar));
 	--sidebar-border: oklch(1 0 0 / 10%);
 	--sidebar-ring: oklch(0.552 0.016 285.938);
+	/* Opaque half-strength secondary for a badge whose button is disabled. The button
+	   fades itself with disabled:opacity-50, and the badge overlaps its edge, so a
+	   second opacity layer would let that edge show through. Flattened against
+	   --card because these badges sit on the auth card. */
+	--badge-secondary-disabled: color-mix(in srgb, var(--secondary) 50%, var(--card));
+	--badge-secondary-disabled-foreground: color-mix(
+		in srgb,
+		var(--secondary-foreground) 50%,
+		var(--card)
+	);
 	--success: oklch(0.723 0.191 149.579);
 	--success-foreground: oklch(1 0 0);
 	--warning: oklch(0.795 0.184 86.047);
@@ -174,6 +197,8 @@
 	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-ring: var(--sidebar-ring);
+	--color-badge-secondary-disabled: var(--badge-secondary-disabled);
+	--color-badge-secondary-disabled-foreground: var(--badge-secondary-disabled-foreground);
 	--color-success: var(--success);
 	--color-success-foreground: var(--success-foreground);
 	--color-warning: var(--warning);
@@ -557,7 +582,7 @@
 		}
 
 		&::-webkit-scrollbar-thumb {
-			background: color-mix(in oklch, var(--primary) 15%, transparent);
+			background: color-mix(in srgb, var(--primary) 15%, transparent);
 		}
 
 		&::-webkit-scrollbar-track {


### PR DESCRIPTION
The repository mixed colours in three interpolation spaces with no rule saying which to use, and the disabled `Last used` badge repeated the same two `color-mix()` expressions across all three OAuth buttons. Anyone re-theming this starter would have had to guess the space and edit three class strings.

Measured in Chrome, `in srgb` was the only space that ever reproduced what the browser composites: exact for the near-neutral tokens this theme ships, and within 1/255 for every in-gamut colour tried, where `in oklab` and `in oklch` were far off even for plain red. Wide-gamut sources are not uniform, so a theme that reaches outside the output gamut wants its flattened values checked by eye whichever space they name; the comment records that rather than asserting a rule. Mixing toward `transparent` is space-independent under premultiplied alpha, so `srgb` costs nothing there either, and the scrollbar thumb was the one site in a different space and is visually unchanged.

The badge colours become a `@utility` instead of three copies of the same pair. Deliberately a utility and not a token: a custom property declared on `:root` computes its mix there and inherits the result, so a card or shell that scopes `--secondary` and `--card` would have been ignored. The Playwright guard now scopes those inputs on the wrapper and requires both badge colours to follow, because every other assertion in it passes for the frozen-token version too.