### PR TITLE
feat(email): Add founder incident delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ An AI agent built on [Convex Agent](https://www.convex.dev/components/agent) and
 
 ### Email System
 
-Transactional email delivered through [Resend](https://www.convex.dev/components/resend) with automatic retries, idempotency, and delivery tracking. Templates are written as Svelte components using a shadcn-style email component library (same `tv()` variants, same design tokens) and compiled to inline HTML at build time. Your logo is converted to an email-safe PNG automatically. `bun run build:emails` renders every template, and a snapshot test (`src/lib/emails/__tests__/email-snapshots.test.ts`) flags any unintended markup change.
+Transactional email delivered through [Resend](https://www.convex.dev/components/resend) with automatic retries, idempotency, and delivery tracking. HTML templates are written as Svelte components using a shadcn-style email component library (same `tv()` variants, same design tokens) and compiled to inline HTML at build time; operational plain-text email remains in Convex source. Your logo is converted to an email-safe PNG automatically. `bun run build:emails` renders every HTML template, and a snapshot test (`src/lib/emails/__tests__/email-snapshots.test.ts`) flags any unintended markup change.
 
 ### Internationalization
 
@@ -479,7 +479,7 @@ Renovate groups non-major updates into a single PR and creates separate PRs for 
 
 ### Email Development
 
-Email templates are Svelte components compiled to inline HTML on `postinstall` and during builds. `bun run build:emails` renders each template with mock data, and the snapshot test `src/lib/emails/__tests__/email-snapshots.test.ts` catches any unexpected markup change.
+HTML email templates are Svelte components compiled to inline HTML on `postinstall` and during builds. `bun run build:emails` renders each HTML template with mock data, and the snapshot test `src/lib/emails/__tests__/email-snapshots.test.ts` catches any unexpected markup change.
 
 </details>
 

--- a/src/lib/convex/AGENTS.md
+++ b/src/lib/convex/AGENTS.md
@@ -45,6 +45,8 @@ When an intentional bounded `.collect()`, sequential mutation, or other normally
 
 Production email uses `@convex-dev/resend`. Keep send helpers, templates, generated email output, and webhook event handling in their existing `emails/` boundaries. Use the `convexResend` btca resource for component behavior and `betterSvelteEmail` for template tooling.
 
+Applications own incident audiences, stable keys, renderers, and contact resolution. Register incident senders as internal single-recipient mutations. The ledger permits at most one committed component enqueue per incident/user; verify delivery through the component and provider state.
+
 ## Analytics
 
 Server analytics is best-effort and scheduled off the request path. Identify by Convex user ID, never email. Properties contain only non-PII enums, booleans, buckets, statuses, and tool names; never bodies, names, email addresses, provider IDs, URLs, search terms, or raw errors.

--- a/src/lib/convex/_generated/api.d.ts
+++ b/src/lib/convex/_generated/api.d.ts
@@ -43,6 +43,8 @@ import type * as autumn from "../autumn.js";
 import type * as constants from "../constants.js";
 import type * as crons from "../crons.js";
 import type * as emails_events from "../emails/events.js";
+import type * as emails_founderIncidentCore from "../emails/founderIncidentCore.js";
+import type * as emails_founderIncidentDelivery from "../emails/founderIncidentDelivery.js";
 import type * as emails_founderIncidentTypes from "../emails/founderIncidentTypes.js";
 import type * as emails_helpers from "../emails/helpers.js";
 import type * as emails_resend from "../emails/resend.js";
@@ -129,6 +131,8 @@ declare const fullApi: ApiFromModules<{
   constants: typeof constants;
   crons: typeof crons;
   "emails/events": typeof emails_events;
+  "emails/founderIncidentCore": typeof emails_founderIncidentCore;
+  "emails/founderIncidentDelivery": typeof emails_founderIncidentDelivery;
   "emails/founderIncidentTypes": typeof emails_founderIncidentTypes;
   "emails/helpers": typeof emails_helpers;
   "emails/resend": typeof emails_resend;

--- a/src/lib/convex/_generated/api.d.ts
+++ b/src/lib/convex/_generated/api.d.ts
@@ -43,6 +43,7 @@ import type * as autumn from "../autumn.js";
 import type * as constants from "../constants.js";
 import type * as crons from "../crons.js";
 import type * as emails_events from "../emails/events.js";
+import type * as emails_founderIncidentTypes from "../emails/founderIncidentTypes.js";
 import type * as emails_helpers from "../emails/helpers.js";
 import type * as emails_resend from "../emails/resend.js";
 import type * as emails_send from "../emails/send.js";
@@ -128,6 +129,7 @@ declare const fullApi: ApiFromModules<{
   constants: typeof constants;
   crons: typeof crons;
   "emails/events": typeof emails_events;
+  "emails/founderIncidentTypes": typeof emails_founderIncidentTypes;
   "emails/helpers": typeof emails_helpers;
   "emails/resend": typeof emails_resend;
   "emails/send": typeof emails_send;

--- a/src/lib/convex/emails/events.ts
+++ b/src/lib/convex/emails/events.ts
@@ -1,6 +1,7 @@
 import { internalMutation } from '../_generated/server';
 import { v } from 'convex/values';
 import { vEmailId, vEmailEvent } from '@convex-dev/resend';
+import { applyFounderIncidentEmailEvent } from './founderIncidentDelivery';
 
 /**
  * Email event handler - called by Resend webhooks
@@ -23,6 +24,8 @@ export const handleEmailEvent = internalMutation({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
+		await applyFounderIncidentEmailEvent(ctx, args);
+
 		// Log the event for monitoring and debugging
 		console.log('Email event received:', {
 			emailId: args.id,
@@ -39,6 +42,14 @@ export const handleEmailEvent = internalMutation({
 
 		// Handle specific event types
 		switch (args.event.type) {
+			case 'email.sent':
+				console.log(`Email ${args.id} sent`);
+				break;
+
+			case 'email.delivery_delayed':
+				console.warn(`Email ${args.id} delivery delayed`);
+				break;
+
 			case 'email.delivered':
 				console.log(`Email ${args.id} delivered successfully`);
 				break;
@@ -63,8 +74,9 @@ export const handleEmailEvent = internalMutation({
 				console.log(`Email ${args.id} link clicked by recipient`);
 				break;
 
-			default:
-				console.log(`Unknown email event type: ${args.event.type}`);
+			case 'email.failed':
+				console.warn(`Email ${args.id} failed:`, args.event.data);
+				break;
 		}
 		return null;
 	}

--- a/src/lib/convex/emails/founderIncidentCore.test.ts
+++ b/src/lib/convex/emails/founderIncidentCore.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createFounderIncidentEmailMutation } from './founderIncidentCore';
+import { defineFounderIncidentRegistry } from './founderIncidentTypes';
+import { resend } from './resend';
+
+type TestUser = {
+	email: string;
+	emailVerified?: boolean;
+	locale?: string | null;
+	name?: string;
+} | null;
+
+type Handler = {
+	_handler: (
+		ctx: unknown,
+		args: { userId: string; incident: string }
+	) => Promise<
+		{ status: 'enqueued' } | { status: 'already_processed' } | { status: 'skipped'; reason: string }
+	>;
+};
+
+function setup({
+	contact = { name: 'Ada', replyTo: 'ada@example.com' } as {
+		name: string;
+		replyTo?: string;
+	} | null,
+	user = {
+		email: 'affected@example.com',
+		emailVerified: true,
+		locale: 'de',
+		name: 'Grace Hopper'
+	} as TestUser,
+	render = ({ locale, recipientName, senderName }: Record<string, string | undefined>) => ({
+		subject: ` Restored for ${locale} `,
+		text: `Hello ${recipientName} from ${senderName}`
+	})
+} = {}) {
+	const registry = defineFounderIncidentRegistry({
+		service_restored_2026_08_24: render
+	});
+	const mutation = createFounderIncidentEmailMutation({
+		registry,
+		resolveContact: async () => contact
+	}) as unknown as Handler;
+	const rows: Array<Record<string, unknown>> = [];
+	const db = {
+		query() {
+			return {
+				withIndex(_name: string, capture: (query: unknown) => unknown) {
+					const filters: Record<string, unknown> = {};
+					const query = {
+						eq(field: string, value: unknown) {
+							filters[field] = value;
+							return query;
+						}
+					};
+					capture(query);
+					return {
+						async unique() {
+							return (
+								rows.find((row) =>
+									Object.entries(filters).every(([field, value]) => row[field] === value)
+								) ?? null
+							);
+						}
+					};
+				}
+			};
+		},
+		async insert(_table: string, row: Record<string, unknown>) {
+			rows.push(row);
+			return `incident_${rows.length}`;
+		}
+	};
+	const ctx = {
+		db,
+		async runQuery() {
+			return user;
+		}
+	};
+	return { ctx, handler: mutation._handler, rows };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+});
+
+describe('createFounderIncidentEmailMutation', () => {
+	it('queues one localized plain-text email and records the component enqueue', async () => {
+		vi.stubEnv('RESEND_API_KEY', 're_test');
+		vi.stubEnv('AUTH_EMAIL', 'founder@example.com');
+		const sendEmail = vi.spyOn(resend, 'sendEmail').mockResolvedValue('email_1' as never);
+		const { ctx, handler, rows } = setup();
+		const args = { userId: 'user_1', incident: 'service_restored_2026_08_24' };
+
+		expect(await handler(ctx, args)).toEqual({ status: 'enqueued' });
+		expect(await handler(ctx, args)).toEqual({ status: 'already_processed' });
+		expect(sendEmail).toHaveBeenCalledTimes(1);
+		expect(sendEmail).toHaveBeenCalledWith(ctx, {
+			from: 'Ada <founder@example.com>',
+			replyTo: ['ada@example.com'],
+			to: 'affected@example.com',
+			subject: 'Restored for de',
+			text: 'Hello Grace Hopper from Ada',
+			headers: [
+				{ name: 'X-Email-Category', value: 'incident' },
+				{ name: 'X-Email-Template', value: 'founder-incident' }
+			]
+		});
+		expect(sendEmail.mock.calls[0]?.[1]).not.toHaveProperty('html');
+		expect(rows).toEqual([
+			expect.objectContaining({
+				userId: 'user_1',
+				incident: 'service_restored_2026_08_24',
+				status: 'enqueued',
+				emailId: 'email_1',
+				locale: 'de',
+				deliveryStatus: 'waiting'
+			})
+		]);
+	});
+
+	it.each([
+		['user_deleted', { user: null }],
+		['not_verified', { user: { email: 'affected@example.com', emailVerified: false } }],
+		['test_email', { user: { email: 'run@e2e.example.com', emailVerified: true } }],
+		['founder_not_configured', { contact: null }]
+	] as const)('records the terminal %s exclusion without enqueueing', async (reason, options) => {
+		const sendEmail = vi.spyOn(resend, 'sendEmail');
+		const { ctx, handler, rows } = setup(options);
+
+		expect(
+			await handler(ctx, { userId: 'user_1', incident: 'service_restored_2026_08_24' })
+		).toEqual({ status: 'skipped', reason });
+		expect(sendEmail).not.toHaveBeenCalled();
+		expect(rows).toEqual([expect.objectContaining({ status: 'skipped', skippedReason: reason })]);
+	});
+
+	it('rejects unknown keys before reading or writing', async () => {
+		const { ctx, handler, rows } = setup();
+		const runQuery = vi.spyOn(ctx, 'runQuery');
+
+		await expect(handler(ctx, { userId: 'user_1', incident: 'unknown' })).rejects.toThrow(
+			'Unknown founder incident key'
+		);
+		expect(runQuery).not.toHaveBeenCalled();
+		expect(rows).toHaveLength(0);
+	});
+
+	it.each([
+		{ subject: '', text: 'Body' },
+		{ subject: 'Broken\nsubject', text: 'Body' },
+		{ subject: 'Subject', text: '   ' }
+	])('rejects invalid rendered content before enqueueing', async (rendered) => {
+		const sendEmail = vi.spyOn(resend, 'sendEmail');
+		const { ctx, handler, rows } = setup({ render: () => rendered });
+
+		await expect(
+			handler(ctx, { userId: 'user_1', incident: 'service_restored_2026_08_24' })
+		).rejects.toThrow('Invalid founder incident email content');
+		expect(sendEmail).not.toHaveBeenCalled();
+		expect(rows).toHaveLength(0);
+	});
+
+	it('falls back to the source locale before rendering', async () => {
+		vi.stubEnv('RESEND_API_KEY', 're_test');
+		vi.stubEnv('AUTH_EMAIL', 'founder@example.com');
+		vi.spyOn(resend, 'sendEmail').mockResolvedValue('email_1' as never);
+		const render = vi.fn(() => ({ subject: 'Restored', text: 'Body' }));
+		const { ctx, handler } = setup({
+			render,
+			user: { email: 'affected@example.com', emailVerified: true, locale: 'xx' }
+		});
+
+		await handler(ctx, { userId: 'user_1', incident: 'service_restored_2026_08_24' });
+		expect(render).toHaveBeenCalledWith(
+			expect.objectContaining({ locale: 'en', senderName: 'Ada' })
+		);
+	});
+});

--- a/src/lib/convex/emails/founderIncidentCore.test.ts
+++ b/src/lib/convex/emails/founderIncidentCore.test.ts
@@ -137,16 +137,19 @@ describe('createFounderIncidentEmailMutation', () => {
 		expect(rows).toEqual([expect.objectContaining({ status: 'skipped', skippedReason: reason })]);
 	});
 
-	it('rejects unknown keys before reading or writing', async () => {
-		const { ctx, handler, rows } = setup();
-		const runQuery = vi.spyOn(ctx, 'runQuery');
+	it.each(['unknown', 'toString', '__proto__'])(
+		'rejects the unregistered %s key before reading or writing',
+		async (incident) => {
+			const { ctx, handler, rows } = setup();
+			const runQuery = vi.spyOn(ctx, 'runQuery');
 
-		await expect(handler(ctx, { userId: 'user_1', incident: 'unknown' })).rejects.toThrow(
-			'Unknown founder incident key'
-		);
-		expect(runQuery).not.toHaveBeenCalled();
-		expect(rows).toHaveLength(0);
-	});
+			await expect(handler(ctx, { userId: 'user_1', incident })).rejects.toThrow(
+				'Unknown founder incident key'
+			);
+			expect(runQuery).not.toHaveBeenCalled();
+			expect(rows).toHaveLength(0);
+		}
+	);
 
 	it.each([
 		{ subject: '', text: 'Body' },

--- a/src/lib/convex/emails/founderIncidentCore.ts
+++ b/src/lib/convex/emails/founderIncidentCore.ts
@@ -41,7 +41,9 @@ export function createFounderIncidentEmailMutation<Registry extends FounderIncid
 		},
 		returns: founderIncidentQueueResultValidator,
 		handler: async (ctx, { userId, incident }) => {
-			const render = registry[incident];
+			const render = Object.prototype.hasOwnProperty.call(registry, incident)
+				? registry[incident]
+				: undefined;
 			if (!render) throw new ConvexError('Unknown founder incident key');
 
 			const existing = await ctx.db

--- a/src/lib/convex/emails/founderIncidentCore.ts
+++ b/src/lib/convex/emails/founderIncidentCore.ts
@@ -1,0 +1,118 @@
+import { ConvexError, v } from 'convex/values';
+import { components } from '../_generated/api';
+import { internalMutation, type MutationCtx } from '../_generated/server';
+import { requireEnv } from '../env';
+import { getValidLocale } from '../i18n/translations';
+import { isTestEmail } from './helpers';
+import { assertResendApiKey, resend } from './resend';
+import {
+	founderIncidentQueueResultValidator,
+	type FounderIncidentContact,
+	type FounderIncidentRegistry,
+	type FounderIncidentSkipReason
+} from './founderIncidentTypes';
+
+type FounderIncidentMutationOptions<Registry extends FounderIncidentRegistry> = {
+	registry: Registry;
+	resolveContact: (ctx: MutationCtx) => Promise<FounderIncidentContact | null>;
+};
+
+function validateRenderedEmail(subject: string, text: string): { subject: string; text: string } {
+	const normalizedSubject = subject.trim();
+	const normalizedText = text.trim();
+	if (!normalizedSubject || /[\r\n]/.test(normalizedSubject) || !normalizedText) {
+		throw new ConvexError('Invalid founder incident email content');
+	}
+	return { subject: normalizedSubject, text: normalizedText };
+}
+
+/**
+ * Build an internal, single-recipient incident sender around an application-owned registry.
+ * Registry membership, eligibility, enqueue, and audit commit in one mutation.
+ */
+export function createFounderIncidentEmailMutation<Registry extends FounderIncidentRegistry>({
+	registry,
+	resolveContact
+}: FounderIncidentMutationOptions<Registry>) {
+	return internalMutation({
+		args: {
+			userId: v.string(),
+			incident: v.string()
+		},
+		returns: founderIncidentQueueResultValidator,
+		handler: async (ctx, { userId, incident }) => {
+			const render = registry[incident];
+			if (!render) throw new ConvexError('Unknown founder incident key');
+
+			const existing = await ctx.db
+				.query('founderIncidentEmails')
+				.withIndex('by_incident_and_user', (q) => q.eq('incident', incident).eq('userId', userId))
+				.unique();
+			if (existing) return { status: 'already_processed' as const };
+
+			const user = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+				model: 'user',
+				where: [{ field: '_id', operator: 'eq', value: userId }]
+			});
+			const now = Date.now();
+			const skip = async (reason: FounderIncidentSkipReason) => {
+				await ctx.db.insert('founderIncidentEmails', {
+					userId,
+					incident,
+					status: 'skipped',
+					skippedReason: reason,
+					createdAt: now
+				});
+				return { status: 'skipped' as const, reason };
+			};
+
+			if (!user) return await skip('user_deleted');
+
+			const { email, emailVerified, locale, name } = user as {
+				email: string;
+				emailVerified?: boolean;
+				locale?: string | null;
+				name?: string;
+			};
+			if (!emailVerified) return await skip('not_verified');
+			if (isTestEmail(email)) return await skip('test_email');
+
+			const contact = await resolveContact(ctx);
+			if (!contact) return await skip('founder_not_configured');
+
+			const effectiveLocale = getValidLocale(locale);
+			const rendered = render({
+				locale: effectiveLocale,
+				recipientName: name,
+				senderName: contact.name
+			});
+			const { subject, text } = validateRenderedEmail(rendered.subject, rendered.text);
+
+			assertResendApiKey();
+			const emailId = await resend.sendEmail(ctx, {
+				from: `${contact.name} <${requireEnv('AUTH_EMAIL', { feature: 'email delivery' })}>`,
+				replyTo: contact.replyTo ? [contact.replyTo] : undefined,
+				to: email,
+				subject,
+				text,
+				headers: [
+					{ name: 'X-Email-Category', value: 'incident' },
+					{ name: 'X-Email-Template', value: 'founder-incident' }
+				]
+			});
+
+			await ctx.db.insert('founderIncidentEmails', {
+				userId,
+				incident,
+				status: 'enqueued',
+				emailId,
+				locale: effectiveLocale,
+				deliveryStatus: 'waiting',
+				deliveryUpdatedAt: now,
+				enqueuedAt: now,
+				createdAt: now
+			});
+			return { status: 'enqueued' as const };
+		}
+	});
+}

--- a/src/lib/convex/emails/founderIncidentDelivery.test.ts
+++ b/src/lib/convex/emails/founderIncidentDelivery.test.ts
@@ -1,0 +1,272 @@
+import type { EmailEvent, EmailId } from '@convex-dev/resend';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	applyFounderIncidentEmailEvent,
+	mergeFounderIncidentDeliveryStatus,
+	reconcileFounderIncidentEmailDelivery
+} from './founderIncidentDelivery';
+import { resend } from './resend';
+
+type IncidentRow = {
+	_id: string;
+	userId: string;
+	incident: string;
+	status: 'enqueued' | 'skipped';
+	emailId?: string;
+	deliveryStatus?:
+		| 'waiting'
+		| 'queued'
+		| 'sent'
+		| 'delivery_delayed'
+		| 'delivered'
+		| 'bounced'
+		| 'failed'
+		| 'cancelled'
+		| 'unknown';
+	deliveryUpdatedAt?: number;
+	complainedAt?: number;
+};
+
+function setup(row: IncidentRow | null) {
+	const patches: Array<Record<string, unknown>> = [];
+	const db = {
+		query() {
+			return {
+				withIndex(_name: string, capture: (query: unknown) => unknown) {
+					const filters: Record<string, unknown> = {};
+					const query = {
+						eq(field: string, value: unknown) {
+							filters[field] = value;
+							return query;
+						}
+					};
+					capture(query);
+					return {
+						async unique() {
+							if (!row) return null;
+							return Object.entries(filters).every(([field, value]) =>
+								field === 'emailId'
+									? row.emailId === value
+									: row[field as keyof IncidentRow] === value
+							)
+								? row
+								: null;
+						}
+					};
+				}
+			};
+		},
+		async patch(_id: string, patch: Record<string, unknown>) {
+			patches.push(patch);
+			if (row) Object.assign(row, patch);
+		}
+	};
+	return { ctx: { db, runQuery: vi.fn() }, patches, row };
+}
+
+function event(type: EmailEvent['type'], created_at = '2026-08-24T10:00:00.000Z'): EmailEvent {
+	return { type, created_at, data: {} } as EmailEvent;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('Resend status contract', () => {
+	it('returns the installed component snapshot or null without reshaping it', async () => {
+		const snapshot = {
+			status: 'delivered' as const,
+			errorMessage: null,
+			bounced: false,
+			complained: true,
+			failed: false,
+			deliveryDelayed: false,
+			opened: false,
+			clicked: false
+		};
+		const runQuery = vi.fn().mockResolvedValueOnce(snapshot).mockResolvedValueOnce(null);
+		const ctx = { runQuery };
+		const emailId = 'email_1' as EmailId;
+
+		expect(await resend.status(ctx as never, emailId)).toBe(snapshot);
+		expect(await resend.status(ctx as never, emailId)).toBeNull();
+		expect(runQuery).toHaveBeenCalledWith(resend.component.lib.getStatus, { emailId });
+	});
+});
+
+describe('mergeFounderIncidentDeliveryStatus', () => {
+	it('follows the component status precedence and keeps cancellation terminal', () => {
+		expect(mergeFounderIncidentDeliveryStatus('waiting', 'sent')).toBe('sent');
+		expect(mergeFounderIncidentDeliveryStatus('delivered', 'delivery_delayed')).toBe('delivered');
+		expect(mergeFounderIncidentDeliveryStatus('delivered', 'bounced')).toBe('bounced');
+		expect(mergeFounderIncidentDeliveryStatus('bounced', 'failed')).toBe('bounced');
+		expect(mergeFounderIncidentDeliveryStatus('cancelled', 'delivered')).toBe('cancelled');
+		expect(mergeFounderIncidentDeliveryStatus('unknown', 'queued')).toBe('queued');
+		expect(mergeFounderIncidentDeliveryStatus('sent', 'unknown')).toBe('sent');
+	});
+});
+
+describe('applyFounderIncidentEmailEvent', () => {
+	it.each([
+		['email.sent', 'sent'],
+		['email.delivery_delayed', 'delivery_delayed'],
+		['email.delivered', 'delivered'],
+		['email.bounced', 'bounced'],
+		['email.failed', 'failed']
+	] as const)('records %s as %s', async (eventType, deliveryStatus) => {
+		const { ctx, patches } = setup({
+			_id: 'row_1',
+			userId: 'user_1',
+			incident: 'incident_1',
+			status: 'enqueued',
+			emailId: 'email_1',
+			deliveryStatus: 'waiting'
+		});
+
+		await applyFounderIncidentEmailEvent(ctx as never, {
+			id: 'email_1' as EmailId,
+			event: event(eventType)
+		});
+		expect(patches).toEqual([
+			{ deliveryStatus, deliveryUpdatedAt: Date.parse('2026-08-24T10:00:00.000Z') }
+		]);
+	});
+
+	it('records a complaint without changing delivery status', async () => {
+		const { ctx, patches } = setup({
+			_id: 'row_1',
+			userId: 'user_1',
+			incident: 'incident_1',
+			status: 'enqueued',
+			emailId: 'email_1',
+			deliveryStatus: 'delivered'
+		});
+
+		await applyFounderIncidentEmailEvent(ctx as never, {
+			id: 'email_1' as EmailId,
+			event: event('email.complained')
+		});
+		expect(patches).toEqual([{ complainedAt: Date.parse('2026-08-24T10:00:00.000Z') }]);
+	});
+
+	it.each(['email.opened', 'email.clicked'] as const)(
+		'ignores %s for the incident row',
+		async (type) => {
+			const { ctx, patches } = setup({
+				_id: 'row_1',
+				userId: 'user_1',
+				incident: 'incident_1',
+				status: 'enqueued',
+				emailId: 'email_1',
+				deliveryStatus: 'delivered'
+			});
+
+			await applyFounderIncidentEmailEvent(ctx as never, {
+				id: 'email_1' as EmailId,
+				event: event(type)
+			});
+			expect(patches).toEqual([]);
+		}
+	);
+});
+
+describe('reconcileFounderIncidentEmailDelivery', () => {
+	const handler = (reconcileFounderIncidentEmailDelivery as unknown as { _handler: unknown })
+		._handler as (ctx: unknown, args: { userId: string; incident: string }) => Promise<unknown>;
+
+	it('refreshes component state and preserves a recorded complaint', async () => {
+		const { ctx, patches } = setup({
+			_id: 'row_1',
+			userId: 'user_1',
+			incident: 'incident_1',
+			status: 'enqueued',
+			emailId: 'email_1',
+			deliveryStatus: 'sent',
+			complainedAt: 1
+		});
+		vi.spyOn(resend, 'status').mockResolvedValue({
+			status: 'delivered',
+			errorMessage: null,
+			bounced: false,
+			complained: false,
+			failed: false,
+			deliveryDelayed: false,
+			opened: false,
+			clicked: false
+		});
+
+		await expect(handler(ctx, { userId: 'user_1', incident: 'incident_1' })).resolves.toEqual({
+			status: 'reconciled',
+			deliveryStatus: 'delivered',
+			complained: true
+		});
+		expect(patches).toEqual([
+			expect.objectContaining({
+				deliveryStatus: 'delivered',
+				deliveryUpdatedAt: expect.any(Number)
+			})
+		]);
+	});
+
+	it.each([
+		['not_found', null],
+		[
+			'skipped',
+			{
+				_id: 'row_1',
+				userId: 'user_1',
+				incident: 'incident_1',
+				status: 'skipped'
+			} satisfies IncidentRow
+		]
+	] as const)('returns %s without asking the component', async (status, row) => {
+		const { ctx, patches } = setup(row);
+		const componentStatus = vi.spyOn(resend, 'status');
+
+		await expect(handler(ctx, { userId: 'user_1', incident: 'incident_1' })).resolves.toEqual({
+			status
+		});
+		expect(componentStatus).not.toHaveBeenCalled();
+		expect(patches).toEqual([]);
+	});
+
+	it('marks a nonterminal row unknown after component retention expires', async () => {
+		const { ctx, patches } = setup({
+			_id: 'row_1',
+			userId: 'user_1',
+			incident: 'incident_1',
+			status: 'enqueued',
+			emailId: 'email_1',
+			deliveryStatus: 'sent'
+		});
+		vi.spyOn(resend, 'status').mockResolvedValue(null);
+
+		await expect(handler(ctx, { userId: 'user_1', incident: 'incident_1' })).resolves.toEqual({
+			status: 'reconciled',
+			deliveryStatus: 'unknown',
+			complained: false
+		});
+		expect(patches).toEqual([
+			expect.objectContaining({ deliveryStatus: 'unknown', deliveryUpdatedAt: expect.any(Number) })
+		]);
+	});
+
+	it('preserves a terminal row after component retention expires', async () => {
+		const { ctx, patches } = setup({
+			_id: 'row_1',
+			userId: 'user_1',
+			incident: 'incident_1',
+			status: 'enqueued',
+			emailId: 'email_1',
+			deliveryStatus: 'delivered'
+		});
+		vi.spyOn(resend, 'status').mockResolvedValue(null);
+
+		await expect(handler(ctx, { userId: 'user_1', incident: 'incident_1' })).resolves.toEqual({
+			status: 'reconciled',
+			deliveryStatus: 'delivered',
+			complained: false
+		});
+		expect(patches).toEqual([]);
+	});
+});

--- a/src/lib/convex/emails/founderIncidentDelivery.ts
+++ b/src/lib/convex/emails/founderIncidentDelivery.ts
@@ -1,0 +1,144 @@
+import type { EmailEvent, EmailId } from '@convex-dev/resend';
+import { v } from 'convex/values';
+import { internalMutation, type MutationCtx } from '../_generated/server';
+import { resend } from './resend';
+import {
+	founderIncidentDeliveryStatusValidator,
+	type FounderIncidentDeliveryStatus
+} from './founderIncidentTypes';
+
+const deliveryRank: Record<Exclude<FounderIncidentDeliveryStatus, 'unknown'>, number> = {
+	waiting: 0,
+	queued: 1,
+	sent: 2,
+	delivery_delayed: 3,
+	delivered: 4,
+	bounced: 5,
+	failed: 5,
+	cancelled: 100
+};
+
+const terminalDeliveryStatuses = new Set<FounderIncidentDeliveryStatus>([
+	'delivered',
+	'bounced',
+	'failed',
+	'cancelled'
+]);
+
+export function mergeFounderIncidentDeliveryStatus(
+	current: FounderIncidentDeliveryStatus | undefined,
+	next: FounderIncidentDeliveryStatus
+): FounderIncidentDeliveryStatus {
+	if (!current || current === 'unknown') return next;
+	if (next === 'unknown' || current === 'cancelled') return current;
+	return deliveryRank[next] > deliveryRank[current] ? next : current;
+}
+
+function deliveryStatusForEvent(event: EmailEvent): FounderIncidentDeliveryStatus | null {
+	switch (event.type) {
+		case 'email.sent':
+			return 'sent';
+		case 'email.delivery_delayed':
+			return 'delivery_delayed';
+		case 'email.delivered':
+			return 'delivered';
+		case 'email.bounced':
+			return 'bounced';
+		case 'email.failed':
+			return 'failed';
+		case 'email.complained':
+		case 'email.opened':
+		case 'email.clicked':
+			return null;
+	}
+}
+
+function eventTimestamp(event: EmailEvent): number {
+	const timestamp = Date.parse(event.created_at);
+	return Number.isFinite(timestamp) ? timestamp : Date.now();
+}
+
+/** Apply a component webhook callback to the matching persistent incident row. */
+export async function applyFounderIncidentEmailEvent(
+	ctx: MutationCtx,
+	{ id, event }: { id: EmailId; event: EmailEvent }
+): Promise<void> {
+	const incidentEmail = await ctx.db
+		.query('founderIncidentEmails')
+		.withIndex('by_email_id', (q) => q.eq('emailId', id))
+		.unique();
+	if (!incidentEmail) return;
+
+	const timestamp = eventTimestamp(event);
+	if (event.type === 'email.complained') {
+		if (!incidentEmail.complainedAt) {
+			await ctx.db.patch(incidentEmail._id, { complainedAt: timestamp });
+		}
+		return;
+	}
+
+	const observedStatus = deliveryStatusForEvent(event);
+	if (!observedStatus) return;
+	const deliveryStatus = mergeFounderIncidentDeliveryStatus(
+		incidentEmail.deliveryStatus,
+		observedStatus
+	);
+	if (deliveryStatus === incidentEmail.deliveryStatus) return;
+
+	await ctx.db.patch(incidentEmail._id, {
+		deliveryStatus,
+		deliveryUpdatedAt: timestamp
+	});
+}
+
+const reconciliationResultValidator = v.union(
+	v.object({ status: v.literal('not_found') }),
+	v.object({ status: v.literal('skipped') }),
+	v.object({
+		status: v.literal('reconciled'),
+		deliveryStatus: founderIncidentDeliveryStatusValidator,
+		complained: v.boolean()
+	})
+);
+
+/** Refresh one incident row from the Resend component's retained delivery state. */
+export const reconcileFounderIncidentEmailDelivery = internalMutation({
+	args: {
+		userId: v.string(),
+		incident: v.string()
+	},
+	returns: reconciliationResultValidator,
+	handler: async (ctx, { userId, incident }) => {
+		const incidentEmail = await ctx.db
+			.query('founderIncidentEmails')
+			.withIndex('by_incident_and_user', (q) => q.eq('incident', incident).eq('userId', userId))
+			.unique();
+		if (!incidentEmail) return { status: 'not_found' as const };
+		if (incidentEmail.status === 'skipped') return { status: 'skipped' as const };
+
+		const snapshot = incidentEmail.emailId
+			? await resend.status(ctx, incidentEmail.emailId as EmailId)
+			: null;
+		const complained = Boolean(incidentEmail.complainedAt || snapshot?.complained);
+		const now = Date.now();
+
+		if (!snapshot && terminalDeliveryStatuses.has(incidentEmail.deliveryStatus ?? 'unknown')) {
+			return {
+				status: 'reconciled' as const,
+				deliveryStatus: incidentEmail.deliveryStatus as FounderIncidentDeliveryStatus,
+				complained
+			};
+		}
+
+		const deliveryStatus = snapshot
+			? mergeFounderIncidentDeliveryStatus(incidentEmail.deliveryStatus, snapshot.status)
+			: 'unknown';
+		await ctx.db.patch(incidentEmail._id, {
+			deliveryStatus,
+			deliveryUpdatedAt: now,
+			...(!incidentEmail.complainedAt && snapshot?.complained ? { complainedAt: now } : {})
+		});
+
+		return { status: 'reconciled' as const, deliveryStatus, complained };
+	}
+});

--- a/src/lib/convex/emails/founderIncidentTypes.ts
+++ b/src/lib/convex/emails/founderIncidentTypes.ts
@@ -1,0 +1,77 @@
+import { v, type Infer } from 'convex/values';
+import type { SupportedLocale } from '../i18n/translations';
+
+export const founderIncidentSkipReasonValidator = v.union(
+	v.literal('user_deleted'),
+	v.literal('not_verified'),
+	v.literal('test_email'),
+	v.literal('founder_not_configured')
+);
+
+export const founderIncidentDeliveryStatusValidator = v.union(
+	v.literal('waiting'),
+	v.literal('queued'),
+	v.literal('sent'),
+	v.literal('delivery_delayed'),
+	v.literal('delivered'),
+	v.literal('bounced'),
+	v.literal('failed'),
+	v.literal('cancelled'),
+	v.literal('unknown')
+);
+
+export const founderIncidentQueueResultValidator = v.union(
+	v.object({ status: v.literal('enqueued') }),
+	v.object({ status: v.literal('already_processed') }),
+	v.object({
+		status: v.literal('skipped'),
+		reason: founderIncidentSkipReasonValidator
+	})
+);
+
+export const founderIncidentEmailFields = {
+	userId: v.string(),
+	incident: v.string(),
+	status: v.union(v.literal('enqueued'), v.literal('skipped')),
+	emailId: v.optional(v.string()),
+	skippedReason: v.optional(founderIncidentSkipReasonValidator),
+	locale: v.optional(v.string()),
+	deliveryStatus: v.optional(founderIncidentDeliveryStatusValidator),
+	deliveryUpdatedAt: v.optional(v.number()),
+	complainedAt: v.optional(v.number()),
+	enqueuedAt: v.optional(v.number()),
+	createdAt: v.number()
+};
+
+export type FounderIncidentSkipReason = Infer<typeof founderIncidentSkipReasonValidator>;
+export type FounderIncidentDeliveryStatus = Infer<typeof founderIncidentDeliveryStatusValidator>;
+export type FounderIncidentQueueResult = Infer<typeof founderIncidentQueueResultValidator>;
+
+export type FounderIncidentContact = {
+	name: string;
+	replyTo?: string;
+};
+
+export type FounderIncidentRenderInput = {
+	locale: SupportedLocale;
+	recipientName?: string;
+	senderName: string;
+};
+
+export type FounderIncidentRenderedEmail = {
+	subject: string;
+	text: string;
+};
+
+export type FounderIncidentRenderer = (
+	input: FounderIncidentRenderInput
+) => FounderIncidentRenderedEmail;
+
+export type FounderIncidentRegistry = Readonly<Record<string, FounderIncidentRenderer>>;
+
+/** Retain literal incident keys while checking every entry against the renderer contract. */
+export function defineFounderIncidentRegistry<const Registry extends FounderIncidentRegistry>(
+	registry: Registry
+): Registry {
+	return registry;
+}

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -2,6 +2,7 @@ import { defineSchema, defineTable } from 'convex/server';
 import { v } from 'convex/values';
 import { vEmailEvent } from '@convex-dev/resend';
 import { supportThreadFields } from './support/supportThreadFields';
+import { founderIncidentEmailFields } from './emails/founderIncidentTypes';
 
 export default defineSchema({
 	// Note: Better Auth component manages its own tables (users, sessions, accounts, verifications)
@@ -191,6 +192,12 @@ export default defineSchema({
 		skippedReason: v.optional(v.string()),
 		createdAt: v.number()
 	}).index('by_user', ['userId']),
+
+	// One durable outcome per app-owned incident key and Better Auth user.
+	// The exact index read and component enqueue share the caller's mutation.
+	founderIncidentEmails: defineTable(founderIncidentEmailFields)
+		.index('by_incident_and_user', ['incident', 'userId'])
+		.index('by_email_id', ['emailId']),
 
 	// AI chat feature registry.
 	// Source of truth for AI chat membership and sidebar state.


### PR DESCRIPTION
Forks that send direct incident follow-ups currently have to re-create the safety boundary around eligibility, stable incident keys, duplicate prevention, and delivery evidence. That makes the most sensitive part of the workflow application-specific even though its guarantees are shared.

This adds a template-owned registry factory and durable incident ledger while leaving audience selection, copy, contact resolution, and keys with each application. A single-recipient internal mutation validates registry membership before any read, records terminal exclusions, and commits the Resend enqueue with its audit row. Webhook callbacks mirror the component's monotonic delivery state, complaints remain independent, and an internal reconciliation mutation refreshes one row without erasing terminal evidence after component retention expires.

Verified with 1,383 unit tests, changed-file static checks, Convex typecheck, and the production build. Knip reports only its existing baseline findings.
