### PR TITLE
fix(lint): Scan source for control bytes before checkers run

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -39,7 +39,7 @@
 			"args": ["run", "static-checks:staged"],
 			"group": "test",
 			"problemMatcher": ["$eslint-compact", "$tsc"],
-			"detail": "Run pre-commit checks on staged files only",
+			"detail": "Scan source safety across the tree, then run staged pre-commit checks",
 			"presentation": {
 				"clear": true
 			}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ The command fetches and branches from remote trunk by default. Worktrees live be
 
 Never use `EnterWorktree`. Prefix every later action with the absolute worktree path because command working directories do not persist. Before committing, run `git branch` and confirm the worktree branch. After a merge, run `bun run worktree:prune`; it safely removes confirmed-merged worktrees and branches and fast-forwards a clean local trunk.
 
-The pre-commit hook intentionally runs fast staged lint only, so commit freely while iterating. Immediately before every push, including after a rebase or CI fix, run `bun scripts/static-checks.ts <all changed files...>` and do not push unless the full lint-and-types check passes.
+The pre-commit hook first runs source safety over the working tree, then fast staged lint, so commit freely while iterating. An unrelated or Git-ignored text file can fail that first scan. Immediately before every push, including after a rebase or CI fix, run `bun scripts/static-checks.ts <all changed files...>` and do not push unless the full lint-and-types check passes.
 
 For reviews and audits, fetch and inspect `origin/main` rather than the shared main checkout, which may intentionally lag behind. Revalidate every finding against that baseline before reporting or changing code.
 
@@ -116,8 +116,8 @@ A finished mechanical guard fails on the buggy revision for the same causal reas
 - `bun run build` — production build
 - `bun run dev` — local Vite + embedded Convex backend
 - `bun run dev:cloud` — Vite + cloud Convex backend
-- `bun scripts/static-checks.ts <changed files...>` — required after implementation
-- `bun scripts/static-checks.ts --scope types` — required once before final handoff or PR for changes to JS, TS, Svelte, Convex, email templates, or Autumn config; pre-commit intentionally runs staged lint only
+- `bun scripts/static-checks.ts <changed files...>` — required after implementation; source safety scans the working tree first, then the remaining checks use the named files
+- `bun scripts/static-checks.ts --scope types` — required once before final handoff or PR for changes to JS, TS, Svelte, Convex, email templates, or Autumn config; pre-commit runs working-tree source safety plus staged lint
 - `bun run test:unit` — Vitest suite
 - `bun run test:e2e` — Playwright suite; required after E2E changes
 - `bun run test` — complete test suite

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Each worktree gets its own isolated Convex backend, port, and auth secret via [c
 
 ### Pre-Commit Hooks
 
-Every commit is checked automatically. `varlock scan` looks for leaked secrets, then `static-checks:staged` runs spell checking, banned pattern detection (catches deprecated Tailwind tokens, bare `animate-spin`, and similar issues), Prettier, ESLint, and oxlint on staged files only.
+Every commit is checked automatically. `static-checks:staged` first scans the working tree for unsafe source characters, then runs spell checking, banned pattern detection (catches deprecated Tailwind tokens, bare `animate-spin`, and similar issues), Prettier, ESLint, and oxlint on staged files. `varlock scan` checks the staged changes for leaked secrets afterwards.
 
 ### Dead Code Detection
 

--- a/eslint/control-character-policy.js
+++ b/eslint/control-character-policy.js
@@ -1,0 +1,152 @@
+/**
+ * The closed set of characters this repository refuses to store as raw bytes,
+ * and the two operations every consumer of that set needs.
+ *
+ * Three consumers share it and must not drift apart: the `no-literal-control-char`
+ * ESLint rule, the Svelte parser wrapper that sanitizes a fatal parser message, and
+ * the source-safety preflight in `scripts/static-checks.ts`. A second copy of the
+ * ranges is how one of them ends up accepting a character the others reject.
+ *
+ * The set is spelled out rather than derived from Unicode properties, so widening
+ * it is a visible edit in review and a Unicode revision cannot do it silently.
+ */
+
+// Tab, line feed and carriage return are what source is made of. Flagging them
+// would flag every file, and a check that noisy gets switched off the same day.
+const STRUCTURAL = new Set([0x09, 0x0a, 0x0d]);
+
+/** @typedef {'C0 control' | 'DEL' | 'C1 control' | 'bidirectional formatting' | 'line separator'} CharacterCategory */
+/** @typedef {{ codepoint: string, category: CharacterCategory, escape: string }} CharacterData */
+/** @typedef {{ line: number, column: number, data: CharacterData }} SourceFinding */
+
+// Every character Unicode gives the Bidi_Control property: the marks (U+061C,
+// U+200E, U+200F) set a run's direction, the embeddings and overrides
+// (U+202A-U+202E) and the isolates (U+2066-U+2069) reorder it.
+const BIDI = new Set([
+	0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069
+]);
+
+/** @param {number} code @returns {CharacterCategory | null} */
+function baseCategory(code) {
+	if (code < 0x20) return 'C0 control';
+	if (code === 0x7f) return 'DEL';
+	if (code >= 0x80 && code <= 0x9f) return 'C1 control';
+	return BIDI.has(code) ? 'bidirectional formatting' : null;
+}
+
+/** The category a banned source codepoint belongs to, or null when it is legal. */
+/** @param {number} code @returns {CharacterCategory | null} */
+export function category(code) {
+	return STRUCTURAL.has(code) ? null : baseCategory(code);
+}
+
+/**
+ * A diagnostic field cannot treat source structure as structure of its own.
+ * Newline, carriage return and tab are legal between source tokens; inside a path
+ * they split, overwrite or indent the terminal diagnostic that names that path.
+ * JavaScript's two Unicode line separators have the same problem there.
+ */
+/** @param {number} code @returns {CharacterCategory | null} */
+export function diagnosticCategory(code) {
+	if (code === 0x2028 || code === 0x2029) return 'line separator';
+	return baseCategory(code);
+}
+
+/** The three ways a finding names its character, none of which is the character. */
+/** @param {number} code @param {CharacterCategory} kind @returns {CharacterData} */
+export function dataFor(code, kind) {
+	const hex = code.toString(16).padStart(4, '0').toUpperCase();
+	return { codepoint: `U+${hex}`, category: kind, escape: `\\u${hex}` };
+}
+
+/**
+ * Incremental source scanner. The deferred CR keeps CRLF correct when a stream splits
+ * the pair across chunks; columns remain UTF-16 code units, which is ESLint's model.
+ */
+/** @param {(finding: SourceFinding) => void} onFinding */
+export function createLiteralControlCharacterScanner(onFinding) {
+	let line = 1;
+	let column = 0;
+	let pendingCarriageReturn = false;
+
+	return {
+		/** @param {string} text */
+		write(text) {
+			for (let index = 0; index < text.length; index++) {
+				const code = text.charCodeAt(index);
+				if (pendingCarriageReturn) {
+					line++;
+					column = 0;
+					pendingCarriageReturn = false;
+					if (code === 0x0a) continue;
+				}
+				if (code === 0x0d) {
+					pendingCarriageReturn = true;
+					continue;
+				}
+				if (code === 0x0a || code === 0x2028 || code === 0x2029) {
+					line++;
+					column = 0;
+					continue;
+				}
+				const kind = category(code);
+				if (kind !== null) onFinding({ line, column, data: dataFor(code, kind) });
+				column++;
+			}
+		},
+		end() {
+			if (!pendingCarriageReturn) return;
+			line++;
+			column = 0;
+			pendingCarriageReturn = false;
+		}
+	};
+}
+
+/** Every banned character and its ESLint location in the supplied source. */
+/** @param {string} text @returns {SourceFinding[]} */
+export function findLiteralControlCharacters(text) {
+	/** @type {SourceFinding[]} */
+	const findings = [];
+	const scanner = createLiteralControlCharacterScanner((finding) => findings.push(finding));
+	scanner.write(text);
+	scanner.end();
+	return findings;
+}
+
+/** Every character that is unsafe inside one diagnostic field. */
+/** @param {string} text @returns {{ index: number, data: CharacterData }[]} */
+export function findDiagnosticControlCharacters(text) {
+	/** @type {{ index: number, data: CharacterData }[]} */
+	const findings = [];
+	for (let index = 0; index < text.length; index++) {
+		const code = text.charCodeAt(index);
+		const kind = diagnosticCategory(code);
+		if (kind !== null) findings.push({ index, data: dataFor(code, kind) });
+	}
+	return findings;
+}
+
+/** Make one filename, token or source excerpt safe to place on a terminal line. */
+/** @param {string} text @returns {string} */
+export function sanitizeDiagnosticField(text) {
+	let safe = '';
+	for (let index = 0; index < text.length; index++) {
+		const code = text.charCodeAt(index);
+		const kind = diagnosticCategory(code);
+		safe += kind === null ? text[index] : dataFor(code, kind).codepoint;
+	}
+	return safe;
+}
+
+/** Remove banned characters from diagnostic prose before a formatter sees it. */
+/** @param {string} text @returns {string} */
+export function sanitizeDiagnosticText(text) {
+	let safe = '';
+	for (let index = 0; index < text.length; index++) {
+		const code = text.charCodeAt(index);
+		const kind = category(code);
+		safe += kind === null ? text[index] : dataFor(code, kind).codepoint;
+	}
+	return safe;
+}

--- a/eslint/parsers/safe-svelte-parser.js
+++ b/eslint/parsers/safe-svelte-parser.js
@@ -1,5 +1,5 @@
 import * as svelteParser from 'svelte-eslint-parser';
-import { sanitizeDiagnosticText } from '../rules/no-literal-control-char.js';
+import { sanitizeDiagnosticText } from '../control-character-policy.js';
 
 /**
  * Keep parser failures safe for terminal and CI output.

--- a/eslint/rules/no-literal-control-char.js
+++ b/eslint/rules/no-literal-control-char.js
@@ -25,6 +25,11 @@
  * the line would show the reader nothing, and an escape sequence pasted into a
  * terminal reprograms it.
  *
+ * This rule is the editor-facing half of the policy. It sees a file only once a
+ * parser has accepted it and only for the extensions ESLint is configured for, so
+ * `scripts/source-safety.ts` runs the same closed set over the whole repository
+ * before any checker starts. Both read `../control-character-policy.js`.
+ *
  * The example is described instead of written out. Spelling the byte here would
  * put the character this rule bans into the rule that bans it. The first run over
  * the repository found exactly that in this file.
@@ -33,74 +38,10 @@
  * Good: the same separator written as the six characters of a unicode escape.
  */
 
-// Tab, line feed and carriage return are what source is made of. Flagging them
-// would flag every file, and a check that noisy gets switched off the same day.
-const STRUCTURAL = new Set([0x09, 0x0a, 0x0d]);
-
-// Every character Unicode gives the Bidi_Control property: the marks (U+061C,
-// U+200E, U+200F) set a run's direction, the embeddings and overrides
-// (U+202A-U+202E) and the isolates (U+2066-U+2069) reorder it. Spelled out instead
-// of matched with `\p{Bidi_Control}`, so adding a member is a visible edit and a
-// Unicode revision cannot silently widen what this rule rejects.
-const BIDI = new Set([
-	0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069
-]);
+import { findLiteralControlCharacters } from '../control-character-policy.js';
 
 const MESSAGE =
 	'{{codepoint}} ({{category}}) is written as the character itself, so it is invisible in editors, diffs and text search. Remove it or replace it with visible whitespace. If it belongs inside a string or template literal, write {{escape}}.';
-
-/** The category a banned codepoint belongs to, or null when it is legal. */
-function category(code) {
-	if (STRUCTURAL.has(code)) return null;
-	if (code < 0x20) return 'C0 control';
-	if (code === 0x7f) return 'DEL';
-	if (code >= 0x80 && code <= 0x9f) return 'C1 control';
-	return BIDI.has(code) ? 'bidirectional formatting' : null;
-}
-
-function dataFor(code, kind) {
-	const hex = code.toString(16).padStart(4, '0').toUpperCase();
-	return { codepoint: `U+${hex}`, category: kind, escape: `\\u${hex}` };
-}
-
-/** Every banned character and its ESLint location in the supplied source. */
-export function findLiteralControlCharacters(text) {
-	const findings = [];
-	let line = 1;
-	let column = 0;
-	for (let index = 0; index < text.length; index++) {
-		const code = text.charCodeAt(index);
-		// ESLint counts four line terminators. CR is one of them, so a CRLF pair
-		// advances once when the following LF is processed.
-		if (code === 0x0d) {
-			if (text.charCodeAt(index + 1) !== 0x0a) {
-				line++;
-				column = 0;
-			}
-			continue;
-		}
-		if (code === 0x0a || code === 0x2028 || code === 0x2029) {
-			line++;
-			column = 0;
-			continue;
-		}
-		const kind = category(code);
-		if (kind !== null) findings.push({ line, column, data: dataFor(code, kind) });
-		column++;
-	}
-	return findings;
-}
-
-/** Remove banned characters from diagnostic prose before a formatter sees it. */
-export function sanitizeDiagnosticText(text) {
-	let safe = '';
-	for (let index = 0; index < text.length; index++) {
-		const code = text.charCodeAt(index);
-		const kind = category(code);
-		safe += kind === null ? text[index] : dataFor(code, kind).codepoint;
-	}
-	return safe;
-}
 
 export default {
 	meta: {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"dev:cloud": "bun-tasks dev:frontend ::: dev:backend:cloud",
 		"dev:test": "VARLOCK_ENV=test bun scripts/dev-test.ts",
 		"generate": "bun scripts/generate-convex.ts",
-		"postinstall": "bun svelte-kit sync && varlock codegen && varlock codegen --path .env-convex.schema && bun run build:emails",
+		"postinstall": "bun run source:safety && bun svelte-kit sync && varlock codegen && varlock codegen --path .env-convex.schema && bun run build:emails",
 		"prebuild": "bun run build:emails",
 		"build": "bun scripts/build.ts",
 		"postbuild": "bun scripts/patch-cf-worker.ts",
@@ -25,7 +25,7 @@
 		"check:watch": "bun svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"check:convex": "tsc -p src/lib/convex/tsconfig.json --noEmit",
 		"check:convex-compat": "bun scripts/convex-consumer-compat.ts",
-		"format": "prettier --write .",
+		"format": "bun run source:safety && prettier --write .",
 		"lint": "eslint . --cache --concurrency auto && oxlint",
 		"lint:convex": "oxlint",
 		"knip": "knip",
@@ -35,7 +35,7 @@
 		"test:e2e": "VARLOCK_ENV=test playwright test",
 		"test:e2e:headed": "VARLOCK_ENV=test playwright test --headed",
 		"test": "bun run test:e2e && bun run test:unit",
-		"test:unit": "vitest --run --reporter=verbose --passWithNoTests",
+		"test:unit": "bun run source:safety && vitest --run --reporter=verbose --passWithNoTests",
 		"model:eval": "bun scripts/model-eval.ts",
 		"i18n:pull": "varlock run -- bun run _tolgee:pull && prettier --write src/i18n/*.json",
 		"i18n:push": "varlock run -- bun run _tolgee:push",
@@ -49,7 +49,8 @@
 		"worktree:prune": "bun scripts/prune-worktrees.ts",
 		"setup": "bun scripts/template-setup.ts",
 		"upstream:fork-point": "bun .agents/skills/upstream-sync/scripts/find-fork-point.ts",
-		"upstream:changes": "bun .agents/skills/upstream-sync/scripts/list-upstream-changes.ts"
+		"upstream:changes": "bun .agents/skills/upstream-sync/scripts/list-upstream-changes.ts",
+		"source:safety": "bun scripts/source-safety.ts"
 	},
 	"packageManager": "bun@1.3.9",
 	"dependencies": {

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -6,7 +6,7 @@ All scripts must work on macOS, Linux, and Windows. Use TypeScript executed by B
 
 ## Validation
 
-`bun scripts/static-checks.ts <changed files...>` is the primary targeted validation command.
+`bun scripts/static-checks.ts <changed files...>` is the primary validation command. Source safety scans the working tree first; the remaining checks target the named files. An unrelated or Git-ignored text file can therefore fail the command before targeted validation begins.
 
 Root `AGENTS.md` decides whether a fix earns a regression guard and which mechanism carries it. Two mappings are specific to this scope:
 

--- a/scripts/source-safety.test.ts
+++ b/scripts/source-safety.test.ts
@@ -1,0 +1,372 @@
+import { spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	collectFindings,
+	formatFindings,
+	inventory,
+	isMissing,
+	shouldScanContents,
+	scanFile,
+	scannableFiles,
+	type SourceSafetyFinding
+} from './source-safety';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// Every forbidden character is constructed, never typed. A fixture spelling one out
+// would put the banned byte into the file that bans it, and the scan covers its own
+// test the same as any other source file.
+const ch = (code: number) => String.fromCharCode(code);
+const ESC = ch(0x1b);
+
+const codepoints = (findings: SourceSafetyFinding[]) =>
+	findings.flatMap((finding) => (finding.kind === 'character' ? [finding.codepoint] : []));
+
+let repo: string;
+
+/** A throwaway tree, so the scan can be measured without touching this repository. */
+function write(file: string, contents: string | Uint8Array): void {
+	const target = path.join(repo, file);
+	mkdirSync(path.dirname(target), { recursive: true });
+	writeFileSync(target, contents);
+}
+
+beforeAll(() => {
+	repo = mkdtempSync(path.join(tmpdir(), 'source-safety-'));
+	write('.gitignore', 'ignored/\n');
+	write('ignored/secret.ts', 'export const a = 1;\n');
+});
+
+afterAll(() => rmSync(repo, { recursive: true, force: true }));
+
+describe('the scanned file set', () => {
+	it('includes files regardless of repository ignore rules', () => {
+		write('ordinary.ts', 'export const value = 1;\n');
+
+		const files = inventory(repo);
+
+		expect(files).toContain('ordinary.ts');
+		expect(files).toContain('ignored/secret.ts');
+	});
+
+	it('skips root output directories without hiding an ordinary nested source directory', () => {
+		write('build/root-output.ts', 'export const output = 1;\n');
+		write('src/build/source.ts', 'export const source = 1;\n');
+
+		const files = inventory(repo);
+
+		expect(files).not.toContain('build/root-output.ts');
+		expect(files).toContain('src/build/source.ts');
+	});
+
+	it('ignores only a disappeared directory entry', () => {
+		expect(isMissing(Object.assign(new Error('gone'), { code: 'ENOENT' }))).toBe(true);
+		expect(isMissing(Object.assign(new Error('denied'), { code: 'EACCES' }))).toBe(false);
+	});
+
+	it('drops duplicates and sorts, so a named file is not reported twice', () => {
+		expect(scannableFiles(['b.ts', 'a.ts', 'b.ts'])).toEqual(['a.ts', 'b.ts']);
+	});
+
+	it('scans source formats and exempts only known opaque or generated contents', () => {
+		expect(shouldScanContents('src/app.ts')).toBe(true);
+		expect(shouldScanContents('docs/readme.md')).toBe(true);
+		expect(shouldScanContents('wrangler.toml')).toBe(true);
+		expect(shouldScanContents('src/other.test.ts.snap')).toBe(true);
+		expect(shouldScanContents('static/pixel.bmp')).toBe(false);
+		expect(
+			shouldScanContents('src/lib/emails/__tests__/__snapshots__/email-snapshots.test.ts.snap')
+		).toBe(false);
+	});
+
+	// The exclusion above is only sound while Prettier refuses to parse a snapshot. It
+	// pads inbox preview text with bidi marks, so the day Prettier starts reading .snap
+	// is the day the exclusion becomes a hole, and this is what says so.
+	it('keeps the snapshot exclusion honest against the installed Prettier', () => {
+		const result = spawnSync(
+			'bun',
+			[
+				'prettier',
+				'--file-info',
+				'src/lib/emails/__tests__/__snapshots__/email-snapshots.test.ts.snap'
+			],
+			{ cwd: REPO_ROOT, encoding: 'utf-8' }
+		);
+
+		expect(JSON.parse(result.stdout).inferredParser).toBeNull();
+	});
+});
+
+describe('what counts as a finding', () => {
+	it('reports a C0 control and leaves tab, line feed and carriage return alone', async () => {
+		write('c0.ts', `const a = '\t';\r\nconst b = '${ch(0x0b)}';\n`);
+
+		const findings = await collectFindings(['c0.ts'], repo);
+
+		expect(findings).toHaveLength(1);
+		expect(findings[0]).toMatchObject({ line: 2, column: 12, codepoint: 'U+000B' });
+	});
+
+	it('covers DEL and the whole C1 range without reaching past it', async () => {
+		const codes = [0x7f, 0x80, 0x9f];
+		for (const code of codes) {
+			write('range.ts', `const a = '${ch(code)}';\n`);
+			expect(await collectFindings(['range.ts'], repo)).toHaveLength(1);
+		}
+		write('range.ts', `const a = '${ch(0x1f)}${ch(0x20)}${ch(0xa0)}';\n`);
+		expect(codepoints(await collectFindings(['range.ts'], repo))).toEqual(['U+001F']);
+	});
+
+	it('reports every bidi control, which is what makes source read as one thing and run as another', async () => {
+		const bidi = [
+			0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069
+		];
+		write('bidi.ts', `// ${bidi.map(ch).join('')}\n`);
+
+		const found = await collectFindings(['bidi.ts'], repo);
+
+		expect(codepoints(found)).toEqual(
+			bidi.map((c) => `U+${c.toString(16).toUpperCase().padStart(4, '0')}`)
+		);
+		expect(
+			found.every(
+				(finding) => finding.kind === 'character' && finding.category === 'bidirectional formatting'
+			)
+		).toBe(true);
+	});
+
+	it('accepts the escape that spells the same character', async () => {
+		write('escaped.ts', "const a = '\\u001B';\n");
+
+		expect(await collectFindings(['escaped.ts'], repo)).toEqual([]);
+	});
+
+	it('reads a path as source too, because every diagnostic prints the file name', async () => {
+		const findings = await scanFile(`weird${ESC}name.ts`, repo);
+
+		const finding = findings.find((candidate) => candidate.kind === 'character');
+		expect(finding).toMatchObject({ line: 0, codepoint: 'U+001B' });
+		expect(finding!.file).toContain('U+001B');
+		expect(finding!.file).not.toContain(ESC);
+	});
+
+	it('uses the stricter diagnostic policy for structure inside a file name', async () => {
+		for (const code of [0x09, 0x0a, 0x0d, 0x2028, 0x2029]) {
+			const findings = await scanFile(`before${ch(code)}after.ts`, repo);
+			expect(codepoints(findings)).toEqual([
+				`U+${code.toString(16).toUpperCase().padStart(4, '0')}`
+			]);
+			const finding = findings.find((candidate) => candidate.kind === 'character');
+			expect(finding!.file).not.toContain(ch(code));
+		}
+	});
+
+	it('checks the name even when generated contents are exempt', async () => {
+		const generated = `src/lib/emails/generated/snapshot${ESC}.ts`;
+		write(generated, `intentional ${ch(0x200e)} padding`);
+
+		const findings = await scanFile(generated, repo);
+
+		expect(codepoints(findings)).toEqual(['U+001B']);
+	});
+});
+
+describe('what the scan refuses to guess about', () => {
+	it('skips contents whose file extension marks them as binary', async () => {
+		write('logo.png', new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe]));
+
+		expect(await collectFindings(['logo.png'], repo)).toEqual([]);
+	});
+
+	// NUL takes a file out of code review because git stops diffing it as text. A source
+	// extension keeps the file on the text path, so NUL cannot masquerade as binary data.
+	it('still reports a NUL in a text file instead of calling the file binary', async () => {
+		write('nul.ts', `const key = 'a${ch(0x00)}b';\n`);
+
+		expect(codepoints(await collectFindings(['nul.ts'], repo))).toEqual(['U+0000']);
+	});
+
+	it('fails a source file whose UTF-8 cannot be decoded instead of treating it as binary', async () => {
+		write('invalid.ts', new Uint8Array([0x2f, 0x2f, 0x20, 0xff, 0x0a]));
+
+		expect(await collectFindings(['invalid.ts'], repo)).toContainEqual({
+			kind: 'encoding',
+			file: 'invalid.ts'
+		});
+	});
+
+	it('keeps a lone CR as a line break when the next character is in another chunk', async () => {
+		write('streamed.ts', `${'a'.repeat(65_535)}${ch(0x0d)}${ESC}`);
+
+		const findings = await collectFindings(['streamed.ts'], repo);
+
+		expect(findings).toContainEqual(
+			expect.objectContaining({ kind: 'character', line: 2, column: 1, codepoint: 'U+001B' })
+		);
+	});
+
+	it('counts a CRLF split across stream chunks as one line break', async () => {
+		write('streamed-crlf.ts', `${'a'.repeat(65_535)}${ch(0x0d)}${ch(0x0a)}${ESC}`);
+
+		const findings = await collectFindings(['streamed-crlf.ts'], repo);
+
+		expect(findings).toContainEqual(
+			expect.objectContaining({ kind: 'character', line: 2, column: 1, codepoint: 'U+001B' })
+		);
+	});
+
+	it('retains only the findings the bounded report can display', async () => {
+		write('many.ts', new Uint8Array(1_000_000));
+
+		const retained = await scanFile('many.ts', repo);
+		const findings = await collectFindings(['many.ts'], repo);
+
+		expect(retained).toHaveLength(21);
+		expect(findings).toHaveLength(21);
+		expect(findings.at(-1)).toEqual({ kind: 'omitted' });
+	});
+
+	it('says nothing about a file that is gone, which is what a staged deletion looks like', async () => {
+		expect(await collectFindings(['never-existed.ts'], repo)).toEqual([]);
+	});
+});
+
+describe('the report', () => {
+	const finding = (line: number): SourceSafetyFinding => ({
+		kind: 'character',
+		file: 'src/a.ts',
+		line,
+		column: 1,
+		codepoint: 'U+001B',
+		category: 'C0 control',
+		escape: '\\u001B'
+	});
+
+	it('names the codepoint and the position, and never the character', async () => {
+		const [line] = formatFindings([finding(7)]);
+
+		expect(line).toBe('src/a.ts:7:1: U+001B (C0 control)');
+		expect(line).not.toContain(ESC);
+	});
+
+	it('counts the rest rather than filling the terminal with them', async () => {
+		const lines = formatFindings([
+			...Array.from({ length: 20 }, (_, i) => finding(i + 1)),
+			{ kind: 'omitted' }
+		]);
+
+		expect(lines).toHaveLength(21);
+		expect(lines.at(-1)).toBe('More findings omitted; fix these and run again');
+	});
+});
+
+describe('the command boundary', () => {
+	it('scans before importing the rest of the static-check implementation', () => {
+		const source = readFileSync(path.join(REPO_ROOT, 'scripts/static-checks.ts'), 'utf8');
+		const preflight = source.indexOf('await runSourceSafetyPreflight(REPO_ROOT)');
+
+		expect(preflight).toBeGreaterThanOrEqual(0);
+		expect(preflight).toBeLessThan(source.indexOf("import('../knowledge-policy.config')"));
+		expect(source).not.toMatch(/^import .*knowledge-policy/m);
+	});
+
+	it('runs source safety before install, format, and unit-test parsers', () => {
+		const pkg = JSON.parse(readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+
+		for (const script of ['postinstall', 'format', 'test:unit']) {
+			expect(pkg.scripts[script]).toMatch(/^bun run source:safety && /);
+		}
+	});
+
+	it('sanitizes a missing caller-controlled path before printing it', () => {
+		const missing = `missing${ESC}]0;title${ch(0x07)}.ts`;
+		const result = spawnSync('bun', ['scripts/static-checks.ts', missing], {
+			cwd: REPO_ROOT,
+			encoding: 'utf8'
+		});
+		const output = result.stdout + result.stderr;
+
+		expect(result.status).not.toBe(0);
+		expect(output).not.toContain(`${ESC}]0;title${ch(0x07)}`);
+		expect(output).toContain('U+001B');
+	});
+});
+
+describe('the whole run', () => {
+	// Prettier builds its parse-error code frame from the original source. The fixture
+	// lives in a unique directory under the repository because the runner resolves only
+	// repository paths; uniqueness keeps the test from overwriting somebody's file.
+	const payload = `${ESC}]0;title${ch(0x07)}`;
+
+	it('stops before the first checker instead of letting one quote the file', async () => {
+		const directory = mkdtempSync(path.join(REPO_ROOT, 'source-safety-regression-'));
+		const fixture = path.relative(REPO_ROOT, path.join(directory, 'fixture.ts'));
+		try {
+			writeFileSync(
+				path.join(REPO_ROOT, fixture),
+				`// padding ${payload} here
+const a = 1;
+const b = ;
+`,
+				'utf8'
+			);
+
+			const prettier = spawnSync('bun', ['prettier', '--no-color', '--check', fixture], {
+				cwd: REPO_ROOT,
+				encoding: 'utf-8'
+			});
+			// Without a guard the sequence travels. If this ever stops holding, the guard is
+			// no longer load-bearing and the reason for it should be re-argued, not deleted.
+			expect(prettier.stdout + prettier.stderr).toContain(payload);
+
+			const checks = spawnSync('bun', ['scripts/static-checks.ts', '--scope', 'lint', fixture], {
+				cwd: REPO_ROOT,
+				encoding: 'utf-8'
+			});
+			const output = checks.stdout + checks.stderr;
+
+			expect(checks.status).not.toBe(0);
+			expect(output).not.toContain(payload);
+			expect(output).toContain('U+001B');
+			expect(output).not.toContain('SvelteKit sync');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}, 60_000);
+
+	it('fails closed when the same source also contains malformed UTF-8', async () => {
+		const directory = mkdtempSync(path.join(REPO_ROOT, 'source-safety-encoding-'));
+		const fixture = path.relative(REPO_ROOT, path.join(directory, 'fixture.ts'));
+		try {
+			writeFileSync(
+				path.join(REPO_ROOT, fixture),
+				Buffer.concat([
+					Buffer.from(
+						`// ${payload}
+const a = ;
+`,
+						'utf8'
+					),
+					Buffer.from([0xff])
+				])
+			);
+
+			const checks = spawnSync('bun', ['scripts/static-checks.ts', '--scope', 'lint', fixture], {
+				cwd: REPO_ROOT,
+				encoding: 'utf-8'
+			});
+			const output = checks.stdout + checks.stderr;
+
+			expect(checks.status).not.toBe(0);
+			expect(output).not.toContain(payload);
+			expect(output).toContain('invalid UTF-8');
+			expect(output).not.toContain('SvelteKit sync');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}, 60_000);
+});

--- a/scripts/source-safety.ts
+++ b/scripts/source-safety.ts
@@ -1,0 +1,306 @@
+/**
+ * Reject control and bidi characters before any checker reads the working tree.
+ *
+ * `local/no-literal-control-char` sees only files a parser accepts. Prettier instead
+ * builds a parse-error code frame from the original source: the failing line plus two
+ * above and three below. A raw ESC anywhere in that window reaches the terminal as an
+ * escape introducer, and a bidi control reorders what the developer reads. The
+ * character does not have to cause the syntax error. Measured against Prettier 3.9.5
+ * for JavaScript, TypeScript, Svelte, JSON and CSS, and tracked as issue #832.
+ *
+ * Output filtering cannot distinguish a CSI copied from source from the byte-identical
+ * CSI Prettier emits for colour. This scan runs before the first child process instead,
+ * leaving native output intact. Editors still use the ESLint rule directly; both paths
+ * import the same closed set from `eslint/control-character-policy.js`.
+ */
+
+import { createReadStream, lstatSync, readdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+	createLiteralControlCharacterScanner,
+	findDiagnosticControlCharacters,
+	sanitizeDiagnosticField
+} from '../eslint/control-character-policy.js';
+
+interface CharacterFinding {
+	kind: 'character';
+	/** Repo-relative and already safe to print. */
+	file: string;
+	line: number;
+	/** One-based, for the `file:line:column` convention every editor jumps to. */
+	column: number;
+	codepoint: string;
+	category: string;
+	escape: string;
+}
+
+interface EncodingFinding {
+	kind: 'encoding';
+	/** Repo-relative and already safe to print. */
+	file: string;
+}
+
+interface UnreadableFinding {
+	kind: 'unreadable';
+	/** Repo-relative and already safe to print. */
+	file: string;
+}
+
+interface OmittedFinding {
+	kind: 'omitted';
+}
+
+export type SourceSafetyFinding =
+	CharacterFinding | EncodingFinding | UnreadableFinding | OmittedFinding;
+
+/** Dependency and generated directories skipped wherever they occur. */
+const SKIP_ANYWHERE = new Set(['.git', '.svelte-kit', '.convex', 'node_modules']);
+
+/** Tool output directories skipped only at the repository root. */
+const SKIP_AT_ROOT = new Set(['.output', '.wrangler', 'build', 'dist', 'coverage', 'references']);
+
+/** Text formats a project checker can parse or quote. Every filename stays in scope. */
+const TEXT_EXTENSIONS = new Set([
+	'.astro',
+	'.cjs',
+	'.cts',
+	'.css',
+	'.env',
+	'.example',
+	'.gql',
+	'.graphql',
+	'.htm',
+	'.html',
+	'.js',
+	'.json',
+	'.json5',
+	'.jsonc',
+	'.jsx',
+	'.less',
+	'.lock',
+	'.md',
+	'.mdc',
+	'.mdx',
+	'.mjs',
+	'.mts',
+	'.patch',
+	'.prettierrc',
+	'.schema',
+	'.scss',
+	'.snap',
+	'.svelte',
+	'.svg',
+	'.toml',
+	'.ts',
+	'.tsx',
+	'.txt',
+	'.vue',
+	'.webmanifest',
+	'.xml',
+	'.yaml',
+	'.yml'
+]);
+const TEXT_NAMES = new Set([
+	'.assetsignore',
+	'.gitattributes',
+	'.gitignore',
+	'.npmrc',
+	'.prettierignore',
+	'.prettierrc',
+	'.tolgeerc',
+	'_headers'
+]);
+
+/**
+ * Known generated text with intentional bidi controls.
+ *
+ * `better-svelte-email` pads inbox preview text with LRM and RLM. Its committed
+ * snapshot and ignored generated templates carry those marks repeatedly. Prettier
+ * 3.9.5 reports no parser for that snapshot; the templates are created later by
+ * `build-emails`. Their authored templates and every filename remain checked.
+ */
+const EMAIL_SNAPSHOT = 'src/lib/emails/__tests__/__snapshots__/email-snapshots.test.ts.snap';
+
+/** Whether a file's bytes are source text. File names never use this exemption. */
+export function shouldScanContents(file: string): boolean {
+	if (file === EMAIL_SNAPSHOT || file.startsWith('src/lib/emails/generated/')) return false;
+	const name = path.posix.basename(file);
+	return TEXT_NAMES.has(name) || TEXT_EXTENSIONS.has(path.posix.extname(file).toLowerCase());
+}
+
+/**
+ * Every ordinary file below the repository root, independent of Git's ignore stack.
+ *
+ * Prettier honors the repository `.gitignore`, while Git's `--exclude-standard` also
+ * honors `.git/info/exclude` and the developer's global excludes. Building the file
+ * set through Git therefore misses files that `prettier .` still parses. A byte-level
+ * directory walk includes those files, rejects undecodable names before printing them,
+ * and does not follow symlinks into another tree.
+ */
+export function inventory(root: string): string[] {
+	const files: string[] = [];
+	const decoder = new TextDecoder('utf-8', { fatal: true });
+
+	function walk(absolute: string, relative: string[]): void {
+		let names: Uint8Array[];
+		try {
+			names = readdirSync(absolute, { encoding: 'buffer' }) as unknown as Uint8Array[];
+		} catch {
+			console.error('Source safety: could not read a directory in the working tree');
+			process.exit(1);
+		}
+
+		for (const rawName of names) {
+			let name: string;
+			try {
+				name = decoder.decode(rawName);
+			} catch {
+				console.error(
+					'Source safety: a path in this repository is not valid UTF-8, so it cannot be checked or safely printed'
+				);
+				process.exit(1);
+			}
+
+			const nextRelative = [...relative, name];
+			const nextAbsolute = path.join(absolute, name);
+			let stat;
+			try {
+				stat = lstatSync(nextAbsolute);
+			} catch (error) {
+				if (isMissing(error)) continue;
+				console.error('Source safety: could not inspect an entry in the working tree');
+				process.exit(1);
+			}
+			if (stat.isSymbolicLink()) {
+				files.push(nextRelative.join('/'));
+				continue;
+			}
+			if (stat.isDirectory()) {
+				const skip = SKIP_ANYWHERE.has(name) || (relative.length === 0 && SKIP_AT_ROOT.has(name));
+				if (!skip) walk(nextAbsolute, nextRelative);
+				continue;
+			}
+			if (stat.isFile()) files.push(nextRelative.join('/'));
+		}
+	}
+
+	walk(path.resolve(root), []);
+	return files.sort();
+}
+
+/** The report is bounded in memory as well as on screen. */
+const REPORT_LIMIT = 20;
+const RETAINED_FINDINGS = REPORT_LIMIT + 1;
+
+/** Findings in a file name, which uses a stricter policy than source structure. */
+function scanFileName(file: string): CharacterFinding[] {
+	const safeName = sanitizeDiagnosticField(file);
+	return findDiagnosticControlCharacters(file)
+		.slice(0, RETAINED_FINDINGS)
+		.map((found) => ({
+			kind: 'character',
+			file: safeName,
+			line: 0,
+			column: 0,
+			...found.data
+		}));
+}
+
+export function isMissing(error: unknown): boolean {
+	return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+/** Findings for one file, read incrementally so one large input cannot double memory use. */
+export async function scanFile(file: string, root: string): Promise<SourceSafetyFinding[]> {
+	const safeName = sanitizeDiagnosticField(file);
+	const findings: SourceSafetyFinding[] = scanFileName(file);
+	if (!shouldScanContents(file)) return findings;
+	try {
+		if (lstatSync(path.resolve(root, file)).isSymbolicLink()) return findings;
+	} catch (error) {
+		if (isMissing(error)) return findings;
+		return [...findings, { kind: 'unreadable', file: safeName }];
+	}
+
+	const scanner = createLiteralControlCharacterScanner((found) => {
+		if (findings.length >= RETAINED_FINDINGS) return;
+		findings.push({
+			kind: 'character',
+			file: safeName,
+			line: found.line,
+			column: found.column + 1,
+			...found.data
+		});
+	});
+	const decoder = new TextDecoder('utf-8', { fatal: true });
+
+	try {
+		for await (const chunk of createReadStream(path.resolve(root, file))) {
+			scanner.write(decoder.decode(chunk, { stream: true }));
+		}
+		scanner.write(decoder.decode());
+		scanner.end();
+	} catch (error) {
+		if (isMissing(error)) return findings;
+		if (findings.length < RETAINED_FINDINGS) {
+			if (error instanceof TypeError) findings.push({ kind: 'encoding', file: safeName });
+			else findings.push({ kind: 'unreadable', file: safeName });
+		}
+	}
+	return findings;
+}
+
+/** The scan's own file set: deduplicated and in path order. */
+export function scannableFiles(files: string[]): string[] {
+	return [...new Set(files)].sort();
+}
+
+/** Every finding across the supplied repo-relative paths, in path order. */
+export async function collectFindings(
+	files: string[],
+	root: string
+): Promise<SourceSafetyFinding[]> {
+	const findings: SourceSafetyFinding[] = [];
+	for (const file of files) {
+		findings.push(...(await scanFile(file, root)));
+		if (findings.length > REPORT_LIMIT) {
+			return [...findings.slice(0, REPORT_LIMIT), { kind: 'omitted' }];
+		}
+	}
+	return findings;
+}
+
+export function formatFindings(findings: SourceSafetyFinding[]): string[] {
+	return findings.map((finding) => {
+		if (finding.kind === 'omitted') return 'More findings omitted; fix these and run again';
+		if (finding.kind === 'encoding') return `${finding.file}: invalid UTF-8 in a text file`;
+		if (finding.kind === 'unreadable') return `${finding.file}: file could not be read`;
+		return finding.line === 0
+			? `${finding.file}: ${finding.codepoint} (${finding.category}) in the file name`
+			: `${finding.file}:${finding.line}:${finding.column}: ${finding.codepoint} (${finding.category})`;
+	});
+}
+
+/** Fail before a checker starts, or return how many files were cleared. */
+export async function runSourceSafetyPreflight(
+	root: string,
+	extra: string[] = []
+): Promise<number> {
+	const files = scannableFiles([...inventory(root), ...extra]);
+	const findings = await collectFindings(files, root);
+	if (findings.length === 0) return files.length;
+
+	console.error('Source files are unsafe to pass to a checker:');
+	for (const line of formatFindings(findings)) console.error(`  ${line}`);
+	console.error(
+		'\nUse valid UTF-8. Remove each raw control or bidi character, or write it as its \\uXXXX escape inside a string or template literal.'
+	);
+	process.exit(1);
+}
+
+if (import.meta.main) {
+	const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+	const count = await runSourceSafetyPreflight(root);
+	console.log(`${count} file(s) hold no raw control or bidi characters`);
+}

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -6,14 +6,15 @@
  *   bun scripts/static-checks.ts --ci                  - Check all files, assert-only (CI)
  *   bun scripts/static-checks.ts --ci --scope lint     - Linting checks only (CI job group)
  *   bun scripts/static-checks.ts --ci --scope types    - Type checking only (CI job group)
- *   bun scripts/static-checks.ts --staged              - Check only staged files (pre-commit)
+ *   bun scripts/static-checks.ts --staged              - Scan the tree, then check staged files
  *   bun scripts/static-checks.ts file1.ts file2.svelte - Check specific files
  *   ... | bun scripts/static-checks.ts --files-from -  - Check a computed list of files
  *
  * Flags:
  *   --ci         Assert mode: uses --check for formatting, omits --fix for ESLint.
  *                Requires misspell to be installed (fails if missing).
- *   --staged     Scope to git-staged files only. Auto-fixes and re-stages.
+ *   --staged     After source safety scans the tree, scope the remaining checks to
+ *                git-staged files. Auto-fixes and re-stages.
  *   --scope      Run a subset of checks: "lint" (misspell, banned patterns, prettier,
  *                eslint, oxlint) or "types" (build-emails, svelte-check).
  *                Both groups run svelte-kit sync first. Omit to run all checks.
@@ -32,10 +33,28 @@ import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { parseArgs } from 'util';
-import knowledgePolicy from '../knowledge-policy.config';
-import { getStagedChanges, getStagedFiles, isUnderPreCommit, sanitizedGitEnv } from './git-context';
-import { formatPolicyFinding, matchesKnowledgeCandidate } from './knowledge-policy/policy';
-import { runKnowledgePolicy } from './knowledge-policy/repository';
+import { sanitizeDiagnosticField } from '../eslint/control-character-policy.js';
+import { runSourceSafetyPreflight } from './source-safety';
+
+const REPO_ROOT = realpathSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'));
+
+// The security boundary runs before importing configuration and check implementations
+// that parse project source during module initialization. The scanner and its closed
+// character policy are the deliberately small trust root an in-repository guard cannot
+// validate before Bun parses the guard itself.
+const PRECHECKED_FILES = import.meta.main ? await runSourceSafetyPreflight(REPO_ROOT) : undefined;
+
+const [
+	{ default: knowledgePolicy },
+	{ getStagedChanges, getStagedFiles, isUnderPreCommit, sanitizedGitEnv },
+	{ formatPolicyFinding, matchesKnowledgeCandidate },
+	{ runKnowledgePolicy }
+] = await Promise.all([
+	import('../knowledge-policy.config'),
+	import('./git-context'),
+	import('./knowledge-policy/policy'),
+	import('./knowledge-policy/repository')
+]);
 
 // Configuration (matches CI static-checks.yml exclusions)
 const CONFIG = {
@@ -99,7 +118,6 @@ const colors = {
 /** Repo root, from this script's own location. Correct under worktrees and nesting. */
 // fileURLToPath, not Bun's import.meta.dir: the latter is undefined under vitest,
 // which imports this module for scripts/static-checks.test.ts.
-const REPO_ROOT = realpathSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'));
 
 const USAGE = '  Flags: --ci, --staged, --scope <lint|types>, --files-from <path|->';
 
@@ -144,6 +162,7 @@ export function resolveInputs(raw: string[], origin: string): string[] {
 	const out = new Set<string>();
 
 	for (const arg of raw) {
+		const safeArg = sanitizeDiagnosticField(arg);
 		if (arg.trim() === '') {
 			fail(
 				`Empty path in ${origin}.`,
@@ -166,12 +185,15 @@ export function resolveInputs(raw: string[], origin: string): string[] {
 		// realpath both sides so a checkout reached through a symlink (/tmp ->
 		// /private/tmp, a symlinked worktree) does not read as "outside the repo".
 		const absolute = path.resolve(arg);
-		if (!existsSync(absolute)) fail(`No such file (${origin}): ${arg}`);
+		if (!existsSync(absolute)) fail(`No such file (${origin}): ${safeArg}`);
 
 		const real = realpathSync(absolute);
 		const relative = toPosix(path.relative(REPO_ROOT, real));
 		if (relative === '' || relative.startsWith('..')) {
-			fail(`Path is outside the repository (${origin}): ${arg}`, `  Repo root: ${REPO_ROOT}`);
+			fail(
+				`Path is outside the repository (${origin}): ${safeArg}`,
+				`  Repo root: ${sanitizeDiagnosticField(REPO_ROOT)}`
+			);
 		}
 
 		if (statSync(real).isDirectory()) {
@@ -181,7 +203,7 @@ export function resolveInputs(raw: string[], origin: string): string[] {
 				if (NEVER_WALK.some((skip) => file.includes(skip))) continue;
 				out.add(file);
 			}
-			if (out.size === before) fail(`Directory contains no files to check (${origin}): ${arg}`);
+			if (out.size === before) fail(`Directory contains no files to check (${origin}): ${safeArg}`);
 			continue;
 		}
 
@@ -371,7 +393,10 @@ function parseCli() {
 				allowPositionals: true
 			});
 		} catch (error) {
-			return fail(`Bad arguments: ${(error as Error).message.split('. To specify')[0]}`, USAGE);
+			return fail(
+				`Bad arguments: ${sanitizeDiagnosticField((error as Error).message.split('. To specify')[0]!)}`,
+				USAGE
+			);
 		}
 	})();
 
@@ -382,7 +407,7 @@ function parseCli() {
 	const filesFrom = values['files-from'];
 
 	if (scope && !['lint', 'types'].includes(scope)) {
-		fail(`Invalid --scope value: "${scope}". Use "lint" or "types".`);
+		fail(`Invalid --scope value: "${sanitizeDiagnosticField(scope)}". Use "lint" or "types".`);
 	}
 
 	// Skip first two positionals (bun runtime + script path)
@@ -417,7 +442,9 @@ function runCommand(command: string, args: string[], options?: SpawnSyncOptions)
 	});
 
 	if (result.status !== 0) {
-		console.error(`${colors.red}Command failed: ${command} ${args.join(' ')}${colors.reset}`);
+		console.error(
+			`${colors.red}Command failed: ${sanitizeDiagnosticField(command)} ${sanitizeDiagnosticField(args.join(' '))}${colors.reset}`
+		);
 		process.exit(result.status ?? 1);
 	}
 }
@@ -515,6 +542,17 @@ async function main(): Promise<void> {
 	}
 
 	let step = 1;
+
+	// Source safety runs ahead of every child process, including a scoped run, because
+	// `svelte-kit sync` and oxlint read the whole project whatever this run was given.
+	// A checker that quotes a line puts a raw control character straight into the
+	// terminal, and no filter on its output can tell that byte from the ones the
+	// checker emits itself (see scripts/source-safety.ts).
+	printHeader(step++, 'Source safety');
+	const scannedFiles = PRECHECKED_FILES ?? (await runSourceSafetyPreflight(REPO_ROOT, inputs));
+	console.log(`${scannedFiles} file(s) hold no raw control or bidi characters`);
+	ledger.ran('source safety', scannedFiles);
+	console.log('\n');
 
 	// SvelteKit sync (always runs — needed by both lint and types)
 	printHeader(step++, 'SvelteKit sync');
@@ -769,7 +807,9 @@ if (import.meta.main) {
 	// Default-deny: finish() is the only path that writes a zero exit code.
 	process.exitCode = 2;
 	main().catch((error: Error) => {
-		console.error(`${colors.red}Fatal error: ${error.message}${colors.reset}`);
+		console.error(
+			`${colors.red}Fatal error: ${sanitizeDiagnosticField(error.message)}${colors.reset}`
+		);
 		process.exit(1);
 	});
 }


### PR DESCRIPTION
Closes #832
Regression guard: added `scripts/source-safety.test.ts`

Parsers can copy raw source into diagnostics before ESLint reports it safely. Reordering checks leaves other parsers and file types open, while output filtering cannot distinguish source-owned CSI from the identical bytes a formatter emits for colour.

The preflight runs before the static-check import graph, installation generators, formatting, and unit tests. It walks the working tree independently of Git's global ignores, validates every filename strictly, streams known text formats, fails closed on malformed UTF-8, and retains only the findings its bounded report can display. Generated email previews keep a narrow content exemption while their filenames remain covered. The ESLint rule, Svelte parser wrapper, and preflight share one character policy.

Verified with the static-check pipeline and complete unit suite. Twenty-seven cases cover parser leaks, malformed encoding, ignored files, filename structure, opaque assets, stream boundaries, report bounds, and collision-safe fixtures.
