### PR TITLE
docs(agents): Decide when a fix earns a guard

### DIFF
--- a/.github/workflows/require-regression-guard.yml
+++ b/.github/workflows/require-regression-guard.yml
@@ -1,4 +1,4 @@
-# Enforces the regression-guard contract from scripts/AGENTS.md:
+# Enforces the regression-guard contract from AGENTS.md:
 # every fix PR must state its regression-guard verdict in the body
 # (added <name> / covered by <name> / not warranted, <reason>).
 name: Require Regression Guard
@@ -30,6 +30,6 @@ jobs:
             echo "  Regression guard: added <name>"
             echo "  Regression guard: covered by <name>"
             echo "  Regression guard: not warranted, <one-line reason>"
-            echo "See scripts/AGENTS.md, section Validation."
+            echo "See AGENTS.md, section Regression guards."
             exit 1
           fi

--- a/.github/workflows/require-regression-guard.yml
+++ b/.github/workflows/require-regression-guard.yml
@@ -22,9 +22,9 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           python - <<'PY'
+          import html
           import os
           import re
-          import sys
 
           title = os.environ.get('PR_TITLE', '')
           if not re.match(r'^fix(?:\([^)]+\))?!?: ', title):
@@ -35,22 +35,54 @@ jobs:
           verdict = re.compile(
               r'^Regression guard: (?:(added|covered by) (.+)|not warranted, (.+))$'
           )
-          fence = None
+          fence_character = None
+          fence_length = 0
+          in_comment = False
 
           for line in body.splitlines():
-              marker = re.match(r'^\s*(`{3,}|~{3,})', line)
-              if marker:
-                  character = marker.group(1)[0]
-                  fence = None if fence == character else character if fence is None else fence
+              if in_comment:
+                  if '-->' in line:
+                      in_comment = False
                   continue
-              if fence is not None:
+
+              comment_start = line.find('<!--')
+              if comment_start != -1:
+                  if '-->' not in line[comment_start + 4:]:
+                      in_comment = True
+                  # A verdict sharing a line with a comment is not a plain line.
                   continue
+
+              if fence_character is not None:
+                  closing = re.match(r'^ {0,3}(`{3,}|~{3,})[ \t]*$', line)
+                  if (
+                      closing
+                      and closing.group(1)[0] == fence_character
+                      and len(closing.group(1)) >= fence_length
+                  ):
+                      fence_character = None
+                      fence_length = 0
+                  continue
+
+              opening = re.match(r'^ {0,3}(`{3,}|~{3,})(.*)$', line)
+              if opening:
+                  marker, info = opening.groups()
+                  if marker[0] == '`' and '`' in info:
+                      pass
+                  else:
+                      fence_character = marker[0]
+                      fence_length = len(marker)
+                      continue
 
               match = verdict.fullmatch(line)
               if not match:
                   continue
               payload = match.group(2) or match.group(3) or ''
-              if payload != payload.strip() or payload in {'<name>', '<one-line reason>'}:
+              decoded = html.unescape(payload)
+              visible = re.sub(r'<[^>]*>', '', decoded)
+              visible = re.sub(r'[`*_~\[\]()#>]', '', visible).strip()
+              if payload != payload.strip() or not any(character.isalnum() for character in visible):
+                  continue
+              if '<name>' in decoded.lower() or '<one-line reason>' in decoded.lower():
                   continue
               print('Regression guard verdict found.')
               raise SystemExit(0)

--- a/.github/workflows/require-regression-guard.yml
+++ b/.github/workflows/require-regression-guard.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if printf '%s\n' "$PR_BODY" | grep -qiE '^Regression guard: (added|covered by|not warranted)'; then
+          if printf '%s\n' "$PR_BODY" | tr -d '\r' | grep -qE '^Regression guard: (added .+|covered by .+|not warranted, .+)$'; then
             echo "Regression guard verdict found."
           else
             echo "::error::Fix PRs must state their regression-guard verdict in the body."

--- a/.github/workflows/require-regression-guard.yml
+++ b/.github/workflows/require-regression-guard.yml
@@ -1,5 +1,5 @@
 # Enforces the regression-guard contract from AGENTS.md:
-# every fix PR must state its regression-guard verdict in the body
+# every human-authored fix PR must state its regression-guard verdict in the body
 # (added <name> / covered by <name> / not warranted, <reason>).
 name: Require Regression Guard
 
@@ -13,23 +13,54 @@ jobs:
   check:
     name: Regression Guard Verdict
     runs-on: ubicloud-standard-2
-    # Only fix PRs by humans; bots (Renovate "fix(deps)") are exempt
-    if: |
-      !endsWith(github.actor, '[bot]') &&
-      startsWith(github.event.pull_request.title, 'fix')
+    # Renovate and other bot-authored PRs are exempt for their whole lifecycle.
+    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
     steps:
       - name: Check PR body for verdict line
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if printf '%s\n' "$PR_BODY" | tr -d '\r' | grep -qE '^Regression guard: (added .+|covered by .+|not warranted, .+)$'; then
-            echo "Regression guard verdict found."
-          else
-            echo "::error::Fix PRs must state their regression-guard verdict in the body."
-            echo "Add one line directly above the verification line:"
-            echo "  Regression guard: added <name>"
-            echo "  Regression guard: covered by <name>"
-            echo "  Regression guard: not warranted, <one-line reason>"
-            echo "See AGENTS.md, section Regression guards."
-            exit 1
-          fi
+          python - <<'PY'
+          import os
+          import re
+          import sys
+
+          title = os.environ.get('PR_TITLE', '')
+          if not re.match(r'^fix(?:\([^)]+\))?!?: ', title):
+              print('Not a conventional fix PR; no regression-guard verdict required.')
+              raise SystemExit(0)
+
+          body = os.environ.get('PR_BODY', '').replace('\r\n', '\n').replace('\r', '\n')
+          verdict = re.compile(
+              r'^Regression guard: (?:(added|covered by) (.+)|not warranted, (.+))$'
+          )
+          fence = None
+
+          for line in body.splitlines():
+              marker = re.match(r'^\s*(`{3,}|~{3,})', line)
+              if marker:
+                  character = marker.group(1)[0]
+                  fence = None if fence == character else character if fence is None else fence
+                  continue
+              if fence is not None:
+                  continue
+
+              match = verdict.fullmatch(line)
+              if not match:
+                  continue
+              payload = match.group(2) or match.group(3) or ''
+              if payload != payload.strip() or payload in {'<name>', '<one-line reason>'}:
+                  continue
+              print('Regression guard verdict found.')
+              raise SystemExit(0)
+
+          print('::error::Human-authored fix PRs must state a substantive regression-guard verdict in the body.')
+          print('Add one plain, unindented line:')
+          print('  Regression guard: added <name>')
+          print('  Regression guard: covered by <name>')
+          print('  Regression guard: not warranted, <one-line reason>')
+          print('Replace the placeholder with the actual guard or reason.')
+          print('See AGENTS.md, section Regression guards.')
+          raise SystemExit(1)
+          PY

--- a/.github/workflows/require-regression-guard.yml
+++ b/.github/workflows/require-regression-guard.yml
@@ -1,98 +1,27 @@
 # Enforces the regression-guard contract from AGENTS.md:
-# every human-authored fix PR must state its regression-guard verdict in the body
-# (added <name> / covered by <name> / not warranted, <reason>).
+# every human-authored fix PR must state its regression-guard verdict at the
+# start of the body (added <name> / covered by <name> / not warranted, <reason>).
 name: Require Regression Guard
 
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   check:
     name: Regression Guard Verdict
     runs-on: ubicloud-standard-2
-    # Renovate and other bot-authored PRs are exempt for their whole lifecycle.
-    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - name: Check PR body for verdict line
         env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          python - <<'PY'
-          import html
-          import os
-          import re
-
-          title = os.environ.get('PR_TITLE', '')
-          if not re.match(r'^fix(?:\([^)]+\))?!?: ', title):
-              print('Not a conventional fix PR; no regression-guard verdict required.')
-              raise SystemExit(0)
-
-          body = os.environ.get('PR_BODY', '').replace('\r\n', '\n').replace('\r', '\n')
-          verdict = re.compile(
-              r'^Regression guard: (?:(added|covered by) (.+)|not warranted, (.+))$'
-          )
-          fence_character = None
-          fence_length = 0
-          in_comment = False
-
-          for line in body.splitlines():
-              if in_comment:
-                  if '-->' in line:
-                      in_comment = False
-                  continue
-
-              comment_start = line.find('<!--')
-              if comment_start != -1:
-                  if '-->' not in line[comment_start + 4:]:
-                      in_comment = True
-                  # A verdict sharing a line with a comment is not a plain line.
-                  continue
-
-              if fence_character is not None:
-                  closing = re.match(r'^ {0,3}(`{3,}|~{3,})[ \t]*$', line)
-                  if (
-                      closing
-                      and closing.group(1)[0] == fence_character
-                      and len(closing.group(1)) >= fence_length
-                  ):
-                      fence_character = None
-                      fence_length = 0
-                  continue
-
-              opening = re.match(r'^ {0,3}(`{3,}|~{3,})(.*)$', line)
-              if opening:
-                  marker, info = opening.groups()
-                  if marker[0] == '`' and '`' in info:
-                      pass
-                  else:
-                      fence_character = marker[0]
-                      fence_length = len(marker)
-                      continue
-
-              match = verdict.fullmatch(line)
-              if not match:
-                  continue
-              payload = match.group(2) or match.group(3) or ''
-              decoded = html.unescape(payload)
-              visible = re.sub(r'<[^>]*>', '', decoded)
-              visible = re.sub(r'[`*_~\[\]()#>]', '', visible).strip()
-              if payload != payload.strip() or not any(character.isalnum() for character in visible):
-                  continue
-              if '<name>' in decoded.lower() or '<one-line reason>' in decoded.lower():
-                  continue
-              print('Regression guard verdict found.')
-              raise SystemExit(0)
-
-          print('::error::Human-authored fix PRs must state a substantive regression-guard verdict in the body.')
-          print('Add one plain, unindented line:')
-          print('  Regression guard: added <name>')
-          print('  Regression guard: covered by <name>')
-          print('  Regression guard: not warranted, <one-line reason>')
-          print('Replace the placeholder with the actual guard or reason.')
-          print('See AGENTS.md, section Regression guards.')
-          raise SystemExit(1)
-          PY
+        run: bun scripts/check-regression-guard.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,14 @@ This repository is a SaaS template built with SvelteKit, Svelte 5, Convex, Bette
 
 The nearest `AGENTS.md` owns task-specific guidance. Read the relevant file before editing that area:
 
-| Scope                                  | Guidance                                                 |
-| -------------------------------------- | -------------------------------------------------------- |
-| Application code                       | [`src/AGENTS.md`](./src/AGENTS.md)                       |
-| Routes, rendering, forms               | [`src/routes/AGENTS.md`](./src/routes/AGENTS.md)         |
-| Convex backend                         | [`src/lib/convex/AGENTS.md`](./src/lib/convex/AGENTS.md) |
-| E2E tests                              | [`e2e/AGENTS.md`](./e2e/AGENTS.md)                       |
-| Scripts, deployment, regression guards | [`scripts/AGENTS.md`](./scripts/AGENTS.md)               |
-| Repository documentation               | [`docs/AGENTS.md`](./docs/AGENTS.md)                     |
+| Scope                             | Guidance                                                 |
+| --------------------------------- | -------------------------------------------------------- |
+| Application code                  | [`src/AGENTS.md`](./src/AGENTS.md)                       |
+| Routes, rendering, forms          | [`src/routes/AGENTS.md`](./src/routes/AGENTS.md)         |
+| Convex backend                    | [`src/lib/convex/AGENTS.md`](./src/lib/convex/AGENTS.md) |
+| E2E tests                         | [`e2e/AGENTS.md`](./e2e/AGENTS.md)                       |
+| Scripts, deployment, build guards | [`scripts/AGENTS.md`](./scripts/AGENTS.md)               |
+| Repository documentation          | [`docs/AGENTS.md`](./docs/AGENTS.md)                     |
 
 Skills hold dependency and workflow tutorials. Use the applicable skill instead of copying its contents into an instruction file.
 
@@ -75,7 +75,7 @@ Scope is required when meaningful. Use imperative mood, capitalize the subject, 
 
 ## Where knowledge belongs
 
-A plan is a PR body. An audit finding is an issue. A convention is a lint rule. A fact or invariant about code is a test. Repository documents are for knowledge code cannot express: rejected alternatives and rationale, external constraints, external-system runbooks, stable domain/editorial vocabulary, and thin navigation maps.
+A plan is a PR body. An audit finding is an issue. A convention is a lint rule. A fact or invariant about code is a test, once Regression guards below establishes that it needs a guard and that behavior is what proves it. Repository documents are for knowledge code cannot express: rejected alternatives and rationale, external constraints, external-system runbooks, stable domain/editorial vocabulary, and thin navigation maps.
 
 Never preserve current symbols, signatures, enums, file lists, or implementation steps “for reference.” Split mixed documents: keep the non-derivable rationale and move load-bearing implementation facts into tests. Historical decisions remain immutable; supersede them with a new dated record and an explicit link.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,9 @@ Scope is required when meaningful. Use imperative mood, capitalize the subject, 
 
 ## Where knowledge belongs
 
-A plan is a PR body. An audit finding is an issue. A convention is a lint rule. A fact or invariant about code is a test, once Regression guards below establishes that it needs a guard and that behavior is what proves it. Repository documents are for knowledge code cannot express: rejected alternatives and rationale, external constraints, external-system runbooks, stable domain/editorial vocabulary, and thin navigation maps.
+A plan is a PR body. An audit finding is an issue. Apply Regression guards below before adding enforcement. A convention with a recognizable source pattern belongs in lint or a static check after it earns a guard; a judgement call without one belongs in the nearest `AGENTS.md` or skill. A code fact belongs in the cheapest faithful test only when behavior is what proves the admitted guard. Repository documents are for knowledge code cannot express: rejected alternatives and rationale, external constraints, external-system runbooks, stable domain/editorial vocabulary, and thin navigation maps.
 
-Never preserve current symbols, signatures, enums, file lists, or implementation steps “for reference.” Split mixed documents: keep the non-derivable rationale and move load-bearing implementation facts into tests. Historical decisions remain immutable; supersede them with a new dated record and an explicit link.
+Never preserve current symbols, signatures, enums, file lists, or implementation steps “for reference.” Split mixed documents: keep the non-derivable rationale and move any admitted guard into the mechanism selected below rather than narrating the current implementation. Historical decisions remain immutable; supersede them with a new dated record and an explicit link.
 
 `knowledge-policy.config.ts` is the executable repository policy. The template default checks relative links and validates decision/runbook metadata when those directories are used, while allowing product forks to keep their own API guides, contribution documents, domain manuals, local READMEs, or stricter document classes. Change the configuration deliberately rather than bypassing the guard.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Build a guard when all three hold:
 2. The wrong path is still writable. When a type or API already makes it impossible, that is the guard.
 3. The correct pattern fits in one sentence. An unnameable rule cannot be enforced or explained.
 
-Every human-authored fix PR states its verdict as a plain, unindented line in the body. Bot-authored PRs such as Renovate updates are exempt:
+Every human-authored fix PR puts its verdict in plain text at the start of the body, immediately after an optional `Closes #N` line. Bot-authored PRs such as Renovate updates are exempt:
 
 ```text
 Regression guard: added <name>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Build a guard when all three hold:
 2. The wrong path is still writable. When a type or API already makes it impossible, that is the guard.
 3. The correct pattern fits in one sentence. An unnameable rule cannot be enforced or explained.
 
-Every human-authored fix PR puts its verdict in plain text at the start of the body, immediately after an optional `Closes #N` line. Bot-authored PRs such as Renovate updates are exempt:
+Every human-authored PR with a conventional `fix` title puts its verdict in plain text at the start of the body, immediately after an optional `Closes #N` line. Bot-authored PRs such as Renovate updates are exempt:
 
 ```text
 Regression guard: added <name>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Build a guard when all three hold:
 2. The wrong path is still writable. When a type or API already makes it impossible, that is the guard.
 3. The correct pattern fits in one sentence. An unnameable rule cannot be enforced or explained.
 
-Every fix PR states its verdict in the body, one line above the verification line:
+Every human-authored fix PR states its verdict as a plain, unindented line in the body. Bot-authored PRs such as Renovate updates are exempt:
 
 ```text
 Regression guard: added <name>
@@ -109,7 +109,7 @@ Pick the earliest mechanism that fires, not the most thorough one. A guard that 
 
 Guard a rendered detail (DOM ancestry, wrapper placement, CSS class, copy, cosmetic pixels, transition-timed styles) only when that exact property is a published user or platform contract.
 
-A finished guard fails on the buggy revision for the same causal reason, and its message names the correct pattern. When it does not, move one boundary outward or rewrite the message.
+A finished mechanical guard fails on the buggy revision for the same causal reason, and its message names the correct pattern. When it does not, move one boundary outward or rewrite the message. A written guard is finished when one sentence names both the triggering situation and the required pattern in the nearest `AGENTS.md` or applicable skill.
 
 ## Core commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,36 @@ Never preserve current symbols, signatures, enums, file lists, or implementation
 
 `knowledge-policy.config.ts` is the executable repository policy. The template default checks relative links and validates decision/runbook metadata when those directories are used, while allowing product forks to keep their own API guides, contribution documents, domain manuals, local READMEs, or stricter document classes. Change the configuration deliberately rather than bypassing the guard.
 
+## Regression guards
+
+A guard stops the next agent from repeating a mistake with fresh context. Fixing something does not earn one.
+
+Build a guard when all three hold:
+
+1. The correct path was not obvious: a wrong first instinct, required research, or a plausible-looking alternative that is subtly wrong.
+2. The wrong path is still writable. When a type or API already makes it impossible, that is the guard.
+3. The correct pattern fits in one sentence. An unnameable rule cannot be enforced or explained.
+
+Every fix PR states its verdict in the body, one line above the verification line:
+
+```text
+Regression guard: added <name>
+Regression guard: covered by <name>
+Regression guard: not warranted, <one-line reason>
+```
+
+Pick the earliest mechanism that fires, not the most thorough one. A guard that fires while the agent writes the line teaches the pattern; one that fires in CI reports a failure after the reasoning is already committed.
+
+1. Make it unexpressible: narrow the type, signature, schema, or API.
+2. Catch it while writing: an ESLint rule or PreToolUse hook, for any mistake with a recognizable source pattern. State the correct pattern and its reason in the message.
+3. Catch it before the push: a static check or build artifact guard.
+4. Prove the behavior: a test, when only the outcome separates right from wrong. Take the cheapest layer that fails for the same causal reason, from pure Vitest, `convex-test`, component, SvelteKit HTTP, artifact, and local Playwright through deployed HTTP and deployed Playwright.
+5. Write it down: an `AGENTS.md` line or a skill, for judgement calls with no mechanical signature. Weakest option, because it works only when read first.
+
+Guard a rendered detail (DOM ancestry, wrapper placement, CSS class, copy, cosmetic pixels, transition-timed styles) only when that exact property is a published user or platform contract.
+
+A finished guard fails on the buggy revision for the same causal reason, and its message names the correct pattern. When it does not, move one boundary outward or rewrite the message.
+
 ## Core commands
 
 - `bun run build` — production build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-%233fb950)](https://opensource.org/licenses/MIT)
 
 An open-source SvelteKit + Convex starter/reference application with auth, billing, admin, AI chat, email, and i18n wired end to end.<br>
-Recurring bug classes become ESLint rules, validators, and tests that keep your agents in check.
+Non-obvious recurring bug classes become the earliest guard that can catch them, including types, lint rules, static checks, focused tests, and targeted agent instructions.
 
 **Start on free tiers. Deploy to Cloudflare/Vercel, or your own Node server.**
 
@@ -15,7 +15,7 @@ Recurring bug classes become ESLint rules, validators, and tests that keep your 
 
 I kept rebuilding the same stack and pointing my agent at old repos to copy patterns I had already built, so I collected the best versions here: streaming AI chat with tool calling and file uploads, support chat with human handoff, auth, billing, admin features, emails, and i18n.
 
-The same mistakes also kept showing up across repos. In addition to giving agents good patterns to copy, the codebase enforces its own rules. Every recurring class of bug becomes an ESLint rule, banned-pattern check, test, or Convex validator. CI requires every fix PR to include a `Regression guard:` verdict. This makes the same defect harder to introduce twice.
+The same mistakes also kept showing up across repos. In addition to giving agents good patterns to copy, the codebase enforces its own rules. A recurring bug earns a guard only when the correct path was non-obvious and the mistake remains writable. CI requires every human-authored fix PR to include a `Regression guard:` verdict; bot PRs are exempt. The accepted guard fires at the earliest useful point, which can be a type, lint rule, static check, focused test, or targeted instruction.
 
 The stack is deliberately opinionated, following [Rich Harris's case](https://www.youtube.com/watch?v=SmHgtyym6OA&t=2388s) for smart defaults that fit well together.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Non-obvious recurring bug classes become the earliest guard that can catch them,
 
 I kept rebuilding the same stack and pointing my agent at old repos to copy patterns I had already built, so I collected the best versions here: streaming AI chat with tool calling and file uploads, support chat with human handoff, auth, billing, admin features, emails, and i18n.
 
-The same mistakes also kept showing up across repos. In addition to giving agents good patterns to copy, the codebase enforces its own rules. A recurring bug earns a guard only when the correct path was non-obvious and the mistake remains writable. CI requires every human-authored fix PR to include a `Regression guard:` verdict; bot PRs are exempt. The accepted guard fires at the earliest useful point, which can be a type, lint rule, static check, focused test, or targeted instruction.
+The same mistakes also kept showing up across repos. In addition to giving agents good patterns to copy, the codebase enforces its own rules. A recurring bug earns a guard only when the correct path was non-obvious and the mistake remains writable. CI requires every human-authored PR with a conventional `fix` title to include a `Regression guard:` verdict; bot PRs are exempt. The accepted guard fires at the earliest useful point, which can be a type, lint rule, static check, focused test, or targeted instruction.
 
 The stack is deliberately opinionated, following [Rich Harris's case](https://www.youtube.com/watch?v=SmHgtyym6OA&t=2388s) for smart defaults that fit well together.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,7 +8,7 @@ Repository docs contain only knowledge code cannot express:
 4. stable domain or editorial vocabulary;
 5. thin maps that route readers to authoritative code, tests, decisions, and runbooks.
 
-Plans belong in PR bodies. Audit findings belong in issues. Conventions belong in lint/static checks. Code facts and invariants belong in tests.
+Plans belong in PR bodies. Audit findings belong in issues. Apply the root Regression guards decision before adding enforcement. A convention with a recognizable source pattern belongs in lint or a static check after it earns a guard; a judgement call without one belongs in the nearest `AGENTS.md` or skill. A code fact belongs in the cheapest faithful test only when behavior is what proves the admitted guard.
 
 Do not preserve obsolete generated output, implementation snapshots, symbol catalogues, or current file lists “for reference.” If a document mixes durable rationale with current implementation, keep the rationale and replace the implementation narrative with links to authoritative entry points.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,4 +5,4 @@ This directory holds only knowledge the code cannot carry.
 - [`setup/`](./setup/) — runbooks for configuring external services such as Cloudflare, PostHog, and Tolgee.
 - [`recipes/`](./recipes/) — optional extension paths for template adopters. Durable rationale stays in prose; copyable implementation should be tested or pinned to a stable interface.
 
-Plans live in PR bodies, findings in issues, conventions in checks, and implementation facts in tests. See [`AGENTS.md`](./AGENTS.md) for the complete placement rule.
+Plans live in PR bodies and findings in issues. The root regression-guard decision determines whether a recurring mistake needs enforcement; [`AGENTS.md`](./AGENTS.md) maps an admitted guard to the earliest mechanism that can catch it.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -12,6 +12,7 @@ Every step here is charged to the whole repository. The suite runs `workers: 1` 
 
 ## How to write them
 
+- Justify the browser before writing the spec, in the PR body or a comment on the spec: `Cheaper layers rejected because: <the browser or deployed behavior they cannot reach>`.
 - Run `bun run test:e2e` after every E2E change.
 - Tests run against isolated deterministic ports and an isolated local Convex backend. Do not point them at a developer's cloud deployment.
 - Use the seeded test/admin flows and helpers rather than introducing production bypasses.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -5,6 +5,7 @@
 Every step here is charged to the whole repository. The suite runs `workers: 1` because it shares one preview Convex backend and the admin specs mutate shared rows, `E2E Tests` is a required check on `main`, and against a CF preview each Playwright step pays a round trip: measured in the traces at roughly 2s to resolve a locator and 3s to dispatch a click. What the suite spends is steps, so a spec costs whatever its interactions cost, however few tests it declares.
 
 - A test earns a place here when its failure needs a real browser **and** a deployed backend to appear at all: sign-up and sign-in, entitlement and payment, gates and redirects, prerender and preview-bypass paths, anything whose breakage would be silent in production.
+- A deployed failure that needs no browser earns a request-only spec here instead, driven by Playwright's `request` fixture: adapter output, response headers, edge caching, discovery documents. It is the cheaper form and the right one whenever no page has to open.
 - Whatever one layer can answer belongs to that layer. Component behaviour, CSS, copy, pure logic, and Convex function behaviour are cheaper and more precise as a unit test, a component test, or a lint rule.
 - "A unit test cannot reach it" is on its own no reason to spend a browser on it. Weigh what the defect costs a user against two to three seconds on every future merge. A one-pixel offset in a press state loses that trade; a silent authorization hole wins it.
 - Never assert sub-pixel geometry, computed styles read after a transition, or a row count that a later assertion then indexes. Each of those reads as a precise check and is really a race against layout, the animation clock, or a query that has not resolved yet.
@@ -12,7 +13,7 @@ Every step here is charged to the whole repository. The suite runs `workers: 1` 
 
 ## How to write them
 
-- Justify the browser before writing the spec, in the PR body or a comment on the spec: `Cheaper layers rejected because: <the browser or deployed behavior they cannot reach>`.
+- Justify the deployment before writing the spec, in the PR body or a comment on the spec: `Cheaper layers rejected because: <the browser or deployed behavior they cannot reach>`. A spec that opens a page also says why a request-only check cannot reach it.
 - Run `bun run test:e2e` after every E2E change.
 - Tests run against isolated deterministic ports and an isolated local Convex backend. Do not point them at a developer's cloud deployment.
 - Use the seeded test/admin flows and helpers rather than introducing production bypasses.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -6,14 +6,14 @@ All scripts must work on macOS, Linux, and Windows. Use TypeScript executed by B
 
 ## Validation
 
-`bun scripts/static-checks.ts <changed files...>` is the primary targeted validation command. Add regression guards at the closest executable layer:
+`bun scripts/static-checks.ts <changed files...>` is the primary targeted validation command.
 
-- source pattern or convention → ESLint/static check
-- pure behavior or configuration relationship → Vitest
-- public route or user flow → Playwright
-- generated/build artifact → build script plus artifact test
+Root `AGENTS.md` decides whether a fix earns a regression guard and which mechanism carries it. Two mappings are specific to this scope:
+
 - environment requirement → Varlock schema
-- security header → server hook/config plus response test
+- security header → server hook/config plus a response test
+
+Route content, configuration, and generated assets belong in Vitest or an artifact test. Playwright covers deployed response behavior and load-bearing user flows.
 
 Tests and checks should name the invariant, not mirror a current file list unless that file relationship is itself the contract.
 

--- a/scripts/check-regression-guard.test.ts
+++ b/scripts/check-regression-guard.test.ts
@@ -40,6 +40,10 @@ describe('checkRegressionGuard', () => {
 		'Regression guard: added <!-- hidden -->',
 		'Regression guard: added TODO',
 		'Regression guard: not warranted, TBD',
+		'Regression guard: added __TODO__',
+		'Regression guard: covered by _TBD_',
+		`Regression guard: added TO${String.fromCodePoint(0x034f)}DO`,
+		`Regression guard: added TO${String.fromCodePoint(7)}DO`,
 		'Regression guard: covered by ㅤ',
 		'Regression guard: added guard.test.ts ',
 		' Regression guard: added guard.test.ts'

--- a/scripts/check-regression-guard.test.ts
+++ b/scripts/check-regression-guard.test.ts
@@ -36,12 +36,12 @@ describe('checkRegressionGuard', () => {
 
 	it.each([
 		'Regression guard: added `<name>`',
-		'Regression guard: added [](https://example.com/guard.test.ts)',
-		'Regression guard: added <!-- hidden -->',
+		'Regression guard: added name',
+		'Regression guard: not warranted, one-line reason',
 		'Regression guard: added TODO',
 		'Regression guard: not warranted, TBD',
-		'Regression guard: added __TODO__',
-		'Regression guard: covered by _TBD_',
+		'Regression guard: added ＴＯＤＯ',
+		'Regression guard: added TÓDO',
 		`Regression guard: added TO${String.fromCodePoint(0x034f)}DO`,
 		`Regression guard: added TO${String.fromCodePoint(7)}DO`,
 		'Regression guard: covered by ㅤ',
@@ -49,6 +49,17 @@ describe('checkRegressionGuard', () => {
 		' Regression guard: added guard.test.ts'
 	])('rejects markup, placeholders, invisible text, and whitespace: %s', (body) => {
 		expect(verdict(body)).toMatchObject({ required: true, valid: false });
+	});
+
+	it.each([
+		'Regression guard: added src/lib/convex/_generated/api.test.ts',
+		'Regression guard: added src/routes/[[lang]]/guard.test.ts',
+		'Regression guard: not warranted, auth and billing share A & B',
+		'Regression guard: not warranted, the type guarantees count < limit',
+		'Regression guard: covered by eslint/no-todo-comments',
+		'Regression guard: added TODO_test'
+	])('accepts practical names and reasons: %s', (body) => {
+		expect(verdict(body)).toMatchObject({ required: true, valid: true });
 	});
 
 	it.each(['fix: Correct callback', 'fix!: Correct callback', 'fix(auth)!: Correct callback'])(

--- a/scripts/check-regression-guard.test.ts
+++ b/scripts/check-regression-guard.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { checkRegressionGuard } from './check-regression-guard';
+
+const FIX = 'fix(auth): Correct callback';
+const AUTHOR = 'stickerdaniel';
+
+function verdict(body: string, title = FIX, author = AUTHOR) {
+	return checkRegressionGuard({ title, body, author });
+}
+
+describe('checkRegressionGuard', () => {
+	it.each([
+		'Regression guard: added scripts/auth-callback.test.ts',
+		'Regression guard: covered by eslint/no-unsafe-callback',
+		'Regression guard: not warranted, the callback type excludes the old value'
+	])('accepts a plain verdict as the first substantive line: %s', (body) => {
+		expect(verdict(body)).toMatchObject({ required: true, valid: true });
+	});
+
+	it('allows one issue-closing line before the verdict', () => {
+		expect(
+			verdict('Closes #832\n\nRegression guard: added scripts/source-safety.test.ts')
+		).toMatchObject({ valid: true });
+	});
+
+	it.each([
+		'',
+		'Problem first.\n\nRegression guard: added guard.test.ts',
+		'```text\nRegression guard: added guard.test.ts\n```',
+		'<!--\nRegression guard: added guard.test.ts\n-->',
+		'<details>\nRegression guard: added guard.test.ts\n</details>',
+		'Closes #832\n\nProblem first.\nRegression guard: added guard.test.ts'
+	])('rejects a missing or displaced verdict: %s', (body) => {
+		expect(verdict(body)).toMatchObject({ required: true, valid: false });
+	});
+
+	it.each([
+		'Regression guard: added `<name>`',
+		'Regression guard: added [](https://example.com/guard.test.ts)',
+		'Regression guard: added <!-- hidden -->',
+		'Regression guard: added TODO',
+		'Regression guard: not warranted, TBD',
+		'Regression guard: covered by ㅤ',
+		'Regression guard: added guard.test.ts ',
+		' Regression guard: added guard.test.ts'
+	])('rejects markup, placeholders, invisible text, and whitespace: %s', (body) => {
+		expect(verdict(body)).toMatchObject({ required: true, valid: false });
+	});
+
+	it.each(['fix: Correct callback', 'fix!: Correct callback', 'fix(auth)!: Correct callback'])(
+		'requires the conventional fix title %s',
+		(title) => {
+			expect(verdict('Regression guard: added guard.test.ts', title)).toMatchObject({
+				required: true,
+				valid: true
+			});
+		}
+	);
+
+	it.each(['fixtures(auth): Refresh samples', 'Fix(auth): Correct callback', 'fixup docs'])(
+		'exempts the non-fix title %s',
+		(title) => {
+			expect(verdict('', title)).toMatchObject({ required: false, valid: true });
+		}
+	);
+
+	it.each(['renovate[bot]', 'app/renovate'])('exempts the bot author %s', (author) => {
+		expect(verdict('', FIX, author)).toMatchObject({ required: false, valid: true });
+	});
+
+	it('normalizes CRLF bodies', () => {
+		expect(verdict('Closes #832\r\n\r\nRegression guard: added guard.test.ts\r\n')).toMatchObject({
+			valid: true
+		});
+	});
+});

--- a/scripts/check-regression-guard.ts
+++ b/scripts/check-regression-guard.ts
@@ -13,9 +13,9 @@ export interface RegressionGuardResult {
 const FIX_TITLE = /^fix(?:\([^)]+\))?!?: /;
 const ISSUE_CLOSURE = /^Closes #\d+$/;
 const VERDICT = /^Regression guard: (?:(added|covered by) (.+)|not warranted, (.+))$/;
-const UNSAFE_MARKDOWN = /[<>&[\]*~`\\]/;
-const PLACEHOLDER = /\b(?:TODO|TBD|FIXME)\b/i;
-const INVISIBLE_FORMAT = /\p{Cf}/u;
+const UNSAFE_MARKDOWN = /[<>&[\]*_~`\\]/;
+const PLACEHOLDER = /(?:^|[^A-Za-z0-9])(?:TODO|TBD|FIXME)(?:$|[^A-Za-z0-9])/i;
+const INVISIBLE = /[\p{Cc}\p{Cf}\p{Default_Ignorable_Code_Point}]/u;
 
 function firstVerdictLine(body: string): string | undefined {
 	const lines = body.replaceAll('\r\n', '\n').replaceAll('\r', '\n').split('\n');
@@ -50,7 +50,7 @@ export function checkRegressionGuard(input: RegressionGuardInput): RegressionGua
 		!/[A-Za-z0-9]/.test(payload) ||
 		UNSAFE_MARKDOWN.test(payload) ||
 		PLACEHOLDER.test(payload) ||
-		INVISIBLE_FORMAT.test(payload)
+		INVISIBLE.test(payload)
 	) {
 		return {
 			required: true,

--- a/scripts/check-regression-guard.ts
+++ b/scripts/check-regression-guard.ts
@@ -1,0 +1,75 @@
+export interface RegressionGuardInput {
+	title: string;
+	body: string;
+	author: string;
+}
+
+export interface RegressionGuardResult {
+	required: boolean;
+	valid: boolean;
+	message: string;
+}
+
+const FIX_TITLE = /^fix(?:\([^)]+\))?!?: /;
+const ISSUE_CLOSURE = /^Closes #\d+$/;
+const VERDICT = /^Regression guard: (?:(added|covered by) (.+)|not warranted, (.+))$/;
+const UNSAFE_MARKDOWN = /[<>&[\]*~`\\]/;
+const PLACEHOLDER = /\b(?:TODO|TBD|FIXME)\b/i;
+const INVISIBLE_FORMAT = /\p{Cf}/u;
+
+function firstVerdictLine(body: string): string | undefined {
+	const lines = body.replaceAll('\r\n', '\n').replaceAll('\r', '\n').split('\n');
+	let index = lines.findIndex((line) => line.trim() !== '');
+	if (index === -1) return undefined;
+
+	if (ISSUE_CLOSURE.test(lines[index]!)) {
+		index += 1;
+		while (index < lines.length && lines[index]!.trim() === '') index += 1;
+	}
+	return lines[index];
+}
+
+export function checkRegressionGuard(input: RegressionGuardInput): RegressionGuardResult {
+	if (input.author.endsWith('[bot]') || input.author.startsWith('app/')) {
+		return { required: false, valid: true, message: 'Bot-authored PR; verdict not required.' };
+	}
+	if (!FIX_TITLE.test(input.title)) {
+		return {
+			required: false,
+			valid: true,
+			message: 'Not a conventional fix PR; verdict not required.'
+		};
+	}
+
+	const line = firstVerdictLine(input.body);
+	const match = line ? VERDICT.exec(line) : null;
+	const payload = match ? (match[2] ?? match[3] ?? '') : '';
+	if (
+		!match ||
+		payload !== payload.trim() ||
+		!/[A-Za-z0-9]/.test(payload) ||
+		UNSAFE_MARKDOWN.test(payload) ||
+		PLACEHOLDER.test(payload) ||
+		INVISIBLE_FORMAT.test(payload)
+	) {
+		return {
+			required: true,
+			valid: false,
+			message:
+				'Put a plain-text `Regression guard: added <name>`, `covered by <name>`, or `not warranted, <reason>` verdict at the start of the body, immediately after an optional `Closes #N` line, and replace the placeholder.'
+		};
+	}
+
+	return { required: true, valid: true, message: 'Regression guard verdict found.' };
+}
+
+if (import.meta.main) {
+	const result = checkRegressionGuard({
+		title: process.env.PR_TITLE ?? '',
+		body: process.env.PR_BODY ?? '',
+		author: process.env.PR_AUTHOR ?? ''
+	});
+	if (!result.valid) console.error(`::error::${result.message}`);
+	else console.log(result.message);
+	process.exit(result.valid ? 0 : 1);
+}

--- a/scripts/check-regression-guard.ts
+++ b/scripts/check-regression-guard.ts
@@ -13,8 +13,7 @@ export interface RegressionGuardResult {
 const FIX_TITLE = /^fix(?:\([^)]+\))?!?: /;
 const ISSUE_CLOSURE = /^Closes #\d+$/;
 const VERDICT = /^Regression guard: (?:(added|covered by) (.+)|not warranted, (.+))$/;
-const UNSAFE_MARKDOWN = /[<>&[\]*_~`\\]/;
-const PLACEHOLDER = /(?:^|[^A-Za-z0-9])(?:TODO|TBD|FIXME)(?:$|[^A-Za-z0-9])/i;
+const PLACEHOLDERS = new Set(['name', 'one-line reason', 'reason', 'todo', 'tbd', 'fixme']);
 const INVISIBLE = /[\p{Cc}\p{Cf}\p{Default_Ignorable_Code_Point}]/u;
 
 function firstVerdictLine(body: string): string | undefined {
@@ -44,12 +43,17 @@ export function checkRegressionGuard(input: RegressionGuardInput): RegressionGua
 	const line = firstVerdictLine(input.body);
 	const match = line ? VERDICT.exec(line) : null;
 	const payload = match ? (match[2] ?? match[3] ?? '') : '';
+	const normalizedPayload = payload
+		.normalize('NFKC')
+		.normalize('NFD')
+		.replace(/\p{M}/gu, '')
+		.toLowerCase();
+	const placeholderCandidate = normalizedPayload.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
 	if (
 		!match ||
 		payload !== payload.trim() ||
 		!/[A-Za-z0-9]/.test(payload) ||
-		UNSAFE_MARKDOWN.test(payload) ||
-		PLACEHOLDER.test(payload) ||
+		PLACEHOLDERS.has(placeholderCandidate) ||
 		INVISIBLE.test(payload)
 	) {
 		return {

--- a/src/lib/convex/AGENTS.md
+++ b/src/lib/convex/AGENTS.md
@@ -27,7 +27,7 @@ Authorization and tenant-boundary policy belongs to the backend layer, never to 
 
 `convex-test` is a mock. Once a release matching the pinned `convex` version is adopted, with the local Better Auth component registered, it can test function behavior such as application-driven rollback and atomic scheduling. It cannot prove platform retry, execution, or hosted-state guarantees. A hand-written store or scheduler spy has the same limit.
 
-The local backend runs the real backend code and covers transaction limits, cron activation, and client subscriptions when kept current. Hosted retry behavior, plan quotas, search ranking, and index readiness require a preview or production deployment with the relevant state and constraints.
+The local backend runs the real backend code and covers transaction limits, cron activation, client subscriptions, search ranking, and index backfill/readiness against local state when kept current. Hosted retry behavior, plan quotas, cloud durability, and behavior that depends on production data require a preview or production deployment with the relevant state and constraints.
 
 A hand-written provider payload, context double, or auth session is a claim about that dependency. Derive it from a measured sample or an official fixture.
 
@@ -36,7 +36,7 @@ A hand-written provider payload, context double, or auth session is a claim abou
 - Scheduling from mutations is atomic; scheduled mutations execute exactly once with platform retries for internal failures.
 - Scheduling from actions is not atomic, and actions execute at most once.
 - `@convex-dev/resend` handles durable retry and idempotency; permanent send errors may be caught and reported.
-- `@useautumn/convex` returns an error/non-data result on non-2xx and throws on network failure. State-changing entitlement gates fail closed when the answer is indeterminate.
+- `@useautumn/convex` returns `{ data: null, error }` for non-2xx and transport failures. State-changing entitlement gates fail closed whenever `error` is present or `data` is missing or indeterminate.
 - Convex components own isolated storage namespaces. Access component files through component APIs, not application `ctx.storage`.
 
 When an intentional bounded `.collect()`, sequential mutation, or other normally flagged pattern is correct, add a short inline reason at the call site.

--- a/src/lib/convex/AGENTS.md
+++ b/src/lib/convex/AGENTS.md
@@ -25,9 +25,9 @@ Validators and generated types carry the mechanical API boundary, so a test that
 
 Authorization and tenant-boundary policy belongs to the backend layer, never to a browser test. A pure test over an extracted rule or a hand-written context double is sufficient only when that rule is the behavior under test.
 
-`convex-test` is a mock. Once a release matching the pinned `convex` version is adopted, with the local Better Auth component registered, it can test function behavior but cannot prove platform retry, execution, or hosted-state guarantees. A hand-written store or scheduler spy has the same limit.
+`convex-test` is a mock. Once a release matching the pinned `convex` version is adopted, with the local Better Auth component registered, it can test function behavior such as application-driven rollback and atomic scheduling. It cannot prove platform retry, execution, or hosted-state guarantees. A hand-written store or scheduler spy has the same limit.
 
-Transaction rollback and atomic scheduling require the local backend or a preview deployment. Hosted retry behavior, production limits, real cron activation, search ranking, live subscriptions, and index readiness require a preview or production deployment with the relevant state and plan constraints; a local backend cannot reproduce those hosted conditions.
+The local backend runs the real backend code and covers transaction limits, cron activation, and client subscriptions when kept current. Hosted retry behavior, plan quotas, search ranking, and index readiness require a preview or production deployment with the relevant state and constraints.
 
 A hand-written provider payload, context double, or auth session is a claim about that dependency. Derive it from a measured sample or an official fixture.
 

--- a/src/lib/convex/AGENTS.md
+++ b/src/lib/convex/AGENTS.md
@@ -21,11 +21,13 @@ The public E2E helper mutations in `tests.ts` are safe only while `AUTH_E2E_TEST
 
 ## Where a backend guard belongs
 
-Validators and generated types carry the mechanical API boundary, so a test that re-proves them adds nothing. `convex-test` carries the authorization, tenant-boundary, transaction, index-semantics, and scheduler matrix; browser tests never repeat those combinations.
+Validators and generated types carry the mechanical API boundary, so a test that re-proves them adds nothing.
 
-Escalate past `convex-test` when the defect depends on behavior it simulates rather than reproduces: production limits, real cron activation, search ranking, live subscriptions, or hosted index readiness. Those need the local backend or a preview deployment.
+Authorization, tenant-boundary, transaction, and scheduler behavior belongs to the backend layer, never to a browser test. This repository currently reaches that layer through pure tests over extracted rules plus hand-written context doubles; `convex-test` is the intended home once a release matching the pinned `convex` version is adopted, which is its own change with a representative test and the local Better Auth component registered.
 
-A hand-written provider payload or auth session is a claim about that dependency. Derive it from a measured sample or an official fixture.
+Whichever layer holds it, a defect that depends on production limits, real cron activation, search ranking, live subscriptions, or hosted index readiness needs the local backend or a preview deployment, because those are simulated rather than reproduced.
+
+A hand-written provider payload, context double, or auth session is a claim about that dependency. Derive it from a measured sample or an official fixture.
 
 ## Platform and durability rules
 

--- a/src/lib/convex/AGENTS.md
+++ b/src/lib/convex/AGENTS.md
@@ -25,9 +25,9 @@ Validators and generated types carry the mechanical API boundary, so a test that
 
 Authorization and tenant-boundary policy belongs to the backend layer, never to a browser test. A pure test over an extracted rule or a hand-written context double is sufficient only when that rule is the behavior under test.
 
-Transaction rollback, atomic scheduling, retry, and execution guarantees require a real Convex runtime. Use `convex-test` once a release matching the pinned `convex` version is adopted, with the local Better Auth component registered; until then, use the local backend or a preview deployment. A hand-written store or scheduler spy cannot claim coverage for those guarantees.
+`convex-test` is a mock. Once a release matching the pinned `convex` version is adopted, with the local Better Auth component registered, it can test function behavior but cannot prove platform retry, execution, or hosted-state guarantees. A hand-written store or scheduler spy has the same limit.
 
-Production limits, real cron activation, search ranking, live subscriptions, and hosted index readiness likewise need the local backend or a preview deployment, because lighter layers simulate them.
+Transaction rollback and atomic scheduling require the local backend or a preview deployment. Hosted retry behavior, production limits, real cron activation, search ranking, live subscriptions, and index readiness require a preview or production deployment with the relevant state and plan constraints; a local backend cannot reproduce those hosted conditions.
 
 A hand-written provider payload, context double, or auth session is a claim about that dependency. Derive it from a measured sample or an official fixture.
 

--- a/src/lib/convex/AGENTS.md
+++ b/src/lib/convex/AGENTS.md
@@ -19,6 +19,14 @@ Use the local Better Auth component. Derive identity server-side; never authoriz
 
 The public E2E helper mutations in `tests.ts` are safe only while `AUTH_E2E_TEST_SECRET` is absent from production. Never configure that variable in the production Convex environment.
 
+## Where a backend guard belongs
+
+Validators and generated types carry the mechanical API boundary, so a test that re-proves them adds nothing. `convex-test` carries the authorization, tenant-boundary, transaction, index-semantics, and scheduler matrix; browser tests never repeat those combinations.
+
+Escalate past `convex-test` when the defect depends on behavior it simulates rather than reproduces: production limits, real cron activation, search ranking, live subscriptions, or hosted index readiness. Those need the local backend or a preview deployment.
+
+A hand-written provider payload or auth session is a claim about that dependency. Derive it from a measured sample or an official fixture.
+
 ## Platform and durability rules
 
 - Scheduling from mutations is atomic; scheduled mutations execute exactly once with platform retries for internal failures.

--- a/src/lib/convex/AGENTS.md
+++ b/src/lib/convex/AGENTS.md
@@ -23,9 +23,11 @@ The public E2E helper mutations in `tests.ts` are safe only while `AUTH_E2E_TEST
 
 Validators and generated types carry the mechanical API boundary, so a test that re-proves them adds nothing.
 
-Authorization, tenant-boundary, transaction, and scheduler behavior belongs to the backend layer, never to a browser test. This repository currently reaches that layer through pure tests over extracted rules plus hand-written context doubles; `convex-test` is the intended home once a release matching the pinned `convex` version is adopted, which is its own change with a representative test and the local Better Auth component registered.
+Authorization and tenant-boundary policy belongs to the backend layer, never to a browser test. A pure test over an extracted rule or a hand-written context double is sufficient only when that rule is the behavior under test.
 
-Whichever layer holds it, a defect that depends on production limits, real cron activation, search ranking, live subscriptions, or hosted index readiness needs the local backend or a preview deployment, because those are simulated rather than reproduced.
+Transaction rollback, atomic scheduling, retry, and execution guarantees require a real Convex runtime. Use `convex-test` once a release matching the pinned `convex` version is adopted, with the local Better Auth component registered; until then, use the local backend or a preview deployment. A hand-written store or scheduler spy cannot claim coverage for those guarantees.
+
+Production limits, real cron activation, search ranking, live subscriptions, and hosted index readiness likewise need the local backend or a preview deployment, because lighter layers simulate them.
 
 A hand-written provider payload, context double, or auth session is a claim about that dependency. Derive it from a measured sample or an official fixture.
 


### PR DESCRIPTION
The repository said every code invariant belonged in a test, so simple fixes kept buying permanent coverage at the most expensive layer. The removed sign-in badge spec reached 135 lines of bounding boxes, pixel tolerances, and animation waits. Playwright accounts for about 8% of listed cases and roughly three quarters of observed test-step wall time.

A guard now starts with a narrower question: would a fresh-context agent repeat a non-obvious mistake that remains writable? Root `AGENTS.md` then chooses the earliest mechanism that can catch it, with tests reserved for behavior that cheaper mechanisms cannot prove. Scoped Svelte, Convex, script, and E2E guidance maps those tests to the cheapest faithful layer. CI accepts only substantive plain-text verdicts on human-authored conventional fix PRs; bot PRs stay exempt for their whole lifecycle.

Verified with the workflow matcher matrix and `bun scripts/static-checks.ts` over all changed files.
