### PR TITLE
fix(lint): Route compatibility safely

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"check": "bun svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "bun svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"check:convex": "bun run generate:content && tsc -p src/lib/convex/tsconfig.json --noEmit",
-		"check:convex-compat": "bun scripts/convex-consumer-compat.ts",
+		"check:convex-compat": "bun scripts/static-checks.ts --scope compat",
 		"format": "prettier --write .",
 		"lint": "eslint . --cache --concurrency auto && oxlint",
 		"lint:convex": "oxlint",

--- a/scripts/convex-consumer-compat.test.ts
+++ b/scripts/convex-consumer-compat.test.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -7,8 +11,20 @@ import {
 	scheduledIdentifiersIn
 } from './convex-consumer-compat';
 import type { Surface } from './convex-surface';
+import { sanitizedGitEnv } from './git-context';
+import { testExecutable } from './test-executable';
 
 const file = 'src/example.ts';
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = path.join(ROOT, 'scripts', 'convex-consumer-compat.ts');
+const BUN = testExecutable('bun');
+
+function compatibilityFixtureEnv(): NodeJS.ProcessEnv {
+	const env = sanitizedGitEnv();
+	delete env.CI;
+	delete env.CONVEX_COMPAT_BASE;
+	return env;
+}
 
 describe('Convex consumer references', () => {
 	it('reads a direct public or internal function path', () => {
@@ -137,4 +153,290 @@ describe('Convex consumer references', () => {
 			)
 		).toEqual([]);
 	});
+});
+
+describe('Convex compatibility entrypoint', () => {
+	it('fails when no trunk baseline exists', () => {
+		const scratch = path.join(ROOT, 'scratch');
+		mkdirSync(scratch, { recursive: true });
+		const directory = mkdtempSync(path.join(scratch, 'convex-compat-no-baseline-'));
+		try {
+			expect(
+				spawnSync('git', ['init', '--quiet', '--initial-branch=feature'], {
+					cwd: directory,
+					env: sanitizedGitEnv()
+				}).status
+			).toBe(0);
+			writeFileSync(path.join(directory, 'README.md'), 'fixture\n');
+			expect(
+				spawnSync('git', ['add', '--', 'README.md'], {
+					cwd: directory,
+					env: sanitizedGitEnv()
+				}).status
+			).toBe(0);
+			expect(
+				spawnSync(
+					'git',
+					[
+						'-c',
+						'user.name=Probe',
+						'-c',
+						'user.email=probe@example.com',
+						'commit',
+						'--quiet',
+						'--no-gpg-sign',
+						'--no-verify',
+						'-m',
+						'Add fixture'
+					],
+					{ cwd: directory, env: sanitizedGitEnv() }
+				).status
+			).toBe(0);
+
+			const env = compatibilityFixtureEnv();
+			const result = spawnSync(BUN, [SCRIPT], {
+				cwd: directory,
+				encoding: 'utf8',
+				env
+			});
+			const output = `${result.stdout}${result.stderr}`;
+
+			expect(result.status).toBe(1);
+			expect(output).toContain('no trunk to compare against (looked for origin/main and main)');
+			expect(output).toContain('compatibility cannot be certified without a baseline');
+			expect(output).not.toContain('Skipping');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}, 30_000);
+
+	it('fails when shallow trunk history hides the previous commit', () => {
+		const scratch = path.join(ROOT, 'scratch');
+		mkdirSync(scratch, { recursive: true });
+		const directory = mkdtempSync(path.join(scratch, 'convex-compat-shallow-'));
+		const source = path.join(directory, 'source');
+		const shallow = path.join(directory, 'shallow');
+		const env = compatibilityFixtureEnv();
+		const git = (cwd: string, args: string[]) =>
+			spawnSync('git', args, { cwd, env, encoding: 'utf8' });
+		try {
+			mkdirSync(source);
+			expect(git(source, ['init', '--quiet', '--initial-branch=main']).status).toBe(0);
+			for (const [message, content] of [
+				['Initial', 'one\n'],
+				['Update', 'two\n']
+			] as const) {
+				writeFileSync(path.join(source, 'README.md'), content);
+				expect(git(source, ['add', '--', 'README.md']).status).toBe(0);
+				expect(
+					git(source, [
+						'-c',
+						'user.name=Probe',
+						'-c',
+						'user.email=probe@example.com',
+						'commit',
+						'--quiet',
+						'--no-gpg-sign',
+						'--no-verify',
+						'-m',
+						message
+					]).status
+				).toBe(0);
+			}
+			expect(
+				spawnSync(
+					'git',
+					[
+						'-c',
+						'protocol.file.allow=always',
+						'clone',
+						'--quiet',
+						'--depth',
+						'1',
+						pathToFileURL(source).href,
+						shallow
+					],
+					{ env, encoding: 'utf8' }
+				).status
+			).toBe(0);
+
+			const result = spawnSync(BUN, [SCRIPT], {
+				cwd: shallow,
+				encoding: 'utf8',
+				env
+			});
+			const output = `${result.stdout}${result.stderr}`;
+
+			expect(result.status).toBe(1);
+			expect(output).toContain('trunk history is shallow');
+			expect(output).toContain('compatibility cannot be certified');
+			expect(output).not.toContain('root commit');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}, 30_000);
+
+	it('accepts a shallow clone whose HEAD is a genuine root commit', () => {
+		const scratch = path.join(ROOT, 'scratch');
+		mkdirSync(scratch, { recursive: true });
+		const directory = mkdtempSync(path.join(scratch, 'convex-compat-root-'));
+		const source = path.join(directory, 'source');
+		const shallow = path.join(directory, 'shallow');
+		const env = compatibilityFixtureEnv();
+		const git = (cwd: string, args: string[]) =>
+			spawnSync('git', args, { cwd, env, encoding: 'utf8' });
+		try {
+			mkdirSync(source);
+			expect(
+				spawnSync('git', ['init', '--quiet', '--initial-branch=main'], { cwd: source, env }).status
+			).toBe(0);
+			writeFileSync(path.join(source, 'README.md'), 'root\n');
+			expect(spawnSync('git', ['add', '--', 'README.md'], { cwd: source, env }).status).toBe(0);
+			expect(
+				spawnSync(
+					'git',
+					[
+						'-c',
+						'user.name=Probe',
+						'-c',
+						'user.email=probe@example.com',
+						'commit',
+						'--quiet',
+						'--no-gpg-sign',
+						'--no-verify',
+						'-m',
+						'Initial',
+						'-m',
+						'parent deadbeef'
+					],
+					{ cwd: source, env }
+				).status
+			).toBe(0);
+			expect(git(source, ['switch', '--orphan', 'other']).status).toBe(0);
+			writeFileSync(path.join(source, 'README.md'), 'other one\n');
+			expect(git(source, ['add', '--', 'README.md']).status).toBe(0);
+			for (const [message, content] of [
+				['Other root', 'other one\n'],
+				['Other update', 'other two\n']
+			] as const) {
+				writeFileSync(path.join(source, 'README.md'), content);
+				expect(git(source, ['add', '--', 'README.md']).status).toBe(0);
+				expect(
+					git(source, [
+						'-c',
+						'user.name=Probe',
+						'-c',
+						'user.email=probe@example.com',
+						'commit',
+						'--quiet',
+						'--no-gpg-sign',
+						'--no-verify',
+						'-m',
+						message
+					]).status
+				).toBe(0);
+			}
+			expect(git(source, ['switch', '--quiet', 'main']).status).toBe(0);
+			expect(
+				spawnSync(
+					'git',
+					[
+						'-c',
+						'protocol.file.allow=always',
+						'clone',
+						'--quiet',
+						'--no-single-branch',
+						'--depth',
+						'1',
+						pathToFileURL(source).href,
+						shallow
+					],
+					{ env }
+				).status
+			).toBe(0);
+
+			expect(git(shallow, ['rev-parse', '--is-shallow-repository']).stdout.trim()).toBe('true');
+			const result = spawnSync(BUN, [SCRIPT], { cwd: shallow, encoding: 'utf8', env });
+			expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+			expect(`${result.stdout}${result.stderr}`).toContain('root commit, nothing promised yet');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}, 30_000);
+
+	it('fails when shallow feature and trunk tips hide their merge base', () => {
+		const scratch = path.join(ROOT, 'scratch');
+		mkdirSync(scratch, { recursive: true });
+		const directory = mkdtempSync(path.join(scratch, 'convex-compat-merge-base-'));
+		const source = path.join(directory, 'source');
+		const shallow = path.join(directory, 'shallow');
+		const env = compatibilityFixtureEnv();
+		const git = (cwd: string, args: string[]) =>
+			spawnSync('git', args, { cwd, env, encoding: 'utf8' });
+		const commit = (cwd: string, message: string, content: string) => {
+			writeFileSync(path.join(cwd, 'README.md'), content);
+			expect(git(cwd, ['add', '--', 'README.md']).status).toBe(0);
+			expect(
+				git(cwd, [
+					'-c',
+					'user.name=Probe',
+					'-c',
+					'user.email=probe@example.com',
+					'commit',
+					'--quiet',
+					'--no-gpg-sign',
+					'--no-verify',
+					'-m',
+					message
+				]).status
+			).toBe(0);
+		};
+		try {
+			mkdirSync(source);
+			expect(git(source, ['init', '--quiet', '--initial-branch=main']).status).toBe(0);
+			commit(source, 'Initial', 'initial\n');
+			expect(git(source, ['branch', 'feature']).status).toBe(0);
+			commit(source, 'Main update', 'main\n');
+			expect(git(source, ['switch', '--quiet', 'feature']).status).toBe(0);
+			commit(source, 'Feature update', 'feature\n');
+			expect(
+				spawnSync(
+					'git',
+					[
+						'-c',
+						'protocol.file.allow=always',
+						'clone',
+						'--quiet',
+						'--depth',
+						'1',
+						'--branch',
+						'feature',
+						pathToFileURL(source).href,
+						shallow
+					],
+					{ env }
+				).status
+			).toBe(0);
+			expect(
+				git(shallow, [
+					'-c',
+					'protocol.file.allow=always',
+					'fetch',
+					'--quiet',
+					'--depth',
+					'1',
+					'origin',
+					'main:refs/remotes/origin/main'
+				]).status
+			).toBe(0);
+
+			const result = spawnSync(BUN, [SCRIPT], { cwd: shallow, encoding: 'utf8', env });
+			const output = `${result.stdout}${result.stderr}`;
+			expect(result.status).toBe(1);
+			expect(output).toContain('branch merge base is unavailable');
+			expect(output).toContain('compatibility cannot be certified');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}, 30_000);
 });

--- a/scripts/convex-consumer-compat.ts
+++ b/scripts/convex-consumer-compat.ts
@@ -68,7 +68,7 @@ function git(args: string[]): string {
 	});
 }
 
-type Baseline = { commit: string } | { root: true } | null;
+type Baseline = { commit: string } | { root: true } | { unavailable: string } | null;
 
 function resolveBaseline(): Baseline {
 	// Set by CI on trunk pushes to the push event's pre-push SHA: a push can
@@ -115,7 +115,10 @@ function resolveBaseline(): Baseline {
 			// never promised to keep.
 			base = git(['merge-base', 'HEAD', candidate]).trim();
 		} catch {
-			return { commit: candidate };
+			return {
+				unavailable:
+					'convex-consumer-compat: the branch merge base is unavailable. Fetch the full branch and trunk history before running this check; compatibility cannot be certified against the trunk tip.'
+			};
 		}
 		// On the trunk itself the merge base is HEAD, and a commit would be asked
 		// only about the consumer it just rewrote: it would bless its own removal.
@@ -125,8 +128,19 @@ function resolveBaseline(): Baseline {
 			try {
 				return { commit: git(['rev-parse', 'HEAD~1']).trim() };
 			} catch {
-				// A root commit has nothing to have promised.
-				return { root: true };
+				const commitHeaders = git(['cat-file', '-p', 'HEAD']).split(/\r?\n\r?\n/, 1)[0]!;
+				const hasParent = /^parent [0-9a-f]+$/m.test(commitHeaders);
+				if (!hasParent) return { root: true };
+				if (git(['rev-parse', '--is-shallow-repository']).trim() === 'true') {
+					return {
+						unavailable:
+							'convex-consumer-compat: trunk history is shallow. Fetch the full trunk history before running this check; compatibility cannot be certified without the previous deployed commit.'
+					};
+				}
+				return {
+					unavailable:
+						'convex-consumer-compat: the previous trunk commit is unavailable. Fetch the trunk history before running this check; compatibility cannot be certified without a baseline.'
+				};
 			}
 		}
 		return { commit: base };
@@ -459,14 +473,14 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 export async function main(): Promise<void> {
 	const baseline = resolveBaseline();
 	if (!baseline) {
-		const message =
-			'convex-consumer-compat: no trunk to compare against (looked for origin/main and main).';
-		if (process.env.CI) {
-			console.error(`${message} CI needs the full history for this check.`);
-			process.exit(1);
-		}
-		console.warn(`${message} Skipping; CI will run it against the trunk.`);
-		process.exit(0);
+		console.error(
+			'convex-consumer-compat: no trunk to compare against (looked for origin/main and main). Fetch the trunk history before running this check; compatibility cannot be certified without a baseline.'
+		);
+		process.exit(1);
+	}
+	if ('unavailable' in baseline) {
+		console.error(baseline.unavailable);
+		process.exit(1);
 	}
 	if ('root' in baseline) {
 		console.log('convex-consumer-compat: root commit, nothing promised yet.');

--- a/scripts/static-checks.compat.test.ts
+++ b/scripts/static-checks.compat.test.ts
@@ -1,0 +1,179 @@
+import { spawnSync } from 'node:child_process';
+import {
+	chmodSync,
+	copyFileSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync
+} from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { sanitizedGitEnv } from './git-context';
+import { compatibilityInvocation } from './static-checks';
+import { testExecutable } from './test-executable';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = path.join(ROOT, 'scripts', 'static-checks.ts');
+const BUN = testExecutable('bun');
+
+function run(args: string[], env = sanitizedGitEnv()) {
+	return spawnSync(BUN, [SCRIPT, ...args], {
+		cwd: ROOT,
+		encoding: 'utf8',
+		env
+	});
+}
+
+function createCheckerClone(): { directory: string; repository: string } {
+	const directory = path.join(ROOT, 'scratch', `static-compat-${process.pid}-${Date.now()}`);
+	const repository = path.join(directory, 'repository');
+	mkdirSync(directory, { recursive: true });
+	try {
+		const result = spawnSync(
+			'git',
+			['clone', '--quiet', '--local', '--no-hardlinks', ROOT, repository],
+			{ env: sanitizedGitEnv(), encoding: 'utf8' }
+		);
+		if (result.status !== 0) throw new Error(`Local checker clone failed: ${result.stderr}`);
+		symlinkSync(
+			path.join(ROOT, 'node_modules'),
+			path.join(repository, 'node_modules'),
+			process.platform === 'win32' ? 'junction' : 'dir'
+		);
+		copyFileSync(SCRIPT, path.join(repository, 'scripts', 'static-checks.ts'));
+		return { directory, repository };
+	} catch (error) {
+		rmSync(directory, { recursive: true, force: true });
+		throw error;
+	}
+}
+
+function writeFakeBun(directory: string): void {
+	if (process.platform === 'win32') {
+		const source = path.join(directory, 'fake-bun.ts');
+		writeFileSync(
+			source,
+			String.raw`import { writeFileSync } from 'node:fs';
+const log = process.env.STATIC_CHECK_LOG;
+if (!log) process.exit(42);
+writeFileSync(log, [process.argv[1] ?? '', process.env.GIT_DIR ?? '', process.env.GIT_WORK_TREE ?? '', process.env.CI ?? ''].join('\n') + '\n');
+`
+		);
+		const result = spawnSync(
+			BUN,
+			['build', '--compile', source, '--outfile', path.join(directory, 'bun.exe')],
+			{
+				encoding: 'utf8'
+			}
+		);
+		if (result.status !== 0) throw new Error(`Failed to compile fake Bun: ${result.stderr}`);
+		return;
+	}
+	const command = path.join(directory, 'bun');
+	writeFileSync(
+		command,
+		'#!/bin/sh\nprintf \'%s\\n%s\\n%s\\n%s\\n\' "$1" "${GIT_DIR-}" "${GIT_WORK_TREE-}" "${CI-}" > "$STATIC_CHECK_LOG"\n'
+	);
+	chmodSync(command, 0o755);
+}
+
+describe('Convex compatibility static-check entrypoint', () => {
+	it('builds the sanitized child invocation', () => {
+		const savedDir = process.env.GIT_DIR;
+		const savedWorktree = process.env.GIT_WORK_TREE;
+		process.env.GIT_DIR = path.join(ROOT, 'scratch', 'foreign.git');
+		process.env.GIT_WORK_TREE = path.join(ROOT, 'scratch', 'foreign-worktree');
+		try {
+			const invocation = compatibilityInvocation(true);
+			expect(invocation.command).toBe('bun');
+			expect(invocation.args).toEqual(['scripts/convex-consumer-compat.ts']);
+			expect(invocation.options.env?.GIT_DIR).toBeUndefined();
+			expect(invocation.options.env?.GIT_WORK_TREE).toBeUndefined();
+			expect(invocation.options.env?.CI).toBe('true');
+		} finally {
+			if (savedDir === undefined) delete process.env.GIT_DIR;
+			else process.env.GIT_DIR = savedDir;
+			if (savedWorktree === undefined) delete process.env.GIT_WORK_TREE;
+			else process.env.GIT_WORK_TREE = savedWorktree;
+		}
+	});
+
+	it('runs the compatibility child with the sanitized CI environment', () => {
+		const directory = path.join(ROOT, 'scratch', `compat-child-${process.pid}-${Date.now()}`);
+		const log = path.join(directory, 'child.log');
+		mkdirSync(directory, { recursive: true });
+		try {
+			writeFakeBun(directory);
+			const env = sanitizedGitEnv();
+			env.PATH = `${directory}${path.delimiter}${env.PATH ?? ''}`;
+			env.STATIC_CHECK_LOG = log;
+			env.GIT_DIR = path.join(directory, 'foreign.git');
+			env.GIT_WORK_TREE = path.join(directory, 'foreign-worktree');
+			const result = run(['--ci', '--scope', 'compat'], env);
+			const output = `${result.stdout}${result.stderr}`;
+			const [argument, gitDir, gitWorktree, ci] = readFileSync(log, 'utf8').trimEnd().split('\n');
+
+			expect(result.status, output).toBe(0);
+			expect(argument).toBe('scripts/convex-consumer-compat.ts');
+			expect(gitDir).toBe('');
+			expect(gitWorktree).toBe('');
+			expect(ci).toBe('true');
+			expect(output).toContain('Convex consumer compatibility');
+			expect(output).not.toContain('SvelteKit sync');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it.skipIf(process.platform === 'win32')(
+		'rejects an unsafe repository path before the compatibility child runs',
+		() => {
+			const checkout = createCheckerClone();
+			try {
+				const payload = `${String.fromCharCode(0x1b)}]0;OWNED${String.fromCharCode(0x07)}`;
+				const unsafeDirectory = path.join(checkout.repository, 'scripts', 'unsafe');
+				const file = path.join(unsafeDirectory, `bad${payload}.md`);
+				mkdirSync(unsafeDirectory, { recursive: true });
+				writeFileSync(file, 'safe');
+				const result = spawnSync(
+					BUN,
+					[path.join(checkout.repository, 'scripts', 'static-checks.ts'), '--scope', 'compat'],
+					{ cwd: checkout.repository, encoding: 'utf8', env: sanitizedGitEnv() }
+				);
+				const output = `${result.stdout}${result.stderr}`;
+
+				expect(result.status).toBe(1);
+				expect(output).toContain('U+001B');
+				expect(output).not.toContain(payload);
+				expect(output).not.toContain(String.fromCharCode(0x07));
+				expect(output).not.toContain('Convex consumer compatibility');
+			} finally {
+				rmSync(checkout.directory, { recursive: true, force: true });
+			}
+		}
+	);
+
+	it.each([
+		['staged mode', ['--scope', 'compat', '--staged']],
+		['an explicit file', ['--scope', 'compat', 'README.md']],
+		['--files-from', ['--scope', 'compat', '--files-from', '-']]
+	])('rejects %s before starting compatibility', (_label, args) => {
+		const result = run(args);
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.status).toBe(1);
+		expect(output).toContain('--scope compat only supports a full-project run');
+		expect(output).not.toContain('Convex consumer compatibility');
+	});
+
+	it('owns the package alias', () => {
+		const packageJson = JSON.parse(readFileSync(path.join(ROOT, 'package.json'), 'utf8')) as {
+			scripts: Record<string, string>;
+		};
+		expect(packageJson.scripts['check:convex-compat']).toBe(
+			'bun scripts/static-checks.ts --scope compat'
+		);
+	});
+});

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -6,6 +6,7 @@
  *   bun scripts/static-checks.ts --ci                  - Check all files, assert-only (CI)
  *   bun scripts/static-checks.ts --ci --scope lint     - Linting checks only (CI job group)
  *   bun scripts/static-checks.ts --ci --scope types    - Type checking only (CI job group)
+ *   bun scripts/static-checks.ts --scope compat        - Convex consumer compatibility only
  *   bun scripts/static-checks.ts --staged              - Check only staged files (pre-commit)
  *   bun scripts/static-checks.ts file1.ts file2.svelte - Check specific files
  *   ... | bun scripts/static-checks.ts --files-from -  - Check a computed list of files
@@ -15,8 +16,9 @@
  *                Requires misspell to be installed (fails if missing).
  *   --staged     Assert-only staged-file gate. Run fix mode before staging and retrying.
  *   --scope      Run a subset of checks: "lint" (misspell, literal controls, banned patterns, prettier,
- *                eslint, oxlint) or "types" (build-emails, svelte-check).
- *                Both groups run svelte-kit sync first. Omit to run all checks.
+ *                eslint, oxlint), "types" (build-emails, svelte-check), or full-project-only
+ *                "compat" (Convex consumer compatibility). Lint and types run svelte-kit sync first.
+ *                Omit to run lint and types.
  *   --files-from Read newline-separated paths from a file, or from stdin with "-".
  *                Use this for a COMPUTED list: unlike positionals, this channel can
  *                carry an empty list, which is an honest no-op instead of a silent
@@ -119,7 +121,7 @@ const colors =
 // which imports this module for scripts/static-checks.test.ts.
 const REPO_ROOT = realpathSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'));
 
-const USAGE = '  Flags: --ci, --staged, --scope <lint|types>, --files-from <path|->';
+const USAGE = '  Flags: --ci, --staged, --scope <lint|types|compat>, --files-from <path|->';
 
 /** Directories never descended into when a directory argument is expanded. */
 const NEVER_WALK = ['node_modules/', '.git/', '.svelte-kit/', '.convex/', 'build/', 'dist/'];
@@ -479,11 +481,11 @@ function parseCli() {
 	const { values, positionals } = parsed;
 	const stagedOnly = values.staged ?? false;
 	const ciMode = values.ci ?? false;
-	const scope = values.scope as 'lint' | 'types' | undefined;
+	const scope = values.scope as 'lint' | 'types' | 'compat' | undefined;
 	const filesFrom = values['files-from'];
 
-	if (scope && !['lint', 'types'].includes(scope)) {
-		fail(`Invalid --scope value: "${scope}". Use "lint" or "types".`);
+	if (scope && !['lint', 'types', 'compat'].includes(scope)) {
+		fail(`Invalid --scope value: "${scope}". Use "lint", "types", or "compat".`);
 	}
 
 	// Skip first two positionals (bun runtime + script path)
@@ -503,6 +505,12 @@ function parseCli() {
 	// Mode follows what was ASKED FOR, not what survived filtering.
 	const mode: Mode =
 		filesFrom !== undefined || rawPositionals.length > 0 ? 'files' : stagedOnly ? 'staged' : 'full';
+
+	if (scope === 'compat' && mode !== 'full') {
+		fail(
+			'--scope compat only supports a full-project run; omit --staged, file arguments, and --files-from.'
+		);
+	}
 
 	return { ciMode, scope, mode, rawPositionals, filesFrom };
 }
@@ -530,6 +538,16 @@ async function runCommand(
 		console.error(`${colors.red}Command failed: ${invocation}${colors.reset}`);
 		process.exit(result.status ?? 1);
 	}
+}
+
+export function compatibilityInvocation(ciMode = false) {
+	const env = sanitizedGitEnv();
+	if (ciMode) env.CI = 'true';
+	return {
+		command: 'bun',
+		args: ['scripts/convex-consumer-compat.ts'],
+		options: { env } satisfies SanitizedCommandOptions
+	};
 }
 
 /**
@@ -645,6 +663,17 @@ async function main(): Promise<void> {
 	);
 	console.log('======================================================\n');
 
+	let step = 1;
+	if (scope === 'compat') {
+		printHeader(step, 'Convex consumer compatibility');
+		const invocation = compatibilityInvocation(ciMode);
+		await runCommand(invocation.command, invocation.args, invocation.options);
+		ledger.ran('convex compat');
+		console.log('\n');
+		finish(ledger, scopeLabel);
+		return;
+	}
+
 	if (!shouldRunLint) {
 		for (const id of LINT_CHECKS) {
 			ledger.skipped(id, `--scope ${scope}`, scopedMode && ledger.filesFor(id).length > 0);
@@ -655,8 +684,6 @@ async function main(): Promise<void> {
 			ledger.skipped(id, `--scope ${scope}`, scopedMode && ledger.filesFor(id).length > 0);
 		}
 	}
-
-	let step = 1;
 
 	// SvelteKit sync (always runs — needed by both lint and types)
 	printHeader(step++, 'SvelteKit sync');

--- a/scripts/test-executable.ts
+++ b/scripts/test-executable.ts
@@ -1,0 +1,25 @@
+import { accessSync, constants } from 'node:fs';
+import path from 'node:path';
+
+/** Resolve a test dependency without relying on the optional `which` utility. */
+export function testExecutable(name: string): string {
+	const extensions =
+		process.platform === 'win32'
+			? (process.env.PATHEXT ?? '.COM;.EXE')
+					.split(';')
+					.filter((extension) => ['.COM', '.EXE'].includes(extension.toUpperCase()))
+			: [''];
+	for (const directory of (process.env.PATH ?? '').split(path.delimiter)) {
+		if (!directory) continue;
+		for (const extension of extensions) {
+			const candidate = path.join(directory, `${name}${extension.toLowerCase()}`);
+			try {
+				accessSync(candidate, constants.X_OK);
+				return candidate;
+			} catch {
+				// Try the next PATH entry.
+			}
+		}
+	}
+	throw new Error(`Required test executable ${JSON.stringify(name)} is not on PATH.`);
+}


### PR DESCRIPTION
Regression guard: added deterministic compatibility entrypoint and shallow-history tests

The Convex compatibility checker ran outside the shared terminal-output boundary, inherited foreign Git context, and could skip locally when no trustworthy trunk baseline existed.

`check:convex-compat` now enters `static-checks` through a full-project-only scope. The wrapper sanitizes repository paths and child output, strips inherited Git context, forwards CI mode, and fails closed for missing merge bases, missing parents, and incomplete shallow history while preserving the genuine root-commit exception.

The Varlock pre-commit path is unchanged and remains tracked in #848. The separate staged-state boundary is tracked in #855.

Verified with 1,658 passing unit tests, changed-file static and type checks, and the real compatibility check confirming 91 referenced functions remain published unchanged.
