### PR TITLE
fix(git): Preserve temporary commit index

### DIFF
--- a/scripts/git-context.staged-files.test.ts
+++ b/scripts/git-context.staged-files.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -7,76 +7,240 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 const HELPER = resolve(process.cwd(), 'scripts/git-context.ts');
 
 function runHelper<T>(cwd: string, expression: string, extraEnv: Record<string, string> = {}): T {
-	const code = `import(${JSON.stringify(HELPER)}).then((m) => { process.stdout.write(JSON.stringify(${expression})); });`;
+	const code = `import(${JSON.stringify(HELPER)}).then((m) => process.stdout.write(JSON.stringify(${expression})));`;
 	const result = spawnSync('bun', ['-e', code], {
 		cwd,
 		env: { ...process.env, ...extraEnv },
 		encoding: 'utf-8'
 	});
-	if (result.status !== 0) {
-		throw new Error(`harness failed (status ${result.status}): ${result.stderr}`);
-	}
+	if (result.status !== 0) throw new Error(result.stderr);
 	return JSON.parse(result.stdout || '[]') as T;
 }
 
-function runGetStagedFiles(cwd: string, extraEnv: Record<string, string> = {}): string[] {
-	return runHelper<string[]>(cwd, 'm.getStagedFiles()', extraEnv);
+function git(cwd: string, args: string[], env: NodeJS.ProcessEnv = process.env): string {
+	const result = spawnSync('git', args, { cwd, env, encoding: 'utf-8' });
+	if (result.status !== 0) throw new Error(result.stderr);
+	return result.stdout;
 }
 
-function gitInTmp(tmp: string, args: string[]): void {
-	const result = spawnSync('git', args, { cwd: tmp, encoding: 'utf-8' });
-	if (result.status !== 0) {
-		throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
-	}
+function installAssertOnlyHook(repository: string, log: string): void {
+	const hook = join(repository, '.git', 'hooks', 'pre-commit');
+	writeFileSync(
+		hook,
+		`#!/usr/bin/env bun
+import { appendFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import {
+	activeGitIndexFingerprint,
+	getStagedFiles,
+	stagedFilesMatchWorktree,
+	stagedGitEnv
+} from ${JSON.stringify(HELPER)};
+
+const cwd = process.cwd();
+const before = activeGitIndexFingerprint(cwd);
+if (process.env.TEST_EARLY_STAGE) {
+	const result = spawnSync('git', ['add', '--', process.env.TEST_EARLY_STAGE], {
+		cwd,
+		env: stagedGitEnv(cwd),
+		encoding: 'utf-8'
+	});
+	if (result.status !== 0) process.exit(result.status ?? 1);
+}
+const files = getStagedFiles(cwd);
+const matchesBefore = stagedFilesMatchWorktree(files, cwd);
+appendFileSync(
+	${JSON.stringify(log)},
+	JSON.stringify({ index: process.env.GIT_INDEX_FILE, files, matchesBefore }) + '\\n'
+);
+if (!matchesBefore) process.exit(1);
+if (process.env.TEST_LATE_WORKTREE && files[0]) {
+	writeFileSync(files[0], process.env.TEST_LATE_WORKTREE);
+}
+if (process.env.TEST_LATE_STAGE) {
+	const result = spawnSync('git', ['add', '--', process.env.TEST_LATE_STAGE], {
+		cwd,
+		env: stagedGitEnv(cwd),
+		encoding: 'utf-8'
+	});
+	if (result.status !== 0) process.exit(result.status ?? 1);
+}
+if (activeGitIndexFingerprint(cwd) !== before) process.exit(1);
+if (!stagedFilesMatchWorktree(files, cwd)) process.exit(1);
+`
+	);
+	chmodSync(hook, 0o755);
 }
 
-describe('getStagedFiles (integration)', () => {
-	let tmp: string;
+describe('staged Git lifecycle', () => {
+	let repository = '';
 
 	beforeEach(() => {
-		tmp = mkdtempSync(join(tmpdir(), 'git-context-test-'));
-
-		gitInTmp(tmp, ['init', '-q', '-b', 'main']);
-		gitInTmp(tmp, ['config', 'user.email', 'test@example.com']);
-		gitInTmp(tmp, ['config', 'user.name', 'Test']);
-		gitInTmp(tmp, ['config', 'commit.gpgsign', 'false']);
-
-		mkdirSync(join(tmp, 'web', 'src'), { recursive: true });
-		mkdirSync(join(tmp, 'other'), { recursive: true });
-		writeFileSync(join(tmp, 'web', 'src', 'a.ts'), 'export const a = 1;\n');
-		writeFileSync(join(tmp, 'other', 'b.ts'), 'export const b = 2;\n');
-
-		gitInTmp(tmp, ['add', 'web/src/a.ts', 'other/b.ts']);
+		repository = mkdtempSync(join(tmpdir(), 'git-context-test-'));
+		git(repository, ['init', '-q', '-b', 'main']);
+		git(repository, ['config', 'user.email', 'test@example.com']);
+		git(repository, ['config', 'user.name', 'Test']);
+		git(repository, ['config', 'commit.gpgsign', 'false']);
+		mkdirSync(join(repository, 'web', 'src'), { recursive: true });
+		mkdirSync(join(repository, 'other'), { recursive: true });
+		writeFileSync(join(repository, 'web', 'src', 'a.ts'), 'export const a = 1;\n');
+		writeFileSync(join(repository, 'other', 'b.ts'), 'export const b = 2;\n');
+		git(repository, ['add', 'web/src/a.ts', 'other/b.ts']);
 	});
 
 	afterEach(() => {
-		if (tmp) rmSync(tmp, { recursive: true, force: true });
+		rmSync(repository, { recursive: true, force: true });
 	});
 
-	it('returns paths under cwd only, with the cwd prefix stripped', () => {
-		const files = runGetStagedFiles(join(tmp, 'web'));
-		expect(files).toEqual(['src/a.ts']);
+	it('filters siblings and anchors a relative index after cd', () => {
+		expect(
+			runHelper<string[]>(join(repository, 'web'), 'm.getStagedFiles()', {
+				GIT_INDEX_FILE: '.git/index'
+			})
+		).toEqual(['src/a.ts']);
 	});
 
-	it('preserves delete and rename metadata while file output keeps live targets only', () => {
-		gitInTmp(tmp, ['commit', '-qm', 'Initial']);
-		writeFileSync(join(tmp, 'web', 'src', 'added.ts'), 'export const added = true;\n');
-		gitInTmp(tmp, ['add', 'web/src/added.ts']);
-		gitInTmp(tmp, ['rm', '-q', 'web/src/a.ts']);
-		gitInTmp(tmp, ['mv', 'other/b.ts', 'other/c.ts']);
+	it.each([
+		['commit -a', ['-a'], /^index\.lock$/, ['other/b.ts', 'web/src/a.ts']],
+		['path-limited commit', ['--', 'web/src/a.ts'], /^next-index-\d+\.lock$/, ['web/src/a.ts']]
+	] as const)(
+		'reads the active index during %s without changing it',
+		(_label, args, indexName, expectedFiles) => {
+			git(repository, ['commit', '-qm', 'Initial']);
+			writeFileSync(join(repository, 'web', 'src', 'a.ts'), 'export const a = 10;\n');
+			writeFileSync(join(repository, 'other', 'b.ts'), 'export const b = 20;\n');
+			const log = join(repository, '.git', 'hook.jsonl');
+			installAssertOnlyHook(repository, log);
 
-		expect(runHelper(join(tmp, 'web'), 'm.getStagedChanges()')).toEqual([
-			{ status: 'D', path: 'src/a.ts' },
-			{ status: 'A', path: 'src/added.ts' }
-		]);
-		expect(runGetStagedFiles(join(tmp, 'web'))).toEqual(['src/added.ts']);
-	});
+			const result = spawnSync('git', ['commit', '-qm', 'Update', ...args], {
+				cwd: repository,
+				encoding: 'utf-8'
+			});
 
-	it('filters siblings + relativizes when GIT_DIR is set externally', () => {
-		const files = runGetStagedFiles(join(tmp, 'web'), {
-			GIT_DIR: join(tmp, '.git'),
-			GIT_WORK_TREE: ''
+			expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+			const observed = JSON.parse(readFileSync(log, 'utf8').trim()) as {
+				index?: string;
+				files: string[];
+				matchesBefore: boolean;
+			};
+			expect(observed.index?.split(/[\\/]/).at(-1)).toMatch(indexName);
+			expect(observed.files).toEqual(expectedFiles);
+			expect(observed.matchesBefore).toBe(true);
+		}
+	);
+
+	it('aborts a patch commit whose rejected hunks remain in the worktree', () => {
+		const file = join(repository, 'web', 'src', 'a.ts');
+		const initial = Array.from({ length: 20 }, (_, index) => `export const line${index} = 0;`);
+		writeFileSync(file, `${initial.join('\n')}\n`);
+		git(repository, ['add', 'web/src/a.ts']);
+		git(repository, ['commit', '-qm', 'Initial']);
+		const changed = [...initial];
+		changed[0] = 'export const line0 = 1;';
+		changed[19] = 'export const line19 = 1;';
+		writeFileSync(file, `${changed.join('\n')}\n`);
+		installAssertOnlyHook(repository, join(repository, '.git', 'hook.jsonl'));
+
+		const result = spawnSync('git', ['commit', '-p', '-m', 'Patch'], {
+			cwd: repository,
+			input: 'y\nn\n',
+			encoding: 'utf-8',
+			env: { ...process.env, GIT_PAGER: 'cat' }
 		});
-		expect(files).toEqual(['src/a.ts']);
+
+		expect(result.status).toBe(1);
+		expect(git(repository, ['show', 'HEAD:web/src/a.ts'])).toBe(`${initial.join('\n')}\n`);
+	});
+
+	it('aborts when staged bytes differ from the checked worktree', () => {
+		git(repository, ['commit', '-qm', 'Initial']);
+		const file = join(repository, 'web', 'src', 'a.ts');
+		writeFileSync(file, 'export const secret = "staged";\n');
+		git(repository, ['add', 'web/src/a.ts']);
+		writeFileSync(file, 'export const a = 2;\n');
+		installAssertOnlyHook(repository, join(repository, '.git', 'hook.jsonl'));
+
+		const result = spawnSync('git', ['commit', '-qm', 'Unsafe'], {
+			cwd: repository,
+			encoding: 'utf-8'
+		});
+
+		expect(result.status).toBe(1);
+		expect(git(repository, ['show', ':web/src/a.ts'])).toContain('secret');
+		expect(readFileSync(file, 'utf8')).toBe('export const a = 2;\n');
+	});
+
+	it('aborts when the index changes before staged file selection', () => {
+		git(repository, ['commit', '-qm', 'Initial']);
+		writeFileSync(join(repository, 'web', 'src', 'a.ts'), 'export const a = 10;\n');
+		git(repository, ['add', 'web/src/a.ts']);
+		writeFileSync(join(repository, 'other', 'b.ts'), 'export const b = 20;\n');
+		installAssertOnlyHook(repository, join(repository, '.git', 'hook.jsonl'));
+
+		const result = spawnSync('git', ['commit', '-qm', 'Unsafe'], {
+			cwd: repository,
+			encoding: 'utf-8',
+			env: { ...process.env, TEST_EARLY_STAGE: 'other/b.ts' }
+		});
+
+		expect(result.status).toBe(1);
+		expect(git(repository, ['show', 'HEAD:other/b.ts'])).toBe('export const b = 2;\n');
+	});
+
+	it('aborts when the index changes after file selection', () => {
+		git(repository, ['commit', '-qm', 'Initial']);
+		writeFileSync(join(repository, 'web', 'src', 'a.ts'), 'export const a = 10;\n');
+		git(repository, ['add', 'web/src/a.ts']);
+		writeFileSync(join(repository, 'other', 'b.ts'), 'export const b = 20;\n');
+		installAssertOnlyHook(repository, join(repository, '.git', 'hook.jsonl'));
+
+		const result = spawnSync('git', ['commit', '-qm', 'Unsafe'], {
+			cwd: repository,
+			encoding: 'utf-8',
+			env: { ...process.env, TEST_LATE_STAGE: 'other/b.ts' }
+		});
+
+		expect(result.status).toBe(1);
+		expect(git(repository, ['show', 'HEAD:other/b.ts'])).toBe('export const b = 2;\n');
+	});
+
+	it('aborts when checked worktree bytes change before completion', () => {
+		git(repository, ['commit', '-qm', 'Initial']);
+		writeFileSync(join(repository, 'web', 'src', 'a.ts'), 'export const a = 10;\n');
+		git(repository, ['add', 'web/src/a.ts']);
+		installAssertOnlyHook(repository, join(repository, '.git', 'hook.jsonl'));
+
+		const result = spawnSync('git', ['commit', '-qm', 'Unsafe'], {
+			cwd: repository,
+			encoding: 'utf-8',
+			env: { ...process.env, TEST_LATE_WORKTREE: 'export const a = 99;\n' }
+		});
+
+		expect(result.status).toBe(1);
+		expect(git(repository, ['show', 'HEAD:web/src/a.ts'])).toBe('export const a = 1;\n');
+	});
+
+	it.each(['relative', 'external'] as const)('commits through a %s alternative index', (kind) => {
+		git(repository, ['commit', '-qm', 'Initial']);
+		const index = kind === 'relative' ? '.git/release-index' : join(repository, 'release-index');
+		const env = {
+			...process.env,
+			GIT_INDEX_FILE: index,
+			...(kind === 'external' ? { STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX: '1' } : {})
+		};
+		git(repository, ['read-tree', 'HEAD'], env);
+		writeFileSync(join(repository, 'web', 'src', 'a.ts'), 'export const a = 10;\n');
+		git(repository, ['add', 'web/src/a.ts'], env);
+		const log = join(repository, '.git', 'hook.jsonl');
+		installAssertOnlyHook(repository, log);
+
+		const result = spawnSync('git', ['commit', '-qm', 'Alternative'], {
+			cwd: repository,
+			env,
+			encoding: 'utf-8'
+		});
+
+		expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+		expect(git(repository, ['show', 'HEAD:web/src/a.ts'])).toBe('export const a = 10;\n');
 	});
 });

--- a/scripts/git-context.test.ts
+++ b/scripts/git-context.test.ts
@@ -1,13 +1,47 @@
+import { spawnSync } from 'node:child_process';
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { isUnderPreCommit, sanitizedGitEnv } from './git-context';
+import {
+	activeGitIndexFingerprint,
+	getStagedFiles,
+	sanitizedGitEnv,
+	stagedFilesMatchWorktree,
+	stagedFilesWithCleanFilters,
+	stagedGitEnv
+} from './git-context';
 
-const SCRUBBED = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_OBJECT_DIRECTORY'] as const;
-const PRE_COMMIT_KEYS = [
-	'PRE_COMMIT',
-	'PRE_COMMIT_FROM_REF',
-	'PRE_COMMIT_TO_REF',
-	'PRE_COMMIT_HOME'
-];
+const SCRUBBED = [
+	'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+	'GIT_COMMON_DIR',
+	'GIT_CONFIG',
+	'GIT_DIR',
+	'GIT_GRAFT_FILE',
+	'GIT_IMPLICIT_WORK_TREE',
+	'GIT_INDEX_FILE',
+	'GIT_NO_REPLACE_OBJECTS',
+	'GIT_OBJECT_DIRECTORY',
+	'GIT_PREFIX',
+	'GIT_REPLACE_REF_BASE',
+	'GIT_SHALLOW_FILE',
+	'GIT_WORK_TREE'
+] as const;
+const EXTERNAL_INDEX_OPT_IN = 'STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX';
+
+function git(cwd: string, args: string[], env: NodeJS.ProcessEnv = sanitizedGitEnv()): string {
+	const result = spawnSync('git', args, { cwd, env, encoding: 'utf-8' });
+	if (result.status !== 0) throw new Error(result.stderr);
+	return result.stdout;
+}
 
 describe('sanitizedGitEnv', () => {
 	const saved = new Map<string, string | undefined>();
@@ -24,36 +58,67 @@ describe('sanitizedGitEnv', () => {
 		saved.clear();
 	});
 
-	it('removes all four scrubbed git env vars', () => {
+	it('removes Git repository, index, and object-store context', () => {
 		for (const key of SCRUBBED) process.env[key] = 'parent-value';
 		const env = sanitizedGitEnv();
-		for (const key of SCRUBBED) {
-			expect(env[key]).toBeUndefined();
-		}
+		for (const key of SCRUBBED) expect(env[key]).toBeUndefined();
 	});
 
-	it('preserves other env vars', () => {
-		process.env['GIT_DIR'] = '/parent/.git';
-		process.env['MY_UNRELATED_VAR'] = 'keep-me';
+	it('preserves command-scoped Git configuration', () => {
+		process.env.GIT_CONFIG_PARAMETERS = "'safe.directory'='/checkout'";
+		process.env.GIT_CONFIG_COUNT = '1';
+		process.env.GIT_CONFIG_KEY_0 = 'core.autocrlf';
+		process.env.GIT_CONFIG_VALUE_0 = 'false';
 		const env = sanitizedGitEnv();
-		expect(env['GIT_DIR']).toBeUndefined();
-		expect(env['MY_UNRELATED_VAR']).toBe('keep-me');
-		delete process.env['MY_UNRELATED_VAR'];
+		expect(env.GIT_CONFIG_PARAMETERS).toBe(process.env.GIT_CONFIG_PARAMETERS);
+		expect(env.GIT_CONFIG_COUNT).toBe('1');
+		expect(env.GIT_CONFIG_KEY_0).toBe('core.autocrlf');
+		expect(env.GIT_CONFIG_VALUE_0).toBe('false');
+		delete process.env.GIT_CONFIG_PARAMETERS;
+		delete process.env.GIT_CONFIG_COUNT;
+		delete process.env.GIT_CONFIG_KEY_0;
+		delete process.env.GIT_CONFIG_VALUE_0;
 	});
 
-	it('returns a copy, does not mutate process.env', () => {
-		process.env['GIT_DIR'] = '/parent/.git';
-		sanitizedGitEnv();
-		expect(process.env['GIT_DIR']).toBe('/parent/.git');
+	it('removes Git context regardless of environment-name casing', () => {
+		process.env.git_dir = '/parent/.git';
+		process.env.git_index_file = '/parent/.git/index';
+		const env = sanitizedGitEnv();
+		expect(env.git_dir).toBeUndefined();
+		expect(env.git_index_file).toBeUndefined();
+		delete process.env.git_dir;
+		delete process.env.git_index_file;
+	});
+
+	it('preserves unrelated variables without mutating process.env', () => {
+		process.env.GIT_DIR = '/parent/.git';
+		process.env.MY_UNRELATED_VAR = 'keep-me';
+		const env = sanitizedGitEnv();
+		expect(env.MY_UNRELATED_VAR).toBe('keep-me');
+		expect(process.env.GIT_DIR).toBe('/parent/.git');
+		delete process.env.MY_UNRELATED_VAR;
 	});
 });
 
-describe('isUnderPreCommit', () => {
+describe('staged Git context', () => {
 	const saved = new Map<string, string | undefined>();
+	let directory = '';
+	let repository = '';
+	let gitDirectory = '';
 
 	beforeEach(() => {
-		for (const key of [...SCRUBBED, ...PRE_COMMIT_KEYS]) saved.set(key, process.env[key]);
-		for (const key of [...SCRUBBED, ...PRE_COMMIT_KEYS]) delete process.env[key];
+		for (const key of [...SCRUBBED, EXTERNAL_INDEX_OPT_IN]) saved.set(key, process.env[key]);
+		for (const key of [...SCRUBBED, EXTERNAL_INDEX_OPT_IN]) delete process.env[key];
+		directory = mkdtempSync(path.join(tmpdir(), 'git-context-'));
+		repository = path.join(directory, 'repository');
+		mkdirSync(repository);
+		git(repository, ['init', '-q', '-b', 'main']);
+		git(repository, ['config', 'user.email', 'test@example.com']);
+		git(repository, ['config', 'user.name', 'Test']);
+		git(repository, ['config', 'commit.gpgsign', 'false']);
+		writeFileSync(path.join(repository, 'a.ts'), 'export const a = 1;\n');
+		git(repository, ['add', 'a.ts']);
+		gitDirectory = git(repository, ['rev-parse', '--absolute-git-dir']).trimEnd();
 	});
 
 	afterEach(() => {
@@ -62,24 +127,238 @@ describe('isUnderPreCommit', () => {
 			else process.env[key] = value;
 		}
 		saved.clear();
+		rmSync(directory, { recursive: true, force: true });
 	});
 
-	it('returns false when no relevant env vars are set', () => {
-		expect(isUnderPreCommit()).toBe(false);
+	it.each(['index.lock', 'next-index-123.lock'])(
+		'preserves repository temporary index %s',
+		(name) => {
+			const candidate = path.join(gitDirectory, name);
+			writeFileSync(candidate, 'index fixture');
+			process.env.GIT_INDEX_FILE = candidate;
+			process.env.GIT_DIR = path.join(directory, 'foreign.git');
+
+			expect(stagedGitEnv(repository).GIT_INDEX_FILE).toBe(candidate);
+		}
+	);
+
+	it('scrubs a Git-owned temporary index from a native parent hook', () => {
+		const parent = path.join(directory, 'parent');
+		const nested = path.join(parent, 'nested');
+		mkdirSync(parent);
+		git(parent, ['init', '-q', '-b', 'main']);
+		mkdirSync(nested);
+		git(nested, ['init', '-q', '-b', 'main']);
+		const parentGitDirectory = git(parent, ['rev-parse', '--absolute-git-dir']).trimEnd();
+		const parentIndex = path.join(parentGitDirectory, 'index.lock');
+		writeFileSync(parentIndex, 'parent index');
+		process.env.GIT_INDEX_FILE = parentIndex;
+
+		expect(stagedGitEnv(nested).GIT_INDEX_FILE).toBeUndefined();
 	});
 
-	it('returns false when only GIT_DIR is set (git itself sets this for every hook)', () => {
-		process.env['GIT_DIR'] = '/parent/.git';
-		expect(isUnderPreCommit()).toBe(false);
+	it('fails closed for an unowned external index.lock', () => {
+		const external = path.join(directory, 'external');
+		mkdirSync(external);
+		const candidate = path.join(external, 'index.lock');
+		writeFileSync(candidate, 'external index');
+		process.env.GIT_INDEX_FILE = candidate;
+
+		expect(() => stagedGitEnv(repository)).toThrow(
+			'requires STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX'
+		);
 	});
 
-	it('returns true when PRE_COMMIT is set', () => {
-		process.env['PRE_COMMIT'] = '1';
-		expect(isUnderPreCommit()).toBe(true);
+	it('fails closed for an unowned arbitrary external index', () => {
+		const candidate = path.join(directory, 'release-index');
+		writeFileSync(candidate, 'external index');
+		process.env.GIT_INDEX_FILE = candidate;
+
+		expect(() => stagedGitEnv(repository)).toThrow(
+			'requires STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX'
+		);
 	});
 
-	it('returns true when any PRE_COMMIT_* var is set', () => {
-		process.env['PRE_COMMIT_FROM_REF'] = 'abc123';
-		expect(isUnderPreCommit()).toBe(true);
+	it('preserves an explicitly allowed external index.lock', () => {
+		const external = path.join(directory, 'external');
+		mkdirSync(external);
+		const candidate = path.join(external, 'index.lock');
+		writeFileSync(candidate, 'external index');
+		process.env.GIT_INDEX_FILE = candidate;
+		process.env.STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX = '1';
+
+		expect(stagedGitEnv(repository).GIT_INDEX_FILE).toBe(candidate);
+	});
+
+	it('anchors a relative index at the discovered Git root after cd', () => {
+		const nested = path.join(repository, 'web');
+		mkdirSync(nested);
+		process.env.GIT_INDEX_FILE = '.git/index';
+
+		expect(stagedGitEnv(nested).GIT_INDEX_FILE).toBe(path.join(gitDirectory, 'index'));
+	});
+
+	it('preserves explicitly allowed external indices and object stores', () => {
+		const index = path.join(directory, 'release-index');
+		const objects = path.join(directory, 'release-objects');
+		const alternate = path.join(directory, 'alternate-objects');
+		writeFileSync(index, 'index fixture');
+		mkdirSync(objects);
+		mkdirSync(alternate);
+		process.env.GIT_INDEX_FILE = index;
+		process.env.STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX = '1';
+		process.env.GIT_OBJECT_DIRECTORY = objects;
+		process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES = alternate;
+
+		const env = stagedGitEnv(repository);
+		expect(env.GIT_INDEX_FILE).toBe(index);
+		expect(env.GIT_OBJECT_DIRECTORY).toBe(realpathSync(objects));
+		expect(env.GIT_ALTERNATE_OBJECT_DIRECTORIES).toBe(alternate);
+	});
+
+	it.skipIf(process.platform === 'win32')('accepts a symlinked object directory', () => {
+		const target = path.join(directory, 'object-target');
+		const link = path.join(directory, 'object-link');
+		mkdirSync(target);
+		symlinkSync(target, link, 'dir');
+		process.env.GIT_OBJECT_DIRECTORY = link;
+
+		expect(stagedGitEnv(repository).GIT_OBJECT_DIRECTORY).toBe(realpathSync(target));
+	});
+
+	it('preserves an explicit alternate store with the standard index', () => {
+		const alternate = path.join(directory, 'alternate-objects');
+		mkdirSync(alternate);
+		process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES = alternate;
+
+		expect(stagedGitEnv(repository).GIT_ALTERNATE_OBJECT_DIRECTORIES).toBe(alternate);
+	});
+
+	it('preserves Git-quoted alternate object paths verbatim', () => {
+		const alternate = path.join(directory, 'source:repo', 'objects');
+		mkdirSync(alternate, { recursive: true });
+		const quoted = JSON.stringify(alternate);
+		process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES = quoted;
+
+		expect(stagedGitEnv(repository).GIT_ALTERNATE_OBJECT_DIRECTORIES).toBe(quoted);
+	});
+
+	it('scrubs an index and object stores inherited from a foreign repository', () => {
+		const foreign = path.join(directory, 'foreign.git');
+		const objects = path.join(foreign, 'objects');
+		mkdirSync(objects, { recursive: true });
+		const index = path.join(foreign, 'index');
+		writeFileSync(index, 'index fixture');
+		process.env.GIT_DIR = foreign;
+		process.env.GIT_INDEX_FILE = index;
+		process.env.GIT_OBJECT_DIRECTORY = objects;
+		process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES = objects;
+
+		const env = stagedGitEnv(repository);
+		expect(env.GIT_INDEX_FILE).toBeUndefined();
+		expect(env.GIT_OBJECT_DIRECTORY).toBeUndefined();
+		expect(env.GIT_ALTERNATE_OBJECT_DIRECTORIES).toBeUndefined();
+	});
+
+	it('preserves a Git directory ending with whitespace', () => {
+		const worktree = path.join(directory, 'separate-worktree');
+		const metadata = path.join(directory, 'metadata ');
+		git(directory, ['init', '-q', '--separate-git-dir', metadata, worktree]);
+		const candidate = path.join(metadata, 'index.lock');
+		writeFileSync(candidate, 'index fixture');
+		process.env.GIT_INDEX_FILE = candidate;
+
+		expect(stagedGitEnv(worktree).GIT_INDEX_FILE).toBe(candidate);
+	});
+
+	it('fails closed for a missing or symlinked explicit index', () => {
+		process.env.STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX = '1';
+		process.env.GIT_INDEX_FILE = path.join(directory, 'missing-index');
+		expect(() => stagedGitEnv(repository)).toThrow('not a regular file');
+
+		if (process.platform !== 'win32') {
+			const target = path.join(directory, 'target-index');
+			const link = path.join(directory, 'linked-index');
+			writeFileSync(target, 'index fixture');
+			symlinkSync(target, link);
+			process.env.GIT_INDEX_FILE = link;
+			expect(() => stagedGitEnv(repository)).toThrow('not a regular file');
+		}
+	});
+
+	it('fingerprints extended index state', () => {
+		const before = activeGitIndexFingerprint(repository);
+		git(repository, ['update-index', '--assume-unchanged', 'a.ts']);
+		expect(activeGitIndexFingerprint(repository)).not.toBe(before);
+	});
+
+	it('enumerates staged paths without applying a replacement for HEAD', () => {
+		writeFileSync(path.join(repository, 'safe.md'), '# Initial\n');
+		git(repository, ['add', 'safe.md']);
+		git(repository, ['commit', '-qm', 'Initial']);
+		writeFileSync(path.join(repository, 'a.ts'), 'export const secret = "LIVE_SECRET_VALUE";\n');
+		git(repository, ['add', 'a.ts']);
+		const replacementTree = git(repository, ['write-tree']).trim();
+		const replacementCommit = git(repository, [
+			'commit-tree',
+			replacementTree,
+			'-p',
+			'HEAD',
+			'-m',
+			'Replacement'
+		]).trim();
+		writeFileSync(path.join(repository, 'safe.md'), '# Changed\n');
+		git(repository, ['add', 'safe.md']);
+		git(repository, ['replace', 'HEAD', replacementCommit]);
+
+		expect(getStagedFiles(repository).sort()).toEqual(['a.ts', 'safe.md']);
+	});
+
+	it('compares staged and worktree blobs through Git clean filters', () => {
+		expect(stagedFilesMatchWorktree(['a.ts'], repository)).toBe(true);
+		expect(stagedFilesWithCleanFilters(['a.ts'], repository)).toEqual([]);
+		writeFileSync(path.join(repository, 'a.ts'), 'export const a = 2;\n');
+		expect(stagedFilesMatchWorktree(['a.ts'], repository)).toBe(false);
+	});
+
+	it.skipIf(process.platform === 'win32')('accepts a clean-filtered staged blob', () => {
+		const filter = path.join(directory, 'filter');
+		writeFileSync(
+			filter,
+			'#!/usr/bin/env bun\nconst input = await Bun.stdin.text();\nprocess.stdout.write(input.replace("= 1", "= x"));\n'
+		);
+		chmodSync(filter, 0o755);
+		git(repository, ['config', 'filter.corrupt.clean', filter]);
+		git(repository, ['config', 'filter.corrupt.required', 'true']);
+		writeFileSync(path.join(repository, '.gitattributes'), 'a.ts filter=corrupt\n');
+		git(repository, ['add', '.gitattributes', 'a.ts']);
+
+		expect(stagedFilesMatchWorktree(['a.ts'], repository)).toBe(true);
+		expect(stagedFilesWithCleanFilters(['a.ts'], repository)).toEqual(['a.ts']);
+	});
+
+	it.skipIf(process.platform === 'win32')('rejects a staged path replaced by a FIFO', () => {
+		const file = path.join(repository, 'a.ts');
+		rmSync(file);
+		const result = spawnSync('mkfifo', [file], { encoding: 'utf8' });
+		if (result.status !== 0) throw new Error(result.stderr);
+
+		expect(() => stagedFilesMatchWorktree(['a.ts'], repository)).toThrow(
+			'Unsupported worktree path type'
+		);
+	});
+
+	it('accepts a symlink placeholder when its raw blob matches', () => {
+		const target = Buffer.from('target.ts');
+		const objectId = spawnSync('git', ['hash-object', '-w', '--stdin'], {
+			cwd: repository,
+			env: sanitizedGitEnv(),
+			input: target,
+			encoding: 'utf-8'
+		}).stdout.trim();
+		git(repository, ['update-index', '--add', '--cacheinfo', `120000,${objectId},link.ts`]);
+		writeFileSync(path.join(repository, 'link.ts'), target);
+
+		expect(stagedFilesMatchWorktree(['link.ts'], repository)).toBe(true);
 	});
 });

--- a/scripts/git-context.ts
+++ b/scripts/git-context.ts
@@ -1,38 +1,187 @@
 /**
- * Git context helpers for scripts that run inside `git` hooks.
+ * Git context helpers for scripts that run inside hooks.
  *
- * Hooks may be dispatched by tools (notably the Python `pre-commit` framework)
- * that pre-set GIT_DIR / GIT_WORK_TREE in the hook's environment to point at
- * a parent repository. When the saas-starter app is nested in a subdirectory
- * of such a repo, those env vars cause `git diff --cached` and `git add` to
- * operate against the wrong worktree, silently corrupting commits (issue #332).
- *
- * These helpers scrub the relevant env vars before shelling out and prefer
- * `git diff --relative` so paths come back filtered + cwd-relative.
+ * A parent hook may set Git context variables before invoking checks from a
+ * nested application directory. Staged readers must keep the active commit
+ * index when it belongs to this invocation and discard a foreign repository's
+ * context.
  */
 
 import { spawnSync } from 'child_process';
+import { existsSync, lstatSync, readFileSync, readlinkSync, realpathSync } from 'fs';
+import path from 'path';
 
-const SCRUBBED = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_OBJECT_DIRECTORY'] as const;
+const SCRUBBED = [
+	'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+	'GIT_COMMON_DIR',
+	'GIT_CONFIG',
+	'GIT_DIR',
+	'GIT_GRAFT_FILE',
+	'GIT_IMPLICIT_WORK_TREE',
+	'GIT_INDEX_FILE',
+	'GIT_NO_REPLACE_OBJECTS',
+	'GIT_OBJECT_DIRECTORY',
+	'GIT_PREFIX',
+	'GIT_REPLACE_REF_BASE',
+	'GIT_SHALLOW_FILE',
+	'GIT_WORK_TREE'
+] as const;
 
-/** process.env with externally-set git context vars removed. */
+/** process.env with externally set Git context variables removed. */
 export function sanitizedGitEnv(): NodeJS.ProcessEnv {
 	const env = { ...process.env };
-	for (const key of SCRUBBED) delete env[key];
+	const scrubbed = new Set<string>(SCRUBBED);
+	for (const key of Object.keys(env)) {
+		if (scrubbed.has(key.toUpperCase())) delete env[key];
+	}
 	return env;
 }
 
-/**
- * True if the Python `pre-commit` framework is dispatching this hook
- * (detected via its `PRE_COMMIT*` env vars). Used only for diagnostics —
- * does NOT change behavior.
- *
- * Note: `GIT_DIR` is intentionally NOT checked. Git sets `GIT_DIR` for
- * every hook invocation (Husky, native, anything), so it's not a useful
- * signal for "pre-commit framework specifically."
- */
-export function isUnderPreCommit(): boolean {
-	return Object.keys(process.env).some((k) => k.startsWith('PRE_COMMIT'));
+function stripFinalLineEnding(value: string): string {
+	return value.endsWith('\r\n')
+		? value.slice(0, -2)
+		: value.endsWith('\n')
+			? value.slice(0, -1)
+			: value;
+}
+
+function gitPath(cwd: string, env: NodeJS.ProcessEnv, argument: string): string {
+	const result = spawnSync('git', ['rev-parse', argument], { cwd, env, encoding: 'utf-8' });
+	if (result.status !== 0) throw new Error(`Failed to resolve Git path ${argument}.`);
+	return realpathSync(stripFinalLineEnding(result.stdout));
+}
+
+function envPathPointsElsewhere(
+	value: string | undefined,
+	expected: string,
+	root: string
+): boolean {
+	if (!value) return false;
+	try {
+		return realpathSync(path.resolve(root, value)) !== expected;
+	} catch {
+		return true;
+	}
+}
+
+function resolveDirectory(value: string, root: string, label: string): string {
+	const resolved = path.isAbsolute(value) ? value : path.resolve(root, value);
+	try {
+		const canonical = realpathSync(resolved);
+		if (!lstatSync(canonical).isDirectory()) throw new Error();
+		return canonical;
+	} catch {
+		throw new Error(`${label} is not a directory.`);
+	}
+}
+
+function temporaryIndexOwner(candidateDirectory: string): string | undefined {
+	let worktree: string | undefined;
+	if (path.basename(candidateDirectory) === '.git') {
+		worktree = path.dirname(candidateDirectory);
+	} else {
+		const gitdirFile = path.join(candidateDirectory, 'gitdir');
+		if (!existsSync(gitdirFile)) return undefined;
+		const worktreeGitFile = stripFinalLineEnding(readFileSync(gitdirFile, 'utf8'));
+		worktree = path.dirname(path.resolve(candidateDirectory, worktreeGitFile));
+	}
+
+	try {
+		return gitPath(worktree, sanitizedGitEnv(), '--absolute-git-dir') === candidateDirectory
+			? realpathSync(worktree)
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function isNestedParentTemporaryIndex(
+	candidate: string,
+	candidateDirectory: string,
+	worktree: string
+): boolean {
+	if (!/^(?:index\.lock|next-index-\d+\.lock)$/.test(path.basename(candidate))) return false;
+	const owner = temporaryIndexOwner(candidateDirectory);
+	return owner !== undefined && worktree.startsWith(`${owner}${path.sep}`);
+}
+
+/** Preserve an active index and its explicit object stores for this invocation. */
+export function stagedGitEnv(cwd = process.cwd()): NodeJS.ProcessEnv {
+	const env = sanitizedGitEnv();
+	const rawIndex = process.env.GIT_INDEX_FILE;
+	const rawObjectDirectory = process.env.GIT_OBJECT_DIRECTORY;
+	const rawAlternates = process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES;
+	if (!rawIndex && !rawObjectDirectory && !rawAlternates) return env;
+
+	const gitDirectory = gitPath(cwd, env, '--absolute-git-dir');
+	const worktree = gitPath(cwd, env, '--show-toplevel');
+	const foreignContext =
+		envPathPointsElsewhere(process.env.GIT_DIR, gitDirectory, worktree) ||
+		envPathPointsElsewhere(process.env.GIT_WORK_TREE, worktree, worktree);
+
+	if (rawIndex) {
+		const candidate = path.isAbsolute(rawIndex) ? rawIndex : path.resolve(worktree, rawIndex);
+		const candidateDirectory = realpathSync(path.dirname(candidate));
+		if (candidateDirectory !== gitDirectory) {
+			const externalAllowed = process.env.STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX === '1';
+			if (!externalAllowed && foreignContext) return env;
+			if (
+				!externalAllowed &&
+				isNestedParentTemporaryIndex(candidate, candidateDirectory, worktree)
+			) {
+				return env;
+			}
+			if (!externalAllowed) {
+				throw new Error(
+					'External GIT_INDEX_FILE requires STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX=1.'
+				);
+			}
+		}
+		if (!existsSync(candidate) || !lstatSync(candidate).isFile()) {
+			throw new Error('The active GIT_INDEX_FILE is not a regular file.');
+		}
+		env.GIT_INDEX_FILE = candidate;
+	}
+
+	const preserveObjectStores = !foreignContext || env.GIT_INDEX_FILE !== undefined;
+	if (preserveObjectStores && rawObjectDirectory) {
+		env.GIT_OBJECT_DIRECTORY = resolveDirectory(
+			rawObjectDirectory,
+			worktree,
+			'The active GIT_OBJECT_DIRECTORY'
+		);
+	}
+	if (preserveObjectStores && rawAlternates) {
+		env.GIT_ALTERNATE_OBJECT_DIRECTORIES = rawAlternates;
+	}
+	return env;
+}
+
+/** Path to the index that staged Git commands will read. */
+export function activeGitIndexPath(cwd = process.cwd(), env = stagedGitEnv(cwd)): string {
+	if (env.GIT_INDEX_FILE) return realpathSync(env.GIT_INDEX_FILE);
+	const result = spawnSync('git', ['rev-parse', '--path-format=absolute', '--git-path', 'index'], {
+		cwd,
+		env,
+		encoding: 'utf-8'
+	});
+	if (result.status !== 0) throw new Error('Failed to resolve the active Git index.');
+	return realpathSync(stripFinalLineEnding(result.stdout));
+}
+
+/** Stable fingerprint of the complete active index, including extended flags. */
+export function activeGitIndexFingerprint(cwd = process.cwd(), env = stagedGitEnv(cwd)): string {
+	const result = spawnSync(
+		'git',
+		['hash-object', '--no-filters', '--', activeGitIndexPath(cwd, env)],
+		{
+			cwd,
+			env: sanitizedGitEnv(),
+			encoding: 'utf-8'
+		}
+	);
+	if (result.status !== 0) throw new Error('Failed to fingerprint the active Git index.');
+	return stripFinalLineEnding(result.stdout);
 }
 
 export interface GitChange {
@@ -41,15 +190,12 @@ export interface GitChange {
 	previousPath?: string;
 }
 
-/**
- * Staged changes relative to the current working directory. `--relative`
- * filters siblings outside cwd and strips the cwd prefix in one shot.
- * NUL-delimited name-status output preserves renames and unusual filenames.
- */
-export function getStagedChanges(): GitChange[] {
+/** Staged changes filtered and relativized to the current directory. */
+export function getStagedChanges(cwd = process.cwd(), env = stagedGitEnv(cwd)): GitChange[] {
 	const result = spawnSync(
 		'git',
 		[
+			'--no-replace-objects',
 			'diff',
 			'--cached',
 			'--name-status',
@@ -59,13 +205,9 @@ export function getStagedChanges(): GitChange[] {
 			'--diff-filter=ACDMRT',
 			'--relative'
 		],
-		{ encoding: 'utf-8', env: sanitizedGitEnv() }
+		{ cwd, encoding: 'utf-8', env }
 	);
-
-	if (result.status !== 0) {
-		console.error('Failed to get staged changes');
-		process.exit(1);
-	}
+	if (result.status !== 0) throw new Error('Failed to get staged changes.');
 
 	const fields = result.stdout.split('\0');
 	if (fields.at(-1) === '') fields.pop();
@@ -87,9 +229,183 @@ export function getStagedChanges(): GitChange[] {
 	return changes;
 }
 
-/** Files still present in the final index, for file-scoped checks and re-staging. */
-export function getStagedFiles(): string[] {
-	return getStagedChanges()
+/** Files present in the final index. */
+export function getStagedFiles(cwd = process.cwd(), env = stagedGitEnv(cwd)): string[] {
+	return getStagedChanges(cwd, env)
 		.filter((change) => change.status !== 'D')
 		.map((change) => change.path);
+}
+
+/** Staged paths whose worktree bytes pass through a custom Git clean filter. */
+export function stagedFilesWithCleanFilters(
+	files: string[],
+	cwd = process.cwd(),
+	env = stagedGitEnv(cwd)
+): string[] {
+	if (files.length === 0) return [];
+	const result = spawnSync('git', ['check-attr', '-z', '--stdin', 'filter'], {
+		cwd,
+		env,
+		encoding: 'utf8',
+		input: `${files.join('\0')}\0`,
+		maxBuffer: 16 * 1024 * 1024
+	});
+	if (result.status !== 0) throw new Error('Failed to inspect Git clean filters.');
+	const fields = result.stdout.split('\0');
+	if (fields.at(-1) === '') fields.pop();
+	if (fields.length !== files.length * 3) throw new Error('Malformed Git attribute response.');
+	const filtered: string[] = [];
+	for (let index = 0; index < fields.length; index += 3) {
+		const [file, attribute, value] = fields.slice(index, index + 3);
+		if (file !== files[index / 3] || attribute !== 'filter' || !value) {
+			throw new Error('Malformed Git attribute response.');
+		}
+		if (value !== 'unspecified' && value !== 'unset') filtered.push(file);
+	}
+	return filtered;
+}
+
+export interface GitIndexEntry {
+	mode: string;
+	objectId: string;
+	path: string;
+}
+
+export function getStageZeroIndexEntries(
+	files: string[],
+	cwd = process.cwd(),
+	env = stagedGitEnv(cwd)
+): GitIndexEntry[] {
+	if (files.length === 0) return [];
+	const result = spawnSync('git', ['ls-files', '--stage', '-z'], {
+		cwd,
+		encoding: 'utf-8',
+		env,
+		maxBuffer: 64 * 1024 * 1024
+	});
+	if (result.status !== 0) throw new Error('Failed to read staged index entries.');
+
+	const requested = new Set(files);
+	const entries = new Map<string, Array<GitIndexEntry & { stage: number }>>();
+	for (const record of result.stdout.split('\0').filter(Boolean)) {
+		const separator = record.indexOf('\t');
+		const metadata = separator < 0 ? [] : record.slice(0, separator).split(' ');
+		const file = separator < 0 ? '' : record.slice(separator + 1);
+		if (!requested.has(file)) continue;
+		const [mode, objectId, stageText] = metadata;
+		if (
+			!mode ||
+			!objectId ||
+			!stageText ||
+			!/^[0-7]{6}$/.test(mode) ||
+			!/^[0-9a-f]{40,64}$/.test(objectId) ||
+			!/^[0-3]$/.test(stageText)
+		) {
+			throw new Error('Malformed staged index entry.');
+		}
+		const matches = entries.get(file) ?? [];
+		matches.push({ mode, objectId, path: file, stage: Number(stageText) });
+		entries.set(file, matches);
+	}
+
+	return files.map((file) => {
+		const matches = entries.get(file) ?? [];
+		if (matches.length !== 1 || matches[0]!.stage !== 0) {
+			throw new Error(`Missing or ambiguous stage-zero index entry for ${JSON.stringify(file)}.`);
+		}
+		const { mode, objectId, path: entryPath } = matches[0]!;
+		return { mode, objectId, path: entryPath };
+	});
+}
+
+type WorktreeObject = { kind: 'file' | 'symlink' | 'gitlink'; id: string };
+
+function hashWorktreePaths(
+	entries: GitIndexEntry[],
+	cwd: string,
+	env: NodeJS.ProcessEnv
+): Map<string, WorktreeObject> {
+	const objects = new Map<string, WorktreeObject>();
+	const regularFiles: string[] = [];
+	const rawFiles: string[] = [];
+	for (const entry of entries) {
+		const file = entry.path;
+		const absolute = path.resolve(cwd, file);
+		const stat = lstatSync(absolute);
+		if (stat.isDirectory()) {
+			const result = spawnSync('git', ['-C', absolute, 'rev-parse', 'HEAD'], {
+				env: sanitizedGitEnv(),
+				encoding: 'utf-8'
+			});
+			if (result.status !== 0) throw new Error(`Failed to read gitlink ${JSON.stringify(file)}.`);
+			objects.set(file, { kind: 'gitlink', id: stripFinalLineEnding(result.stdout) });
+		} else if (stat.isSymbolicLink()) {
+			const result = spawnSync('git', ['hash-object', '--stdin'], {
+				cwd,
+				env,
+				encoding: 'utf-8',
+				input: readlinkSync(absolute, { encoding: 'buffer' })
+			});
+			if (result.status !== 0) {
+				throw new Error(`Failed to hash worktree path ${JSON.stringify(file)}.`);
+			}
+			objects.set(file, { kind: 'symlink', id: stripFinalLineEnding(result.stdout) });
+		} else if (stat.isFile()) {
+			(entry.mode === '120000' ? rawFiles : regularFiles).push(file);
+		} else {
+			throw new Error(`Unsupported worktree path type for ${JSON.stringify(file)}.`);
+		}
+	}
+
+	const hashFiles = (files: string[], noFilters: boolean): void => {
+		if (files.length === 0) return;
+		if (files.some((file) => /[\r\n]/.test(file))) {
+			throw new Error('A worktree path cannot be passed safely to Git hash-object.');
+		}
+		const result = spawnSync(
+			'git',
+			['hash-object', ...(noFilters ? ['--no-filters'] : []), '--stdin-paths'],
+			{
+				cwd,
+				env,
+				encoding: 'utf-8',
+				input: `${files.map((file) => path.resolve(cwd, file)).join('\n')}\n`,
+				maxBuffer: 16 * 1024 * 1024
+			}
+		);
+		if (result.status !== 0) throw new Error('Failed to hash staged worktree paths.');
+		const objectIds = result.stdout.split('\n').filter(Boolean);
+		if (objectIds.length !== files.length) throw new Error('Malformed Git hash response.');
+		for (let index = 0; index < files.length; index++) {
+			objects.set(files[index]!, { kind: 'file', id: objectIds[index]! });
+		}
+	};
+	hashFiles(regularFiles, false);
+	hashFiles(rawFiles, true);
+	return objects;
+}
+
+/** Whether every checked worktree byte sequence is the exact staged object. */
+export function stagedFilesMatchWorktree(
+	files: string[],
+	cwd = process.cwd(),
+	env = stagedGitEnv(cwd)
+): boolean {
+	const entries = getStageZeroIndexEntries(files, cwd, env);
+	const worktreeObjects = hashWorktreePaths(entries, cwd, env);
+	return entries.every((entry) => {
+		const worktree = worktreeObjects.get(entry.path)!;
+		if (entry.mode === '160000') {
+			return worktree.kind === 'gitlink' && worktree.id === entry.objectId;
+		}
+		if (entry.mode === '120000') {
+			return (
+				(worktree.kind === 'symlink' || worktree.kind === 'file') && worktree.id === entry.objectId
+			);
+		}
+		if (entry.mode === '100644' || entry.mode === '100755') {
+			return worktree.kind === 'file' && worktree.id === entry.objectId;
+		}
+		throw new Error(`Unsupported Git index mode ${entry.mode}.`);
+	});
 }

--- a/scripts/knowledge-policy/repository.test.ts
+++ b/scripts/knowledge-policy/repository.test.ts
@@ -6,10 +6,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { blocking, defineKnowledgePolicy, exactPaths, fileExtension, underPath } from './policy';
 import { runKnowledgePolicy } from './repository';
 
-function git(root: string, ...args: string[]): string {
-	const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+function gitWithEnv(root: string, args: string[], env = process.env, input?: string): string {
+	const result = spawnSync('git', args, { cwd: root, env, input, encoding: 'utf8' });
 	if (result.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
 	return result.stdout.trim();
+}
+
+function git(root: string, ...args: string[]): string {
+	return gitWithEnv(root, args);
 }
 
 function write(root: string, file: string, contents: string): void {
@@ -80,6 +84,80 @@ describe('repository policy scopes', () => {
 		expect(result.findings).toMatchObject([
 			{ ruleId: 'knowledge.relative-link-missing', file: 'README.md' }
 		]);
+	});
+
+	it('ignores replacement refs when reading staged policy blobs', () => {
+		const hash = (contents: string): string => {
+			const result = spawnSync('git', ['hash-object', '-w', '--stdin'], {
+				cwd: root,
+				input: contents,
+				encoding: 'utf8'
+			});
+			if (result.status !== 0) throw new Error(result.stderr);
+			return result.stdout.trim();
+		};
+		const original = hash('[missing](missing.md)\n');
+		const replacement = hash('# Clean replacement\n');
+		git(root, 'update-index', '--cacheinfo', `100644,${original},README.md`);
+		git(root, 'replace', original, replacement);
+
+		const result = runKnowledgePolicy({ root, policy: testPolicy, scope: { kind: 'staged' } });
+		expect(result.findings).toMatchObject([
+			{ ruleId: 'knowledge.relative-link-missing', file: 'README.md' }
+		]);
+	});
+
+	it('reads an allowed external index through its explicit object stores', () => {
+		const index = path.join(root, 'external-index');
+		const objects = path.join(root, 'external-objects');
+		const defaultObjects = path.join(root, '.git', 'objects');
+		mkdirSync(objects);
+		const externalEnv = {
+			...process.env,
+			GIT_INDEX_FILE: index,
+			GIT_OBJECT_DIRECTORY: objects,
+			GIT_ALTERNATE_OBJECT_DIRECTORIES: defaultObjects
+		};
+		gitWithEnv(root, ['read-tree', 'HEAD'], externalEnv);
+		const objectId = gitWithEnv(
+			root,
+			['hash-object', '-w', '--stdin'],
+			externalEnv,
+			'[missing](missing.md)\n'
+		);
+		gitWithEnv(root, ['update-index', '--cacheinfo', `100644,${objectId},README.md`], externalEnv);
+
+		const keys = [
+			'GIT_DIR',
+			'GIT_WORK_TREE',
+			'GIT_INDEX_FILE',
+			'GIT_OBJECT_DIRECTORY',
+			'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+			'STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX'
+		] as const;
+		const saved = new Map(keys.map((key) => [key, process.env[key]]));
+		try {
+			process.env.GIT_DIR = path.join(root, 'foreign.git');
+			process.env.GIT_WORK_TREE = path.join(root, 'foreign-worktree');
+			process.env.GIT_INDEX_FILE = index;
+			process.env.GIT_OBJECT_DIRECTORY = objects;
+			process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES = defaultObjects;
+			process.env.STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX = '1';
+
+			const result = runKnowledgePolicy({
+				root,
+				policy: testPolicy,
+				scope: { kind: 'staged' }
+			});
+			expect(result.findings).toMatchObject([
+				{ ruleId: 'knowledge.relative-link-missing', file: 'README.md' }
+			]);
+		} finally {
+			for (const [key, value] of saved) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+		}
 	});
 
 	it('staged deletion and rename remove old link targets from the index', () => {

--- a/scripts/knowledge-policy/repository.ts
+++ b/scripts/knowledge-policy/repository.ts
@@ -1,7 +1,7 @@
 import { lstatSync, readFileSync, readlinkSync } from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { sanitizedGitEnv } from '../git-context';
+import { sanitizedGitEnv, stagedGitEnv } from '../git-context';
 import {
 	evaluateKnowledgePolicy,
 	matchesKnowledgeCandidate,
@@ -27,12 +27,17 @@ interface IndexEntry {
 	file: string;
 }
 
-function git(root: string, args: string[], input?: Buffer | string) {
+function git(
+	root: string,
+	args: string[],
+	input?: Buffer | string,
+	env: NodeJS.ProcessEnv = sanitizedGitEnv()
+) {
 	const result = spawnSync('git', args, {
 		cwd: root,
 		encoding: input === undefined ? 'utf8' : undefined,
 		input,
-		env: sanitizedGitEnv(),
+		env,
 		maxBuffer: 128 * 1024 * 1024
 	});
 	if (result.status !== 0) {
@@ -65,12 +70,16 @@ function pathEntryExists(file: string): boolean {
 	}
 }
 
-function commitExists(root: string, sha: string): boolean {
+function commitExists(
+	root: string,
+	sha: string,
+	env: NodeJS.ProcessEnv = sanitizedGitEnv()
+): boolean {
 	return (
-		spawnSync('git', ['cat-file', '-e', `${sha}^{commit}`], {
+		spawnSync('git', ['--no-replace-objects', 'cat-file', '-e', `${sha}^{commit}`], {
 			cwd: root,
 			stdio: 'ignore',
-			env: sanitizedGitEnv()
+			env
 		}).status === 0
 	);
 }
@@ -102,8 +111,8 @@ function workingTreeRepository(root: string, files: readonly string[]): PolicyRe
 	};
 }
 
-function listIndexEntries(root: string): IndexEntry[] {
-	const result = git(root, ['ls-files', '--stage', '-z']);
+function listIndexEntries(root: string, env: NodeJS.ProcessEnv): IndexEntry[] {
+	const result = git(root, ['ls-files', '--stage', '-z'], undefined, env);
 	return String(result.stdout)
 		.split('\0')
 		.filter(Boolean)
@@ -119,10 +128,19 @@ function listIndexEntries(root: string): IndexEntry[] {
 		});
 }
 
-function readIndexBlobs(root: string, oids: readonly string[]): Map<string, string> {
+function readIndexBlobs(
+	root: string,
+	oids: readonly string[],
+	env: NodeJS.ProcessEnv
+): Map<string, string> {
 	const unique = [...new Set(oids)];
 	if (unique.length === 0) return new Map();
-	const result = git(root, ['cat-file', '--batch'], `${unique.join('\n')}\n`);
+	const result = git(
+		root,
+		['--no-replace-objects', 'cat-file', '--batch'],
+		`${unique.join('\n')}\n`,
+		env
+	);
 	const output = Buffer.from(result.stdout as Buffer);
 	const values = new Map<string, string>();
 	let cursor = 0;
@@ -137,7 +155,9 @@ function readIndexBlobs(root: string, oids: readonly string[]): Map<string, stri
 		const start = newline + 1;
 		const end = start + size;
 		if (end >= output.length) throw new Error(`Incomplete cat-file body for ${requested}.`);
-		if (match[2] !== 'blob') throw new Error(`Index object ${requested} is not a blob.`);
+		if (match[1] !== requested || match[2] !== 'blob') {
+			throw new Error(`Index object ${requested} is not the requested blob.`);
+		}
 		values.set(requested, output.subarray(start, end).toString('utf8'));
 		cursor = end + 1;
 	}
@@ -147,25 +167,25 @@ function readIndexBlobs(root: string, oids: readonly string[]): Map<string, stri
 function assertPolicyRuntimeMatchesIndex(
 	root: string,
 	policy: KnowledgePolicyConfig,
-	entries: readonly IndexEntry[]
+	entries: readonly IndexEntry[],
+	env: NodeJS.ProcessEnv
 ): void {
 	const trackedRuntime = entries.filter((entry) => policy.repository.runtimeFiles(entry.file));
 	const differences =
 		trackedRuntime.length === 0
 			? []
 			: String(
-					git(root, [
-						'diff',
-						'--name-only',
-						'-z',
-						'--',
-						...trackedRuntime.map((entry) => entry.file)
-					]).stdout
+					git(
+						root,
+						['diff', '--name-only', '-z', '--', ...trackedRuntime.map((entry) => entry.file)],
+						undefined,
+						env
+					).stdout
 				)
 					.split('\0')
 					.filter(Boolean);
 	const untrackedRuntime = String(
-		git(root, ['ls-files', '--others', '--exclude-standard', '-z']).stdout
+		git(root, ['ls-files', '--others', '--exclude-standard', '-z'], undefined, env).stdout
 	)
 		.split('\0')
 		.filter((file) => file && policy.repository.runtimeFiles(toPosix(file)));
@@ -179,7 +199,8 @@ function assertPolicyRuntimeMatchesIndex(
 function indexRepository(
 	root: string,
 	policy: KnowledgePolicyConfig,
-	entries: readonly IndexEntry[]
+	entries: readonly IndexEntry[],
+	env: NodeJS.ProcessEnv
 ): PolicyRepository {
 	const conflicts = entries.filter((entry) => entry.stage !== 0);
 	if (conflicts.length > 0) {
@@ -191,7 +212,7 @@ function indexRepository(
 	const candidateOids = entries
 		.filter((entry) => entry.mode !== '160000' && matchesKnowledgeCandidate(policy, entry.file))
 		.map((entry) => entry.oid);
-	const blobs = readIndexBlobs(root, candidateOids);
+	const blobs = readIndexBlobs(root, candidateOids, env);
 	return {
 		files: entries.map((entry) => entry.file),
 		readText(file) {
@@ -206,7 +227,7 @@ function indexRepository(
 			const prefix = file.endsWith('/') ? file : `${file}/`;
 			return entries.some((entry) => entry.file.startsWith(prefix));
 		},
-		commitExists: (sha) => commitExists(root, sha)
+		commitExists: (sha) => commitExists(root, sha, env)
 	};
 }
 
@@ -235,9 +256,10 @@ export function runKnowledgePolicy(input: {
 	}
 
 	if (effectiveScope.kind === 'staged') {
-		const entries = listIndexEntries(root);
-		assertPolicyRuntimeMatchesIndex(root, input.policy, entries);
-		repository = indexRepository(root, input.policy, entries);
+		const env = stagedGitEnv(root);
+		const entries = listIndexEntries(root, env);
+		assertPolicyRuntimeMatchesIndex(root, input.policy, entries, env);
+		repository = indexRepository(root, input.policy, entries, env);
 	} else if (effectiveScope.kind === 'full') {
 		repository = workingTreeRepository(root, listWorkingTreeFiles(root));
 	} else {

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -31,7 +31,8 @@ import {
 	ROUTES,
 	resolveInputs,
 	spellcheckFiles,
-	unsafePathCodepoints
+	unsafePathCodepoints,
+	usesAssertOnlyChecks
 } from './static-checks';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -41,6 +42,14 @@ const SCRIPT = path.join(ROOT, 'scripts', 'static-checks.ts');
 function run(...args: string[]): number {
 	return spawnSync('bun', [SCRIPT, ...args], { cwd: ROOT, encoding: 'utf8' }).status ?? -1;
 }
+
+describe('checker mutation mode', () => {
+	it('keeps staged and CI runs assert-only', () => {
+		expect(usesAssertOnlyChecks(false, 'staged')).toBe(true);
+		expect(usesAssertOnlyChecks(true, 'full')).toBe(true);
+		expect(usesAssertOnlyChecks(false, 'files')).toBe(false);
+	});
+});
 
 describe('route predicates', () => {
 	it('routes knowledge files through repository policy candidates and ignores', () => {
@@ -214,6 +223,16 @@ describe('resolveInputs', () => {
 });
 
 describe('bad input dies at the boundary', () => {
+	it('omits parent-owned ANSI when NO_COLOR is set', () => {
+		const result = spawnSync('bun', [SCRIPT, '--unknown'], {
+			cwd: ROOT,
+			encoding: 'utf8',
+			env: { ...sanitizedGitEnv(), NO_COLOR: '1' }
+		});
+		expect(result.status).toBe(1);
+		expect(`${result.stdout}${result.stderr}`).not.toContain('\x1b');
+	});
+
 	it.each([
 		['an empty argument', ['']],
 		['a whitespace argument', ['   ']],
@@ -226,17 +245,8 @@ describe('bad input dies at the boundary', () => {
 		expect(run(...args)).toBe(1);
 	});
 
-	// `--staged` is the one case here that is not bad input, so it has to be asserted
-	// or nothing pins that the guards above leave it alone.
-	//
-	// It reads the real git index, which is the developer's, so with anything staged
-	// it lints those files for real and outruns vitest's default per-test timeout,
-	// which nothing here raises. The index cannot be
-	// substituted from outside either: `sanitizedGitEnv` scrubs `GIT_INDEX_FILE`
-	// deliberately, because a pre-commit framework setting it points the run at the
-	// wrong worktree (#332). CI stages nothing, so the assertion always runs where it
-	// gates a merge, and a developer mid-commit gets a skip with the reason instead of
-	// a timeout that looks like a broken script.
+	// A staged run with a clean index is an honest no-op. Skip this local assertion
+	// while a developer has real staged files, since it would run the complete gate.
 	const nothingStaged =
 		spawnSync('git', ['diff', '--cached', '--quiet'], {
 			cwd: ROOT,

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -13,7 +13,7 @@
  * Flags:
  *   --ci         Assert mode: uses --check for formatting, omits --fix for ESLint.
  *                Requires misspell to be installed (fails if missing).
- *   --staged     Scope to git-staged files only. Auto-fixes and re-stages.
+ *   --staged     Assert-only staged-file gate. Run fix mode before staging and retrying.
  *   --scope      Run a subset of checks: "lint" (misspell, literal controls, banned patterns, prettier,
  *                eslint, oxlint) or "types" (build-emails, svelte-check).
  *                Both groups run svelte-kit sync first. Omit to run all checks.
@@ -34,7 +34,15 @@ import { fileURLToPath } from 'url';
 import { parseArgs } from 'util';
 import knowledgePolicy from '../knowledge-policy.config';
 import { findLiteralControlCharacters } from '../eslint/control-character-policy.js';
-import { getStagedChanges, getStagedFiles, isUnderPreCommit, sanitizedGitEnv } from './git-context';
+import {
+	activeGitIndexFingerprint,
+	getStagedChanges,
+	getStagedFiles,
+	sanitizedGitEnv,
+	stagedFilesMatchWorktree,
+	stagedFilesWithCleanFilters,
+	stagedGitEnv
+} from './git-context';
 import { formatPolicyFinding, matchesKnowledgeCandidate } from './knowledge-policy/policy';
 import { runKnowledgePolicy } from './knowledge-policy/repository';
 import {
@@ -90,14 +98,17 @@ const CONFIG = {
 	}
 };
 
-// ANSI colors for terminal output
-const colors = {
-	reset: '\x1b[0m',
-	bold: '\x1b[1m',
-	green: '\x1b[32m',
-	yellow: '\x1b[33m',
-	red: '\x1b[31m'
-};
+// ANSI colors for direct terminal runs; wrappers set NO_COLOR before sanitizing output.
+const colors =
+	process.env.NO_COLOR === undefined
+		? {
+				reset: '\x1b[0m',
+				bold: '\x1b[1m',
+				green: '\x1b[32m',
+				yellow: '\x1b[33m',
+				red: '\x1b[31m'
+			}
+		: { reset: '', bold: '', green: '', yellow: '', red: '' };
 
 // ===========================================================================
 // Intake — argv and file arguments become validated, repo-relative POSIX paths
@@ -325,6 +336,10 @@ const LINT_CHECKS: CheckId[] = [
 const TYPE_CHECKS: CheckId[] = ['svelte-check', 'convex'];
 
 type Mode = 'files' | 'staged' | 'full';
+
+export function usesAssertOnlyChecks(ciMode: boolean, mode: Mode): boolean {
+	return ciMode || mode === 'staged';
+}
 type Outcome =
 	| { kind: 'ran'; files: number | 'project' }
 	| { kind: 'skipped'; reason: string; suppressed: boolean };
@@ -556,12 +571,15 @@ async function main(): Promise<void> {
 	const shouldRunLint = !scope || scope === 'lint';
 	const shouldRunTypes = !scope || scope === 'types';
 	const scopedMode = mode === 'files' || mode === 'staged';
+	const assertMode = usesAssertOnlyChecks(ciMode, mode);
 	const scopeLabel = scope ?? 'lint + types';
 
 	// Resolve caller-typed paths against the invocation cwd, BEFORE the chdir below.
 	let inputs: string[] = [];
-	// Staged mode only: the paths exactly as git reported them, for the re-stage.
+	// Staged mode keeps the exact Git paths and the complete starting index state.
 	let stagedIndexPaths: string[] = [];
+	let stagedIndexFingerprint: string | undefined;
+	let stagedEnv: NodeJS.ProcessEnv | undefined;
 	if (mode === 'files') {
 		const raw = filesFrom !== undefined ? readFilesFrom(filesFrom) : rawPositionals;
 		if (filesFrom !== undefined && raw.length === 0) {
@@ -585,16 +603,32 @@ async function main(): Promise<void> {
 	process.chdir(REPO_ROOT);
 
 	if (mode === 'staged') {
-		const stagedChanges = getStagedChanges();
+		stagedEnv = stagedGitEnv(REPO_ROOT);
+		stagedIndexFingerprint = activeGitIndexFingerprint(REPO_ROOT, stagedEnv);
+		const stagedChanges = getStagedChanges(REPO_ROOT, stagedEnv);
 		if (stagedChanges.length === 0) {
 			console.log('No staged files to check');
 			process.exit(0);
 		}
-		// Keep the original index paths for re-staging. resolveInputs realpaths
-		// symlinks, and adding those resolved targets would commit the wrong files.
-		stagedIndexPaths = getStagedFiles();
+		// Keep the original index paths. resolveInputs realpaths symlinks, while
+		// later comparisons must address the paths recorded by Git.
+		stagedIndexPaths = getStagedFiles(REPO_ROOT, stagedEnv);
 		assertSafePaths(stagedIndexPaths);
+		const cleanFiltered = stagedFilesWithCleanFilters(stagedIndexPaths, REPO_ROOT, stagedEnv);
+		if (cleanFiltered.length > 0) {
+			fail(
+				'Custom Git clean filters are unsupported in staged checks.',
+				'  Remove the filter from checked paths, then stage the intended bytes and retry.'
+			);
+		}
 		inputs = stagedIndexPaths.length > 0 ? resolveInputs(stagedIndexPaths, 'the git index') : [];
+		if (!stagedFilesMatchWorktree(stagedIndexPaths, REPO_ROOT, stagedEnv)) {
+			fail(
+				'Staged file contents differ from the worktree.',
+				'  Run the checks in fix mode, review the result, stage the intended bytes,\n' +
+					'  and retry the commit.'
+			);
+		}
 	}
 
 	const fullRepositoryPaths = mode === 'full' ? repositoryPaths() : [];
@@ -741,7 +775,7 @@ async function main(): Promise<void> {
 		// Code formatting
 		printHeader(step++, 'Code formatting');
 		{
-			const formatFlag = ciMode ? '--check' : '--write';
+			const formatFlag = assertMode ? '--check' : '--write';
 			const files = ledger.filesFor('prettier');
 			if (!scopedMode) {
 				await runCommand('bun', ['prettier', formatFlag, '.']);
@@ -767,7 +801,7 @@ async function main(): Promise<void> {
 		// ESLint
 		printHeader(step++, 'ESLint');
 		{
-			const fixArgs = ciMode ? [] : ['--fix'];
+			const fixArgs = assertMode ? [] : ['--fix'];
 			const files = ledger.filesFor('eslint');
 			if (!scopedMode) {
 				await runCommand('bun', ['eslint', '.', ...fixArgs]);
@@ -844,22 +878,6 @@ async function main(): Promise<void> {
 		console.log('\n');
 	}
 
-	// Re-stage files if they were modified during --staged checks.
-	// Sanitized env ensures `git add` writes into the correct index even when
-	// a parent process (e.g. the pre-commit framework) set GIT_DIR/GIT_WORK_TREE.
-	if (mode === 'staged' && !ciMode && stagedIndexPaths.length > 0) {
-		console.log('Re-staging modified files...');
-		if (isUnderPreCommit()) {
-			console.log(
-				'  (note: pre-commit framework detected. It will report "files were modified ' +
-					'by this hook" and abort the commit. Run `git commit` again with no further ' +
-					'changes to land the auto-fixes.)'
-			);
-		}
-		await runCommand('git', ['add', ...stagedIndexPaths], { env: sanitizedGitEnv() });
-		console.log('');
-	}
-
 	if (shouldRunLint) {
 		printHeader(step, 'Knowledge placement');
 		const policyScope =
@@ -887,6 +905,15 @@ async function main(): Promise<void> {
 		ledger.ran('knowledge-placement', result.filesEvaluated);
 		if (errors > 0) process.exit(1);
 		console.log('');
+	}
+
+	if (stagedIndexFingerprint) {
+		if (!stagedFilesMatchWorktree(stagedIndexPaths, REPO_ROOT, stagedEnv)) {
+			fail('Checked worktree bytes changed while staged checks were running.');
+		}
+		if (activeGitIndexFingerprint(REPO_ROOT, stagedEnv) !== stagedIndexFingerprint) {
+			fail('The active Git index changed while staged checks were running.');
+		}
 	}
 
 	finish(ledger, scopeLabel);


### PR DESCRIPTION
Regression guard: added native commit lifecycle tests

Git's `commit -a` and path-limited commits use temporary indexes, while staged checks previously discarded that context and could inspect or restage the default index. Partial staging could also move unchecked bytes into a commit.

Staged checks now preserve repository-owned active indexes and explicit object stores, sanitize foreign repository context, run Prettier and ESLint assert-only, reject partial staging and custom clean filters, verify index and worktree immutability, and make Knowledge Policy read exact staged blobs with replacement refs disabled.

Verified with 1,647 unit tests, changed-file static and type checks, and native commit lifecycle coverage. See also #848.
