### PR TITLE
docs(skills): Cut AI tells from fork-owned skills

### DIFF
--- a/.agents/skills/autumn-best-practices/SKILL.md
+++ b/.agents/skills/autumn-best-practices/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: autumn-best-practices
-description: Skill for integrating Autumn - the billing and entitlements layer over Stripe.
+description: Integrate Autumn, the billing and entitlements layer over Stripe.
 ---
 
 # Autumn Integration Guide
 
 **Always consult [docs.useautumn.com](https://docs.useautumn.com) for code examples and latest API.**
 
-Autumn is a TypeScript-first billing SDK supporting subscriptions, usage-based pricing, credits, trials, and more via Stripe.
+Autumn is a TypeScript-first billing SDK for subscriptions, usage-based pricing, credits, and trials on top of Stripe.
 
 ---
 
@@ -15,7 +15,7 @@ Autumn is a TypeScript-first billing SDK supporting subscriptions, usage-based p
 
 ### Environment Variables
 
-- `AUTUMN_SECRET_KEY` - API key (required). Get one at [app.useautumn.com](https://app.useautumn.com/dev?tab=api_keys)
+- `AUTUMN_SECRET_KEY`: API key (required). Get one at [app.useautumn.com](https://app.useautumn.com/dev?tab=api_keys)
 
 ### Installation
 
@@ -131,12 +131,12 @@ import { AutumnProvider } from 'autumn-js/react';
 
 ## Common Gotchas
 
-1. **URL field** - Checkout URL is `data.url`, not `data.checkout_url`
-2. **Frontend checks** - For UX only. Always enforce on backend
-3. **Track after success** - Only track usage after work completes
-4. **Credit systems** - Track metered features, not the credit system itself
-5. **Cancel via free plan** - Prefer `attach({ product_id: "free" })` over `cancel()`
-6. **Idempotent creation** - `customers.create` returns existing customer if ID exists
+1. **URL field.** The checkout URL is `data.url`, not `data.checkout_url`
+2. **Frontend checks.** For UX only. Always enforce on the backend
+3. **Track after success.** Only track usage after the work completes
+4. **Credit systems.** Track metered features, not the credit system itself
+5. **Cancel via free plan.** Prefer `attach({ product_id: "free" })` over `cancel()`
+6. **Idempotent creation.** `customers.create` returns the existing customer if the ID exists
 
 ---
 

--- a/.agents/skills/svelte-form-builder/SKILL.md
+++ b/.agents/skills/svelte-form-builder/SKILL.md
@@ -27,7 +27,7 @@ Generate a form JSON structure for the Svelte form builder using this exact sche
 - Each field must have:
   - `"id"`: unique string (e.g., `"field-1"`)
   - `"name"`: display name (e.g., `"Input"`, `"Email"`)
-  - `"type"`: field type — `text`, `email`, `password`, `number`, `textarea`, `boolean`, `select`, `radio`, `date-picker`, `slider`, `input-otp`, `phone`, `combobox`, `tags-input`, `file`, `location-input`
+  - `"type"`: one of `text`, `email`, `password`, `number`, `textarea`, `boolean`, `select`, `radio`, `date-picker`, `slider`, `input-otp`, `phone`, `combobox`, `tags-input`, `file`, `location-input`
   - `"category"`: same as type for most fields, or `"checkbox"`/`"switch"` for boolean
   - `"label"`: field label shown to user
   - `"description"`: helper text (optional)

--- a/.agents/skills/triage-reviews/SKILL.md
+++ b/.agents/skills/triage-reviews/SKILL.md
@@ -23,21 +23,21 @@ Fetch all review comments on the current PR, verify each finding against real co
    gh api --paginate repos/{owner}/{repo}/issues/{pr}/comments
    ```
 
-3. Extract unique findings — deduplicate across Copilot, Greptile, and human reviewers. Group by file and line.
+3. Extract unique findings, deduplicating across Copilot, Greptile, and human reviewers. Group by file and line.
 
 ## Phase 2: Verify Each Finding
 
 For EVERY finding, verify against real code before accepting or rejecting:
 
 1. **Read the actual code** at the referenced file:line
-2. **Check if the issue still exists** — it may already be fixed in a later commit
+2. **Check if the issue still exists.** It may already be fixed in a later commit
 3. **Verify correctness** using:
    - Code analysis (read surrounding context, trace call paths)
    - Invoke the `btca-local` skill for library/framework questions, then inspect the relevant repository clones registered in `btca.config.jsonc`
    - Web search for API behavior, language semantics, or CVEs
 4. **Classify** each finding:
-   - **Valid** — real bug, real gap, or real improvement needed
-   - **False positive** — reviewer misread the code, outdated reference, or style preference
+   - **Valid.** Real bug, real gap, or real improvement needed
+   - **False positive.** Reviewer misread the code, outdated reference, or style preference
 
 ## Phase 3: Fix & Ship
 
@@ -65,5 +65,5 @@ Present a final summary table of ALL findings with verdicts:
 ## Notes
 
 - Never dismiss a finding without reading the actual code first
-- If unsure, err toward "Valid" — it's cheaper to fix than to miss a bug
-- For library/API questions, always use btca or web search — don't guess
+- If unsure, err toward "Valid". Fixing costs less than missing a bug
+- For library/API questions, use btca or web search rather than guessing

--- a/.agents/skills/upstream-sync/SKILL.md
+++ b/.agents/skills/upstream-sync/SKILL.md
@@ -7,10 +7,10 @@ allowed-tools: Bash, Read, Edit, Grep, Glob
 
 # Upstream Template Sync
 
-Pull later template changes into this fork. The goal is to review **every** upstream
-enhancement, understand it, and integrate what fits — bug fixes, features, refactors,
-chores, and security fixes alike. Security fixes are never optional and apply first,
-but this is a comprehensive review, not a security-only pass.
+Pull later template changes into this fork. Review **every** upstream commit and
+integrate what fits: bug fixes, features, refactors, chores, and security fixes alike.
+Security fixes apply first and are never optional, and every other commit still gets
+the same review.
 
 This fork was created by **content-copy** (GitHub "Use this template"), so it shares
 **NO git ancestor** with upstream: `git merge`, `git rebase`, and `gh repo sync` do
@@ -23,12 +23,12 @@ manually-adapted port.
 
 ## When to STOP and ask the human
 
-- A candidate commit touches a file this fork has heavily rewritten (auth, schema, deploy config) — show the diff, do not auto-apply.
-- Fork-point detection returns a `closest-tree GUESS` (the bootstrap commit was edited) — confirm before proceeding.
+- A candidate commit touches a file this fork has heavily rewritten (auth, schema, deploy config). Show the diff, do not auto-apply.
+- Fork-point detection returns a `closest-tree GUESS` (the bootstrap commit was edited). Confirm before proceeding.
 - A ported commit needs an env var that does not exist as a preview deployment default.
 - Before opening the PR, and before any merge. Never auto-merge.
 
-## Step 1 — Discover (read-only, never writes)
+## Step 1: Discover (read-only)
 
 ```bash
 bun .agents/skills/upstream-sync/scripts/find-fork-point.ts        # fork point via tree-SHA match
@@ -43,7 +43,7 @@ the default). The upstream defaults to the template this skill shipped from; if 
 fork was forked from another fork, pass `--upstream <url>` (or set `upstreamUrl` in the
 marker) to point at the right template.
 
-## Step 2 — Isolated worktree off main
+## Step 2: Isolated worktree off main
 
 Never work in the shared checkout (a parallel process can sweep up staged files).
 
@@ -51,31 +51,31 @@ Never work in the shared checkout (a parallel process can sweep up staged files)
 bun run worktree chore/upstream-sync --base main
 ```
 
-## Step 3 — Detect THIS fork's divergences
+## Step 3: Detect THIS fork's divergences
 
 Do not assume; detect from the diff against the fork point. Categories: branding/legal
 config, theme/design tokens, env/deploy config, i18n content, fork-owned features. See
 [reference/divergence-categories.md](reference/divergence-categories.md). A commit
 touching a diverged file needs extra care: re-apply the upstream _intent_ onto the
-fork's values. A commit that touches no diverged area is **not** a free pass — it still
-gets the full Step 4 verdict. Divergence categories change how much adaptation a commit
-needs, never whether you review it.
+fork's values. A commit that touches no diverged area still gets the full Step 4
+verdict. Divergence categories change how much adaptation a commit needs, never whether
+you review it.
 
-## Step 4 — Review and classify every commit
+## Step 4: Review and classify every commit
 
-The priority tag and divergence categories from Step 1 are **hints only** — for
-ordering and for how much adaptation a commit needs. They are never a gate or a
-substitute for review. Read **every** commit's actual diff and give it an explicit
-verdict; never integrate, skip, or exclude a commit from its label alone, and never
-blind-apply an untagged or unlabeled commit. "Security first" is about apply order, not
-about which commits to look at — you look at all of them.
+The priority tag and divergence categories from Step 1 are **hints only**: they set
+ordering and how much adaptation a commit needs. They are never a gate or a substitute
+for review. Read **every** commit's actual diff and give it an explicit verdict; never
+integrate, skip, or exclude a commit from its label alone, and never blind-apply an
+untagged or unlabeled commit. "Security first" is about apply order; you still read
+every commit.
 
 Process oldest-first (dependency order). Apply security and bug fixes first, then
 features/refactors/chores. For each commit, from its diff, decide:
 
-- **Integrate** — applies to this fork (possibly adapted).
-- **Already present** — the fork already has equivalent code (grep / `git log` the fork). Skip.
-- **Exclude** — conflicts with a deliberate fork divergence, or re-introduces something
+- **Integrate.** Applies to this fork, possibly adapted.
+- **Already present.** The fork already has equivalent code (grep / `git log` the fork). Skip.
+- **Exclude.** Conflicts with a deliberate fork divergence, or re-introduces something
   the fork removed. Record `{sha, reason}` in `.upstream-sync.json` so it is not
   re-triaged next sync.
 
@@ -85,15 +85,15 @@ rename). Port prerequisites first or together; never batch-apply the whole range
 The review unit is the squashed first-parent commit; for an oversized commit, triage
 within it by file/hunk. See [reference/triage.md](reference/triage.md).
 
-## Step 5 — Apply, dependency-aware
+## Step 5: Apply, dependency-aware
 
 Cherry-pick or hand-port in order.
 
-- **Branding/theme/config**: re-apply the upstream _intent_ on the fork's values; never clobber fork branding or tokens.
-- **i18n JSON conflicts**: use a JSON-aware 3-way deep merge, NEVER a line-based resolver (it corrupts nested objects). See [reference/i18n-merge.md](reference/i18n-merge.md), then run the locale-parity test.
+- **Branding/theme/config.** Re-apply the upstream _intent_ on the fork's values; never clobber fork branding or tokens.
+- **i18n JSON conflicts.** Use a JSON-aware 3-way deep merge, NEVER a line-based resolver (it corrupts nested objects). See [reference/i18n-merge.md](reference/i18n-merge.md), then run the locale-parity test.
 - Skip any commit that purely reverts a fork choice (rebrand, font, removed feature).
 
-## Step 6 — Validate against WHOLE-PROJECT CI (not file-scoped)
+## Step 6: Validate against WHOLE-PROJECT CI
 
 `scripts/static-checks.ts` is file-scoped and misses project-wide gates. Run the
 project-wide lint, type check, unit tests, and a build before the PR. A newly ported
@@ -102,7 +102,7 @@ var, ensure it exists as a preview deployment default (CI's `convex deploy` fail
 missing required var; a green local build does not cover the deploy step). See
 [reference/ci-gotchas.md](reference/ci-gotchas.md).
 
-## Step 7 — Ship ONE consolidated PR (never a stack)
+## Step 7: Ship ONE consolidated PR
 
 One branch off current `main` with all integrated commits, grouped thematically for
 readable history but applied in dependency order. Do NOT stack PRs (deleting a stack
@@ -116,12 +116,11 @@ commit `.upstream-sync.json`.
 
 ## Large syncs (many commits): fan out per-commit, not per-category
 
-Run the two discovery scripts once, then parallelize the _triage_ one agent per commit
-(plus an adversarial recheck of every dismissal) — the commit is the atomic unit of
-intent and the only granularity where cross-commit dependencies are visible. A single
-**lead** owns the one worktree branch and is the only writer (serialized commits);
-subagents return patches + verdicts + dependency notes as text, the lead applies them
-in dependency order. Keep the invariant: one branch, one writer, one consolidated PR.
+Run the two discovery scripts once, then parallelize the _triage_ one agent per commit,
+plus an adversarial recheck of every dismissal. The commit is the unit of intent and the
+only level where cross-commit dependencies are visible. A single **lead** owns the one
+worktree branch and is the only writer (serialized commits); subagents return patches +
+verdicts + dependency notes as text, the lead applies them in dependency order. Keep the invariant: one branch, one writer, one consolidated PR.
 
 ## Template-bug linkage (do not strip on rebrand)
 

--- a/.agents/skills/upstream-sync/SKILL.md
+++ b/.agents/skills/upstream-sync/SKILL.md
@@ -120,7 +120,8 @@ Run the two discovery scripts once, then parallelize the _triage_ one agent per 
 plus an adversarial recheck of every dismissal. The commit is the unit of intent and the
 only level where cross-commit dependencies are visible. A single **lead** owns the one
 worktree branch and is the only writer (serialized commits); subagents return patches +
-verdicts + dependency notes as text, the lead applies them in dependency order. Keep the invariant: one branch, one writer, one consolidated PR.
+verdicts + dependency notes as text, the lead applies them in dependency order. Keep the
+invariant: one branch, one writer, one consolidated PR.
 
 ## Template-bug linkage (do not strip on rebrand)
 

--- a/.agents/skills/upstream-sync/reference/ci-gotchas.md
+++ b/.agents/skills/upstream-sync/reference/ci-gotchas.md
@@ -7,7 +7,7 @@ the gates that fail an upstream-sync PR in CI. Check these explicitly before the
 
 CI runs the project-wide `lint` script (`eslint .` + `oxlint`). When a ported commit adds
 a new ESLint rule, that rule fires on **all pre-existing fork files**, not just the files
-the commit changed — so a file-scoped check passes while CI fails. Always run the full
+the commit changed, so a file-scoped check passes while CI fails. Always run the full
 project lint before the PR:
 
 ```bash
@@ -21,7 +21,7 @@ rule), or the rule's PR cannot merge.
 
 If a ported commit adopts typed environment variables (declaring required vars that the
 backend deploy validates), the CI deploy step runs the backend deploy and **fails on a
-missing required var** — even though the local build never deploys. For each newly
+missing required var**, even though the local build never deploys. For each newly
 required var, ensure it exists as a preview deployment default (and in production) before
 merging. A required var that is set dynamically per-deploy must still have a default so
 the presence check passes.
@@ -30,7 +30,7 @@ the presence check passes.
 
 Deploy runs in CI, not locally. A green local build proves compilation, not deployability.
 Backend-deploy permission/secret problems (e.g. a deploy key lacking a permission a new
-command needs) only surface in the CI build log — read it there rather than trusting the
+command needs) only surface in the CI build log. Read it there rather than trusting the
 local build.
 
 ## 4. Merge state

--- a/.agents/skills/upstream-sync/reference/divergence-categories.md
+++ b/.agents/skills/upstream-sync/reference/divergence-categories.md
@@ -1,11 +1,11 @@
 # Detecting this fork's divergences
 
 A fork diverges from the template in a few predictable areas. Detect them from the actual
-diff against the fork point — never hardcode fork specifics. When an upstream commit
+diff against the fork point, never from hardcoded fork specifics. When an upstream commit
 touches a file in a diverged area, re-apply the upstream _intent_ on top of the fork's
 values; do not clobber the fork's choices.
 
-Get the fork's divergence surface once:
+List the files the fork has diverged on, once:
 
 ```bash
 # files the fork changed vs the template baseline (forkPoint from .upstream-sync.json)
@@ -17,24 +17,24 @@ Cross-reference that list with each candidate commit's changed files (the
 
 ## Categories (generic shapes)
 
-- **branding / legal** — brand name, wordmark, logo, legal/operator/address config, SEO
+- **branding / legal.** Brand name, wordmark, logo, legal/operator/address config, SEO
   defaults, marketing copy, manifest/favicon. Upstream changes here usually must be
   re-expressed with the fork's brand values, not copied verbatim.
-- **theme / design tokens** — global CSS, design tokens, Tailwind theme, color/spacing
+- **theme / design tokens.** Global CSS, design tokens, Tailwind theme, color/spacing
   scales, fonts. A fork that re-themed will conflict on token files; keep the fork's
   token values, take only genuinely new tokens or structural fixes.
-- **env / deploy config** — env schema, deploy scripts, CI workflows, platform config
+- **env / deploy config.** Env schema, deploy scripts, CI workflows, platform config
   (wrangler/vercel/docker), backend component/config. Adapt to the fork's deploy targets;
   a fork may have disabled a platform the template still ships.
-- **i18n content** — translation JSON. Resolve with the JSON-aware 3-way deep merge
+- **i18n content.** Translation JSON. Resolve with the JSON-aware 3-way deep merge
   (see i18n-merge.md), never line-based.
-- **fork-owned features** — directories/modules the fork added that the template has no
+- **fork-owned features.** Directories/modules the fork added that the template has no
   concept of. Upstream rarely touches these; if a refactor does (e.g. a renamed shared
   helper the fork's feature imports), port the rename into the fork's feature too.
 
 ## Decision
 
-- File NOT in the fork's divergence surface → the commit usually applies cleanly (still
+- File NOT in the fork's diverged file list → the commit usually applies cleanly (still
   review intent).
 - File IN a diverged area → adapt. If the fork rewrote that file heavily (auth, schema,
   deploy config), STOP and show the human the diff rather than auto-applying.

--- a/.agents/skills/upstream-sync/reference/i18n-merge.md
+++ b/.agents/skills/upstream-sync/reference/i18n-merge.md
@@ -1,16 +1,16 @@
 # i18n conflict resolution: JSON-aware 3-way deep merge
 
 When an upstream commit changes translation JSON the fork has also edited, **never use a
-line-based merge resolver** — it corrupts nested objects (orphan commas, duplicated or
+line-based merge resolver**. It corrupts nested objects (orphan commas, duplicated or
 broken keys, `"a": {,`). Resolve at the JSON object level.
 
 ## The merge
 
 Use git's three stages of the conflicted file:
 
-- `git show :1:src/i18n/<locale>.json` — base (the common version before either side)
-- `git show :2:src/i18n/<locale>.json` — ours (the fork's current values)
-- `git show :3:src/i18n/<locale>.json` — theirs (upstream's new version)
+- `git show :1:src/i18n/<locale>.json`: base, the common version before either side
+- `git show :2:src/i18n/<locale>.json`: ours, the fork's current values
+- `git show :3:src/i18n/<locale>.json`: theirs, upstream's new version
 
 Deep-merge recursively:
 

--- a/.agents/skills/upstream-sync/reference/triage.md
+++ b/.agents/skills/upstream-sync/reference/triage.md
@@ -2,14 +2,15 @@
 
 The review unit is the **squashed first-parent commit** on upstream's default branch.
 Upstream squash-merges PRs, so each commit is the canonical, net, reviewed diff of one
-PR. Do not pull pre-squash branch commits — they carry intra-PR churn (WIP, fix-the-fix,
+PR. Do not pull pre-squash branch commits; they carry intra-PR churn (WIP, fix-the-fix,
 reverts that net out) and give worse signal. For an oversized commit, triage _within_ it
 by file/hunk instead.
 
 ## Order
 
 Process oldest-first; that is the dependency/integration order. Apply security and bug
-fixes first, then features/refactors/chores — but review all of them, not just security.
+fixes first, then features/refactors/chores. Review all of them, not only the security
+ones.
 
 ## Verdict per commit
 
@@ -18,11 +19,11 @@ category labels. Those are hints (ordering + how much adaptation), never a gate:
 untagged or unlabeled commit still gets read and given a verdict, and is never
 blind-applied.
 
-- **integrate** — applies to this fork. May need adaptation (see divergence-categories.md).
-- **already-present** — the fork already has equivalent behavior. Verify before skipping:
+- **integrate.** Applies to this fork. May need adaptation (see divergence-categories.md).
+- **already-present.** The fork already has equivalent behavior. Verify before skipping:
   grep the fork for the symbol/string/file the commit adds; check `git log` for an
   independent equivalent. A substring match in a _different_ key/path is not a hit.
-- **exclude** — conflicts with a deliberate fork divergence, or re-introduces something
+- **exclude.** Conflicts with a deliberate fork divergence, or re-introduces something
   the fork intentionally removed/changed (rebrand, font, dropped feature). Record
   `{ "sha": "<sha>", "reason": "<one line>" }` in `.upstream-sync.json.excluded` so the
   next sync does not re-triage it.
@@ -43,7 +44,7 @@ and port prerequisites first or together. Never batch-apply the whole range blin
 ## Adversarial recheck of dismissals
 
 For every "already-present" and "exclude" verdict, re-verify against the real file at the
-cited path before trusting it — dismissals are where real fixes get silently dropped.
+cited path before trusting it. Dismissals are where real fixes get silently dropped.
 
 ## Oversized commits
 

--- a/.agents/skills/upstream-sync/scripts/find-fork-point.ts
+++ b/.agents/skills/upstream-sync/scripts/find-fork-point.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env bun
 /**
- * find-fork-point.ts — locate the upstream commit this fork was copied from.
+ * find-fork-point.ts: locate the upstream commit this fork was copied from.
  *
  * Forks of this template are created by content-copy (GitHub "Use this template"),
  * so they share NO git ancestor with upstream: `git merge-base`, `rebase`, and
- * `gh repo sync` do not apply. The only reliable link is TREE-SHA identity — the
+ * `gh repo sync` do not apply. The only reliable link is TREE-SHA identity. The
  * fork's bootstrap commit copied an upstream tree verbatim, so its tree SHA equals
  * some upstream commit's tree SHA. This script finds that commit.
  *
@@ -21,7 +21,7 @@ import { join } from 'node:path';
 import { parseArgs } from 'node:util';
 
 // Default upstream = the template this skill ships from (the template's own
-// identity, inherited by every fork — not a fork specific). Override via the
+// identity, inherited by every fork, not a fork specific). Override via the
 // marker's `upstreamUrl` or `--upstream`.
 const DEFAULT_UPSTREAM = 'https://github.com/stickerdaniel/saas-starter.git';
 const MARKER = '.upstream-sync.json';
@@ -114,7 +114,7 @@ function main() {
 		// Fallback: bootstrap was edited after copy, so no tree is identical. Pick the
 		// upstream commit with the SMALLEST diff to the fork root tree. This is a GUESS.
 		console.error(
-			'No exact tree-SHA match — bootstrap commit was likely edited. Computing closest tree (GUESS)...'
+			'No exact tree-SHA match, bootstrap commit was likely edited. Computing closest tree (GUESS)...'
 		);
 		let best = '';
 		let bestChanges = Number.POSITIVE_INFINITY;
@@ -130,7 +130,7 @@ function main() {
 			}
 		}
 		forkPoint = best;
-		method = `closest-tree GUESS (~${bestChanges} line diff) — CONFIRM before syncing`;
+		method = `closest-tree GUESS (~${bestChanges} line diff), CONFIRM before syncing`;
 	}
 
 	const forkPointSubject = git(['log', '-1', '--format=%s', forkPoint], true);
@@ -153,7 +153,7 @@ function main() {
 	const mark = values['mark-synced'] as string | boolean | undefined;
 	if (mark !== undefined) {
 		const newLastSynced = typeof mark === 'string' && mark ? mark : upstreamHead;
-		// Reject anything that is not a real upstream commit — a bogus lastSynced would
+		// Reject anything that is not a real upstream commit; a bogus lastSynced would
 		// silently break the next sync's `<lastSynced>..upstream/main` range.
 		const resolved = git(['rev-parse', '--verify', '--quiet', `${newLastSynced}^{commit}`], true);
 		if (!resolved) {
@@ -205,7 +205,7 @@ function main() {
 	console.log(`Fork point:   ${forkPoint}  (${method})`);
 	console.log(`              ${forkPointSubject}`);
 	console.log(
-		`Last synced:  ${lastSynced}${marker?.lastSynced ? '' : '  (no marker yet — defaults to fork point)'}`
+		`Last synced:  ${lastSynced}${marker?.lastSynced ? '' : '  (no marker yet, defaults to fork point)'}`
 	);
 	console.log(`Upstream HEAD: ${upstreamHead}`);
 	console.log(

--- a/.agents/skills/upstream-sync/scripts/find-fork-point.ts
+++ b/.agents/skills/upstream-sync/scripts/find-fork-point.ts
@@ -114,7 +114,7 @@ function main() {
 		// Fallback: bootstrap was edited after copy, so no tree is identical. Pick the
 		// upstream commit with the SMALLEST diff to the fork root tree. This is a GUESS.
 		console.error(
-			'No exact tree-SHA match, bootstrap commit was likely edited. Computing closest tree (GUESS)...'
+			'No exact tree-SHA match; the bootstrap commit was likely edited. Computing closest tree (GUESS)...'
 		);
 		let best = '';
 		let bestChanges = Number.POSITIVE_INFINITY;
@@ -130,7 +130,7 @@ function main() {
 			}
 		}
 		forkPoint = best;
-		method = `closest-tree GUESS (~${bestChanges} line diff), CONFIRM before syncing`;
+		method = `closest-tree GUESS (~${bestChanges} line diff); CONFIRM before syncing`;
 	}
 
 	const forkPointSubject = git(['log', '-1', '--format=%s', forkPoint], true);

--- a/.agents/skills/upstream-sync/scripts/list-upstream-changes.ts
+++ b/.agents/skills/upstream-sync/scripts/list-upstream-changes.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env bun
 /**
- * list-upstream-changes.ts — list upstream commits to review for this fork.
+ * list-upstream-changes.ts: list upstream commits to review for this fork.
  *
  * Lists every upstream commit since the last sync (or the fork point) so EACH can
  * be reviewed, understood, and consciously integrated or excluded. This is not a
  * security-only tool: all enhancements are candidates. Each commit gets a priority
- * tag (security highest) and the divergence categories it touches, but nothing is
- * filtered out by default — comprehensive review is the goal.
+ * tag (security highest) and the divergence categories it touches, and nothing is
+ * filtered out by default, so every commit stays in view.
  *
  * Unit of review = the squashed first-parent commit on upstream's default branch.
  * Upstream squash-merges PRs, so each commit is the canonical, net, reviewed unit
@@ -45,7 +45,7 @@ function git(args: string[], allowFail = false): string {
 }
 
 // Divergence categories: which fork-divergence area a changed path belongs to.
-// Generic shapes, not fork specifics — used to flag commits that need adaptation.
+// Generic shapes, not fork specifics. Used to flag commits that need adaptation.
 const CATEGORY_RULES: Array<[string, RegExp]> = [
 	['i18n', /^src\/i18n\/|\bmessages?\/|\.ftl$/],
 	['theme', /layout\.css$|app\.css$|tailwind|theme|design-?tokens|design-?system/i],
@@ -110,7 +110,7 @@ function main() {
 	let base = (marker?.lastSynced as string) || (marker?.forkPoint as string);
 	if (!base) {
 		// First run, no marker yet: derive the fork point from the sibling script.
-		console.error('No marker yet — deriving fork point via find-fork-point.ts ...');
+		console.error('No marker yet, deriving fork point via find-fork-point.ts ...');
 		const out = execFileSync('bun', [join(import.meta.dir, 'find-fork-point.ts'), '--json'], {
 			encoding: 'utf-8',
 			env: gitEnv(),
@@ -172,7 +172,7 @@ function main() {
 				.join('  ')
 	);
 	console.log(
-		'Review EVERY commit by reading its diff — integrate, mark already-present, or exclude with a reason.'
+		'Review EVERY commit by reading its diff: integrate, mark already-present, or exclude with a reason.'
 	);
 	console.log(
 		'Tags/categories are hints only (ordering + how much adaptation), never a gate: do not skip, integrate, or exclude a commit from its label.'
@@ -188,11 +188,9 @@ function main() {
 	}
 	console.log('');
 	console.log(
-		'A category flags a fork-divergence area to adapt carefully. NO category is not a free pass —'
+		'A category flags a fork-divergence area to adapt carefully. A commit with NO category'
 	);
-	console.log(
-		'still read the diff and give that commit a verdict; never blind-apply an untagged one.'
-	);
+	console.log('still gets its diff read and a verdict; never blind-apply an untagged one.');
 	console.log('Oversized commit? Triage within it by file/hunk, not by pre-squash branch commits.');
 }
 


### PR DESCRIPTION
The skills this repo owns were written in the house style of a model rather than mine: em dashes as the default connector, definition lists hung off them, and lines that restate the line above. `upstream-sync` carried most of it, including in the two scripts, whose console output is what an agent reads while triaging commits.

Every em dash is gone, the definition lists became bold lead-ins with a period, and the wording that said nothing came out: `read-only, never writes` names one property twice, `is not a free pass` is immediately followed by the positive form of the same rule, and `atomic unit of intent` is a unit of intent. The Step 6 and Step 7 headings each drop a parenthetical that the sentence below already spells out. No instruction changed. Vendored skills are untouched so they stay comparable to their sources.

`static-checks.ts` and the `list-upstream-changes` unit tests pass.