### PR TITLE
chore(sync): Name the upstream scripts for what they do

### DIFF
--- a/.agents/skills/upstream-sync/scripts/find-fork-point.ts
+++ b/.agents/skills/upstream-sync/scripts/find-fork-point.ts
@@ -12,7 +12,7 @@
  * else in the working tree. Persist the fork point yourself in
  * `.upstream-sync.json` (this script prints a ready-to-commit block).
  *
- * `--mark-synced <sha>` is the one exception and the one write: it sets
+ * `--mark-synced <sha>` is the one write it performs: it sets
  * `lastSynced` + `syncedAt` in the marker, which is how a finished sync records
  * where the next one starts. Commit that file as the sync branch's final commit.
  *

--- a/.agents/skills/upstream-sync/scripts/find-fork-point.ts
+++ b/.agents/skills/upstream-sync/scripts/find-fork-point.ts
@@ -8,12 +8,17 @@
  * fork's bootstrap commit copied an upstream tree verbatim, so its tree SHA equals
  * some upstream commit's tree SHA. This script finds that commit.
  *
- * Read-only: it adds + fetches the `upstream` remote and prints results. It never
- * modifies the working tree or writes any file. Persist the result yourself in
+ * It adds + fetches the `upstream` remote and prints results, and touches nothing
+ * else in the working tree. Persist the fork point yourself in
  * `.upstream-sync.json` (this script prints a ready-to-commit block).
+ *
+ * `--mark-synced <sha>` is the one exception and the one write: it sets
+ * `lastSynced` + `syncedAt` in the marker, which is how a finished sync records
+ * where the next one starts. Commit that file as the sync branch's final commit.
  *
  * Usage:
  *   bun .agents/skills/upstream-sync/scripts/find-fork-point.ts [--upstream <git-url>] [--json]
+ *   bun .agents/skills/upstream-sync/scripts/find-fork-point.ts --mark-synced <upstream-sha>
  */
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ If a fork discovers a bug or unexpected behavior that originates in the template
 
 <!-- DO NOT rename or remove this section when rebranding a fork. -->
 
-Use the `upstream-sync` skill (`.agents/skills/upstream-sync/SKILL.md`) and start with `bun run upstream:sync`. Forks are content copies without a shared Git ancestor, so ordinary merge/rebase/sync workflows do not apply.
+Use the `upstream-sync` skill (`.agents/skills/upstream-sync/SKILL.md`) and start with `bun run upstream:fork-point` and `bun run upstream:changes`. Forks are content copies without a shared Git ancestor, so ordinary merge/rebase/sync workflows do not apply.
 
 ## Global rules
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
 		"worktree:setup": "bun scripts/create-worktree.ts --setup-only",
 		"worktree:prune": "bun scripts/prune-worktrees.ts",
 		"setup": "bun scripts/template-setup.ts",
-		"upstream:sync": "bun .agents/skills/upstream-sync/scripts/find-fork-point.ts"
+		"upstream:fork-point": "bun .agents/skills/upstream-sync/scripts/find-fork-point.ts",
+		"upstream:changes": "bun .agents/skills/upstream-sync/scripts/list-upstream-changes.ts"
 	},
 	"packageManager": "bun@1.3.9",
 	"dependencies": {


### PR DESCRIPTION
`upstream:sync` locates the fork point and, with `--mark-synced`, writes the
marker. It syncs nothing. The second discovery script, which lists the commits
to review, had no alias at all, so a fork running a sync reached for a full path
beside a `bun run` for the first step. Adding a sibling under the existing name
would have made the pair harder to read rather than easier, so both are named
after what they do and the `AGENTS.md` pointer follows.

The header of `find-fork-point.ts` claimed to modify nothing and to write no
file, and told the reader to persist the result themselves. `--mark-synced` has
written the marker for as long as the flag has existed, and the usage block did
not mention it, so the one write the script performs was documented as
impossible.

Verified by running both aliases in this repository, where the second correctly
reports that origin is the template and there is nothing to sync, and with
static checks over the three changed files.
