### PR TITLE
fix(lint): Sanitize checker output at terminal

### DIFF
--- a/eslint/control-character-policy.js
+++ b/eslint/control-character-policy.js
@@ -1,0 +1,97 @@
+/**
+ * One closed character policy for source lint and terminal diagnostics.
+ *
+ * Source structure may contain tab, LF, and CR. A terminal field may not: those
+ * characters can indent, split, or overwrite the diagnostic that contains it. A
+ * complete output stream keeps tab and LF for layout and handles CRLF separately.
+ */
+
+const SOURCE_STRUCTURE = new Set([0x09, 0x0a, 0x0d]);
+const OUTPUT_STRUCTURE = new Set([0x09, 0x0a]);
+const BIDI = new Set([
+	0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069
+]);
+
+/** @typedef {'C0 control' | 'DEL' | 'C1 control' | 'bidirectional formatting' | 'line separator'} CharacterCategory */
+/** @typedef {{ codepoint: string, category: CharacterCategory, escape: string }} CharacterData */
+/** @typedef {{ line: number, column: number, data: CharacterData }} SourceFinding */
+
+/** @param {number} code @returns {CharacterCategory | null} */
+function baseCategory(code) {
+	if (code < 0x20) return 'C0 control';
+	if (code === 0x7f) return 'DEL';
+	if (code >= 0x80 && code <= 0x9f) return 'C1 control';
+	return BIDI.has(code) ? 'bidirectional formatting' : null;
+}
+
+/** @param {number} code @returns {CharacterCategory | null} */
+export function sourceCategory(code) {
+	return SOURCE_STRUCTURE.has(code) ? null : baseCategory(code);
+}
+
+/** @param {number} code @returns {CharacterCategory | null} */
+export function terminalCategory(code) {
+	if (code === 0x2028 || code === 0x2029) return 'line separator';
+	return OUTPUT_STRUCTURE.has(code) ? null : baseCategory(code);
+}
+
+/** @param {number} code @returns {CharacterCategory | null} */
+function fieldCategory(code) {
+	if (code === 0x2028 || code === 0x2029) return 'line separator';
+	return baseCategory(code);
+}
+
+/** @param {number} code @param {CharacterCategory} kind @returns {CharacterData} */
+export function dataFor(code, kind) {
+	const hex = code.toString(16).padStart(4, '0').toUpperCase();
+	return { codepoint: `U+${hex}`, category: kind, escape: `\\u${hex}` };
+}
+
+/** @param {string} text @returns {SourceFinding[]} */
+export function findLiteralControlCharacters(text) {
+	/** @type {SourceFinding[]} */
+	const findings = [];
+	let line = 1;
+	let column = 0;
+	for (let index = 0; index < text.length; index++) {
+		const code = text.charCodeAt(index);
+		if (code === 0x0d) {
+			if (text.charCodeAt(index + 1) !== 0x0a) {
+				line++;
+				column = 0;
+			}
+			continue;
+		}
+		if (code === 0x0a || code === 0x2028 || code === 0x2029) {
+			line++;
+			column = 0;
+			continue;
+		}
+		const kind = sourceCategory(code);
+		if (kind !== null) findings.push({ line, column, data: dataFor(code, kind) });
+		column++;
+	}
+	return findings;
+}
+
+/** Preserve source structure while neutralizing a parser message. @param {string} text */
+export function sanitizeDiagnosticText(text) {
+	let safe = '';
+	for (let index = 0; index < text.length; index++) {
+		const code = text.charCodeAt(index);
+		const kind = sourceCategory(code);
+		safe += kind === null ? text[index] : dataFor(code, kind).codepoint;
+	}
+	return safe;
+}
+
+/** Neutralize one filename, token, argument, or source excerpt. @param {string} text */
+export function sanitizeTerminalField(text) {
+	let safe = '';
+	for (let index = 0; index < text.length; index++) {
+		const code = text.charCodeAt(index);
+		const kind = fieldCategory(code);
+		safe += kind === null ? text[index] : dataFor(code, kind).codepoint;
+	}
+	return safe;
+}

--- a/eslint/parsers/safe-svelte-parser.js
+++ b/eslint/parsers/safe-svelte-parser.js
@@ -1,5 +1,5 @@
 import * as svelteParser from 'svelte-eslint-parser';
-import { sanitizeDiagnosticText } from '../rules/no-literal-control-char.js';
+import { sanitizeDiagnosticText } from '../control-character-policy.js';
 
 /**
  * Keep parser failures safe for terminal and CI output.

--- a/eslint/rules/no-literal-control-char.js
+++ b/eslint/rules/no-literal-control-char.js
@@ -33,74 +33,10 @@
  * Good: the same separator written as the six characters of a unicode escape.
  */
 
-// Tab, line feed and carriage return are what source is made of. Flagging them
-// would flag every file, and a check that noisy gets switched off the same day.
-const STRUCTURAL = new Set([0x09, 0x0a, 0x0d]);
-
-// Every character Unicode gives the Bidi_Control property: the marks (U+061C,
-// U+200E, U+200F) set a run's direction, the embeddings and overrides
-// (U+202A-U+202E) and the isolates (U+2066-U+2069) reorder it. Spelled out instead
-// of matched with `\p{Bidi_Control}`, so adding a member is a visible edit and a
-// Unicode revision cannot silently widen what this rule rejects.
-const BIDI = new Set([
-	0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069
-]);
+import { findLiteralControlCharacters } from '../control-character-policy.js';
 
 const MESSAGE =
 	'{{codepoint}} ({{category}}) is written as the character itself, so it is invisible in editors, diffs and text search. Remove it or replace it with visible whitespace. If it belongs inside a string or template literal, write {{escape}}.';
-
-/** The category a banned codepoint belongs to, or null when it is legal. */
-function category(code) {
-	if (STRUCTURAL.has(code)) return null;
-	if (code < 0x20) return 'C0 control';
-	if (code === 0x7f) return 'DEL';
-	if (code >= 0x80 && code <= 0x9f) return 'C1 control';
-	return BIDI.has(code) ? 'bidirectional formatting' : null;
-}
-
-function dataFor(code, kind) {
-	const hex = code.toString(16).padStart(4, '0').toUpperCase();
-	return { codepoint: `U+${hex}`, category: kind, escape: `\\u${hex}` };
-}
-
-/** Every banned character and its ESLint location in the supplied source. */
-export function findLiteralControlCharacters(text) {
-	const findings = [];
-	let line = 1;
-	let column = 0;
-	for (let index = 0; index < text.length; index++) {
-		const code = text.charCodeAt(index);
-		// ESLint counts four line terminators. CR is one of them, so a CRLF pair
-		// advances once when the following LF is processed.
-		if (code === 0x0d) {
-			if (text.charCodeAt(index + 1) !== 0x0a) {
-				line++;
-				column = 0;
-			}
-			continue;
-		}
-		if (code === 0x0a || code === 0x2028 || code === 0x2029) {
-			line++;
-			column = 0;
-			continue;
-		}
-		const kind = category(code);
-		if (kind !== null) findings.push({ line, column, data: dataFor(code, kind) });
-		column++;
-	}
-	return findings;
-}
-
-/** Remove banned characters from diagnostic prose before a formatter sees it. */
-export function sanitizeDiagnosticText(text) {
-	let safe = '';
-	for (let index = 0; index < text.length; index++) {
-		const code = text.charCodeAt(index);
-		const kind = category(code);
-		safe += kind === null ? text[index] : dataFor(code, kind).codepoint;
-	}
-	return safe;
-}
 
 export default {
 	meta: {

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -27,7 +27,6 @@
  * hard error, never a run that checks nothing and reports success.
  */
 
-import { spawnSync, type SpawnSyncOptions } from 'child_process';
 import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -36,6 +35,12 @@ import knowledgePolicy from '../knowledge-policy.config';
 import { getStagedChanges, getStagedFiles, isUnderPreCommit, sanitizedGitEnv } from './git-context';
 import { formatPolicyFinding, matchesKnowledgeCandidate } from './knowledge-policy/policy';
 import { runKnowledgePolicy } from './knowledge-policy/repository';
+import {
+	runSanitizedCommand,
+	sanitizeTerminalField,
+	sanitizeTerminalText,
+	type SanitizedCommandOptions
+} from './terminal-output';
 
 // Configuration (matches CI static-checks.yml exclusions)
 const CONFIG = {
@@ -110,8 +115,8 @@ const NEVER_WALK = ['node_modules/', '.git/', '.svelte-kit/', '.convex/', 'build
  * Reject the run. A gate that cannot see its input must never report success.
  */
 function fail(message: string, hint?: string): never {
-	console.error(`${colors.red}${message}${colors.reset}`);
-	if (hint) console.error(hint);
+	console.error(`${colors.red}${sanitizeTerminalField(message)}${colors.reset}`);
+	if (hint) console.error(sanitizeTerminalText(hint));
 	process.exit(1);
 }
 
@@ -409,15 +414,24 @@ function parseCli() {
 /**
  * Run a command and exit if it fails
  */
-function runCommand(command: string, args: string[], options?: SpawnSyncOptions): void {
-	const result = spawnSync(command, args, {
-		stdio: 'inherit',
-		encoding: 'utf-8',
-		...options
-	});
+async function runCommand(
+	command: string,
+	args: string[],
+	options?: SanitizedCommandOptions
+): Promise<void> {
+	let result;
+	try {
+		result = await runSanitizedCommand(command, args, options);
+	} catch {
+		console.error(
+			`${colors.red}Command could not start: ${sanitizeTerminalField(command)}${colors.reset}`
+		);
+		process.exit(1);
+	}
 
 	if (result.status !== 0) {
-		console.error(`${colors.red}Command failed: ${command} ${args.join(' ')}${colors.reset}`);
+		const invocation = sanitizeTerminalField(`${command} ${args.join(' ')}`);
+		console.error(`${colors.red}Command failed: ${invocation}${colors.reset}`);
 		process.exit(result.status ?? 1);
 	}
 }
@@ -518,7 +532,7 @@ async function main(): Promise<void> {
 
 	// SvelteKit sync (always runs — needed by both lint and types)
 	printHeader(step++, 'SvelteKit sync');
-	runCommand('bun', ['svelte-kit', 'sync']);
+	await runCommand('bun', ['svelte-kit', 'sync']);
 	ledger.ran('svelte-kit sync');
 	console.log('\n');
 
@@ -540,7 +554,7 @@ async function main(): Promise<void> {
 				// Batch files to avoid command line length limits
 				const chunkSize = 100;
 				for (let i = 0; i < files.length; i += chunkSize) {
-					runCommand('misspell', ['-error', ...files.slice(i, i + chunkSize)]);
+					await runCommand('misspell', ['-error', ...files.slice(i, i + chunkSize)]);
 				}
 			}
 			ledger.ran('misspell', files.length);
@@ -601,7 +615,9 @@ async function main(): Promise<void> {
 
 			if (violations.length > 0) {
 				console.error(`${colors.red}Found ${violations.length} banned pattern(s):${colors.reset}`);
-				for (const v of violations) console.error(`  ${v}`);
+				for (const violation of violations) {
+					console.error(`  ${sanitizeTerminalField(violation)}`);
+				}
 				process.exit(1);
 			}
 			console.log(`Scanned ${filesToScan.length} files — no banned patterns found`);
@@ -615,10 +631,10 @@ async function main(): Promise<void> {
 			const formatFlag = ciMode ? '--check' : '--write';
 			const files = ledger.filesFor('prettier');
 			if (!scopedMode) {
-				runCommand('bun', ['prettier', formatFlag, '.']);
+				await runCommand('bun', ['prettier', formatFlag, '.']);
 				ledger.ran('prettier');
 			} else if (files.length > 0) {
-				runCommand('bun', [
+				await runCommand('bun', [
 					'prettier',
 					formatFlag,
 					'--plugin',
@@ -641,10 +657,10 @@ async function main(): Promise<void> {
 			const fixArgs = ciMode ? [] : ['--fix'];
 			const files = ledger.filesFor('eslint');
 			if (!scopedMode) {
-				runCommand('bun', ['eslint', '.', ...fixArgs]);
+				await runCommand('bun', ['eslint', '.', ...fixArgs]);
 				ledger.ran('eslint');
 			} else if (files.length > 0) {
-				runCommand('bun', ['eslint', ...fixArgs, ...files]);
+				await runCommand('bun', ['eslint', ...fixArgs, ...files]);
 				ledger.ran('eslint', files.length);
 			} else {
 				console.log('No JS/TS/Svelte files to lint');
@@ -655,7 +671,7 @@ async function main(): Promise<void> {
 
 		// oxlint
 		printHeader(step++, 'oxlint');
-		runCommand('bun', ['oxlint']);
+		await runCommand('bun', ['oxlint']);
 		ledger.ran('oxlint');
 		console.log('\n');
 	}
@@ -665,7 +681,7 @@ async function main(): Promise<void> {
 	if (shouldRunTypes) {
 		// Build emails (required before type checking)
 		printHeader(step++, 'Build emails');
-		runCommand('bun', ['scripts/build-emails.ts']);
+		await runCommand('bun', ['scripts/build-emails.ts']);
 		ledger.ran('build-emails');
 		console.log('\n');
 
@@ -677,7 +693,7 @@ async function main(): Promise<void> {
 				console.log('No TypeScript/Svelte files to check');
 				ledger.ran('svelte-check', 0);
 			} else {
-				runCommand('bun', ['svelte-check', '--tsconfig', './tsconfig.json'], {
+				await runCommand('bun', ['svelte-check', '--tsconfig', './tsconfig.json'], {
 					env: { ...process.env, NODE_OPTIONS: '--max-old-space-size=8192' }
 				});
 				// svelte-check is tsconfig-driven: the routed files decide WHETHER it runs,
@@ -692,7 +708,7 @@ async function main(): Promise<void> {
 		{
 			const files = ledger.filesFor('convex');
 			if (!scopedMode || files.length > 0) {
-				runCommand('bun', ['run', 'check:convex']);
+				await runCommand('bun', ['run', 'check:convex']);
 				ledger.ran('convex', 'project');
 			} else {
 				console.log('No Convex files to check');
@@ -710,7 +726,7 @@ async function main(): Promise<void> {
 		// human-readable output, so there is no stable primitive to build a drift
 		// guard from; auto-pushing from CI would be worse).
 		printHeader(step, 'Autumn config');
-		runCommand('bun', ['atmn', 'preview']);
+		await runCommand('bun', ['atmn', 'preview']);
 		ledger.ran('atmn preview');
 		console.log('\n');
 	}
@@ -727,7 +743,7 @@ async function main(): Promise<void> {
 					'changes to land the auto-fixes.)'
 			);
 		}
-		runCommand('git', ['add', ...stagedIndexPaths], { env: sanitizedGitEnv() });
+		await runCommand('git', ['add', ...stagedIndexPaths], { env: sanitizedGitEnv() });
 		console.log('');
 	}
 
@@ -745,7 +761,7 @@ async function main(): Promise<void> {
 			scope: policyScope
 		});
 		for (const policyFinding of result.findings) {
-			const line = formatPolicyFinding(policyFinding);
+			const line = sanitizeTerminalField(formatPolicyFinding(policyFinding));
 			console[policyFinding.severity === 'error' ? 'error' : 'warn'](`  ${line}`);
 		}
 		const errors = result.findings.filter((item) => item.severity === 'error').length;
@@ -769,7 +785,9 @@ if (import.meta.main) {
 	// Default-deny: finish() is the only path that writes a zero exit code.
 	process.exitCode = 2;
 	main().catch((error: Error) => {
-		console.error(`${colors.red}Fatal error: ${error.message}${colors.reset}`);
+		console.error(
+			`${colors.red}Fatal error: ${sanitizeTerminalField(error.message)}${colors.reset}`
+		);
 		process.exit(1);
 	});
 }

--- a/scripts/terminal-output.test.ts
+++ b/scripts/terminal-output.test.ts
@@ -1,0 +1,279 @@
+import { spawnSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import path from 'path';
+import { PassThrough, Writable } from 'stream';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import {
+	colorlessEnvironment,
+	runSanitizedCommand,
+	TerminalOutputDecoder
+} from './terminal-output';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ch = (code: number) => String.fromCharCode(code);
+const bytes = (text: string) => new TextEncoder().encode(text);
+
+function sanitize(chunks: Uint8Array[]): string {
+	const decoder = new TerminalOutputDecoder();
+	return chunks.map((chunk) => decoder.write(chunk)).join('') + decoder.end();
+}
+
+function capture(stream: PassThrough): () => string {
+	const chunks: Buffer[] = [];
+	stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+	return () => Buffer.concat(chunks).toString('utf8');
+}
+
+class SlowCapture extends Writable {
+	readonly chunks: Buffer[] = [];
+	drains = 0;
+
+	constructor() {
+		super({ highWaterMark: 1 });
+		this.on('drain', () => this.drains++);
+	}
+
+	override _write(
+		chunk: Buffer,
+		_encoding: BufferEncoding,
+		callback: (error?: Error | null) => void
+	): void {
+		this.chunks.push(Buffer.from(chunk));
+		setTimeout(callback, 1);
+	}
+
+	text(): string {
+		return Buffer.concat(this.chunks).toString('utf8');
+	}
+}
+
+describe('terminal output text', () => {
+	it('neutralizes every non-structural C0, DEL, C1, and bidi control', () => {
+		const bidi = [
+			0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069
+		];
+		const prohibited = [
+			...Array.from({ length: 0x20 }, (_, code) => code).filter(
+				(code) => code !== 0x09 && code !== 0x0a
+			),
+			0x7f,
+			...Array.from({ length: 0x20 }, (_, offset) => 0x80 + offset),
+			...bidi
+		];
+
+		for (const code of prohibited) {
+			const output = sanitize([bytes(`a${ch(code)}b`)]);
+			expect(output).toContain(`U+${code.toString(16).toUpperCase().padStart(4, '0')}`);
+			expect(output).not.toContain(ch(code));
+		}
+		expect(sanitize([bytes('a\tb\nc')])).toBe('a\tb\nc');
+	});
+
+	it('normalizes CRLF across chunks and exposes a lone carriage return', () => {
+		expect(sanitize([bytes('a\r'), bytes('\nb')])).toBe('a\nb');
+		expect(sanitize([bytes('a\r'), bytes('b')])).toBe('aU+000Db');
+		expect(sanitize([bytes('a\r')])).toBe('aU+000D');
+	});
+
+	it('reassembles split UTF-8 before classifying the character', () => {
+		const encoded = bytes(`a${ch(0x202e)}b`);
+		for (let split = 1; split < encoded.length; split++) {
+			expect(sanitize([encoded.slice(0, split), encoded.slice(split)])).toBe('aU+202Eb');
+		}
+	});
+
+	it('makes complete terminal sequences inert without deleting their payload', () => {
+		const esc = ch(0x1b);
+		const bel = ch(0x07);
+		const output = sanitize([
+			bytes(`${esc}[31mred${esc}[0m ${esc}]8;;https://example.com${bel}link${esc}]8;;${bel}`)
+		]);
+
+		expect(output).not.toContain(esc);
+		expect(output).not.toContain(bel);
+		expect(output).toContain('U+001B[31mredU+001B[0m');
+		expect(output).toContain('https://example.com');
+	});
+
+	it('turns malformed UTF-8 into a printable replacement character', () => {
+		expect(sanitize([new Uint8Array([0x61, 0xff, 0x62])])).toBe('a�b');
+	});
+});
+
+describe('sanitized commands', () => {
+	it('removes force-colour variables only from the child environment', () => {
+		const parent = { ...process.env };
+		const overrides = { FORCE_COLOR: '1', clicolor_force: '1', NO_COLOR: '' };
+		const inheritedKey = Object.keys(process.env).find(
+			(key) => !Object.keys(overrides).includes(key)
+		);
+		const env = colorlessEnvironment(overrides);
+
+		expect(inheritedKey).toBeDefined();
+		expect(env[inheritedKey!]).toBeUndefined();
+		expect(env.NO_COLOR).toBe('1');
+		expect(Object.keys(env).map((key) => key.toUpperCase())).not.toContain('FORCE_COLOR');
+		expect(Object.keys(env).map((key) => key.toUpperCase())).not.toContain('CLICOLOR_FORCE');
+		expect(process.env).toEqual(parent);
+	});
+
+	it('sanitizes stdout and stderr independently and preserves the exit status', async () => {
+		const stdout = new PassThrough();
+		const stderr = new PassThrough();
+		const readStdout = capture(stdout);
+		const readStderr = capture(stderr);
+		const script = `
+			const e = String.fromCharCode(27), b = String.fromCharCode(7);
+			process.stdout.write('out' + e + ']0;title' + b);
+			process.stderr.write('err' + e + '[2J');
+			process.exitCode = 2;
+		`;
+
+		const result = await runSanitizedCommand(process.execPath, ['-e', script], {
+			stdout,
+			stderr,
+			githubActions: false
+		});
+
+		expect(result.status).toBe(2);
+		expect(readStdout()).toBe('outU+001B]0;titleU+0007');
+		expect(readStderr()).toBe('errU+001B[2J');
+	});
+
+	it('serializes both streams between random GitHub markers in order', async () => {
+		const stdout = new PassThrough();
+		const stderr = new PassThrough();
+		const readStdout = capture(stdout);
+		const readStderr = capture(stderr);
+		stdout.write('parent-prefix');
+		const script = `
+			process.stdout.write('diagnostic');
+			process.stderr.write('::warning::source');
+			process.exitCode = 2;
+		`;
+
+		const result = await runSanitizedCommand(process.execPath, ['-e', script], {
+			stdout,
+			stderr,
+			githubActions: true
+		});
+		const output = readStdout();
+		const token = output.match(/^::stop-commands::([^\n]+)$/m)?.[1];
+		const stop = output.indexOf(`::stop-commands::${token}`);
+		const diagnostic = output.indexOf('diagnostic');
+		const warning = output.indexOf('::warning::source');
+		const resume = output.indexOf(`::${token}::`);
+
+		expect(result.status).toBe(2);
+		expect(token).toMatch(
+			/^terminal-output-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+		);
+		expect(readStderr()).toBe('');
+		expect(stop).toBeGreaterThan('parent-prefix'.length - 1);
+		expect(diagnostic).toBeGreaterThan(stop);
+		expect(warning).toBeGreaterThan(stop);
+		expect(resume).toBeGreaterThan(diagnostic);
+		expect(resume).toBeGreaterThan(warning);
+		expect(output).toMatch(new RegExp(`^::${token}::$`, 'm'));
+	});
+
+	it('uses a fresh balanced marker pair when spawn fails', async () => {
+		const outputs = await Promise.all(
+			[1, 2].map(async () => {
+				const stdout = new PassThrough();
+				const readStdout = capture(stdout);
+				await expect(
+					runSanitizedCommand(`missing-terminal-output-command-${Date.now()}`, [], {
+						stdout,
+						stderr: new PassThrough(),
+						githubActions: true
+					})
+				).rejects.toThrow();
+				return readStdout();
+			})
+		);
+		const tokens = outputs.map((output) => output.match(/^::stop-commands::([^\n]+)$/m)?.[1]);
+
+		expect(tokens[0]).toBeDefined();
+		expect(tokens[1]).toBeDefined();
+		expect(tokens[0]).not.toBe(tokens[1]);
+		for (let index = 0; index < outputs.length; index++) {
+			const token = tokens[index]!;
+			const stop = outputs[index].indexOf(`::stop-commands::${token}`);
+			const resume = outputs[index].indexOf(`::${token}::`);
+			expect(token).toMatch(
+				/^terminal-output-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+			);
+			expect(stop).toBeGreaterThanOrEqual(0);
+			expect(resume).toBeGreaterThan(stop);
+			expect(outputs[index]).toMatch(new RegExp(`^::${token}::$`, 'm'));
+		}
+	});
+
+	it('drains both pipes while a child writes more than their capacity', async () => {
+		const stdout = new SlowCapture();
+		const stderr = new SlowCapture();
+		const script = `
+			process.stdout.write('a'.repeat(262144));
+			process.stderr.write('b'.repeat(262144));
+		`;
+
+		const result = await runSanitizedCommand(process.execPath, ['-e', script], {
+			stdout,
+			stderr,
+			githubActions: false
+		});
+
+		expect(result.status).toBe(0);
+		expect(stdout.drains).toBeGreaterThan(0);
+		expect(stderr.drains).toBeGreaterThan(0);
+		expect(stdout.text()).toHaveLength(262144);
+		expect(stderr.text()).toHaveLength(262144);
+	}, 5_000);
+});
+
+describe('static-check boundary', () => {
+	it('neutralizes a Prettier code frame built from malformed source', () => {
+		const directory = mkdtempSync(path.join(ROOT, 'terminal-output-prettier-'));
+		const relative = path.relative(ROOT, path.join(directory, 'fixture.ts'));
+		const esc = ch(0x1b);
+		const bel = ch(0x07);
+		const payload = `${esc}]0;title${bel}`;
+		try {
+			writeFileSync(path.join(ROOT, relative), `// ${payload}\nconst value = ;\n`, 'utf8');
+			const result = spawnSync('bun', ['scripts/static-checks.ts', '--scope', 'lint', relative], {
+				cwd: ROOT,
+				encoding: 'utf8'
+			});
+			const output = result.stdout + result.stderr;
+
+			expect(result.status).toBe(2);
+			expect(output).not.toContain(payload);
+			expect(output).toContain('U+001B]0;titleU+0007');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}, 60_000);
+
+	it('neutralizes a source line printed by the in-process banned-pattern check', () => {
+		const directory = mkdtempSync(path.join(ROOT, 'src/terminal-output-parent-'));
+		const relative = path.relative(ROOT, path.join(directory, 'fixture.ts'));
+		const esc = ch(0x1b);
+		const payload = `${esc}]0;title${ch(0x07)}`;
+		try {
+			writeFileSync(path.join(ROOT, relative), `// execSync( ${payload}\n`, 'utf8');
+			const result = spawnSync('bun', ['scripts/static-checks.ts', '--scope', 'lint', relative], {
+				cwd: ROOT,
+				encoding: 'utf8'
+			});
+			const output = result.stdout + result.stderr;
+
+			expect(result.status).toBe(1);
+			expect(output).not.toContain(payload);
+			expect(output).toContain('U+001B]0;titleU+0007');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}, 60_000);
+});

--- a/scripts/terminal-output.ts
+++ b/scripts/terminal-output.ts
@@ -1,0 +1,138 @@
+/**
+ * Terminal boundary for checker subprocesses.
+ *
+ * A formatter-owned ANSI sequence and the same bytes copied from source are
+ * indistinguishable after rendering. Children therefore run without colour, and every
+ * remaining control or bidi character is written as its visible codepoint. Parent-owned
+ * section colours are added outside this boundary.
+ */
+
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import { once } from 'events';
+import type { Writable } from 'stream';
+import { dataFor, terminalCategory } from '../eslint/control-character-policy.js';
+export { sanitizeTerminalField } from '../eslint/control-character-policy.js';
+
+export interface SanitizedCommandOptions {
+	cwd?: string | URL;
+	env?: NodeJS.ProcessEnv;
+	stdout?: Writable;
+	stderr?: Writable;
+	githubActions?: boolean;
+}
+
+export interface SanitizedCommandResult {
+	status: number | null;
+	signal: NodeJS.Signals | null;
+}
+
+/** Child environment with every common force-colour spelling removed. */
+export function colorlessEnvironment(overrides?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	const env = { ...(overrides ?? process.env) };
+	for (const key of Object.keys(env)) {
+		if (['NO_COLOR', 'FORCE_COLOR', 'CLICOLOR_FORCE'].includes(key.toUpperCase())) {
+			delete env[key];
+		}
+	}
+	env.NO_COLOR = '1';
+	return env;
+}
+
+/** Incremental UTF-8 decoder and terminal-text neutralizer for one stream. */
+export class TerminalOutputDecoder {
+	readonly #decoder = new TextDecoder('utf-8');
+	#pendingCarriageReturn = false;
+
+	write(bytes: Uint8Array): string {
+		return this.#sanitize(this.#decoder.decode(bytes, { stream: true }), false);
+	}
+
+	end(): string {
+		return this.#sanitize(this.#decoder.decode(), true);
+	}
+
+	#sanitize(text: string, final: boolean): string {
+		let safe = '';
+		for (let index = 0; index < text.length; index++) {
+			const code = text.charCodeAt(index);
+			if (this.#pendingCarriageReturn) {
+				this.#pendingCarriageReturn = false;
+				if (code === 0x0a) {
+					safe += '\n';
+					continue;
+				}
+				safe += 'U+000D';
+			}
+			if (code === 0x0d) {
+				this.#pendingCarriageReturn = true;
+				continue;
+			}
+			const kind = terminalCategory(code);
+			safe += kind === null ? text[index] : dataFor(code, kind).codepoint;
+		}
+		if (final && this.#pendingCarriageReturn) {
+			safe += 'U+000D';
+			this.#pendingCarriageReturn = false;
+		}
+		return safe;
+	}
+}
+
+/** Sanitize one complete output block while preserving its line structure. */
+export function sanitizeTerminalText(text: string): string {
+	const decoder = new TerminalOutputDecoder();
+	return decoder.write(new TextEncoder().encode(text)) + decoder.end();
+}
+
+async function write(output: Writable, text: string): Promise<void> {
+	if (text === '' || output.write(text)) return;
+	await once(output, 'drain');
+}
+
+async function forward(input: NodeJS.ReadableStream, output: Writable): Promise<void> {
+	const decoder = new TerminalOutputDecoder();
+	for await (const chunk of input) {
+		await write(output, decoder.write(typeof chunk === 'string' ? Buffer.from(chunk) : chunk));
+	}
+	await write(output, decoder.end());
+}
+
+/** Run one child with separate, live, sanitized stdout and stderr streams. */
+export async function runSanitizedCommand(
+	command: string,
+	args: string[],
+	options: SanitizedCommandOptions = {}
+): Promise<SanitizedCommandResult> {
+	const stdout = options.stdout ?? process.stdout;
+	const stderr = options.stderr ?? process.stderr;
+	const onActions = options.githubActions ?? process.env.GITHUB_ACTIONS === 'true';
+	const commandToken = onActions ? `terminal-output-${randomUUID()}` : null;
+	// The Actions runner consumes stdout and stderr through separate queues, so a
+	// marker on one descriptor can race untrusted output on the other. Serialize both
+	// streams onto stdout while workflow commands are suspended. Local runs retain
+	// their original descriptors.
+	const childStderr = onActions ? stdout : stderr;
+	if (commandToken) await write(stdout, `\n::stop-commands::${commandToken}\n`);
+
+	try {
+		const child = spawn(command, args, {
+			cwd: options.cwd,
+			env: colorlessEnvironment(options.env),
+			stdio: ['inherit', 'pipe', 'pipe']
+		});
+		const result = new Promise<SanitizedCommandResult>((resolve, reject) => {
+			child.once('error', reject);
+			child.once('close', (status, signal) => resolve({ status, signal }));
+		});
+
+		const [completed] = await Promise.all([
+			result,
+			forward(child.stdout, stdout),
+			forward(child.stderr, childStderr)
+		]);
+		return completed;
+	} finally {
+		if (commandToken) await write(stdout, `\n::${commandToken}::\n`);
+	}
+}


### PR DESCRIPTION
Closes #832
Regression guard: added `scripts/terminal-output.test.ts`

Checker diagnostics can copy raw source into a terminal before ESLint reports it safely. A source-owned ANSI sequence is byte-identical to formatter colour, so preserving child colour while removing only source controls is impossible after rendering.

The static-check runner now starts every child without colour, decodes stdout and stderr incrementally, and renders control and bidi characters as visible codepoints before forwarding either stream. Both pipes remain live, with local stream identity and exit status preserved. GitHub Actions serializes both streams onto stdout while workflow commands are suspended. Source-derived diagnostics formatted by the parent use the same policy.

Verified with 12 focused boundary cases, ten killed mutations, the complete static-check pipeline, and 1562 unit tests.
