### PR TITLE
fix(lint): Add safe format-only scope

### DIFF
--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -1,0 +1,200 @@
+import { spawnSync } from 'child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { sanitizedGitEnv } from './git-context';
+import { testExecutable } from './test-executable';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = path.join(ROOT, 'scripts', 'static-checks.ts');
+
+/** Assert-only format run, with the parent's colour and Git context stripped. */
+function formatCheck(...args: string[]): { status: number; output: string } {
+	const result = spawnSync(testExecutable('bun'), [SCRIPT, '--ci', '--scope', 'format', ...args], {
+		cwd: ROOT,
+		env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
+		encoding: 'utf8'
+	});
+	return { status: result.status ?? -1, output: `${result.stdout}${result.stderr}` };
+}
+
+/** Write an unformatted file into the repository for one assertion. */
+function withRepositoryFile(
+	name: string,
+	contents: string,
+	assertion: (file: string) => void
+): void {
+	const file = path.join(ROOT, name);
+	writeFileSync(file, contents);
+	try {
+		assertion(file);
+	} finally {
+		rmSync(file, { force: true });
+	}
+}
+
+describe('format-only static checks', () => {
+	it('routes a real Prettier parse error through the terminal boundary', () => {
+		const relative = `scripts/.format-control-${process.pid}.ts`;
+		const escape = String.fromCharCode(0x1b);
+		withRepositoryFile(relative, `export const value = ${escape}[31m;\n`, (file) => {
+			const { status, output } = formatCheck(file);
+			expect(status).not.toBe(0);
+			expect(output).toContain('U+001B');
+			expect(output).not.toContain(escape);
+			expect(output).not.toContain('SvelteKit sync');
+			expect(output).not.toContain('ESLint');
+		});
+	});
+
+	// Prettier reads a leading-dash path as an option, warns that the option is unknown,
+	// finds no file left to check and exits 0. Both hand-offs therefore pass the paths
+	// after "--": the checker's own CLI, and the Prettier invocation behind it.
+	it('checks a repository file whose name begins with dashes', () => {
+		const relative = `--format-dash-${process.pid}.ts`;
+		withRepositoryFile(relative, 'export const value    =    1;\n', (file) => {
+			// "[warn] <file>" is Prettier's own verdict. Without it the run can still exit
+			// non-zero for having checked nothing at all, which is the failure this pins.
+			const absolute = formatCheck(file);
+			expect(absolute.status).not.toBe(0);
+			expect(absolute.output).toContain(`[warn] ${relative}`);
+
+			// The same file relayed as a repo-relative path behind an explicit separator.
+			const relayed = formatCheck('--', relative);
+			expect(relayed.status).not.toBe(0);
+			expect(relayed.output).toContain(`[warn] ${relative}`);
+			expect(relayed.output).not.toContain('Bad arguments');
+		});
+	});
+
+	it('checks a web app manifest with the real formatter', () => {
+		const relative = `format-manifest-${process.pid}.webmanifest`;
+		withRepositoryFile(relative, '{"name":   "Fixture"}\n', (file) => {
+			const { status, output } = formatCheck(file);
+			expect(status).not.toBe(0);
+			expect(output).toContain(`[warn] ${relative}`);
+		});
+	});
+
+	// Four filenames the hand-written extension grammar did not have and Prettier does.
+	// Each one is written unformatted and has to come back as Prettier's own "[warn]",
+	// because a route that merely stops rejecting them would still be green here if the
+	// file never reached the formatter.
+	it.each([
+		['a Markdown README spelled in full', 'markdown', '#  Title\n\n\ntext   \n'],
+		['a Babel configuration', 'babelrc', '{"presets":   []}\n'],
+		['GeoJSON', 'geojson', '{"type":   "Point"}\n'],
+		['MJML', 'mjml', '<mjml><mj-body>   <mj-text>hi</mj-text></mj-body></mjml>\n']
+	])('checks %s', (_label, kind, contents) => {
+		// .babelrc is matched by its exact basename, so it cannot carry a unique suffix.
+		// A directory of its own keeps it out of the repository root and off every tool
+		// that would otherwise pick up a stray configuration file.
+		const directory = `scripts/.format-${kind}-${process.pid}`;
+		const name = kind === 'babelrc' ? '.babelrc' : `README.${kind}`;
+		const relative = `${directory}/${name}`;
+		mkdirSync(path.join(ROOT, directory), { recursive: true });
+		try {
+			withRepositoryFile(relative, contents, (file) => {
+				const { status, output } = formatCheck(file);
+				expect(status).not.toBe(0);
+				expect(output).toContain(`[warn] ${relative}`);
+			});
+		} finally {
+			rmSync(path.join(ROOT, directory), { recursive: true, force: true });
+		}
+	});
+
+	// Prettier is the only check in a format scope, so it can answer for the whole run:
+	// a file it would skip is not work anyone is owed, and saying so is honest rather
+	// than a hole. The two ways to be skipped are pinned separately because they arrive
+	// from different places, the parser table and the ignore files.
+	it('reports an honest no-op for a file Prettier has no parser for', () => {
+		const relative = `format-unknown-${process.pid}.bin`;
+		withRepositoryFile(relative, 'not source\n', (file) => {
+			const { status, output } = formatCheck(file);
+			expect(status).toBe(0);
+			expect(output).toContain('No formatter work');
+			expect(output).toContain('unknown file type');
+			expect(output).not.toContain('[warn]');
+		});
+	});
+
+	it('reports an honest no-op for a file the formatter ignores', () => {
+		// src/env.d.ts is generated and excluded by .prettierignore, so the CLI would skip
+		// it. Counting it as formatter work would report a check that never happened.
+		const { status, output } = formatCheck(path.join(ROOT, 'src/env.d.ts'));
+		expect(status).toBe(0);
+		expect(output).toContain('No formatter work');
+		expect(output).toContain('prettier         0 file(s)');
+	});
+
+	// The honest no-op above is the format scope's alone. Everywhere else, a named file
+	// no check covers is still the bug it always was: src/i18n is excluded from spell
+	// checking, so a binary there is routed by nothing at all. The scope is "types"
+	// because a lint run ends in a whole-project oxlint, and the sibling terminal-output
+	// suite deletes .ts fixtures under it mid-walk; the invariant is scope-agnostic, so
+	// pinning it from a scope without that walk avoids inheriting the race.
+	it('still refuses to go green on a run no check is responsible for', () => {
+		const relative = `src/i18n/format-unroutable-${process.pid}.bin`;
+		withRepositoryFile(relative, '', (file) => {
+			const result = spawnSync(testExecutable('bun'), [SCRIPT, '--scope', 'types', file], {
+				cwd: ROOT,
+				env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
+				encoding: 'utf8'
+			});
+			expect(result.status).toBe(1);
+			expect(`${result.stdout}${result.stderr}`).toContain('no check ran over any of them');
+		});
+	}, 60_000);
+
+	it('keeps a root file whose name begins with dots inside the repository', () => {
+		const relative = `..format-dots-${process.pid}.ts`;
+		withRepositoryFile(relative, 'export const value    =    1;\n', (file) => {
+			const { status, output } = formatCheck(file);
+			expect(status).not.toBe(0);
+			expect(output).toContain(`[warn] ${relative}`);
+			expect(output).not.toContain('outside the repository');
+		});
+	});
+});
+
+describe('scope routing', () => {
+	it('records a positive formatter match count for a full-project run', () => {
+		const { status, output } = formatCheck();
+		expect(status).toBe(0);
+		expect(output).toMatch(/prettier\s+[1-9]\d* file\(s\)/);
+		expect(output).not.toContain('prettier         whole project');
+	}, 120_000);
+
+	// The staged gate ends by proving the checked bytes are still the staged bytes, and
+	// that argument belongs to the lint-and-types path. A format scope leaves through its
+	// own early exit, so the combination is refused rather than given a second closing.
+	it('refuses a staged format run instead of exiting past the staged closing argument', () => {
+		const result = spawnSync(testExecutable('bun'), [SCRIPT, '--staged', '--scope', 'format'], {
+			cwd: ROOT,
+			env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
+			encoding: 'utf8'
+		});
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.status).toBe(1);
+		expect(output).toContain('--scope format does not support --staged');
+		expect(output).toContain('--files-from');
+		expect(output).not.toContain('Code formatting');
+	});
+
+	// A locale file is Prettier's and nothing else's: no type check, no lint route. The
+	// checker still has to know that, or a `--scope types` over one sees a file no check
+	// covers and fails a run whose only covering check is legitimately switched off.
+	it('recognizes suppressed formatter work in a type-scoped run over a locale file', () => {
+		const result = spawnSync(
+			testExecutable('bun'),
+			[SCRIPT, '--ci', '--scope', 'types', 'src/i18n/en.json'],
+			{ cwd: ROOT, env: { ...sanitizedGitEnv(), NO_COLOR: '1' }, encoding: 'utf8' }
+		);
+		const output = `${result.stdout}${result.stderr}`;
+		expect(output).toContain('every check covering them is switched off');
+		expect(output).not.toContain('no check ran over any of them');
+		expect(result.status).toBe(0);
+	}, 120_000);
+});

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -15,18 +15,22 @@
  *      so these stay fast.
  */
 import { spawnSync } from 'child_process';
-import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
 import { sanitizedGitEnv } from './git-context';
 import {
+	argumentBatches,
 	authoredTextFiles,
 	existingRepositoryPaths,
 	formatPathForDiagnostic,
 	isIgnoredPath,
 	literalControlCharacterViolations,
+	prettierArguments,
+	prettierFormattableFiles,
 	repositoryPaths,
 	ROUTES,
 	resolveInputs,
@@ -49,6 +53,38 @@ describe('checker mutation mode', () => {
 		expect(usesAssertOnlyChecks(true, 'full')).toBe(true);
 		expect(usesAssertOnlyChecks(false, 'files')).toBe(false);
 	});
+
+	it('batches structured arguments by both file count and command length', () => {
+		expect(argumentBatches(['a.ts', 'b.ts', 'c.ts'], ['prettier'], 1_000, 2)).toEqual([
+			['a.ts', 'b.ts'],
+			['c.ts']
+		]);
+		expect(argumentBatches(['aaaa.ts', 'bbbb.ts'], ['command'], 20, 100)).toEqual([
+			['aaaa.ts'],
+			['bbbb.ts']
+		]);
+	});
+});
+
+describe('Prettier invocation', () => {
+	// The project run used to take neither --ignore-unknown nor the plugins while the
+	// file-scoped run passed plugins on the command line, so the two could disagree about
+	// what a given file even is. Both are built here now, and neither names a plugin:
+	// .prettierrc declares them once and every run reads that.
+	it('gives the project run and the file-scoped run the same contract', () => {
+		const project = prettierArguments('--check');
+		const scoped = prettierArguments('--check', ['src/app.ts']);
+
+		expect(project.at(-1)).toBe('.');
+		expect(scoped.slice(-2)).toEqual(['--', 'src/app.ts']);
+
+		const projectOptions = project.slice(0, -1);
+		const scopedOptions = scoped.slice(0, scoped.indexOf('--'));
+		expect(projectOptions).toEqual(scopedOptions);
+		expect(projectOptions).toContain('--ignore-unknown');
+		expect(projectOptions).not.toContain('--plugin');
+		expect(prettierArguments('--write', ['a.ts'])).toContain('--write');
+	});
 });
 
 describe('route predicates', () => {
@@ -64,6 +100,93 @@ describe('route predicates', () => {
 		expect(ROUTES['literal-control-char']('src/lib/content/llms.txt')).toBe(true);
 		expect(ROUTES['literal-control-char']('src/lib/content/privacy.ts')).toBe(false);
 		expect(ROUTES['literal-control-char']('scratch/session/log.txt')).toBe(false);
+	});
+
+	// The Prettier route is the one route that is not a path predicate. It used to be a
+	// hand-written extension grammar, which is a copy of a table Prettier owns and which
+	// had drifted: every filename in the second group is formatted by Prettier and none
+	// of them matched, so a file-scoped run skipped them and called itself green.
+	it('asks Prettier which files it can parse', async () => {
+		const formattable = [
+			'.prettierrc',
+			'config.jsonc',
+			'workflow.yaml',
+			'query.graphql',
+			'page.mdx',
+			'static/site.webmanifest',
+			'README.markdown',
+			'.babelrc',
+			'boundaries.geojson',
+			'campaign.mjml'
+		];
+		expect(await prettierFormattableFiles(formattable)).toEqual(formattable);
+		expect(await prettierFormattableFiles(['static/image.png', 'notes.txt', 'Dockerfile'])).toEqual(
+			[]
+		);
+	});
+
+	// .prettierrc is where this repository declares its formatter contract, and the
+	// formatter subprocess is what reads it. The checker cannot: resolving configuration
+	// to answer a routing question would run a config file and a plugin in the checker's
+	// own process. So the route carries one narrow convention instead, and its licence is
+	// the declaration pinned here.
+	it('takes the Svelte contract from the repository configuration', async () => {
+		const config = JSON.parse(readFileSync(path.join(ROOT, '.prettierrc'), 'utf8')) as {
+			plugins?: string[];
+			overrides?: Array<{ files?: string; options?: { parser?: string } }>;
+		};
+		expect(config.plugins).toContain('prettier-plugin-svelte');
+		expect(
+			config.overrides?.some(
+				(override) => override.files === '*.svelte' && override.options?.parser === 'svelte'
+			)
+		).toBe(true);
+
+		// Prettier has no built-in Svelte language, and loading the plugin to find that out
+		// would run it inside the checker. The route asserts the convention instead, which
+		// is only honest while the two declarations above are the ones the formatter reads.
+		expect(await prettierFormattableFiles(['src/routes/+layout.svelte'])).toEqual([
+			'src/routes/+layout.svelte'
+		]);
+	});
+
+	it('classifies without executing repository configuration', async () => {
+		// Measured: with configuration resolution left on, one malformed .prettierrc makes
+		// getFileInfo throw, so a routing question would take the whole run down before any
+		// check it was classifying for could start. Classification answers from Prettier's
+		// built-in table and the repository convention alone, and never runs a config file
+		// or a plugin inside the checker.
+		const fixture = mkdtempSync(path.join(tmpdir(), 'static-checks-config-'));
+		try {
+			writeFileSync(path.join(fixture, '.prettierrc'), '{ this is not json\n');
+			writeFileSync(path.join(fixture, 'probe.ts'), 'export const probe = 1;\n');
+			writeFileSync(path.join(fixture, 'probe.svelte'), '<p>probe</p>\n');
+			expect(await prettierFormattableFiles(['probe.ts', 'probe.svelte'], fixture)).toEqual([
+				'probe.ts',
+				'probe.svelte'
+			]);
+		} finally {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
+	it('applies the ignore rules the formatter CLI applies', async () => {
+		// The CLI's default --ignore-path is exactly [.gitignore, .prettierignore], and
+		// .prettierignore excludes the generated src/env.d.ts. A file the command would
+		// skip is not work this run may claim, so it must not reach the ledger as one.
+		expect(await prettierFormattableFiles(['src/env.d.ts'])).toEqual([]);
+		expect(await prettierFormattableFiles(['src/routes/+layout.svelte', 'src/env.d.ts'])).toEqual([
+			'src/routes/+layout.svelte'
+		]);
+	});
+
+	it('keeps a run honest about which named files it formatted', async () => {
+		// The count the ledger reports has to be the count Prettier can act on. A named
+		// file it cannot parse is not formatter work, and calling it work would let a run
+		// of nothing but unparseable inputs report success.
+		expect(await prettierFormattableFiles(['README.markdown', 'static/image.png'])).toEqual([
+			'README.markdown'
+		]);
 	});
 
 	it('keeps artifact ignores rooted and includes tracked dot-directory documents', () => {
@@ -205,6 +328,19 @@ describe('resolveInputs', () => {
 			'src/lib/utils/auth-messages.ts'
 		];
 		expect(resolveInputs(forms, 'test')).toEqual(['src/lib/utils/auth-messages.ts']);
+	});
+
+	// Containment is a segment question, not a prefix question: "..valid.ts" is an
+	// ordinary file at the repository root, and only "..", a real ".." segment, or an
+	// absolute result (a different Windows drive) is outside.
+	it('keeps a root file whose name begins with dots', () => {
+		const file = path.join(ROOT, `..resolve-dots-${process.pid}.ts`);
+		writeFileSync(file, 'export const valid = true;\n');
+		try {
+			expect(resolveInputs([file], 'test')).toEqual([path.basename(file)]);
+		} finally {
+			rmSync(file, { force: true });
+		}
 	});
 
 	it('includes dot-directory descendants of a directory argument', () => {

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -7,6 +7,7 @@
  *   bun scripts/static-checks.ts --ci --scope lint     - Linting checks only (CI job group)
  *   bun scripts/static-checks.ts --ci --scope types    - Type checking only (CI job group)
  *   bun scripts/static-checks.ts --scope compat        - Convex consumer compatibility only
+ *   bun scripts/static-checks.ts --scope format files  - Assert formatting only
  *   bun scripts/static-checks.ts --staged              - Check only staged files (pre-commit)
  *   bun scripts/static-checks.ts file1.ts file2.svelte - Check specific files
  *   ... | bun scripts/static-checks.ts --files-from -  - Check a computed list of files
@@ -16,8 +17,9 @@
  *                Requires misspell to be installed (fails if missing).
  *   --staged     Assert-only staged-file gate. Run fix mode before staging and retrying.
  *   --scope      Run a subset of checks: "lint" (misspell, literal controls, banned patterns, prettier,
- *                eslint, oxlint), "types" (build-emails, svelte-check), or full-project-only
- *                "compat" (Convex consumer compatibility). Lint and types run svelte-kit sync first.
+ *                eslint, oxlint), "types" (build-emails, svelte-check), assert-only "format"
+ *                (prettier), or full-project-only "compat" (Convex consumer compatibility).
+ *                Lint and types run svelte-kit sync first.
  *                Omit to run lint and types.
  *   --files-from Read newline-separated paths from a file, or from stdin with "-".
  *                Use this for a COMPUTED list: unlike positionals, this channel can
@@ -32,6 +34,7 @@
 import { spawnSync } from 'child_process';
 import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
 import path from 'path';
+import { getFileInfo } from 'prettier';
 import { fileURLToPath } from 'url';
 import { parseArgs } from 'util';
 import knowledgePolicy from '../knowledge-policy.config';
@@ -121,7 +124,7 @@ const colors =
 // which imports this module for scripts/static-checks.test.ts.
 const REPO_ROOT = realpathSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'));
 
-const USAGE = '  Flags: --ci, --staged, --scope <lint|types|compat>, --files-from <path|->';
+const USAGE = '  Flags: --ci, --staged, --scope <lint|types|format|compat>, --files-from <path|->';
 
 /** Directories never descended into when a directory argument is expanded. */
 const NEVER_WALK = ['node_modules/', '.git/', '.svelte-kit/', '.convex/', 'build/', 'dist/'];
@@ -249,8 +252,17 @@ export function resolveInputs(raw: string[], origin: string): string[] {
 		if (!existsSync(absolute)) fail(`No such file (${origin}): ${formatPathForDiagnostic(arg)}`);
 
 		const real = realpathSync(absolute);
-		const relative = toPosix(path.relative(REPO_ROOT, real));
-		if (relative === '' || relative.startsWith('..')) {
+		const native = path.relative(REPO_ROOT, real);
+		const relative = toPosix(native);
+		// Only an empty result, a bare "..", a real ".." segment, or an absolute result
+		// (a different Windows drive) leaves the repository. A "startsWith('..')" prefix
+		// test also rejects "..valid.ts", which is an ordinary file at the root.
+		if (
+			relative === '' ||
+			relative === '..' ||
+			relative.startsWith('../') ||
+			path.isAbsolute(native)
+		) {
 			fail(
 				`Path is outside the repository (${origin}): ${formatPathForDiagnostic(arg)}`,
 				`  Repo root: ${formatPathForDiagnostic(REPO_ROOT)}`
@@ -301,21 +313,66 @@ export function isIgnoredPath(file: string): boolean {
 
 /**
  * Which checks are responsible for a repo-relative path. The ONLY place a file set is
- * derived, so a check can no longer disagree with the ledger about its own scope, and
- * a new check has to declare a route to be accounted for.
+ * derived from the path itself, so a check can no longer disagree with the ledger about
+ * its own scope, and a new check has to declare a route to be accounted for.
+ *
+ * Prettier is the one route that is not a path predicate, because the mapping from
+ * filename to parser belongs to Prettier and moves when Prettier moves. It is resolved
+ * by prettierFormattableFiles() below and reaches the ledger the same way every other
+ * route does, through filesFor().
  */
 export const ROUTES = {
 	misspell: (f: string) => !CONFIG.misspell.ignore.some((i) => f.includes(i)),
 	'banned-patterns': (f: string) => /\.(svelte|ts)$/.test(f) && f.startsWith('src/'),
 	'literal-control-char': (f: string) => /\.(md|txt)$/.test(f) && !f.startsWith('scratch/'),
 	'knowledge-placement': (f: string) => matchesKnowledgeCandidate(knowledgePolicy, f),
-	prettier: (f: string) => /\.(js|ts|svelte|html|css|md|json)$/.test(f),
 	eslint: (f: string) => /\.(js|ts|svelte)$/.test(f),
 	// The old gate was `jsTsSvelteFiles.length === 0 && svelteFiles.length === 0`;
 	// svelteFiles is a subset of jsTsSvelteFiles, so the second clause was dead.
 	'svelte-check': (f: string) => /\.(js|ts|svelte)$/.test(f),
 	convex: (f: string) => f.startsWith('src/lib/convex/')
 } as const;
+
+/** The ignore files Prettier's CLI consults unless --ignore-path overrides them. */
+const PRETTIER_IGNORE_FILES = ['.gitignore', '.prettierignore'];
+
+/**
+ * Components, which Prettier has no built-in language for. The parser comes from
+ * prettier-plugin-svelte, and .prettierrc declares both the plugin and the `*.svelte`
+ * parser override; loading either to answer a routing question would run a configuration
+ * file and a plugin inside the checker. The checker asserts the convention instead, and
+ * static-checks.test.ts pins the declaration it stands on.
+ */
+const SVELTE_COMPONENT = /\.svelte$/;
+
+/**
+ * The files Prettier would actually format, answered by Prettier.
+ *
+ * This used to be an extension grammar maintained here by hand, which is a copy of a
+ * table Prettier owns and was wrong wherever the two had drifted apart: README.markdown,
+ * .babelrc, .geojson and .mjml are all formatted by Prettier and none of them matched, so
+ * a file-scoped run skipped them and reported success.
+ *
+ * `resolveConfig: false` keeps repository configuration and its plugins out of this
+ * process: a routing question should not be able to take the run down before the checks
+ * it classifies for ever start. The ignore files are still consulted, because they are
+ * read as data and because a file the command will skip is not work this run may claim.
+ */
+export async function prettierFormattableFiles(
+	files: string[],
+	cwd = REPO_ROOT
+): Promise<string[]> {
+	if (files.length === 0) return [];
+	const ignorePath = PRETTIER_IGNORE_FILES.map((file) => path.join(cwd, file));
+	const infos = await Promise.all(
+		files.map((file) => getFileInfo(path.resolve(cwd, file), { ignorePath, resolveConfig: false }))
+	);
+	return files.filter((file, index) => {
+		const info = infos[index]!;
+		if (info.ignored) return false;
+		return info.inferredParser !== null || SVELTE_COMPONENT.test(file);
+	});
+}
 
 export function authoredTextFiles(files: string[]): string[] {
 	return files.filter((file) => ROUTES['literal-control-char'](file) && !isIgnoredPath(file));
@@ -325,8 +382,8 @@ export function spellcheckFiles(files: string[]): string[] {
 	return files.filter((file) => ROUTES.misspell(file) && !isIgnoredPath(file));
 }
 
-type CheckId = keyof typeof ROUTES;
-const CHECK_IDS = Object.keys(ROUTES) as CheckId[];
+type CheckId = keyof typeof ROUTES | 'prettier';
+const CHECK_IDS: CheckId[] = [...(Object.keys(ROUTES) as Array<keyof typeof ROUTES>), 'prettier'];
 const LINT_CHECKS: CheckId[] = [
 	'misspell',
 	'banned-patterns',
@@ -338,6 +395,31 @@ const LINT_CHECKS: CheckId[] = [
 const TYPE_CHECKS: CheckId[] = ['svelte-check', 'convex'];
 
 type Mode = 'files' | 'staged' | 'full';
+
+/** Keep structured command lines below Windows' process argument limit. */
+export function argumentBatches(
+	files: string[],
+	baseArguments: string[] = [],
+	maxCharacters = 24_000,
+	maxFiles = 100
+): string[][] {
+	const batches: string[][] = [];
+	let batch: string[] = [];
+	let characters = baseArguments.reduce((total, argument) => total + argument.length + 1, 0);
+
+	for (const file of files) {
+		const added = file.length + 1;
+		if (batch.length > 0 && (batch.length >= maxFiles || characters + added > maxCharacters)) {
+			batches.push(batch);
+			batch = [];
+			characters = baseArguments.reduce((total, argument) => total + argument.length + 1, 0);
+		}
+		batch.push(file);
+		characters += added;
+	}
+	if (batch.length > 0) batches.push(batch);
+	return batches;
+}
 
 export function usesAssertOnlyChecks(ciMode: boolean, mode: Mode): boolean {
 	return ciMode || mode === 'staged';
@@ -359,19 +441,26 @@ class Ledger {
 	readonly named: number;
 	readonly files: string[];
 	readonly ignored: string[];
+	private readonly formattable: Set<string>;
 	private readonly outcomes = new Map<string, Outcome>();
+	private readonly honestNoWork: string[] = [];
 
 	constructor(
 		readonly mode: Mode,
-		inputs: string[]
+		inputs: string[],
+		/** The inputs Prettier reported a parser for. See prettierFormattableFiles(). */
+		formattable: string[] = []
 	) {
 		this.named = inputs.length;
 		this.ignored = inputs.filter(isIgnoredPath);
 		this.files = inputs.filter((f) => !this.ignored.includes(f));
+		this.formattable = new Set(formattable);
 	}
 
 	filesFor(id: CheckId): string[] {
-		return this.files.filter(ROUTES[id]);
+		return id === 'prettier'
+			? this.files.filter((file) => this.formattable.has(file))
+			: this.files.filter(ROUTES[id]);
 	}
 
 	ran(id: string, files: number | 'project' = 'project'): void {
@@ -380,6 +469,19 @@ class Ledger {
 
 	skipped(id: string, reason: string, suppressed = false): void {
 		this.outcomes.set(id, { kind: 'skipped', reason, suppressed });
+	}
+
+	/**
+	 * Record a reason this run legitimately had nothing to do.
+	 *
+	 * The zero-work invariant asks whether a check COULD have run over the named files,
+	 * and only a single-check scope can answer that from one check. A `--scope format` run
+	 * over files Prettier does not format is such an answer, and it is the caller's answer
+	 * rather than a hole in the gate. Nothing else may call this: for a lint or types run,
+	 * "no check ran" is still the bug it always was.
+	 */
+	noWork(reason: string): void {
+		this.honestNoWork.push(reason);
 	}
 
 	/**
@@ -414,8 +516,8 @@ class Ledger {
 
 		if (this.consumedAnything()) return;
 
-		// Zero work on the named files. Two reasons are honest; anything else is the bug.
-		const honest: string[] = [];
+		// Zero work on the named files. A few reasons are honest; anything else is the bug.
+		const honest: string[] = [...this.honestNoWork];
 		if (this.named > 0 && this.ignored.length === this.named) {
 			honest.push(`all ${this.named} input(s) are excluded by CONFIG.ignorePaths`);
 		}
@@ -426,7 +528,8 @@ class Ledger {
 		if (honest.length === 0) {
 			fail(
 				`${this.named} file(s) named, and no check ran over any of them.`,
-				'  No check in ROUTES is responsible for them, so nothing was verified.\n' +
+				`  No check in the active scope (${scopeLabel}) is responsible for them, so nothing\n` +
+					'  was verified.\n' +
 					'  A run that checks nothing must not report success.'
 			);
 		}
@@ -481,11 +584,11 @@ function parseCli() {
 	const { values, positionals } = parsed;
 	const stagedOnly = values.staged ?? false;
 	const ciMode = values.ci ?? false;
-	const scope = values.scope as 'lint' | 'types' | 'compat' | undefined;
+	const scope = values.scope as 'lint' | 'types' | 'format' | 'compat' | undefined;
 	const filesFrom = values['files-from'];
 
-	if (scope && !['lint', 'types', 'compat'].includes(scope)) {
-		fail(`Invalid --scope value: "${scope}". Use "lint", "types", or "compat".`);
+	if (scope && !['lint', 'types', 'format', 'compat'].includes(scope)) {
+		fail(`Invalid --scope value: "${scope}". Use "lint", "types", "format", or "compat".`);
 	}
 
 	// Skip first two positionals (bun runtime + script path)
@@ -509,6 +612,17 @@ function parseCli() {
 	if (scope === 'compat' && mode !== 'full') {
 		fail(
 			'--scope compat only supports a full-project run; omit --staged, file arguments, and --files-from.'
+		);
+	}
+
+	// A staged run must end by proving the checked bytes are still the staged bytes, and
+	// that closing argument belongs to the lint-and-types path that owns it. Rather than
+	// spread it over a second exit, the combination is refused: --staged stays a lint
+	// consumer, and formatting a staged set is `--files-from -` over the staged names.
+	if (scope === 'format' && mode === 'staged') {
+		fail(
+			'--scope format does not support --staged.',
+			'  It formats a full project or a named file list. Pass explicit paths or use --files-from.'
 		);
 	}
 
@@ -537,6 +651,35 @@ async function runCommand(
 		const invocation = sanitizeTerminalField(`${command} ${args.join(' ')}`);
 		console.error(`${colors.red}Command failed: ${invocation}${colors.reset}`);
 		process.exit(result.status ?? 1);
+	}
+}
+
+/**
+ * One formatter contract, whether the run names files or the whole project.
+ *
+ * Both invocations are built here so they cannot drift: the project run used to take
+ * neither --ignore-unknown nor the plugins while the file-scoped run passed plugins on
+ * the command line, so the two could disagree about what a given file even is. Neither
+ * names a plugin now, because .prettierrc declares them once and the formatter reads it.
+ * --ignore-unknown makes a path Prettier has no parser for a skip in both runs instead
+ * of a hard error in one.
+ */
+export function prettierArguments(formatFlag: '--check' | '--write', files?: string[]): string[] {
+	const invocation = ['prettier', formatFlag, '--ignore-unknown'];
+	// Everything after the separator is a path. Without it Prettier reads a leading-dash
+	// filename as an option, discards it with a warning, finds nothing left to check and
+	// exits 0, so a repository file named "--anything.ts" is never looked at.
+	return files === undefined ? [...invocation, '.'] : [...invocation, '--', ...files];
+}
+
+async function runPrettier(formatFlag: '--check' | '--write', files?: string[]): Promise<void> {
+	if (files === undefined) {
+		await runCommand('bun', prettierArguments(formatFlag));
+		return;
+	}
+	const baseArguments = prettierArguments(formatFlag, []);
+	for (const batch of argumentBatches(files, baseArguments)) {
+		await runCommand('bun', [...baseArguments, ...batch]);
 	}
 }
 
@@ -653,7 +796,11 @@ async function main(): Promise<void> {
 	const fullExistingPaths = existingRepositoryPaths(fullRepositoryPaths);
 	assertSafePaths(mode === 'full' ? fullRepositoryPaths : inputs);
 
-	const ledger = new Ledger(mode, inputs);
+	// Every file-scoped run needs the formatter route for the zero-work invariant. A full
+	// format run also needs the repository preflight set so it can prove Prettier had at
+	// least one supported, nonignored file to check.
+	const ledgerInputs = scope === 'format' && mode === 'full' ? fullExistingPaths : inputs;
+	const ledger = new Ledger(mode, ledgerInputs, await prettierFormattableFiles(ledgerInputs));
 
 	console.log('======================================================');
 	console.log(
@@ -669,6 +816,35 @@ async function main(): Promise<void> {
 		const invocation = compatibilityInvocation(ciMode);
 		await runCommand(invocation.command, invocation.args, invocation.options);
 		ledger.ran('convex compat');
+		console.log('\n');
+		finish(ledger, scopeLabel);
+		return;
+	}
+
+	if (scope === 'format') {
+		printHeader(step, 'Code formatting');
+		const files = ledger.filesFor('prettier');
+		if (!scopedMode) {
+			if (files.length === 0) {
+				fail('Full-project format scope found no supported, nonignored files.');
+			}
+			await runPrettier('--check');
+			ledger.ran('prettier', files.length);
+		} else if (files.length > 0) {
+			await runPrettier('--check', files);
+			ledger.ran('prettier', files.length);
+		} else {
+			// Prettier is the only check in this scope, so it can answer for the whole run:
+			// it would skip every named file, either because it has no parser for it or
+			// because .prettierignore or .gitignore excludes it. Reporting that plainly is
+			// honest; failing would make a caller that passes a mixed file list unusable.
+			console.log(
+				`No formatter work: Prettier formats none of the ${ledger.named} named file(s) ` +
+					'(unknown file type, or excluded by .prettierignore or .gitignore).'
+			);
+			ledger.ran('prettier', 0);
+			ledger.noWork(`Prettier formats none of the ${ledger.named} named file(s)`);
+		}
 		console.log('\n');
 		finish(ledger, scopeLabel);
 		return;
@@ -805,18 +981,10 @@ async function main(): Promise<void> {
 			const formatFlag = assertMode ? '--check' : '--write';
 			const files = ledger.filesFor('prettier');
 			if (!scopedMode) {
-				await runCommand('bun', ['prettier', formatFlag, '.']);
+				await runPrettier(formatFlag);
 				ledger.ran('prettier');
 			} else if (files.length > 0) {
-				await runCommand('bun', [
-					'prettier',
-					formatFlag,
-					'--plugin',
-					'prettier-plugin-svelte',
-					'--plugin',
-					'prettier-plugin-tailwindcss',
-					...files
-				]);
+				await runPrettier(formatFlag, files);
 				ledger.ran('prettier', files.length);
 			} else {
 				console.log('No files to format');


### PR DESCRIPTION
Regression guard: added real Prettier contract and terminal-output tests

Fork hooks need an assert-only formatting entrypoint that keeps parse errors behind the shared terminal boundary without running the full lint-and-types pipeline. Direct Prettier calls can replay source-owned control characters from error frames.

`--scope format` now validates caller paths, asks Prettier which named files it supports and ignores, batches structured arguments, and runs full-project or explicit-file checks through the sanitized child boundary. Both modes share the canonical repository configuration. Unknown or ignored named files produce an explicit no-op, while a full run must prove it matched files. Staged formatting stays with the existing lint scope.

Verified with 1,680 passing unit tests, changed-file static and type checks, the production build, and real parser, control-character, batching, and scope-routing probes. See also https://github.com/stickerdaniel/cadenza-app/issues/727.