### PR TITLE
fix(email): Bind founder incident sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,29 @@ An AI agent built on [Convex Agent](https://www.convex.dev/components/agent) and
 
 Transactional email delivered through [Resend](https://www.convex.dev/components/resend) with automatic retries, idempotency, and delivery tracking. HTML templates are written as Svelte components using a shadcn-style email component library (same `tv()` variants, same design tokens) and compiled to inline HTML at build time; operational plain-text email remains in Convex source. Your logo is converted to an email-safe PNG automatically. `bun run build:emails` renders every HTML template, and a snapshot test (`src/lib/emails/__tests__/email-snapshots.test.ts`) flags any unintended markup change.
 
+#### Founder incident email
+
+The internal founder incident sender contacts one verified user at a time and records each incident/user pair once. Before using it:
+
+1. Set the contact person in `/admin/settings` under Founder Welcome.
+2. Add the reviewed stable key and localized plain-text copy to `src/lib/convex/emails/founderIncidentRegistry.ts`, then deploy it. Keep every used key and its copy unchanged.
+3. Determine the exact production audience from durable evidence outside the repository. Record the selection criteria and recipient count, then obtain operator approval.
+4. Immediately before sending, rerun the audience query and confirm that its count still matches the approved count. Invoke the internal mutation separately for each approved user:
+
+   ```bash
+   bunx convex run emails/founderIncidentSend:queueFounderIncidentEmail \
+     '{"userId":"<better-auth-user-id>","incident":"<stable-incident-key>"}' --prod
+   ```
+
+   `enqueued` means the Resend component accepted the email. `already_processed` means the pair already has a ledger row. `skipped` records a terminal exclusion and also consumes the pair, so correct the cause before invoking a new incident key rather than retrying the same one.
+
+5. Confirm the provider's final state. If the webhook state is missing or stale, reconcile the retained component state:
+
+   ```bash
+   bunx convex run emails/founderIncidentDelivery:reconcileFounderIncidentEmailDelivery \
+     '{"userId":"<better-auth-user-id>","incident":"<stable-incident-key>"}' --prod
+   ```
+
 ### Internationalization
 
 4 languages (EN, DE, ES, FR) with URL-based routing (`/de/pricing`, `/fr/privacy`) powered by [Tolgee](https://docs.tolgee.io/). Edit translations in context with Tolgee DevTools during development. Production builds tag and pull the latest translations automatically. A custom ESLint rule ensures every `aria-label` uses a translation key instead of a hardcoded string.

--- a/src/lib/convex/AGENTS.md
+++ b/src/lib/convex/AGENTS.md
@@ -47,6 +47,8 @@ Production email uses `@convex-dev/resend`. Keep send helpers, templates, genera
 
 Applications own incident audiences, stable keys, renderers, and contact resolution. Register incident senders as internal single-recipient mutations. The ledger permits at most one committed component enqueue per incident/user; verify delivery through the component and provider state.
 
+Keep the template's `founderIncidentRegistry.ts` empty and its application binding exported unconditionally. Forks add reviewed entries to the registry. Incident keys and copy are append-only after use; `__*` keys belong only to binding tests.
+
 ## Analytics
 
 Server analytics is best-effort and scheduled off the request path. Identify by Convex user ID, never email. Properties contain only non-PII enums, booleans, buckets, statuses, and tool names; never bodies, names, email addresses, provider IDs, URLs, search terms, or raw errors.

--- a/src/lib/convex/_generated/api.d.ts
+++ b/src/lib/convex/_generated/api.d.ts
@@ -45,6 +45,8 @@ import type * as crons from "../crons.js";
 import type * as emails_events from "../emails/events.js";
 import type * as emails_founderIncidentCore from "../emails/founderIncidentCore.js";
 import type * as emails_founderIncidentDelivery from "../emails/founderIncidentDelivery.js";
+import type * as emails_founderIncidentRegistry from "../emails/founderIncidentRegistry.js";
+import type * as emails_founderIncidentSend from "../emails/founderIncidentSend.js";
 import type * as emails_founderIncidentTypes from "../emails/founderIncidentTypes.js";
 import type * as emails_helpers from "../emails/helpers.js";
 import type * as emails_resend from "../emails/resend.js";
@@ -133,6 +135,8 @@ declare const fullApi: ApiFromModules<{
   "emails/events": typeof emails_events;
   "emails/founderIncidentCore": typeof emails_founderIncidentCore;
   "emails/founderIncidentDelivery": typeof emails_founderIncidentDelivery;
+  "emails/founderIncidentRegistry": typeof emails_founderIncidentRegistry;
+  "emails/founderIncidentSend": typeof emails_founderIncidentSend;
   "emails/founderIncidentTypes": typeof emails_founderIncidentTypes;
   "emails/helpers": typeof emails_helpers;
   "emails/resend": typeof emails_resend;

--- a/src/lib/convex/admin/founderWelcome/queries.ts
+++ b/src/lib/convex/admin/founderWelcome/queries.ts
@@ -5,7 +5,7 @@ import type { QueryCtx } from '../../_generated/server';
 import { adminQuery } from '../../functions';
 import { FOUNDER_WELCOME_DEFAULTS } from '../../emails/helpers';
 
-type FounderWelcomeConfig =
+export type FounderWelcomeConfig =
 	| {
 			enabled: true;
 			contactUser: { id: string; name: string; email: string };

--- a/src/lib/convex/emails/founderIncidentRegistry.ts
+++ b/src/lib/convex/emails/founderIncidentRegistry.ts
@@ -1,0 +1,9 @@
+import { defineFounderIncidentRegistry } from './founderIncidentTypes';
+
+/**
+ * Add reviewed application incidents here. Keys and copy are append-only after
+ * their first use. Names beginning with `__` are reserved for binding tests.
+ */
+export const founderIncidentRegistry = defineFounderIncidentRegistry({});
+
+export type FounderIncidentKey = keyof typeof founderIncidentRegistry;

--- a/src/lib/convex/emails/founderIncidentSend.test.ts
+++ b/src/lib/convex/emails/founderIncidentSend.test.ts
@@ -97,7 +97,7 @@ describe('founder incident application binding', () => {
 			kind: 'mutation',
 			visibility: 'internal'
 		});
-	});
+	}, 20_000);
 
 	it('rejects the reserved test key before database or auth access', async () => {
 		const db = { query: vi.fn(), insert: vi.fn() };

--- a/src/lib/convex/emails/founderIncidentSend.test.ts
+++ b/src/lib/convex/emails/founderIncidentSend.test.ts
@@ -1,0 +1,164 @@
+import path from 'node:path';
+import type { FunctionReference } from 'convex/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { freshSurfaceOf } from '../../../../scripts/convex-surface';
+import { internal } from '../_generated/api';
+import type { FounderWelcomeConfig } from '../admin/founderWelcome/queries';
+import { founderIncidentRegistry } from './founderIncidentRegistry';
+import { queueFounderIncidentEmail } from './founderIncidentSend';
+import type { FounderIncidentQueueResult, FounderIncidentRenderer } from './founderIncidentTypes';
+import { resend } from './resend';
+
+const testIncident = '__application_binding_test__';
+const generatedReference: FunctionReference<
+	'mutation',
+	'internal',
+	{ userId: string; incident: string },
+	FounderIncidentQueueResult
+> = internal.emails.founderIncidentSend.queueFounderIncidentEmail;
+
+type IncidentHandler = {
+	_handler: (
+		ctx: unknown,
+		args: { userId: string; incident: string }
+	) => Promise<FounderIncidentQueueResult>;
+};
+
+const handler = (queueFounderIncidentEmail as unknown as IncidentHandler)._handler;
+const mutableRegistry = founderIncidentRegistry as Record<string, FounderIncidentRenderer>;
+
+function registerTestIncident(): void {
+	Object.assign(mutableRegistry, {
+		[testIncident]: ({ senderName }) => ({
+			subject: 'Service restored',
+			text: `Sent by ${senderName}`
+		})
+	} satisfies Record<string, FounderIncidentRenderer>);
+}
+
+function makeCtx(config: FounderWelcomeConfig) {
+	const rows: Array<Record<string, unknown>> = [];
+	const db = {
+		query() {
+			return {
+				withIndex(_name: string, capture: (query: unknown) => unknown) {
+					const filters: Record<string, unknown> = {};
+					const query = {
+						eq(field: string, value: unknown) {
+							filters[field] = value;
+							return query;
+						}
+					};
+					capture(query);
+					return {
+						async unique() {
+							return (
+								rows.find((row) =>
+									Object.entries(filters).every(([field, value]) => row[field] === value)
+								) ?? null
+							);
+						}
+					};
+				}
+			};
+		},
+		async insert(_table: string, row: Record<string, unknown>) {
+			rows.push(row);
+			return `incident_${rows.length}`;
+		}
+	};
+	const ctx = {
+		db,
+		async runQuery(_reference: unknown, args: Record<string, unknown>) {
+			if (args.model === 'user') {
+				return {
+					email: 'affected@example.com',
+					emailVerified: true,
+					name: 'Ada Lovelace'
+				};
+			}
+			return config;
+		}
+	};
+	return { ctx, rows };
+}
+
+afterEach(() => {
+	delete mutableRegistry[testIncident];
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+});
+
+describe('founder incident application binding', () => {
+	it('publishes the internal single-recipient mutation', async () => {
+		expect(generatedReference).toBeDefined();
+		const surface = await freshSurfaceOf(path.resolve(__dirname, '..'));
+		expect(surface.get('emails/founderIncidentSend:queueFounderIncidentEmail')).toEqual({
+			kind: 'mutation',
+			visibility: 'internal'
+		});
+	});
+
+	it('rejects the reserved test key before database or auth access', async () => {
+		const db = { query: vi.fn(), insert: vi.fn() };
+		const runQuery = vi.fn();
+
+		await expect(
+			handler({ db, runQuery }, { userId: 'user_1', incident: testIncident })
+		).rejects.toThrow('Unknown founder incident key');
+		expect(db.query).not.toHaveBeenCalled();
+		expect(db.insert).not.toHaveBeenCalled();
+		expect(runQuery).not.toHaveBeenCalled();
+	});
+
+	it('maps the enabled founder contact into delivery', async () => {
+		registerTestIncident();
+		vi.stubEnv('RESEND_API_KEY', 're_test');
+		vi.stubEnv('AUTH_EMAIL', 'founder@example.com');
+		const sendEmail = vi.spyOn(resend, 'sendEmail').mockResolvedValue('email_1' as never);
+		const { ctx } = makeCtx({
+			enabled: true,
+			contactUser: {
+				id: 'founder_1',
+				name: 'Grace Hopper',
+				email: 'grace@example.com'
+			},
+			name: 'Grace',
+			title: 'Founder',
+			subject: 'Welcome',
+			body: 'Welcome aboard',
+			replyTo: 'grace@example.com'
+		});
+
+		await expect(handler(ctx, { userId: 'user_1', incident: testIncident })).resolves.toEqual({
+			status: 'enqueued'
+		});
+		expect(sendEmail).toHaveBeenCalledWith(
+			ctx,
+			expect.objectContaining({
+				from: 'Grace <founder@example.com>',
+				replyTo: ['grace@example.com'],
+				text: 'Sent by Grace'
+			})
+		);
+	});
+
+	it('maps a disabled founder contact to a terminal skip', async () => {
+		registerTestIncident();
+		const sendEmail = vi.spyOn(resend, 'sendEmail');
+		const { ctx, rows } = makeCtx({ enabled: false });
+
+		await expect(handler(ctx, { userId: 'user_1', incident: testIncident })).resolves.toEqual({
+			status: 'skipped',
+			reason: 'founder_not_configured'
+		});
+		expect(sendEmail).not.toHaveBeenCalled();
+		expect(rows).toEqual([
+			expect.objectContaining({
+				incident: testIncident,
+				status: 'skipped',
+				skippedReason: 'founder_not_configured'
+			})
+		]);
+	});
+});

--- a/src/lib/convex/emails/founderIncidentSend.ts
+++ b/src/lib/convex/emails/founderIncidentSend.ts
@@ -1,0 +1,22 @@
+import { internal } from '../_generated/api';
+import type { MutationCtx } from '../_generated/server';
+import type { FounderWelcomeConfig } from '../admin/founderWelcome/queries';
+import { createFounderIncidentEmailMutation } from './founderIncidentCore';
+import { founderIncidentRegistry } from './founderIncidentRegistry';
+import type { FounderIncidentContact } from './founderIncidentTypes';
+
+async function resolveFounderIncidentContact(
+	ctx: MutationCtx
+): Promise<FounderIncidentContact | null> {
+	const config: FounderWelcomeConfig = await ctx.runQuery(
+		internal.admin.founderWelcome.queries.getFounderWelcomeConfigInternal,
+		{}
+	);
+	if (!config.enabled) return null;
+	return { name: config.name, replyTo: config.replyTo };
+}
+
+export const queueFounderIncidentEmail = createFounderIncidentEmailMutation({
+	registry: founderIncidentRegistry,
+	resolveContact: resolveFounderIncidentContact
+});


### PR DESCRIPTION
Regression guard: added founder incident application-binding test

PR #838 shipped the durable founder incident engine without an application module, so a deployed template had no `internal.emails.founderIncidentSend.queueFounderIncidentEmail` to invoke.

This adds an empty application-owned registry and binds the single-recipient mutation to the existing Founder Welcome contact. Disabled contact settings become the existing terminal skip, while the internal function remains exported before a fork adds incident copy. The operator guide covers reviewed keys, audience approval, one-recipient invocation, terminal `skipped` results, and delivery reconciliation.

Verified with 1,549 unit tests, changed-file static checks, Convex type and compatibility checks, generated API inspection, and the production build.