### PR TITLE
fix(lint): Join checker after output failure

### DIFF
--- a/scripts/terminal-output.test.ts
+++ b/scripts/terminal-output.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import path from 'path';
 import { PassThrough, Writable } from 'stream';
 import { fileURLToPath } from 'url';
@@ -45,6 +45,55 @@ class SlowCapture extends Writable {
 
 	text(): string {
 		return Buffer.concat(this.chunks).toString('utf8');
+	}
+}
+
+class FailingCapture extends Writable {
+	override _write(
+		_chunk: Buffer,
+		_encoding: BufferEncoding,
+		callback: (error?: Error | null) => void
+	): void {
+		callback(new Error('output closed'));
+	}
+}
+
+class DelayedFailingCapture extends Writable {
+	constructor() {
+		super();
+		this.on('error', () => {});
+	}
+
+	override _write(
+		_chunk: Buffer,
+		_encoding: BufferEncoding,
+		callback: (error?: Error | null) => void
+	): void {
+		setTimeout(() => callback(new Error('delayed output failure')), 50);
+	}
+}
+
+class ClosingCapture extends Writable {
+	constructor() {
+		super({ highWaterMark: 1 });
+	}
+
+	override _write(): void {
+		this.destroy();
+	}
+}
+
+class CloseAfterFirstCapture extends Writable {
+	#writes = 0;
+
+	override _write(
+		_chunk: Buffer,
+		_encoding: BufferEncoding,
+		callback: (error?: Error | null) => void
+	): void {
+		this.#writes++;
+		if (this.#writes === 1) callback();
+		else this.destroy();
 	}
 }
 
@@ -231,6 +280,93 @@ describe('sanitized commands', () => {
 		expect(stdout.text()).toHaveLength(262144);
 		expect(stderr.text()).toHaveLength(262144);
 	}, 5_000);
+
+	it('joins the child before reporting an output forwarding failure', async () => {
+		const directory = mkdtempSync(path.join(ROOT, 'terminal-output-child-'));
+		const marker = path.join(directory, 'finished');
+		const script = `
+			const { writeFileSync } = require('fs');
+			process.stdout.end('start');
+			setTimeout(() => {
+				writeFileSync(process.argv[1], 'finished');
+				process.exit(0);
+			}, 100);
+		`;
+
+		try {
+			await expect(
+				runSanitizedCommand(process.execPath, ['-e', script, marker], {
+					stdout: new FailingCapture(),
+					stderr: new PassThrough(),
+					githubActions: false
+				})
+			).rejects.toThrow('output closed');
+			expect(existsSync(marker)).toBe(true);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it('waits for an accepted write callback before returning success', async () => {
+		await expect(
+			runSanitizedCommand(process.execPath, ['-e', "process.stdout.write('output')"], {
+				stdout: new DelayedFailingCapture(),
+				stderr: new PassThrough(),
+				githubActions: false
+			})
+		).rejects.toThrow('delayed output failure');
+	});
+
+	it('rejects when a backpressured destination closes without draining', async () => {
+		const outcome = await Promise.race([
+			runSanitizedCommand(process.execPath, ['-e', "process.stdout.write('output')"], {
+				stdout: new ClosingCapture(),
+				stderr: new PassThrough(),
+				githubActions: false
+			}).then(
+				() => 'resolved',
+				() => 'rejected'
+			),
+			new Promise<string>((resolve) => setTimeout(() => resolve('timeout'), 500))
+		]);
+
+		expect(outcome).toBe('rejected');
+	});
+
+	it('rejects when the output destination was already closed', async () => {
+		const stdout = new PassThrough();
+		stdout.destroy();
+		await new Promise((resolve) => stdout.once('close', resolve));
+		const outcome = await Promise.race([
+			runSanitizedCommand(process.execPath, ['-e', "process.stdout.write('output')"], {
+				stdout,
+				stderr: new PassThrough(),
+				githubActions: false
+			}).then(
+				() => 'resolved',
+				() => 'rejected'
+			),
+			new Promise<string>((resolve) => setTimeout(() => resolve('timeout'), 500))
+		]);
+
+		expect(outcome).toBe('rejected');
+	});
+
+	it('settles when GitHub stdout closes before the resume marker', async () => {
+		const outcome = await Promise.race([
+			runSanitizedCommand(process.execPath, ['-e', "process.stdout.write('output')"], {
+				stdout: new CloseAfterFirstCapture(),
+				stderr: new PassThrough(),
+				githubActions: true
+			}).then(
+				() => 'resolved',
+				() => 'rejected'
+			),
+			new Promise<string>((resolve) => setTimeout(() => resolve('timeout'), 500))
+		]);
+
+		expect(outcome).toBe('rejected');
+	});
 });
 
 describe('static-check boundary', () => {

--- a/scripts/terminal-output.ts
+++ b/scripts/terminal-output.ts
@@ -9,7 +9,6 @@
 
 import { spawn } from 'child_process';
 import { randomUUID } from 'crypto';
-import { once } from 'events';
 import type { Writable } from 'stream';
 import { dataFor, terminalCategory } from '../eslint/control-character-policy.js';
 export { sanitizeTerminalField } from '../eslint/control-character-policy.js';
@@ -86,16 +85,51 @@ export function sanitizeTerminalText(text: string): string {
 }
 
 async function write(output: Writable, text: string): Promise<void> {
-	if (text === '' || output.write(text)) return;
-	await once(output, 'drain');
+	if (text === '') return;
+	await new Promise<void>((resolve, reject) => {
+		const cleanup = (): void => {
+			output.off('error', onError);
+			output.off('close', onClose);
+		};
+		const onError = (error: Error): void => {
+			cleanup();
+			reject(error);
+		};
+		const onClose = (): void => {
+			cleanup();
+			reject(new Error('Output closed before the write completed'));
+		};
+		output.once('error', onError);
+		output.once('close', onClose);
+		output.write(text, (error) => {
+			if (error) {
+				reject(error);
+				setImmediate(cleanup);
+				return;
+			}
+			cleanup();
+			resolve();
+		});
+	});
 }
 
 async function forward(input: NodeJS.ReadableStream, output: Writable): Promise<void> {
 	const decoder = new TerminalOutputDecoder();
+	let failed = false;
+	let failure: unknown;
 	for await (const chunk of input) {
-		await write(output, decoder.write(typeof chunk === 'string' ? Buffer.from(chunk) : chunk));
+		const text = decoder.write(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+		if (failed) continue;
+		try {
+			await write(output, text);
+		} catch (error) {
+			failed = true;
+			failure = error;
+		}
 	}
-	await write(output, decoder.end());
+	const final = decoder.end();
+	if (!failed) await write(output, final);
+	if (failed) throw failure;
 }
 
 /** Run one child with separate, live, sanitized stdout and stderr streams. */
@@ -126,12 +160,17 @@ export async function runSanitizedCommand(
 			child.once('close', (status, signal) => resolve({ status, signal }));
 		});
 
-		const [completed] = await Promise.all([
+		const outcomes = await Promise.allSettled([
 			result,
 			forward(child.stdout, stdout),
 			forward(child.stderr, childStderr)
 		]);
-		return completed;
+		const completed = outcomes[0]!;
+		if (completed.status === 'rejected') throw completed.reason;
+		for (const outcome of outcomes.slice(1)) {
+			if (outcome.status === 'rejected') throw outcome.reason;
+		}
+		return completed.value;
 	} finally {
 		if (commandToken) await write(stdout, `\n::${commandToken}::\n`);
 	}


### PR DESCRIPTION
Regression guard: covered by scripts/terminal-output.test.ts

PR #847 returned as soon as an output destination failed, which allowed the checker process or its other stream to continue after the parent reported failure.

The forwarding path now waits for each write callback, rejects errored or closed destinations, keeps draining a child pipe after its destination fails, and joins the checker plus both streams before surfacing the error. A failed formatting or generation check can no longer keep changing files after control returns to the caller.

Verified with 17 focused boundary cases, thirteen killed mutations, the complete static-check pipeline, and 1,567 unit tests.

See also #848.
