### PR TITLE
test(auth): Drop the inert trusted-providers guard

### DIFF
--- a/src/lib/convex/__tests__/accountLinking.test.ts
+++ b/src/lib/convex/__tests__/accountLinking.test.ts
@@ -36,16 +36,8 @@ vi.mock('../_generated/server', () => ({
 const { createAuthOptions } = await import('../auth');
 
 const appOptions = createAuthOptions({} as never) as {
-	account?: { accountLinking?: { trustedProviders?: unknown } };
+	account?: { accountLinking?: { requireLocalEmailVerified?: boolean } };
 };
-
-/**
- * Better Auth resolves the trusted providers from this same option block
- * (`getTrustedProviders` in better-auth/dist/context/helpers.mjs), which also
- * accepts a function. The app uses neither form today, and the case below fails
- * rather than let this quietly resolve to an empty list if that changes.
- */
-const configuredTrustedProviders = appOptions.account?.accountLinking?.trustedProviders;
 
 type LinkContext = Parameters<typeof handleOAuthUserInfo>[0];
 type LinkOptions = Parameters<typeof handleOAuthUserInfo>[1];
@@ -88,7 +80,11 @@ function createContext(localUser: { id: string; email: string; emailVerified: bo
 	const context = {
 		context: {
 			internalAdapter,
-			trustedProviders: Array.isArray(configuredTrustedProviders) ? configuredTrustedProviders : [],
+			// Measured inert for both cases below. `isTrustedProvider` is its own
+			// disjunct in handleOAuthUserInfo and never reaches the local
+			// verification check, and the provider vouches for the address
+			// anyway, so neither verdict moves when this list gains an entry.
+			trustedProviders: [],
 			options: { account: appOptions.account },
 			baseURL: 'https://example.test/api/auth',
 			secret: 'test-secret',
@@ -108,12 +104,6 @@ const linkOptions = {
 } as unknown as LinkOptions;
 
 describe('implicit OAuth account linking', () => {
-	it('resolves the trusted providers the way the context does', () => {
-		// A function here would be resolved per request against the callback,
-		// which this synthetic context cannot reproduce.
-		expect(typeof configuredTrustedProviders).not.toBe('function');
-	});
-
 	it('refuses to link into a local user that never verified its email', async () => {
 		const { context, internalAdapter } = createContext({
 			id: 'local-user-id',


### PR DESCRIPTION
The account-linking contract test opened with an assertion that the app never configures `accountLinking.trustedProviders` as a function. The stated reason was that the synthetic context cannot resolve a function per request, so the two real cases would silently test the wrong thing if that ever changed. Measured against the installed Better Auth, they would not: in `handleOAuthUserInfo` the `isTrustedProvider` term sits in its own disjunct and never reaches the local-verification check, and the fixture's provider already vouches for the address, so an entry in that list moves neither verdict. The assertion guarded nothing while reading like a security check.

Dropping it costs no coverage. `requireLocalEmailVerified: false` is what actually reopens GHSA-g38m-r43w-p2q7, and the fixture reads that from the real option block, so the remaining cases still catch it.

Verified by injecting `requireLocalEmailVerified: false` into `auth.ts`, which fails the unverified-user case.