### PR TITLE
fix(auth): Say set when the account has no password to reset

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -635,7 +635,7 @@
 			"title": "Passwort zurücksetzen"
 		},
 		"set_password": {
-			"body": "Sie möchten sich mit einem Passwort anmelden. Für Ihr Konto ist bisher kein Passwort hinterlegt, daher richtet dieser Link eines ein:",
+			"body": "Wir haben eine Anfrage erhalten, ein Passwort für Ihr Konto einzurichten. Bisher ist keines hinterlegt, dieser Link legt es fest:",
 			"button": "Passwort einrichten",
 			"disclaimer": "Falls Sie das nicht angefordert haben, können Sie diese E-Mail ignorieren. An Ihrem Konto ändert sich nichts, und Sie melden sich weiterhin wie bisher an.",
 			"expiry": "Dieser Link läuft aus Sicherheitsgründen in 1 Stunde ab.",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -635,7 +635,7 @@
 			"title": "Passwort zurücksetzen"
 		},
 		"set_password": {
-			"body": "Sie möchten sich mit einem Passwort anmelden. Ihr Konto nutzt bisher einen verbundenen Anbieter, daher richtet dieser Link zusätzlich ein Passwort ein:",
+			"body": "Sie möchten sich mit einem Passwort anmelden. Für Ihr Konto ist bisher kein Passwort hinterlegt, daher richtet dieser Link eines ein:",
 			"button": "Passwort einrichten",
 			"disclaimer": "Falls Sie das nicht angefordert haben, können Sie diese E-Mail ignorieren. An Ihrem Konto ändert sich nichts, und Sie melden sich weiterhin wie bisher an.",
 			"expiry": "Dieser Link läuft aus Sicherheitsgründen in 1 Stunde ab.",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -634,9 +634,20 @@
 			"preview": "Passwort zurücksetzen",
 			"title": "Passwort zurücksetzen"
 		},
+		"set_password": {
+			"body": "Sie möchten sich mit einem Passwort anmelden. Ihr Konto nutzt bisher einen verbundenen Anbieter, daher richtet dieser Link zusätzlich ein Passwort ein:",
+			"button": "Passwort einrichten",
+			"disclaimer": "Falls Sie das nicht angefordert haben, können Sie diese E-Mail ignorieren. An Ihrem Konto ändert sich nichts, und Sie melden sich weiterhin wie bisher an.",
+			"expiry": "Dieser Link läuft aus Sicherheitsgründen in 1 Stunde ab.",
+			"greeting": "Hallo {userName},",
+			"greeting_fallback": "Hallo,",
+			"preview": "Passwort für Ihr Konto einrichten",
+			"title": "Passwort einrichten"
+		},
 		"subject": {
 			"new_signup": "Neue Benutzerregistrierung: {userEmail}",
 			"reset_password": "Passwort zurücksetzen",
+			"set_password": "Passwort einrichten",
 			"support_reply": "Neue Antwort auf Ihre Support-Anfrage",
 			"ticket_new": "Neues Support-Ticket von {userName}",
 			"ticket_reopened": "Support-Ticket wiedereröffnet von {userName}",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -635,7 +635,7 @@
 			"title": "Reset your password"
 		},
 		"set_password": {
-			"body": "You asked to sign in with a password. Your account signs in with a connected provider today, so this link sets a password you can use as well:",
+			"body": "You asked to sign in with a password. There is no password on your account yet, so this link sets one:",
 			"button": "Set Password",
 			"disclaimer": "If you didn't request this, you can safely ignore this email. Nothing about your account changes and you can keep signing in the way you do now.",
 			"expiry": "This link will expire in 1 hour for security reasons.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -635,7 +635,7 @@
 			"title": "Reset your password"
 		},
 		"set_password": {
-			"body": "You asked to sign in with a password. There is no password on your account yet, so this link sets one:",
+			"body": "We received a request to add a password to your account. There is no password on it yet, so this link sets one:",
 			"button": "Set Password",
 			"disclaimer": "If you didn't request this, you can safely ignore this email. Nothing about your account changes and you can keep signing in the way you do now.",
 			"expiry": "This link will expire in 1 hour for security reasons.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -634,9 +634,20 @@
 			"preview": "Reset your password",
 			"title": "Reset your password"
 		},
+		"set_password": {
+			"body": "You asked to sign in with a password. Your account signs in with a connected provider today, so this link sets a password you can use as well:",
+			"button": "Set Password",
+			"disclaimer": "If you didn't request this, you can safely ignore this email. Nothing about your account changes and you can keep signing in the way you do now.",
+			"expiry": "This link will expire in 1 hour for security reasons.",
+			"greeting": "Hey {userName},",
+			"greeting_fallback": "Hey there,",
+			"preview": "Set a password for your account",
+			"title": "Set a password"
+		},
 		"subject": {
 			"new_signup": "New user signup: {userEmail}",
 			"reset_password": "Reset your password",
+			"set_password": "Set a password",
 			"support_reply": "New reply to your support request",
 			"ticket_new": "New support ticket from {userName}",
 			"ticket_reopened": "Support ticket reopened by {userName}",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -635,12 +635,12 @@
 			"title": "Restablece tu contraseña"
 		},
 		"set_password": {
-			"body": "Has pedido iniciar sesión con una contraseña. Tu cuenta usa hoy un proveedor conectado, así que este enlace establece además una contraseña:",
+			"body": "Has pedido iniciar sesión con una contraseña. Tu cuenta todavía no tiene ninguna, así que este enlace establece una:",
 			"button": "Establecer contraseña",
 			"disclaimer": "Si no lo has solicitado, puedes ignorar este correo. Tu cuenta no cambia y puedes seguir iniciando sesión como hasta ahora.",
 			"expiry": "Este enlace caducará en 1 hora por seguridad.",
 			"greeting": "Hola {userName},",
-			"greeting_fallback": "Hola:",
+			"greeting_fallback": "Hola,",
 			"preview": "Establece una contraseña para tu cuenta",
 			"title": "Establece una contraseña"
 		},

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -635,7 +635,7 @@
 			"title": "Restablece tu contraseña"
 		},
 		"set_password": {
-			"body": "Has pedido iniciar sesión con una contraseña. Tu cuenta todavía no tiene ninguna, así que este enlace establece una:",
+			"body": "Hemos recibido una solicitud para añadir una contraseña a tu cuenta. Todavía no tiene ninguna, así que este enlace la establece:",
 			"button": "Establecer contraseña",
 			"disclaimer": "Si no lo has solicitado, puedes ignorar este correo. Tu cuenta no cambia y puedes seguir iniciando sesión como hasta ahora.",
 			"expiry": "Este enlace caducará en 1 hora por seguridad.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -634,9 +634,20 @@
 			"preview": "Restablecer tu contraseña",
 			"title": "Restablece tu contraseña"
 		},
+		"set_password": {
+			"body": "Has pedido iniciar sesión con una contraseña. Tu cuenta usa hoy un proveedor conectado, así que este enlace establece además una contraseña:",
+			"button": "Establecer contraseña",
+			"disclaimer": "Si no lo has solicitado, puedes ignorar este correo. Tu cuenta no cambia y puedes seguir iniciando sesión como hasta ahora.",
+			"expiry": "Este enlace caducará en 1 hora por seguridad.",
+			"greeting": "Hola {userName},",
+			"greeting_fallback": "Hola:",
+			"preview": "Establece una contraseña para tu cuenta",
+			"title": "Establece una contraseña"
+		},
 		"subject": {
 			"new_signup": "Nuevo registro de usuario: {userEmail}",
 			"reset_password": "Restablecer tu contraseña",
+			"set_password": "Establece una contraseña",
 			"support_reply": "Nueva respuesta a tu solicitud de soporte",
 			"ticket_new": "Nuevo ticket de soporte de {userName}",
 			"ticket_reopened": "Ticket de soporte reabierto por {userName}",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -635,7 +635,7 @@
 			"title": "Réinitialisez votre mot de passe"
 		},
 		"set_password": {
-			"body": "Vous souhaitez vous connecter avec un mot de passe. Votre compte utilise aujourd'hui un fournisseur connecté, ce lien définit donc un mot de passe en complément :",
+			"body": "Vous souhaitez vous connecter avec un mot de passe. Votre compte n'en a pas encore, ce lien vous permet donc d'en définir un :",
 			"button": "Définir le mot de passe",
 			"disclaimer": "Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail. Rien ne change pour votre compte et vous continuez à vous connecter comme aujourd'hui.",
 			"expiry": "Ce lien expirera dans 1 heure pour des raisons de sécurité.",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -635,7 +635,7 @@
 			"title": "Réinitialisez votre mot de passe"
 		},
 		"set_password": {
-			"body": "Vous souhaitez vous connecter avec un mot de passe. Votre compte n'en a pas encore, ce lien vous permet donc d'en définir un :",
+			"body": "Nous avons reçu une demande d'ajout d'un mot de passe à votre compte. Il n'en a pas encore, ce lien vous permet donc d'en définir un :",
 			"button": "Définir le mot de passe",
 			"disclaimer": "Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail. Rien ne change pour votre compte et vous continuez à vous connecter comme aujourd'hui.",
 			"expiry": "Ce lien expirera dans 1 heure pour des raisons de sécurité.",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -634,9 +634,20 @@
 			"preview": "Réinitialisez votre mot de passe",
 			"title": "Réinitialisez votre mot de passe"
 		},
+		"set_password": {
+			"body": "Vous souhaitez vous connecter avec un mot de passe. Votre compte utilise aujourd'hui un fournisseur connecté, ce lien définit donc un mot de passe en complément :",
+			"button": "Définir le mot de passe",
+			"disclaimer": "Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail. Rien ne change pour votre compte et vous continuez à vous connecter comme aujourd'hui.",
+			"expiry": "Ce lien expirera dans 1 heure pour des raisons de sécurité.",
+			"greeting": "Bonjour {userName},",
+			"greeting_fallback": "Bonjour,",
+			"preview": "Définir un mot de passe pour votre compte",
+			"title": "Définir un mot de passe"
+		},
 		"subject": {
 			"new_signup": "Nouvelle inscription : {userEmail}",
 			"reset_password": "Réinitialisez votre mot de passe",
+			"set_password": "Définir un mot de passe",
 			"support_reply": "Nouvelle réponse à votre demande de support",
 			"ticket_new": "Nouveau ticket de support de {userName}",
 			"ticket_reopened": "Ticket de support rouvert par {userName}",

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -10,7 +10,6 @@ import { passkey } from '@better-auth/passkey';
 import { admin } from 'better-auth/plugins/admin';
 import { betterAuth, type BetterAuthOptions } from 'better-auth';
 import authSchema from './betterAuth/schema';
-import { hasUsablePassword } from './credentialAccounts';
 import authConfig from './auth.config';
 import { requireEnv, googleOAuth, githubOAuth } from './env';
 import { getFounderWelcomeDelay } from './emails/helpers';
@@ -398,7 +397,7 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>) => {
 					email,
 					resetUrl: url,
 					userName: user.name ?? undefined,
-					hasPassword: await hasUsablePassword(mutationCtx, user.id)
+					userId: user.id
 				});
 			}
 		},

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -10,6 +10,7 @@ import { passkey } from '@better-auth/passkey';
 import { admin } from 'better-auth/plugins/admin';
 import { betterAuth, type BetterAuthOptions } from 'better-auth';
 import authSchema from './betterAuth/schema';
+import { hasUsablePassword } from './credentialAccounts';
 import authConfig from './auth.config';
 import { requireEnv, googleOAuth, githubOAuth } from './env';
 import { getFounderWelcomeDelay } from './emails/helpers';
@@ -390,10 +391,14 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>) => {
 			sendResetPassword: async ({ user, url }: SendResetPasswordArgs) => {
 				const mutationCtx = requireRunMutationCtx(ctx);
 				const email = requireAuthUserEmail(user, 'reset password email');
+				// Better Auth sends this for an OAuth-only account too, and the link
+				// works there: resetPassword creates the credential account it lacks.
+				// Only the wording has to know the difference.
 				await mutationCtx.runMutation(internal.emails.send.sendResetPasswordEmail, {
 					email,
 					resetUrl: url,
-					userName: user.name ?? undefined
+					userName: user.name ?? undefined,
+					hasPassword: await hasUsablePassword(mutationCtx, user.id)
 				});
 			}
 		},

--- a/src/lib/convex/credentialAccounts.ts
+++ b/src/lib/convex/credentialAccounts.ts
@@ -1,0 +1,34 @@
+import { components } from './_generated/api';
+import type { ActionCtx, QueryCtx } from './_generated/server';
+
+/**
+ * Any context that can run a query. The auth hook hands over a context that can
+ * be either, so neither concrete ctx type covers both callers on its own.
+ */
+type RunQueryCtx = Pick<QueryCtx, 'runQuery'> | Pick<ActionCtx, 'runQuery'>;
+
+/**
+ * Credential accounts belonging to a user, as Better Auth itself counts them.
+ *
+ * Lives apart from its callers because both `users.ts` and `auth.ts` need it and
+ * `users.ts` already imports `auth.ts`.
+ */
+export async function credentialAccounts(
+	ctx: RunQueryCtx,
+	userId: string
+): Promise<Array<{ password?: string | null }>> {
+	const result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
+		model: 'account',
+		where: [
+			{ field: 'userId', operator: 'eq', value: userId },
+			{ field: 'providerId', operator: 'eq', value: 'credential' }
+		],
+		paginationOpts: { cursor: null, numItems: 200 }
+	});
+	return result.page as Array<{ password?: string | null }>;
+}
+
+/** Whether a user can sign in with a password today. */
+export async function hasUsablePassword(ctx: RunQueryCtx, userId: string): Promise<boolean> {
+	return (await credentialAccounts(ctx, userId)).some((account) => account.password);
+}

--- a/src/lib/convex/credentialAccounts.ts
+++ b/src/lib/convex/credentialAccounts.ts
@@ -1,11 +1,12 @@
 import { components } from './_generated/api';
-import type { ActionCtx, QueryCtx } from './_generated/server';
+import type { ActionCtx, MutationCtx, QueryCtx } from './_generated/server';
 
 /**
- * Any context that can run a query. The auth hook hands over a context that can
- * be either, so neither concrete ctx type covers both callers on its own.
+ * Any context that can run a query. The callers sit in a query, a mutation and
+ * an action, so no concrete ctx type covers them on its own.
  */
-type RunQueryCtx = Pick<QueryCtx, 'runQuery'> | Pick<ActionCtx, 'runQuery'>;
+type RunQueryCtx =
+	Pick<QueryCtx, 'runQuery'> | Pick<MutationCtx, 'runQuery'> | Pick<ActionCtx, 'runQuery'>;
 
 /**
  * Credential accounts belonging to a user, as Better Auth itself counts them.

--- a/src/lib/convex/emails/__tests__/passwordResetTemplate.test.ts
+++ b/src/lib/convex/emails/__tests__/passwordResetTemplate.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { renderPasswordResetEmail } from '../templates';
+import en from '../../../../i18n/en.json';
+
+/**
+ * Better Auth sends the reset mail for an account that has never had a password,
+ * and its link works there: resetPassword creates the missing credential account.
+ * Only the wording has to know the difference, so it is the wording that is
+ * asserted here rather than the delivery.
+ */
+describe('renderPasswordResetEmail', () => {
+	// The renderer resolves asset URLs from the Convex environment, which a unit
+	// run does not have.
+	beforeAll(() => {
+		vi.stubEnv('EMAIL_ASSET_URL', 'https://assets.example.test');
+	});
+	afterAll(() => {
+		vi.unstubAllEnvs();
+	});
+
+	const url = 'https://example.com/reset?token=abc';
+	// The HTML half escapes the copy, so compare it against the same source text
+	// rather than a second hand-written copy of every sentence.
+	const unescape = (rendered: string) =>
+		rendered.replaceAll('&#39;', "'").replaceAll('&quot;', '"').replaceAll('&amp;', '&');
+	const reset = en.email.reset_password;
+	const set = en.email.set_password;
+
+	it('reports a reset for an account that has a password', () => {
+		const { html, text } = renderPasswordResetEmail(url, undefined, 'en', true);
+		for (const rendered of [unescape(html), text]) {
+			expect(rendered).toContain(reset.body);
+			expect(rendered).not.toContain(set.body);
+		}
+	});
+
+	it('reports a first password for an account that has none', () => {
+		const { html, text } = renderPasswordResetEmail(url, undefined, 'en', false);
+		for (const rendered of [unescape(html), text]) {
+			expect(rendered).toContain(set.body);
+			expect(rendered).not.toContain(reset.body);
+		}
+	});
+
+	// The disclaimer is the sentence that is actively false for an account with no
+	// password: nothing "remains unchanged" when there is nothing to change.
+	it('never promises an unchanged password to an account without one', () => {
+		const { html, text } = renderPasswordResetEmail(url, undefined, 'en', false);
+		for (const rendered of [unescape(html), text]) {
+			expect(rendered).not.toContain(reset.disclaimer);
+			expect(rendered).toContain(set.disclaimer);
+		}
+	});
+
+	it('defaults to the reset wording, so an older queued call is unchanged', () => {
+		expect(unescape(renderPasswordResetEmail(url, undefined, 'en').html)).toContain(reset.body);
+	});
+});

--- a/src/lib/convex/emails/send.ts
+++ b/src/lib/convex/emails/send.ts
@@ -82,28 +82,34 @@ export const sendResetPasswordEmail = internalMutation({
 	args: {
 		email: v.string(),
 		resetUrl: v.string(),
-		userName: v.optional(v.string())
+		userName: v.optional(v.string()),
+		// Absent means "has one", so an older queued call keeps the reset wording.
+		hasPassword: v.optional(v.boolean())
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
 		const { email, resetUrl, userName } = args;
+		const hasPassword = args.hasPassword ?? true;
 
 		if (shouldSkipTestEmail('sendResetPasswordEmail', email)) return null;
 		assertResendApiKey();
 
 		const locale = await getLocaleForEmail(ctx, email);
-		const { html, text } = renderPasswordResetEmail(resetUrl, userName, locale);
+		const { html, text } = renderPasswordResetEmail(resetUrl, userName, locale, hasPassword);
 
 		await resend.sendEmail(ctx, {
 			from: requireEnv('AUTH_EMAIL', { feature: 'email delivery' }),
 			to: email,
-			subject: t(locale, 'email.subject.reset_password'),
+			subject: t(
+				locale,
+				hasPassword ? 'email.subject.reset_password' : 'email.subject.set_password'
+			),
 			html,
 			text,
 			// Analytics tracking via custom headers
 			headers: [
 				{ name: 'X-Email-Category', value: 'authentication' },
-				{ name: 'X-Email-Template', value: 'password-reset' }
+				{ name: 'X-Email-Template', value: hasPassword ? 'password-reset' : 'password-set' }
 			]
 		});
 		return null;

--- a/src/lib/convex/emails/send.ts
+++ b/src/lib/convex/emails/send.ts
@@ -15,6 +15,7 @@ import { t, getValidLocale, type SupportedLocale } from '../i18n/translations';
 import type { GenericMutationCtx } from 'convex/server';
 import type { DataModel } from '../_generated/dataModel';
 import { buildSupportDeepLink, shouldSkipTestEmail } from './helpers';
+import { hasUsablePassword } from '../credentialAccounts';
 
 /** Type for user result from Better Auth adapter with optional locale field */
 type UserWithLocale = { locale?: string | null } | null;
@@ -83,17 +84,19 @@ export const sendResetPasswordEmail = internalMutation({
 		email: v.string(),
 		resetUrl: v.string(),
 		userName: v.optional(v.string()),
-		// Absent means "has one", so an older queued call keeps the reset wording.
-		hasPassword: v.optional(v.boolean())
+		userId: v.string()
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
 		const { email, resetUrl, userName } = args;
-		const hasPassword = args.hasPassword ?? true;
 
 		if (shouldSkipTestEmail('sendResetPasswordEmail', email)) return null;
 		assertResendApiKey();
 
+		// Resolved here rather than in the caller: the reset hook awaits that
+		// caller, so the lookup would sit on the response path as its own round
+		// trip. Inside the mutation it shares this transaction.
+		const hasPassword = await hasUsablePassword(ctx, args.userId);
 		const locale = await getLocaleForEmail(ctx, email);
 		const { html, text } = renderPasswordResetEmail(resetUrl, userName, locale, hasPassword);
 

--- a/src/lib/convex/emails/templates.ts
+++ b/src/lib/convex/emails/templates.ts
@@ -154,24 +154,57 @@ export function renderVerificationCodeEmail(
  * @param locale - Locale for translated strings (optional, defaults to DEFAULT_LOCALE)
  * @returns Rendered HTML and plain text email
  */
+/**
+ * Renders the reset mail, or the first-password variant of it.
+ *
+ * Better Auth sends this mail for an account that signed up through an OAuth
+ * provider too, and its link works: `resetPassword` creates the missing
+ * credential account. The reset wording does not, because there is no password
+ * to reset and none that "will remain unchanged" if the mail was not expected.
+ * The template takes every string as a prop, so only the key prefix changes.
+ */
 export function renderPasswordResetEmail(
 	resetUrl: PasswordResetEmailData['resetUrl'],
 	userName?: PasswordResetEmailData['userName'],
-	locale: string = DEFAULT_LOCALE
+	locale: string = DEFAULT_LOCALE,
+	hasPassword: boolean = true
 ): RenderedEmail {
 	const baseUrl = getBaseUrl();
+	// Spelled out rather than composed from a prefix, so the orphan-key check can
+	// see that both sets are used.
+	const keys = hasPassword
+		? {
+				title: 'email.reset_password.title',
+				greeting: 'email.reset_password.greeting',
+				greetingFallback: 'email.reset_password.greeting_fallback',
+				preview: 'email.reset_password.preview',
+				body: 'email.reset_password.body',
+				button: 'email.reset_password.button',
+				expiry: 'email.reset_password.expiry',
+				disclaimer: 'email.reset_password.disclaimer'
+			}
+		: {
+				title: 'email.set_password.title',
+				greeting: 'email.set_password.greeting',
+				greetingFallback: 'email.set_password.greeting_fallback',
+				preview: 'email.set_password.preview',
+				body: 'email.set_password.body',
+				button: 'email.set_password.button',
+				expiry: 'email.set_password.expiry',
+				disclaimer: 'email.set_password.disclaimer'
+			};
 
 	const texts = {
 		badgeText: t(locale, 'email.badge.auth'),
-		titleText: t(locale, 'email.reset_password.title'),
+		titleText: t(locale, keys.title),
 		greetingText: userName
-			? t(locale, 'email.reset_password.greeting', { userName })
-			: t(locale, 'email.reset_password.greeting_fallback'),
-		previewText: t(locale, 'email.reset_password.preview'),
-		bodyText: t(locale, 'email.reset_password.body'),
-		buttonText: t(locale, 'email.reset_password.button'),
-		expiryText: t(locale, 'email.reset_password.expiry'),
-		disclaimerText: t(locale, 'email.reset_password.disclaimer')
+			? t(locale, keys.greeting, { userName })
+			: t(locale, keys.greetingFallback),
+		previewText: t(locale, keys.preview),
+		bodyText: t(locale, keys.body),
+		buttonText: t(locale, keys.button),
+		expiryText: t(locale, keys.expiry),
+		disclaimerText: t(locale, keys.disclaimer)
 	};
 
 	const data = {

--- a/src/lib/convex/emails/templates.ts
+++ b/src/lib/convex/emails/templates.ts
@@ -148,13 +148,6 @@ export function renderVerificationCodeEmail(
 }
 
 /**
- * Render password reset email with reset link
- * @param resetUrl - URL to reset password page with token
- * @param userName - User's name for personalization (optional, falls back to a generic greeting)
- * @param locale - Locale for translated strings (optional, defaults to DEFAULT_LOCALE)
- * @returns Rendered HTML and plain text email
- */
-/**
  * Renders the reset mail, or the first-password variant of it.
  *
  * Better Auth sends this mail for an account that signed up through an OAuth
@@ -162,6 +155,12 @@ export function renderVerificationCodeEmail(
  * credential account. The reset wording does not, because there is no password
  * to reset and none that "will remain unchanged" if the mail was not expected.
  * The template takes every string as a prop, so only the key prefix changes.
+ *
+ * @param resetUrl - URL to reset password page with token
+ * @param userName - User's name for personalization (optional, falls back to a generic greeting)
+ * @param locale - Locale for translated strings (optional, defaults to DEFAULT_LOCALE)
+ * @param hasPassword - Whether the account has a password to reset today
+ * @returns Rendered HTML and plain text email
  */
 export function renderPasswordResetEmail(
 	resetUrl: PasswordResetEmailData['resetUrl'],

--- a/src/lib/convex/users.ts
+++ b/src/lib/convex/users.ts
@@ -1,10 +1,10 @@
 import { ConvexError, v } from 'convex/values';
-import { query, type QueryCtx } from './_generated/server';
-import { components } from './_generated/api';
+import { query } from './_generated/server';
 import { authComponent, createAuth } from './auth';
 import { authedQuery, authedMutation } from './functions';
 import { appRateLimiter } from './rateLimit';
 import { tables } from './betterAuth/schema';
+import { credentialAccounts, hasUsablePassword } from './credentialAccounts';
 import * as val from 'valibot';
 import { passwordValidation } from '../schemas/password';
 
@@ -52,22 +52,6 @@ const EXPECTED_SET_PASSWORD_CODES = new Set([
 	'PASSWORD_TOO_SHORT',
 	'PASSWORD_TOO_LONG'
 ]);
-
-/** Credential accounts belonging to a user, as Better Auth itself counts them. */
-async function credentialAccounts(
-	ctx: Pick<QueryCtx, 'runQuery'>,
-	userId: string
-): Promise<Array<{ password?: string | null }>> {
-	const result = await ctx.runQuery(components.betterAuth.adapter.findMany, {
-		model: 'account',
-		where: [
-			{ field: 'userId', operator: 'eq', value: userId },
-			{ field: 'providerId', operator: 'eq', value: 'credential' }
-		],
-		paginationOpts: { cursor: null, numItems: 200 }
-	});
-	return result.page as Array<{ password?: string | null }>;
-}
 
 /**
  * Set a first password for the signed-in user.
@@ -194,6 +178,6 @@ export const hasPassword = authedQuery({
 	args: {},
 	returns: v.boolean(),
 	handler: async (ctx) => {
-		return (await credentialAccounts(ctx, ctx.user._id)).some((account) => account.password);
+		return hasUsablePassword(ctx, ctx.user._id);
 	}
 });


### PR DESCRIPTION
Better Auth sends the password-reset mail for an account created through an OAuth provider as well, and the link in it works: `resetPassword` matches on `providerId` alone and creates the credential account the user never had. The wording was the only part that did not know this. It announced a reset of a password that does not exist, and its disclaimer told the reader that ignoring the mail would leave their password unchanged, which is not true when there is no password to leave.

That mail is what a Google or GitHub signup receives after being told, correctly, that this is how you get a password. It is the last screen in that path still describing a different account than the one reading it.

The template already takes every string as a prop, so nothing about it changes: the send path picks the key set, the subject and the analytics template name. The credential lookup moves into its own module because `users.ts` already imports `auth.ts`, so the hook could not have reached it where it was, and it resolves inside the sending mutation rather than in the hook: Better Auth awaits `sendResetPassword` on the response path of `requestPasswordReset` unless a `backgroundTasks` handler is configured, and there is none, so a lookup there would be a round trip on that path. Both mails word the trigger impersonally, because the endpoint takes no session and anyone can enter an address into it.

The page the link opens still says "reset" in both cases; telling them apart there needs an endpoint that reports the password state for a token, which is its own design question (#817).

Regression guard: added src/lib/convex/emails/__tests__/passwordResetTemplate.test.ts, which asserts each variant renders its own copy in HTML and text and that the unchanged-password disclaimer never reaches an account without one
Verified by removing the branch and confirming two of the four assertions fail, plus the unit and type checks.