### PR TITLE
fix(support): Mark truncated email previews

### DIFF
--- a/src/lib/convex/admin/support/__tests__/mutations.test.ts
+++ b/src/lib/convex/admin/support/__tests__/mutations.test.ts
@@ -45,11 +45,13 @@ vi.mock('../../../_generated/api', () => ({
 
 import { saveMessage, getFile } from '@convex-dev/agent';
 import { authComponent } from '../../../auth';
+import { shouldSendNotification } from '../../../support/threads';
 import { sendAdminReply } from '../mutations';
 
 const saveMessageMock = saveMessage as unknown as ReturnType<typeof vi.fn>;
 const getFileMock = getFile as unknown as ReturnType<typeof vi.fn>;
 const getAuthUserMock = authComponent.getAuthUser as unknown as ReturnType<typeof vi.fn>;
+const shouldSendNotificationMock = shouldSendNotification as unknown as ReturnType<typeof vi.fn>;
 
 type RegisteredFunction<TArgs, TResult> = {
 	_handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
@@ -60,7 +62,7 @@ const replyHandler = sendAdminReply as unknown as RegisteredFunction<
 	null
 >;
 
-function makeCtx() {
+function makeCtx({ notificationEmail }: { notificationEmail?: string } = {}) {
 	return {
 		db: {
 			query: vi.fn(() => ({
@@ -69,7 +71,7 @@ function makeCtx() {
 						_id: 'st_1',
 						threadId: 't1',
 						assignedTo: undefined,
-						notificationEmail: undefined,
+						notificationEmail,
 						notificationSentAt: undefined
 					})
 				}))
@@ -84,7 +86,7 @@ function makeCtx() {
 // the UI relies on to distinguish it from an AI answer. Forwarding attachment
 // fileIds must add to that metadata, never replace the provider fields, and a
 // text-only reply must not gain a fileIds key.
-describe('sendAdminReply attachment refcount metadata', () => {
+describe('sendAdminReply', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		getAuthUserMock.mockResolvedValue({
@@ -93,6 +95,7 @@ describe('sendAdminReply attachment refcount metadata', () => {
 			name: 'Admin User',
 			email: 'admin@example.com'
 		});
+		shouldSendNotificationMock.mockReturnValue(false);
 		saveMessageMock.mockResolvedValue({ messageId: 'm1' });
 		getFileMock.mockResolvedValue({
 			filePart: {
@@ -146,5 +149,21 @@ describe('sendAdminReply attachment refcount metadata', () => {
 		);
 		const patch = ctx.db.patch.mock.calls[0][1];
 		expect(patch.updatedAt).toBe(patch.lastAdminReplyAt);
+	});
+
+	it('marks a truncated email preview with an ellipsis', async () => {
+		shouldSendNotificationMock.mockReturnValue(true);
+		const ctx = makeCtx({ notificationEmail: 'user@example.com' });
+
+		await replyHandler._handler(ctx, {
+			threadId: 't1',
+			prompt: 'a'.repeat(201)
+		});
+
+		expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
+			0,
+			'internal.emails.send.sendAdminReplyNotification',
+			expect.objectContaining({ messagePreview: `${'a'.repeat(199)}…` })
+		);
 	});
 });

--- a/src/lib/convex/admin/support/mutations.ts
+++ b/src/lib/convex/admin/support/mutations.ts
@@ -7,6 +7,18 @@ import { MAX_MESSAGE_LENGTH } from '../../constants';
 import { t } from '../../i18n/translations';
 import type { AssistantContent, TextPart, FilePart } from 'ai';
 
+const EMAIL_REPLY_PREVIEW_CHARACTERS = 200;
+
+function emailReplyPreview(message: string): string {
+	const characters = Array.from(message.trim());
+	if (characters.length <= EMAIL_REPLY_PREVIEW_CHARACTERS) return characters.join('');
+
+	return `${characters
+		.slice(0, EMAIL_REPLY_PREVIEW_CHARACTERS - 1)
+		.join('')
+		.trimEnd()}…`;
+}
+
 /**
  * Assign thread to admin
  *
@@ -251,7 +263,7 @@ export const sendAdminReply = adminMutation({
 			await ctx.scheduler.runAfter(0, internal.emails.send.sendAdminReplyNotification, {
 				email: supportThread.notificationEmail,
 				adminName,
-				messagePreview: args.prompt.trim().slice(0, 200),
+				messagePreview: emailReplyPreview(args.prompt),
 				threadId: supportThread.threadId,
 				pageUrl: supportThread.pageUrl
 			});


### PR DESCRIPTION
Closes #845
Regression guard: added `sendAdminReply` email preview boundary test

Support reply notification emails cut replies at 200 UTF-16 code units with no marker, so recipients see an abrupt ending and `.slice()` can split a surrogate pair.

The preview now reserves its final character for `…`, trims whitespace before it, and counts Unicode code points. Replies within the limit stay unchanged.

Verified with 1,550 unit tests, changed-file static and type checks, the Convex typecheck, and the production build. The guard fails on the original cutoff.