### PR TITLE
feat(skills): Measure upstream relevance

### DIFF
--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -41,23 +41,21 @@ neighbours matched, because git drops an unmatched one without a word. An explic
 if `.upstream-sync.json` changed in the selected commit range. Run without paths so that parent
 change stays in the report.
 
-Four flags, after `--`: `--base <ref>` starts from the merge base with that ref instead
-of with `origin/main`, `--all` lists fork-only files too, `--json` prints machine output,
-and `--fetch` lets the run create the remote and fetch its checked URL. That bound,
-current-run fetch is the only evidence strong enough for `fork-only`, and the only mode
-that touches git state.
+Three active flags follow `--`: `--base <ref>` starts from the merge base with that ref
+instead of with `origin/main`, `--json` prints machine output, and `--fetch` lets the run
+create the remote and fetch its checked URL. Fetch is the only mode that touches Git state.
+The old `--all` flag remains accepted for compatibility and has no effect because every
+classified path is listed.
 
-Each changed file comes back in one of four classes:
+Each changed file comes back in one of three classes:
 
-| Class        | Meaning                                                                                                                                                                                                                                                                                                                                                      | What to do                        |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
-| `fork-only`  | This run fetched upstream, the marker's provenance remains reachable and never contained the path, the path existed at repository creation, it is absent upstream, and every blob, filename, and text comparison ruled out a tie.                                                                                                                            | Nothing. It is not listed.        |
-| `pristine`   | The path exists upstream and was **identical to it** before this change.                                                                                                                                                                                                                                                                                     | Read it.                          |
-| `diverged`   | The path exists upstream but had already been rewritten here.                                                                                                                                                                                                                                                                                                | Read it, highest score first.     |
-| `unmeasured` | A comparison was unavailable or found a possible tie. Covers binary content, missing or shallow history, a missing partial-clone blob, unstaged filtered content, a mode-only change, a submodule, a path upstream also has, a case-only difference, upstream bytes under another mode or path, a unique filename, and text that resembles an upstream file. | Read it, and check the tie first. |
+| Class        | Meaning                                                                                                                                                                                                                                                                                                                                          | What to do                        |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
+| `pristine`   | The path exists upstream and was **identical to it** before this change.                                                                                                                                                                                                                                                                         | Read it.                          |
+| `diverged`   | The path exists upstream but had already been rewritten here.                                                                                                                                                                                                                                                                                    | Read it, highest score first.     |
+| `unmeasured` | A comparison was unavailable or found a possible tie. Covers absent paths, binary content, missing or shallow history, a missing partial-clone blob, unstaged filtered content, a mode-only change, a submodule, a case-only difference, upstream bytes under another mode or path, a unique filename, and text that resembles an upstream file. | Read it, and check the tie first. |
 
-Lines marked `>>` are the ones to read. An unmarked line was ruled out by a measurement. A
-file the detector could not measure is marked, never dropped.
+Every classified path is marked `>>` and stays in the report.
 
 `pristine` is the strongest signal in the tool. Editing template code that this fork had
 never touched means the defect is, almost by construction, present upstream too. The local
@@ -65,28 +63,29 @@ tree must match `main` currently advertised by the configured `upstream` remote 
 URL-bound detector fetch record; another remote may not populate any measured verdict. It takes the mode as well as the bytes, so a symlink standing where
 upstream has a regular file is reported and not waved through.
 
-A `fork-only` verdict ends the conversation, so an absent path has to earn it. The marker needs a
-`forkPoint` or `lastSynced` commit, and every recorded commit must remain reachable from the fetched
-upstream tip. A path found in either marker commit, including a case-only spelling, stays
-`unmeasured` even after upstream deletes or rewrites it. A force-pushed, disconnected history keeps absent paths `unmeasured`. Local history
-must have one root commit, and the path must exist in that root tree. An unrelated-history import
-or a path introduced later stays `unmeasured` because creation-time ownership is ambiguous. The detector then checks case-folded paths and exact blobs across
-the histories reachable from local HEAD and the upstream tip, plus the index and captured working
-tree. Local history follows renames and
-copies down to 1% similarity with Git's candidate limit disabled, including paths created while
-merging either parent. It then checks filenames that
-are unique in the current template and compares text against every historical upstream blob.
-It searches the same extension first and widens to every blob, since ports between JavaScript
-and TypeScript are ordinary. Current upstream blobs are read in one batch; historical blobs are
-retained within fixed bounds. The upstream history walk, object typing, root scan, and local
-ancestry commands have time limits. Local ancestry, shared-path diffs, source-text preprocessing,
-and in-process similarity comparisons also have time or operation-count limits. Reused blobs share
-their prepared text representation. Reaching a limit keeps the path `unmeasured`.
+An absent path always stays `unmeasured`. Presence in the bootstrap root proves when the
+path appeared, not whether it was moved or rewritten from template code before that first
+commit. Negative text resemblance cannot settle ownership either. The detector still checks
+case-folded paths and exact blobs across the histories reachable from local HEAD and the
+upstream tip, plus the index and captured working tree. Local history follows renames and
+copies down to 1% similarity with Git's candidate limit disabled, including paths created
+while merging either parent. It then checks filenames that are unique in the current template
+and compares text against every historical upstream blob. Those ties explain what to inspect;
+a miss leaves the path visible.
+
+The marker needs a `forkPoint` or `lastSynced` commit for provenance checks, and every recorded
+commit must remain reachable from the fetched upstream tip. A force-pushed, disconnected
+history remains `unmeasured`. The detector searches the same extension first and widens to every
+blob, since ports between JavaScript and TypeScript are ordinary. Current upstream blobs are
+read in one batch; historical blobs are retained within fixed bounds. The upstream history walk,
+object typing, root scan, blob reads, and local ancestry commands have time limits. Local
+ancestry, shared-path diffs, source-text preprocessing, and in-process similarity comparisons
+also have time or operation-count limits. Reused blobs share their prepared text representation.
+Reaching a limit keeps the path `unmeasured`.
 
 A missing blob, shallow history, unsafe symlink path, unreadable or oversized source, binary
-input, or an untracked file that disappears during the run produces `unmeasured`. So does an
-absent path when the current run did not fetch upstream or the marker has no reachable provenance.
-Re-run with `--fetch` after checking the configured parent URL when you need a negative verdict.
+input, or an untracked file that disappears during the run also produces `unmeasured`. Re-run
+with `--fetch` after checking the configured parent URL when you need the freshest comparison.
 
 The filename and text checks show resemblance, not proof. The report says that on the line.
 The text threshold is git's 50% rename similarity. Sixty percent lost the real case this
@@ -184,8 +183,8 @@ It exits with the reason when any of these hold:
 
 - there is no local copy of upstream;
 - `refs/remotes/upstream/main` exists but no `upstream` remote does, so nothing ties that
-  ref to the template. An orphan left by a former parent fork classifies half the tree as
-  `fork-only` and looks entirely normal doing it;
+  ref to the template. An orphan left by a former parent fork produces plausible comparisons
+  against the wrong tree;
 - `.upstream-sync.json` is staged, modified, deleted, ignored or untracked, hidden from Git
   status, differs from the committed HEAD file, is a symlink, is oversized, changes identity or
   bytes while read, is unreadable, contains invalid UTF-8 or JSON, is not an object, has an `upstreamUrl`
@@ -236,14 +235,20 @@ base resolution reads origin's unexpanded configured URL, rejects a matching `ur
 rule and any URL owned by this repository's worktrees, and uses `ls-remote` to bind the local
 `origin/main` SHA to `main` there. Use an explicitly verified `--base` when origin is offline.
 Trusted network commands use hashed remote names in a private bare Git directory with the caller's
-object format. The URL lives only in its owner-only config, never in a detector Git argument. Object
-writes still land in the real object store, while shared repository, global, and system Git config
-cannot change the transport mid-run. The private config copies credential helpers and URL-scoped
-HTTPS authorization, client certificate, CA, and proxy settings. Unscoped HTTP authorization stays out because the marker chooses the
-host. Fetch disables automatic maintenance, since the private ref namespace does not describe which
-objects the real repository still needs. A `remote.upstream.uploadpack` helper therefore cannot
-serve a different repository. Matching `url.*.insteadOf`, `core.sshCommand`, and `core.gitProxy`
-overrides are refused. Inherited transport commands and protocol permission variables are scrubbed.
+object format. The URL lives only in its private config, never in a detector Git argument. POSIX
+permissions restrict that file to its owner. Windows reads the marker from the index before touching
+its path and omits credential helpers, authorization headers, credential-bearing proxy URLs, and
+credential-bearing remote URLs from temporary storage. The private config retains safe global and
+URL-scoped CA and proxy settings, URL-scoped client certificate settings, and a matching remote's
+proxy. Unscoped HTTP authorization stays out because the marker chooses the host. Restrictive
+`protocol.*.allow` settings survive; an inherited protocol allowlist is intersected with file, Git,
+HTTP(S), and SSH transports. Matching `url.*.insteadOf`, `core.sshCommand`, and `core.gitProxy`
+overrides remain refused. A `remote.upstream.uploadpack` helper cannot serve a different repository.
+
+Fetch disables automatic maintenance because the private ref namespace does not describe which
+objects the real repository still needs. Fetched objects still land in the real object store. The
+30-second deadline bounds time, not received pack bytes; check free disk space before `--fetch` when
+the configured parent may be unusually large.
 It reads the advertised `main` SHA before and after an object-only fetch that writes neither
 `FETCH_HEAD` nor a tracking ref. It verifies that exact commit before creating a missing shared
 remote. The URL it just wrote remains the expected value, so a concurrent replacement cannot be
@@ -300,11 +305,10 @@ device. Human output, JSON, and fatal diagnostics escape control bytes, C1 contr
 separators, and bidirectional formatting characters before they reach a terminal or log viewer.
 
 A shallow repository has an unknown history before its boundary. Exact evidence found inside
-the available history still proves a tie, but an absent path cannot become `fork-only` until
-the repository is unshallowed.
+the available history still proves a tie; missing history keeps the result `unmeasured`.
 
-An old local copy can miss a tie. The detector therefore keeps an absent path as
-`unmeasured` until this run fetches upstream. It still prints the copy's age. Only the newest
+An old local copy can miss a tie. Absent paths remain `unmeasured`, and the copy's age explains
+how much confidence to place in the available comparisons. Only the newest
 tracking-ref movement counts, it must point at the pinned SHA, and its subject must name the
 configured `upstream` remote with `main` as the source. A successful detector fetch also records
 its SHA, timestamp, and URL fingerprint in local Git config, because a no-op `update-ref` creates no

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -254,18 +254,20 @@ the same repository. SCP-style query and fragment suffixes are treated as secret
 private config denies unknown protocols and preserves restrictive
 `protocol.allow` and `protocol.*.allow` settings. An inherited `GIT_ALLOW_PROTOCOL` is intersected
 with the accepted transports and keeps Git's normal override semantics. HTTPS also requires
-certificate and proxy-certificate verification. Matching `url.*.insteadOf`,
-`core.sshCommand`, and `core.gitProxy` overrides remain refused. A `remote.upstream.uploadpack`
+certificate and proxy-certificate verification. SSH runs with `ssh -F none`, so user and system
+OpenSSH aliases, proxy commands, and host-key policy cannot change the endpoint. Matching
+`url.*.insteadOf`, `core.sshCommand`, and `core.gitProxy` overrides remain refused before template
+self-detection. A `remote.upstream.uploadpack`
 helper cannot serve a different repository. When the marker uses an accepted GitHub alias, transport
 keeps the configured remote's exact spelling so its URL-scoped pins, certificates, and proxy settings
 still match. Remote URLs and their proxy settings are captured together and fenced before output. A
 local remote is bound to its canonical Git common directory, after checking its endpoint, worktree,
-Git directory, common directory, object directory, and Git's recursively loaded local alternates
-against every checkout owned by this repository. Alternate entries follow Git's comment and C-quote
+Git directory, common directory, object directory, loose `main` ref, `packed-refs`, and Git's
+recursively loaded local alternates against every checkout owned by this repository. Filesystem and
+Git-symbolic ref indirection is refused. Alternate entries follow Git's comment and C-quote
 grammar; ambiguous quoted entries stop the run. The check compares ancestor filesystem identity as
-well as spelling. It repeats
-that identity fence around remote reads, while a retargeted alias stays bound to the location first
-validated.
+well as spelling. Ref backing files also pin mode, size, mtime, and ctime. It repeats that fence around
+remote reads, while a retargeted alias stays bound to the location first validated.
 
 Fetch disables automatic maintenance because the private ref namespace does not describe which
 objects the real repository still needs. Fetched objects still land in the real object store. The

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -34,12 +34,13 @@ path instead, the script keeps them relative to your directory.
 
 With no arguments it takes every file changed against the merge-base with `origin/main`,
 plus staged, unstaged, and untracked work, and both sides of a rename. Pass explicit paths
-to narrow it: an explicit path is classified whether or not it changed, and a directory
-expands to everything under it. Automatic discovery and aggregate explicit expansion stop at
-500,000 files. Equivalent path arguments are enumerated once. Every argument must match something, including when its
-neighbours matched, because git drops an unmatched one without a word. An explicit run stops
-if `.upstream-sync.json` changed in the selected commit range. Run without paths so that parent
-change stays in the report.
+to narrow the classification list: an explicit path is classified whether or not it changed,
+and a directory expands to everything under it. Automatic discovery and aggregate explicit
+expansion stop at 500,000 files. Equivalent path arguments are enumerated once. Every argument
+must match something, including when its neighbours matched, because git drops an unmatched one
+without a word. An explicit run stops if `.upstream-sync.json` changed in the selected commit
+range. Run without paths so that parent change stays in the report. Provenance still scans the
+bounded current trees and upstream history, because moved template code may live at any path.
 
 Three active flags follow `--`: `--base <ref>` starts from the merge base with that ref
 instead of with `origin/main`, `--json` prints machine output, and `--fetch` lets the run
@@ -243,12 +244,15 @@ per-process Git config instead of writing them to temporary files. The private c
 global and URL-scoped CA and proxy settings, URL-scoped client certificate settings, and a matching
 remote's proxy. Unscoped HTTP authorization stays out because the marker chooses the host. Transport
 accepts local files, HTTPS, and SSH. Plain HTTP, Git, FTP, `git+ssh`, and arbitrary remote helpers are
-refused. The private config denies unknown protocols, preserves restrictive `protocol.*.allow`
-settings, and intersects an inherited protocol allowlist with the accepted transports. HTTPS also
-requires certificate and proxy-certificate verification. Matching `url.*.insteadOf`,
+refused. The private config denies unknown protocols and preserves restrictive
+`protocol.allow` and `protocol.*.allow` settings. An inherited `GIT_ALLOW_PROTOCOL` is intersected
+with the accepted transports and keeps Git's normal override semantics. HTTPS also requires
+certificate and proxy-certificate verification. Matching `url.*.insteadOf`,
 `core.sshCommand`, and `core.gitProxy` overrides remain refused. A `remote.upstream.uploadpack`
-helper cannot serve a different repository. A local remote is written under the canonical path that
-passed checkout-ownership validation, so retargeting its symlink cannot redirect the later fetch.
+helper cannot serve a different repository. When the marker uses an accepted GitHub alias, transport
+keeps the configured remote's exact spelling so its URL-scoped pins, certificates, and proxy settings
+still match. A local remote is written under the canonical path that passed checkout-ownership
+validation, so retargeting its symlink cannot redirect the later fetch.
 
 Fetch disables automatic maintenance because the private ref namespace does not describe which
 objects the real repository still needs. Fetched objects still land in the real object store. The

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -36,7 +36,8 @@ With no arguments it takes every file changed against the merge-base with `origi
 plus staged, unstaged, and untracked work, and both sides of a rename. Pass explicit paths
 to narrow the classification list: an explicit path is classified whether or not it changed,
 and a directory expands to everything under it. Automatic discovery and aggregate explicit
-expansion stop at 500,000 files. Equivalent path arguments are enumerated once. Every argument
+expansion stop at 500,000 files. Equivalent arguments collapse to one literal pathspec. The script
+reads each explicit expansion twice and requires the same path set both times. Every argument
 must match something, including when its neighbours matched, because git drops an unmatched one
 without a word. An explicit run stops if `.upstream-sync.json` changed in the selected commit
 range. Run without paths so that parent change stays in the report. Provenance still scans the
@@ -223,8 +224,8 @@ It exits with the reason when any of these hold:
   Git directory;
 - a classified path has `assume-unchanged` or `skip-worktree`, which hides tracked edits from
   Git's status and diff;
-- enumerating automatic or explicit paths failed for any reason, since an empty list from a
-  broken git call is indistinguishable from an empty list from a clean tree;
+- enumerating automatic or explicit paths failed, or two explicit expansion reads returned
+  different path sets, since a missing path would otherwise look like a clean tree;
 - origin's URL, `main` ref, fetch mapping, or reflog provenance changes after base validation;
 - HEAD, `.upstream-sync.json`, the caller's index, the shallow boundary, the working-tree status,
   or the bytes of any classified working-tree path change before the report finishes.
@@ -257,9 +258,11 @@ certificate and proxy-certificate verification. Matching `url.*.insteadOf`,
 helper cannot serve a different repository. When the marker uses an accepted GitHub alias, transport
 keeps the configured remote's exact spelling so its URL-scoped pins, certificates, and proxy settings
 still match. Remote URLs and their proxy settings are captured together and fenced before output. A
-local remote is written under the canonical path that passed checkout-ownership validation. The
-ownership check compares ancestor filesystem identity as well as spelling, so a bind-mounted alias or
-retargeted symlink cannot redirect the later fetch back into this repository.
+local remote is bound to its canonical Git common directory, after checking its endpoint, worktree,
+Git directory, common directory, object directory, and local alternates against every checkout owned
+by this repository. The check compares ancestor filesystem identity as well as spelling. It repeats
+that identity fence around remote reads, while a retargeted alias stays bound to the location first
+validated.
 
 Fetch disables automatic maintenance because the private ref namespace does not describe which
 objects the real repository still needs. Fetched objects still land in the real object store. The
@@ -307,9 +310,10 @@ bounded read. Capture, retained resemblance data, and shared-path overlap maps h
 aggregate and representation bounds; content beyond them stays `unmeasured`. When capture space is
 exhausted, the endpoint fence retains file identity, mode, size, mtime, and ctime instead of a generic
 placeholder. A temporary restore or replacement cannot disappear between matching endpoint
-snapshots. Each temp directory carries its owner's process
-id. Cleanup ignores unowned directories, skips a slow
-active report, and removes only abandoned copies older than an hour.
+snapshots. Each temp directory has owner-only permissions and a versioned ownership manifest tied
+to its process id. Cleanup skips every known checkout and Git-storage alias under the temporary root.
+It ignores unauthenticated directories, leaves active reports alone, and removes only abandoned
+copies older than an hour.
 Cleaning up on a signal instead would be worse: the script spends its time inside
 synchronous git calls, where a handler cannot run, and installing one only replaces the
 default disposition, so the run stops answering `SIGTERM` at all.

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -80,9 +80,9 @@ history remains `unmeasured`. The detector searches the same extension first and
 blob, since ports between JavaScript and TypeScript are ordinary. Current upstream blobs are
 read in one batch; historical blobs are retained within fixed bounds. The upstream history walk,
 object typing, root scan, blob reads, and local ancestry commands have time limits. Local
-ancestry, shared-path diffs, source-text preprocessing, and in-process similarity comparisons
-also have time or operation-count limits. Reused blobs share their prepared text representation.
-Reaching a limit keeps the path `unmeasured`.
+ancestry, shared-path diffs, source-text preprocessing, candidate visits, and in-process
+similarity comparisons also have command or operation-count limits. Reused blobs share their
+prepared text representation. Reaching a limit keeps the path `unmeasured`.
 
 A missing blob, shallow history, unsafe symlink path, unreadable or oversized source, binary
 input, or an untracked file that disappears during the run also produces `unmeasured`. Re-run
@@ -243,8 +243,10 @@ its path. It forwards credential helpers, authorization headers, and credential-
 per-process Git config instead of writing them to temporary files. The private config retains safe
 global and URL-scoped CA and proxy settings, URL-scoped client certificate settings, and a matching
 remote's proxy. Unscoped HTTP authorization stays out because the marker chooses the host. Transport
-accepts local files, HTTPS, and SSH. Plain HTTP, Git, FTP, `git+ssh`, and arbitrary remote helpers are
-refused. The private config denies unknown protocols and preserves restrictive
+accepts local files, HTTPS, and SSH. Plain HTTP, Git, FTP, `git+ssh`, forced helper syntax, and
+arbitrary remote helpers are refused. Hosted `file:` URLs and UNC paths are network transports,
+not local files. Windows drive-relative paths are refused because their target depends on process
+state. The private config denies unknown protocols and preserves restrictive
 `protocol.allow` and `protocol.*.allow` settings. An inherited `GIT_ALLOW_PROTOCOL` is intersected
 with the accepted transports and keeps Git's normal override semantics. HTTPS also requires
 certificate and proxy-certificate verification. Matching `url.*.insteadOf`,
@@ -295,8 +297,10 @@ it, then verifies that the private file and its staged entries survive unchanged
 status seeds automatic path discovery. Classification opens each regular file without following
 the final symlink, verifies the descriptor against the path and its parents, then performs a
 bounded read. Capture, retained resemblance data, and shared-path overlap maps have separate
-aggregate and representation bounds; content beyond them stays `unmeasured`. A temporary restore or replacement cannot disappear
-between matching endpoint snapshots. Each temp directory carries its owner's process
+aggregate and representation bounds; content beyond them stays `unmeasured`. When capture space is
+exhausted, the endpoint fence retains file identity, mode, size, mtime, and ctime instead of a generic
+placeholder. A temporary restore or replacement cannot disappear between matching endpoint
+snapshots. Each temp directory carries its owner's process
 id. Cleanup ignores unowned directories, skips a slow
 active report, and removes only abandoned copies older than an hour.
 Cleaning up on a signal instead would be worse: the script spends its time inside

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: upstream-report
-description: Decide whether a change belongs in the upstream saas-starter template, and report it there when it does. Use before opening a PR, after fixing a bug, and whenever an edit touched framework, auth, email, UI-primitive, config, or build code. A script measures which files are template-derived, so one command answers it and no file is judged by eye. Sends fixes up only; pulling template changes down is upstream-sync, which a human starts.
+description: Decide whether a change in a content-copy fork belongs in the upstream saas-starter template, and report it there when it does. Use in a fork before opening a PR, after fixing a bug, and whenever an edit touched framework, auth, email, UI-primitive, config, or build code. The saas-starter template itself does not use this skill. A script measures which files are template-derived, so one command answers it and no file is judged by eye. Sends fixes up only; pulling template changes down is upstream-sync, which a human starts.
 allowed-tools: Bash, Read, Grep, Glob
 ---
 
@@ -239,7 +239,7 @@ Trusted network commands use hashed remote names in a private bare Git directory
 object format. The URL lives only in its owner-only config, never in a detector Git argument. Object
 writes still land in the real object store, while shared repository, global, and system Git config
 cannot change the transport mid-run. The private config copies credential helpers and URL-scoped
-HTTPS client-auth settings. Unscoped HTTP authorization stays out because the marker chooses the
+HTTPS authorization, client certificate, CA, and proxy settings. Unscoped HTTP authorization stays out because the marker chooses the
 host. Fetch disables automatic maintenance, since the private ref namespace does not describe which
 objects the real repository still needs. A `remote.upstream.uploadpack` helper therefore cannot
 serve a different repository. Matching `url.*.insteadOf`, `core.sshCommand`, and `core.gitProxy`

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: upstream-report
+description: Decide whether a change belongs in the upstream saas-starter template, and report it there when it does. Use before opening a PR, after fixing a bug, and whenever an edit touched framework, auth, email, UI-primitive, config, or build code. A script measures which files are template-derived, so one command answers it and no file is judged by eye. Sends fixes up only; pulling template changes down is upstream-sync, which a human starts.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Report a fix upstream
+
+This repository was created from the `saas-starter` template by content-copy. Template
+code and code written here sit side by side in the same tree, and after a few months
+nothing distinguishes them by eye. That costs in both directions: a template bug fixed
+only here leaves every other fork carrying it, and fork-only work offered upstream wastes
+a maintainer's time.
+
+So measure it. Ask the detector.
+
+## Ask the detector
+
+```bash
+bun run upstream:report
+```
+
+Run the package script from the repository root. Bun resolves scripts from the current
+package, so a nested package such as `voice-gateway/` cannot see this one. Move to the root
+first when needed:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+bun run upstream:report
+```
+
+Arguments go after `--` and are repository-relative in this form. Invoked by its own absolute
+path instead, the script keeps them relative to your directory.
+
+With no arguments it takes every file changed against the merge-base with `origin/main`,
+plus staged, unstaged, and untracked work, and both sides of a rename. Pass explicit paths
+to narrow it: an explicit path is classified whether or not it changed, and a directory
+expands to everything under it. Automatic discovery and aggregate explicit expansion stop at
+500,000 files. Equivalent path arguments are enumerated once. Every argument must match something, including when its
+neighbours matched, because git drops an unmatched one without a word. An explicit run stops
+if `.upstream-sync.json` changed in the selected commit range. Run without paths so that parent
+change stays in the report.
+
+Four flags, after `--`: `--base <ref>` starts from the merge base with that ref instead
+of with `origin/main`, `--all` lists fork-only files too, `--json` prints machine output,
+and `--fetch` lets the run create the remote and fetch its checked URL. That bound,
+current-run fetch is the only evidence strong enough for `fork-only`, and the only mode
+that touches git state.
+
+Each changed file comes back in one of four classes:
+
+| Class        | Meaning                                                                                                                                                                                                                                                                                                                                                      | What to do                        |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
+| `fork-only`  | This run fetched upstream, the marker's provenance remains reachable and never contained the path, the path existed at repository creation, it is absent upstream, and every blob, filename, and text comparison ruled out a tie.                                                                                                                            | Nothing. It is not listed.        |
+| `pristine`   | The path exists upstream and was **identical to it** before this change.                                                                                                                                                                                                                                                                                     | Read it.                          |
+| `diverged`   | The path exists upstream but had already been rewritten here.                                                                                                                                                                                                                                                                                                | Read it, highest score first.     |
+| `unmeasured` | A comparison was unavailable or found a possible tie. Covers binary content, missing or shallow history, a missing partial-clone blob, unstaged filtered content, a mode-only change, a submodule, a path upstream also has, a case-only difference, upstream bytes under another mode or path, a unique filename, and text that resembles an upstream file. | Read it, and check the tie first. |
+
+Lines marked `>>` are the ones to read. An unmarked line was ruled out by a measurement. A
+file the detector could not measure is marked, never dropped.
+
+`pristine` is the strongest signal in the tool. Editing template code that this fork had
+never touched means the defect is, almost by construction, present upstream too. The local
+tree must match `main` currently advertised by the configured `upstream` remote or carry a
+URL-bound detector fetch record; another remote may not populate any measured verdict. It takes the mode as well as the bytes, so a symlink standing where
+upstream has a regular file is reported and not waved through.
+
+A `fork-only` verdict ends the conversation, so an absent path has to earn it. The marker needs a
+`forkPoint` or `lastSynced` commit, and every recorded commit must remain reachable from the fetched
+upstream tip. A path found in either marker commit, including a case-only spelling, stays
+`unmeasured` even after upstream deletes or rewrites it. A force-pushed, disconnected history keeps absent paths `unmeasured`. Local history
+must have one root commit, and the path must exist in that root tree. An unrelated-history import
+or a path introduced later stays `unmeasured` because creation-time ownership is ambiguous. The detector then checks case-folded paths and exact blobs across
+the histories reachable from local HEAD and the upstream tip, plus the index and captured working
+tree. Local history follows renames and
+copies down to 1% similarity with Git's candidate limit disabled, including paths created while
+merging either parent. It then checks filenames that
+are unique in the current template and compares text against every historical upstream blob.
+It searches the same extension first and widens to every blob, since ports between JavaScript
+and TypeScript are ordinary. Current upstream blobs are read in one batch; historical blobs are
+retained within fixed bounds. The upstream history walk, object typing, root scan, and local
+ancestry commands have time limits. Local ancestry, shared-path diffs, source-text preprocessing,
+and in-process similarity comparisons also have time or operation-count limits. Reused blobs share
+their prepared text representation. Reaching a limit keeps the path `unmeasured`.
+
+A missing blob, shallow history, unsafe symlink path, unreadable or oversized source, binary
+input, or an untracked file that disappears during the run produces `unmeasured`. So does an
+absent path when the current run did not fetch upstream or the marker has no reachable provenance.
+Re-run with `--fetch` after checking the configured parent URL when you need a negative verdict.
+
+The filename and text checks show resemblance, not proof. The report says that on the line.
+The text threshold is git's 50% rename similarity. Sixty percent lost the real case this
+check was added for. Forty percent started matching generated barrel files that shared only
+the same shape. UTF-8 and detected UTF-16 text use the same comparison regardless of extension.
+Text also compares overlapping eight-character spans. That catches a small
+minified edit and a systematic prefix added to every line. Text
+too short to retain a line or an eight-character span stays `unmeasured`. These
+checks catch a template file copied to a product path and customised in the same commit,
+which has no shared path, blob, or name.
+
+The score on a `diverged` file says how much of what the change replaced still exists
+upstream. It takes the strongest hunk across committed, staged, and captured working-tree
+states rather than scoring the file as a whole. Per hunk because a file that deletes a
+fork-only call in one place and inserts a guard
+beside template code in another otherwise scored on the deletion alone, and sorted last.
+It ranks the reading order and never gates it: three review rounds each found an input
+where a threshold silently dropped a real finding.
+
+A file at or near 0% is the one worth understanding, and it is still a file you read. The
+usual reason is that the edit landed in a block this fork added, where upstream has
+nothing to receive: adding a table to a schema both repositories have is the everyday
+example. The other reason is that this fork had renamed the template's line before fixing
+it, so the removed spelling is absent upstream while the bug is not. Line matching cannot
+tell those two apart, which is why the score orders your reading and never ends it.
+
+A wholly new file with no measurable tie stays `unmeasured`. A missing CI workflow, lint
+rule or framework hook may belong upstream even when the template has no counterpart to
+compare. That is a design judgment, so the detector keeps the file visible and leaves the
+answer to you.
+
+## Decide, per reported file
+
+Read the actual change. Ask one question: **would this be a fix in a repository that has
+none of this fork's features?** Send it upstream only if the answer is yes.
+
+Send it up:
+
+- a bug in template code: wrong logic, a missing guard, a race, an accessibility defect;
+- hardcoded English in a template component that a fork cannot localize without editing it;
+- a security or correctness fix in auth, email, forms, or session handling;
+- a build, lint, or CI defect that every fork inherits.
+
+Keep it here:
+
+- anything naming this product, its domain concepts, its routes, or its branding;
+- config, env, or deploy values specific to this deployment;
+- a workaround that only makes sense given a fork-only feature;
+- translations of fork-owned strings.
+
+Half and half is common: a template component gets both a genuine fix and a fork-specific
+extension. Report the fix alone and describe it in template terms, without the fork's
+vocabulary.
+
+## Report it
+
+Search first, so a known issue gets a comment instead of a duplicate:
+
+```bash
+gh search issues --repo stickerdaniel/saas-starter "<keywords>"
+```
+
+Search without a state filter so closed issues come back too. A fix that was already
+rejected, or already shipped, is the answer as often as an open ticket is.
+
+If nothing matches, read the issue template before writing, so the report arrives in the
+shape the repository expects:
+
+```bash
+gh api repos/stickerdaniel/saas-starter/contents/.github/ISSUE_TEMPLATE
+```
+
+**Ask the human before filing.** Drafting is yours; posting to another repository is
+theirs. Show the draft, then file it once they agree.
+
+Write the report as it would read to someone who has never seen this fork: the template
+file, what goes wrong, how to reproduce it from a clean template, and the fix if you know
+it. A report that only makes sense here will be closed here.
+
+## One direction only
+
+This skill sends fixes up. Bringing template changes down into this fork is
+`upstream-sync`, which reviews the full commit range, adapts each change to this fork's
+divergences, and ships one consolidated PR. A human starts that skill and no one else: a
+sync rewrites files across the whole repository, and that is a decision, not a side effect
+of having edited an email template.
+
+## When the detector cannot answer
+
+An unavailable file comparison becomes `unmeasured` and stays in the report. The command
+exits non-zero when the run itself is incomplete, because an incomplete run looks like
+"nothing to report".
+
+It exits with the reason when any of these hold:
+
+- there is no local copy of upstream;
+- `refs/remotes/upstream/main` exists but no `upstream` remote does, so nothing ties that
+  ref to the template. An orphan left by a former parent fork classifies half the tree as
+  `fork-only` and looks entirely normal doing it;
+- `.upstream-sync.json` is staged, modified, deleted, ignored or untracked, hidden from Git
+  status, differs from the committed HEAD file, is a symlink, is oversized, changes identity or
+  bytes while read, is unreadable, contains invalid UTF-8 or JSON, is not an object, has an `upstreamUrl`
+  without a non-empty string value, or names `forkPoint` or `lastSynced` without a full commit SHA;
+- the `upstream` remote points somewhere other than the URL in `.upstream-sync.json`, origin or the
+  marker URL resolves inside any checkout or Git directory owned by this repository, Git rewrites either
+  URL through `url.*.insteadOf`, `core.sshCommand` or `core.gitProxy` replaces the checked transport,
+  or a remote URL or tracking ref changes before the detector finishes;
+- origin, working-tree status, a changed-path diff, or a requested upstream fetch exceeds 30
+  seconds, the fetch cannot read `refs/heads/main` from the marker's checked URL,
+  or creating a missing shared remote would put URL userinfo, a query, or a fragment into a Git
+  process argument. The standard `git@` user in SSH and SCP GitHub URLs is allowed;
+- `origin/main` is missing and no `--base` was given, its SHA differs from `main` at the
+  currently configured origin URL, a `--base` does not resolve, or HEAD and the requested
+  base have multiple equally valid merge bases;
+- an explicit path argument names nothing, aggregate expansion exceeds 500,000 files,
+  `.upstream-sync.json` changed in the selected range, or an option is misspelled, since a stray value
+  becomes a path and one path replaces the automatic file list;
+- the origin fetch refspec maps anything except `refs/heads/main` into `origin/main`, excludes
+  `refs/heads/main`, or the ref differs from `main` currently advertised by the configured origin.
+  A successful push update is accepted because the live remote SHA binds it;
+- a Git pathname is not valid UTF-8, since JavaScript would collapse distinct raw names into
+  the same replacement-character string;
+- the repository is a partial clone and Git is older than 2.45, where missing-object reads can
+  still fetch lazily during a no-fetch run;
+- the Git index is missing or has unresolved merge stages;
+- Git reports `core.fileMode=false` on a non-Windows filesystem, so executable-bit changes cannot
+  be verified without manufacturing mode differences on filesystems that lack the capability;
+- the existing index uses a split backing file. The detector pins `core.splitIndex=false` so
+  an ordinary copied index cannot activate one during refresh;
+- the private scratch index disappears or its staged entries change during the run;
+- the system temporary directory is relative or resolves inside any checkout attached to the
+  repository or inside shared Git storage, or Git cannot identify a checkout behind a separate
+  Git directory;
+- a classified path has `assume-unchanged` or `skip-worktree`, which hides tracked edits from
+  Git's status and diff;
+- enumerating automatic or explicit paths failed for any reason, since an empty list from a
+  broken git call is indistinguishable from an empty list from a clean tree;
+- origin's URL, `main` ref, fetch mapping, or reflog provenance changes after base validation;
+- HEAD, `.upstream-sync.json`, the caller's index, the shallow boundary, the working-tree status,
+  or the bytes of any classified working-tree path change before the report finishes.
+
+Each of those means "unknown", and none of them means "nothing to report". Say which one
+you got.
+
+It adds no remote, writes no refs and fetches nothing unless `--fetch` is passed. Default
+base resolution reads origin's unexpanded configured URL, rejects a matching `url.*.insteadOf`
+rule and any URL owned by this repository's worktrees, and uses `ls-remote` to bind the local
+`origin/main` SHA to `main` there. Use an explicitly verified `--base` when origin is offline.
+Trusted network commands use hashed remote names in a private bare Git directory with the caller's
+object format. The URL lives only in its owner-only config, never in a detector Git argument. Object
+writes still land in the real object store, while shared repository, global, and system Git config
+cannot change the transport mid-run. The private config copies credential helpers and URL-scoped
+HTTPS client-auth settings. Unscoped HTTP authorization stays out because the marker chooses the
+host. Fetch disables automatic maintenance, since the private ref namespace does not describe which
+objects the real repository still needs. A `remote.upstream.uploadpack` helper therefore cannot
+serve a different repository. Matching `url.*.insteadOf`, `core.sshCommand`, and `core.gitProxy`
+overrides are refused. Inherited transport commands and protocol permission variables are scrubbed.
+It reads the advertised `main` SHA before and after an object-only fetch that writes neither
+`FETCH_HEAD` nor a tracking ref. It verifies that exact commit before creating a missing shared
+remote. The URL it just wrote remains the expected value, so a concurrent replacement cannot be
+adopted as trusted state. It rejects a symbolic tracking ref, then checks the shared URL around an
+unchanged-ref compare-and-swap. A URL race before the write leaves the ref untouched; one immediately
+after it rolls the ref back before failing. A failed initial fetch leaves no remote, ref, or fetch
+timestamp. Without a
+current-run fetch, the local tree may still prove a tie but cannot rule one out. Fetching stays
+opt-in because the URL comes from a file the branch controls. Git stderr stays captured
+until the detector can redact it. Diagnostics and JSON redact scheme-based and SCP-style
+userinfo plus complete query strings and fragments. Repository identity comparisons remove HTTPS
+credentials. GitHub's standard HTTPS, SCP-SSH, and `ssh://git@github.com` forms identify the same
+repository across letter case, an optional `.git` suffix, and an optional trailing slash, matching
+GitHub and the established sync workflow. Every other transport spelling, SSH user, path root,
+trailing slash, `.git` suffix, and byte of a local path stays significant because it may select
+another repository.
+
+Apart from the explicit `--fetch` Git-state writes, it writes nothing inside the repository. A worktree diff refreshes the index when
+stat data moved and content did not, which takes `index.lock` and can fail a concurrent
+`git add`. Measured on git 2.55, `GIT_OPTIONAL_LOCKS=0` suppresses the rewrite for `git
+status` and not for `git diff`, so each run copies an ordinary index into the system temp
+directory. The same scratch directory holds an immutable copy of the shallow boundary and the
+private transport repository. Every history read sees one graph even if another Git process
+shallows or deepens the shared repository.
+The directory must be absolute and outside every checkout attached to the repository and outside
+shared Git storage. Scratch creation and cleanup use that validated canonical path, so a retargeted
+temp-directory symlink cannot move either operation into the repository. Git follows an
+existing split index back to `.git/sharedindex.<sha>` and
+touches that file, so the detector checks the copied bytes, refuses a split index, and pins
+split-index activation off. It also pins Git's full ctime and stat checks. On POSIX it requires
+Git's filesystem probe to report executable-bit support, so repository config cannot hide same-size
+or mode-only edits without inventing changes on incapable filesystems. The snapshot records the caller index at the same instant it copies
+it, then verifies that the private file and its staged entries survive unchanged. Its initial
+status seeds automatic path discovery. Classification opens each regular file without following
+the final symlink, verifies the descriptor against the path and its parents, then performs a
+bounded read. Capture, retained resemblance data, and shared-path overlap maps have separate
+aggregate and representation bounds; content beyond them stays `unmeasured`. A temporary restore or replacement cannot disappear
+between matching endpoint snapshots. Each temp directory carries its owner's process
+id. Cleanup ignores unowned directories, skips a slow
+active report, and removes only abandoned copies older than an hour.
+Cleaning up on a signal instead would be worse: the script spends its time inside
+synchronous git calls, where a handler cannot run, and installing one only replaces the
+default disposition, so the run stops answering `SIGTERM` at all.
+
+One honest limit: Git may apply a `filter.*.clean` driver while status or diff inspects the
+working tree. Git LFS is the common case, and it writes to its object cache. There is no
+per-invocation switch for it, so the guarantee is "this script writes nothing", not "no byte
+moves anywhere". The detector compares captured raw bytes for positive resemblance, then
+keeps an otherwise negative unstaged path `unmeasured` because a clean filter may canonicalize
+it differently. External diff drivers, textconv filters, promisor lazy-fetches and replacement
+refs _are_ refused outright. Git pathspec-mode, namespace, trace-output and command-scope config
+variables are scrubbed case-insensitively, including on Windows. Both inherited and repository-local grafts are disabled through the operating system's null
+device. Human output, JSON, and fatal diagnostics escape control bytes, C1 controls, Unicode line
+separators, and bidirectional formatting characters before they reach a terminal or log viewer.
+
+A shallow repository has an unknown history before its boundary. Exact evidence found inside
+the available history still proves a tie, but an absent path cannot become `fork-only` until
+the repository is unshallowed.
+
+An old local copy can miss a tie. The detector therefore keeps an absent path as
+`unmeasured` until this run fetches upstream. It still prints the copy's age. Only the newest
+tracking-ref movement counts, it must point at the pinned SHA, and its subject must name the
+configured `upstream` remote with `main` as the source. A successful detector fetch also records
+its SHA, timestamp, and URL fingerprint in local Git config, because a no-op `update-ref` creates no
+reflog entry. A no-fetch run otherwise checks the configured remote's live `main`. The tip's commit date is the
+labelled fallback. At one full day,
+JSON marks the copy stale and the summary refuses a clean verdict. Refresh it with
+`bun run upstream:report -- --fetch`; a separate `git fetch upstream` does not record this
+run's trust. Measured here on
+2026-08-22, a copy fetched two days earlier was twelve commits and seven paths behind a tip
+committed the previous day. Changing a remote URL leaves its old tracking ref in place, so
+repoint and fetch together.
+
+Run inside the template itself the script exits 2 and reports nothing, because there the
+repository is upstream.

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -260,7 +260,8 @@ keeps the configured remote's exact spelling so its URL-scoped pins, certificate
 still match. Remote URLs and their proxy settings are captured together and fenced before output. A
 local remote is bound to its canonical Git common directory, after checking its endpoint, worktree,
 Git directory, common directory, object directory, and Git's recursively loaded local alternates
-against every checkout owned by this repository. The check compares ancestor filesystem identity as
+against every checkout owned by this repository. Alternate entries follow Git's comment and C-quote
+grammar; ambiguous quoted entries stop the run. The check compares ancestor filesystem identity as
 well as spelling. It repeats
 that identity fence around remote reads, while a retargeted alias stays bound to the location first
 validated.

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -264,7 +264,9 @@ still match. Remote URLs and their proxy settings are captured together and fenc
 local remote is bound to its canonical Git common directory, after checking its endpoint, worktree,
 Git directory, common directory, object directory, loose `main` ref, `packed-refs`, and Git's
 recursively loaded local alternates against every checkout owned by this repository. Filesystem and
-Git-symbolic ref indirection is refused. Alternate entries follow Git's comment and C-quote
+Git-symbolic ref indirection is refused. That fence reads ref files directly, so a local
+remote must use the `files` ref format; reftable storage stops the run and names itself.
+Alternate entries follow Git's comment and C-quote
 grammar; ambiguous quoted entries stop the run. The check compares ancestor filesystem identity as
 well as spelling. Ref backing files also pin mode, size, mtime, and ctime. It repeats that fence around
 remote reads, while a retargeted alias stays bound to the location first validated.

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -308,8 +308,8 @@ records the caller index at the same instant it copies
 it, then verifies that the private file and its staged entries survive unchanged. Its initial
 status seeds automatic path discovery. Classification opens each regular file without following
 the final symlink, verifies the descriptor against the path and its parents, then performs a
-bounded read. Capture, retained resemblance data, and shared-path overlap maps have separate
-aggregate and representation bounds; content beyond them stays `unmeasured`. When capture space is
+bounded read. Capture, retained resemblance data, completed shared-path diffs, and overlap maps
+have separate aggregate and representation bounds; content beyond them stays `unmeasured`. When capture space is
 exhausted, the endpoint fence retains file identity, mode, size, mtime, and ctime instead of a generic
 placeholder. A temporary restore or replacement cannot disappear between matching endpoint
 snapshots. Each temp directory has owner-only permissions and a versioned ownership manifest tied

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -79,10 +79,10 @@ commit must remain reachable from the fetched upstream tip. A force-pushed, disc
 history remains `unmeasured`. The detector searches the same extension first and widens to every
 blob, since ports between JavaScript and TypeScript are ordinary. Current upstream blobs are
 read in one batch; historical blobs are retained within fixed bounds. The upstream history walk,
-object typing, root scan, blob reads, and local ancestry commands have time limits. Local
-ancestry, shared-path diffs, source-text preprocessing, candidate visits, and in-process
-similarity comparisons also have command or operation-count limits. Reused blobs share their
-prepared text representation. Reaching a limit keeps the path `unmeasured`.
+object typing, root scan, blob reads, retained history records, and local ancestry commands
+have limits. Local ancestry, shared-path diffs, source-text preprocessing, candidate visits, and
+in-process similarity comparisons also have command or operation-count limits. Reused blobs share
+their prepared text representation. Reaching a limit keeps the path `unmeasured`.
 
 A missing blob, shallow history, unsafe symlink path, unreadable or oversized source, binary
 input, or an untracked file that disappears during the run also produces `unmeasured`. Re-run
@@ -239,22 +239,27 @@ rule and any URL owned by this repository's worktrees, and uses `ls-remote` to b
 Trusted network commands use hashed remote names in a private bare Git directory with the caller's
 object format. The URL lives only in its private config, never in a detector Git argument. POSIX
 permissions restrict that file to its owner. Windows reads the marker from the index before touching
-its path. It forwards credential helpers, authorization headers, and credential-bearing proxies as
-per-process Git config instead of writing them to temporary files. The private config retains safe
-global and URL-scoped CA and proxy settings, URL-scoped client certificate settings, and a matching
-remote's proxy. Unscoped HTTP authorization stays out because the marker chooses the host. Transport
-accepts local files, HTTPS, and SSH. Plain HTTP, Git, FTP, `git+ssh`, forced helper syntax, and
-arbitrary remote helpers are refused. Hosted `file:` URLs and UNC paths are network transports,
-not local files. Windows drive-relative paths are refused because their target depends on process
-state. The private config denies unknown protocols and preserves restrictive
+its path. It forwards credential helpers, authorization headers, and every credential-bearing proxy,
+including scheme-less Git proxy syntax, as per-process config instead of writing them to temporary
+files. The private config retains safe global and URL-scoped CA and proxy settings, Schannel CA
+activation, URL-scoped client certificate settings, and a matching remote's proxy. Unscoped HTTP
+authorization stays out because the marker chooses the host. Transport accepts canonical hostless
+`file:///` URLs, absolute local paths, HTTPS, and SSH. Plain HTTP, Git, FTP, `git+ssh`, forced helper
+syntax, and arbitrary remote helpers are refused. Hosted `file:` URLs and UNC paths are network
+transports, not local files. Windows drive-relative paths are refused because their target depends on
+process state. The marker itself must be credential-free even when a clean configured remote names
+the same repository. SCP-style query and fragment suffixes are treated as secret-bearing. The
+private config denies unknown protocols and preserves restrictive
 `protocol.allow` and `protocol.*.allow` settings. An inherited `GIT_ALLOW_PROTOCOL` is intersected
 with the accepted transports and keeps Git's normal override semantics. HTTPS also requires
 certificate and proxy-certificate verification. Matching `url.*.insteadOf`,
 `core.sshCommand`, and `core.gitProxy` overrides remain refused. A `remote.upstream.uploadpack`
 helper cannot serve a different repository. When the marker uses an accepted GitHub alias, transport
 keeps the configured remote's exact spelling so its URL-scoped pins, certificates, and proxy settings
-still match. A local remote is written under the canonical path that passed checkout-ownership
-validation, so retargeting its symlink cannot redirect the later fetch.
+still match. Remote URLs and their proxy settings are captured together and fenced before output. A
+local remote is written under the canonical path that passed checkout-ownership validation. The
+ownership check compares ancestor filesystem identity as well as spelling, so a bind-mounted alias or
+retargeted symlink cannot redirect the later fetch back into this repository.
 
 Fetch disables automatic maintenance because the private ref namespace does not describe which
 objects the real repository still needs. Fetched objects still land in the real object store. The
@@ -291,8 +296,10 @@ temp-directory symlink cannot move either operation into the repository. Git fol
 existing split index back to `.git/sharedindex.<sha>` and
 touches that file, so the detector checks the copied bytes, refuses a split index, and pins
 split-index activation off. It also pins Git's full ctime and stat checks. On POSIX it requires
-Git's filesystem probe to report executable-bit support, so repository config cannot hide same-size
-or mode-only edits without inventing changes on incapable filesystems. The snapshot records the caller index at the same instant it copies
+Git's filesystem probe to report executable-bit support, then pins file-mode detection on every
+later POSIX read so a concurrent config edit cannot hide a mode-only change. Repository-root path
+reads remove only Git's record delimiter, preserving meaningful trailing whitespace. The snapshot
+records the caller index at the same instant it copies
 it, then verifies that the private file and its staged entries survive unchanged. Its initial
 status seeds automatic path discovery. Classification opens each regular file without following
 the final symlink, verifies the descriptor against the path and its parents, then performs a

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -194,9 +194,10 @@ It exits with the reason when any of these hold:
   URL through `url.*.insteadOf`, `core.sshCommand` or `core.gitProxy` replaces the checked transport,
   or a remote URL or tracking ref changes before the detector finishes;
 - origin, working-tree status, a changed-path diff, or a requested upstream fetch exceeds 30
-  seconds, the fetch cannot read `refs/heads/main` from the marker's checked URL,
-  or creating a missing shared remote would put URL userinfo, a query, or a fragment into a Git
-  process argument. The standard `git@` user in SSH and SCP GitHub URLs is allowed;
+  seconds, the fetch cannot read `refs/heads/main` from the marker's checked URL, a remote uses
+  plain HTTP or another transport outside local files, HTTPS, and SSH, HTTPS disables certificate
+  or proxy-certificate verification, or a remote URL carries userinfo, a query, or a fragment.
+  The standard `git@` user in SSH and SCP GitHub URLs is allowed;
 - `origin/main` is missing and no `--base` was given, its SHA differs from `main` at the
   currently configured origin URL, a `--base` does not resolve, or HEAD and the requested
   base have multiple equally valid merge bases;
@@ -237,18 +238,23 @@ rule and any URL owned by this repository's worktrees, and uses `ls-remote` to b
 Trusted network commands use hashed remote names in a private bare Git directory with the caller's
 object format. The URL lives only in its private config, never in a detector Git argument. POSIX
 permissions restrict that file to its owner. Windows reads the marker from the index before touching
-its path and omits credential helpers, authorization headers, credential-bearing proxy URLs, and
-credential-bearing remote URLs from temporary storage. The private config retains safe global and
-URL-scoped CA and proxy settings, URL-scoped client certificate settings, and a matching remote's
-proxy. Unscoped HTTP authorization stays out because the marker chooses the host. Restrictive
-`protocol.*.allow` settings survive; an inherited protocol allowlist is intersected with file, Git,
-HTTP(S), and SSH transports. Matching `url.*.insteadOf`, `core.sshCommand`, and `core.gitProxy`
-overrides remain refused. A `remote.upstream.uploadpack` helper cannot serve a different repository.
+its path. It forwards credential helpers, authorization headers, and credential-bearing proxies as
+per-process Git config instead of writing them to temporary files. The private config retains safe
+global and URL-scoped CA and proxy settings, URL-scoped client certificate settings, and a matching
+remote's proxy. Unscoped HTTP authorization stays out because the marker chooses the host. Transport
+accepts local files, HTTPS, and SSH. Plain HTTP, Git, FTP, `git+ssh`, and arbitrary remote helpers are
+refused. The private config denies unknown protocols, preserves restrictive `protocol.*.allow`
+settings, and intersects an inherited protocol allowlist with the accepted transports. HTTPS also
+requires certificate and proxy-certificate verification. Matching `url.*.insteadOf`,
+`core.sshCommand`, and `core.gitProxy` overrides remain refused. A `remote.upstream.uploadpack`
+helper cannot serve a different repository. A local remote is written under the canonical path that
+passed checkout-ownership validation, so retargeting its symlink cannot redirect the later fetch.
 
 Fetch disables automatic maintenance because the private ref namespace does not describe which
 objects the real repository still needs. Fetched objects still land in the real object store. The
-30-second deadline bounds time, not received pack bytes; check free disk space before `--fetch` when
-the configured parent may be unusually large.
+30-second deadline stops the direct Git process. It does not limit received pack bytes or guarantee
+that every remote-helper descendant has exited. Check free disk space before `--fetch` when the
+configured parent may be unusually large.
 It reads the advertised `main` SHA before and after an object-only fetch that writes neither
 `FETCH_HEAD` nor a tracking ref. It verifies that exact commit before creating a missing shared
 remote. The URL it just wrote remains the expected value, so a concurrent replacement cannot be

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -259,8 +259,9 @@ helper cannot serve a different repository. When the marker uses an accepted Git
 keeps the configured remote's exact spelling so its URL-scoped pins, certificates, and proxy settings
 still match. Remote URLs and their proxy settings are captured together and fenced before output. A
 local remote is bound to its canonical Git common directory, after checking its endpoint, worktree,
-Git directory, common directory, object directory, and local alternates against every checkout owned
-by this repository. The check compares ancestor filesystem identity as well as spelling. It repeats
+Git directory, common directory, object directory, and Git's recursively loaded local alternates
+against every checkout owned by this repository. The check compares ancestor filesystem identity as
+well as spelling. It repeats
 that identity fence around remote reads, while a retargeted alias stays bound to the location first
 validated.
 

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -191,8 +191,9 @@ It exits with the reason when any of these hold:
   status, differs from the committed HEAD file, is a symlink, is oversized, changes identity or
   bytes while read, is unreadable, contains invalid UTF-8 or JSON, is not an object, has an `upstreamUrl`
   without a non-empty string value, or names `forkPoint` or `lastSynced` without a full commit SHA;
-- the `upstream` remote points somewhere other than the URL in `.upstream-sync.json`, origin or the
-  marker URL resolves inside any checkout or Git directory owned by this repository, Git rewrites either
+- the `upstream` remote points somewhere other than the URL in `.upstream-sync.json`, the current
+  marker names this fork's origin while the selected base does not, origin or the marker URL resolves
+  inside any checkout or Git directory owned by this repository, Git rewrites either
   URL through `url.*.insteadOf`, `core.sshCommand` or `core.gitProxy` replaces the checked transport,
   or a remote URL or tracking ref changes before the detector finishes;
 - origin, working-tree status, a changed-path diff, or a requested upstream fetch exceeds 30
@@ -349,4 +350,5 @@ committed the previous day. Changing a remote URL leaves its old tracking ref in
 repoint and fetch together.
 
 Run inside the template itself the script exits 2 and reports nothing, because there the
-repository is upstream.
+repository is upstream. That decision uses the canonical template identity or the marker at the
+selected base. A marker changed on the reviewed branch cannot redefine the fork as its own template.

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -151,11 +151,11 @@ gh search issues --repo stickerdaniel/saas-starter "<keywords>"
 Search without a state filter so closed issues come back too. A fix that was already
 rejected, or already shipped, is the answer as often as an open ticket is.
 
-If nothing matches, read the issue template before writing, so the report arrives in the
-shape the repository expects:
+If nothing matches, inspect recent reports before writing, so the new issue matches the
+repository's current level of detail:
 
 ```bash
-gh api repos/stickerdaniel/saas-starter/contents/.github/ISSUE_TEMPLATE
+gh issue list --repo stickerdaniel/saas-starter --state all --limit 5 --json number,title,body
 ```
 
 **Ask the human before filing.** Drafting is yours; posting to another repository is

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -4686,6 +4686,32 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stderr).toMatch(/inside a checkout or Git directory owned by this repository/);
 	});
 
+	it('rejects repository-owned object storage behind nested alternates', () => {
+		const remote = join(tmp, 'nested-alternate-remote.git');
+		mkdirSync(remote);
+		git(remote, ['init', '--bare', '-q']);
+		const bridge = join(tmp, 'nested-alternate-objects');
+		mkdirSync(join(bridge, 'info'), { recursive: true });
+		writeFileSync(join(remote, 'objects', 'info', 'alternates'), `${bridge}\n`);
+		writeFileSync(
+			join(bridge, 'info', 'alternates'),
+			`${realpathSync(git(fork, ['rev-parse', '--path-format=absolute', '--git-path', 'objects']))}\n`
+		);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: remote }));
+		git(fork, ['commit', '-qam', 'set nested-alternate parent']);
+		git(remote, ['update-ref', 'refs/heads/main', git(fork, ['rev-parse', 'HEAD'])]);
+		git(fork, ['remote', 'set-url', 'upstream', remote]);
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/inside a checkout or Git directory owned by this repository/);
+	});
+
 	itWithGitWrapper('rejects local Git storage replaced after validation', () => {
 		const decoy = join(tmp, 'replacement-source');
 		mkdirSync(decoy);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -6621,6 +6621,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		const protectedCheckout = join(tmp, 'upstream-relevance-index-project');
 		renameSync(fork, protectedCheckout);
 		fork = protectedCheckout;
+		chmodSync(fork, 0o700);
 		writeScratchOwner(fork, 999999999);
 		const old = new Date(Date.now() - 3 * 60 * 60 * 1000);
 		utimesSync(fork, old, old);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -1003,7 +1003,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 
 	it('preserves the overriding semantics of an inherited protocol allowlist', () => {
 		git(fork, ['config', '--local', 'protocol.file.allow', 'never']);
-		const r = run(fork, ['--base', 'HEAD', '--json'], {
+		const r = run(fork, ['--fetch', '--base', 'HEAD', '--json'], {
 			GIT_ALLOW_PROTOCOL: 'file',
 			GIT_PROTOCOL_FROM_USER: 'false'
 		});

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -173,9 +173,39 @@ if [ -n "$FETCH_COMMAND_LOG" ]; then
     *" fetch "*) printf '%s\n' "$command_line" >> "$FETCH_COMMAND_LOG" ;;
   esac
 fi
+if [ -n "$NETWORK_COMMAND_MARKER" ]; then
+  case "$command_line" in
+    *" fetch "*|*" ls-remote "*) : > "$NETWORK_COMMAND_MARKER" ;;
+  esac
+fi
+if [ -n "$RETARGET_REMOTE_LINK" ] && [ ! -e "$RETARGET_REMOTE_MARKER" ]; then
+  case "$command_line" in
+    *" ls-remote "*)
+      for arg in "$@"; do
+        case "$arg" in
+          upstream-report-*)
+            remote_url=$("$REAL_GIT" config --get "remote.$arg.url") || continue
+            if [ "$remote_url" = "$RETARGET_REMOTE_EXPECTED" ]; then
+              rm "$RETARGET_REMOTE_LINK" || exit $?
+              ln -s "$RETARGET_REMOTE_TARGET" "$RETARGET_REMOTE_LINK" || exit $?
+              : > "$RETARGET_REMOTE_MARKER"
+            fi
+            ;;
+        esac
+      done
+      ;;
+  esac
+fi
 if [ -n "$TRANSPORT_CREDENTIAL_LOG" ]; then
   case "$command_line" in
     *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-all credential.helper > "$TRANSPORT_CREDENTIAL_LOG" ;;
+  esac
+fi
+if [ -n "$TRANSPORT_EFFECTIVE_AUTH_LOG" ]; then
+  case "$command_line" in
+    *" ls-remote "*)
+      { "$REAL_GIT" config --get-all credential.helper || :; "$REAL_GIT" config --get-regexp '^(http\\..*\\.(extraheader|proxy)|remote\\..*\\.proxy)$' || :; } > "$TRANSPORT_EFFECTIVE_AUTH_LOG"
+      ;;
   esac
 fi
 if [ -n "$TRANSPORT_HTTP_LOG" ]; then
@@ -896,10 +926,40 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(existsSync(executed)).toBe(false);
 	});
 
+	itWithPosixPaths('uses a safe protocol allowlist when none is inherited', () => {
+		const executed = join(tmp, 'default-ext-protocol-executed');
+		const helper = join(tmp, 'default-ext-protocol-helper');
+		writeFileSync(helper, `#!/bin/sh\n: > "${executed}"\nexit 1\n`);
+		chmodSync(helper, 0o755);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as {
+			forkPoint: string;
+			lastSynced: string;
+		};
+		const url = `ext::${helper}`;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+		git(fork, ['commit', '-qam', 'set default ext parent']);
+		git(fork, ['remote', 'set-url', 'upstream', url]);
+
+		const r = run(fork, ['--fetch', '--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(existsSync(executed)).toBe(false);
+	});
+
 	it('preserves an inherited protocol allowlist that excludes local remotes', () => {
 		const r = run(fork, ['--json', 'shared/pristine.ts'], { GIT_ALLOW_PROTOCOL: 'https' });
 		expect(r.status).not.toBe(0);
 	});
+
+	it.each(['', '0', 'false', 'no', 'off'])(
+		'preserves GIT_PROTOCOL_FROM_USER=%j for local remotes',
+		(value) => {
+			const r = run(fork, ['--json', 'shared/pristine.ts'], {
+				GIT_PROTOCOL_FROM_USER: value
+			});
+			expect(r.status).not.toBe(0);
+		}
+	);
 
 	it('preserves restrictive protocol configuration', () => {
 		git(fork, ['config', '--local', 'protocol.file.allow', 'never']);
@@ -3651,6 +3711,88 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		);
 	});
 
+	itWithGitWrapper('rejects credential-bearing HTTPS before starting its helper', () => {
+		const secret = 'DUMMY_REMOTE_CREDENTIAL';
+		const url = `https://user:${secret}@example.invalid/repo.git`;
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+		git(fork, ['commit', '-qam', 'set credential-bearing parent']);
+		git(fork, ['remote', 'set-url', 'upstream', url]);
+		const wrapper = installGitWrapper(tmp);
+		const helperMarker = join(tmp, 'https-helper-executed');
+		const helper = join(wrapper, 'git-remote-https');
+		writeFileSync(helper, `#!/bin/sh\n: > "${helperMarker}"\nexit 1\n`);
+		chmodSync(helper, 0o755);
+
+		const r = run(fork, ['--fetch', '--base', 'HEAD', '--json'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath()
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain(secret);
+		expect(r.stderr).toMatch(/credential-free remote/);
+		expect(existsSync(helperMarker)).toBe(false);
+	});
+
+	itWithGitWrapper('rejects untrusted network protocols before Git reaches transport', () => {
+		const wrapper = installGitWrapper(tmp);
+		const networkMarker = join(tmp, 'untrusted-network-command');
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		for (const [name, url] of [
+			['HTTP', 'http://example.invalid/repo.git'],
+			['Git', 'git://example.invalid/repo.git'],
+			['FTP', 'ftp://example.invalid/repo.git'],
+			['git+ssh', 'git+ssh://example.invalid/repo.git']
+		] as const) {
+			write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+			git(fork, ['commit', '-qam', `set ${name} parent`]);
+			git(fork, ['remote', 'set-url', 'upstream', url]);
+			rmSync(networkMarker, { force: true });
+
+			const r = run(fork, ['--fetch', '--base', 'HEAD', '--json'], {
+				PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+				REAL_GIT: realGitPath(),
+				NETWORK_COMMAND_MARKER: networkMarker
+			});
+
+			expect(r.status, name).not.toBe(0);
+			expect(r.stderr, name).toMatch(/requires HTTPS, SSH, or a local file transport/);
+			expect(existsSync(networkMarker), name).toBe(false);
+		}
+	});
+
+	itWithGitWrapper.each(['http.sslVerify', 'http.proxySSLVerify'])(
+		'rejects %s=false before HTTPS transport',
+		(key) => {
+			const url = 'https://example.invalid/repo.git';
+			const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+				string,
+				unknown
+			>;
+			write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+			git(fork, ['commit', '-qam', 'set HTTPS parent']);
+			git(fork, ['remote', 'set-url', 'upstream', url]);
+			git(fork, ['config', '--local', key, 'false']);
+			const networkMarker = join(tmp, 'disabled-tls-network-command');
+			const r = run(fork, ['--fetch', '--base', 'HEAD', '--json'], {
+				PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+				REAL_GIT: realGitPath(),
+				NETWORK_COMMAND_MARKER: networkMarker
+			});
+
+			expect(r.status).not.toBe(0);
+			expect(r.stderr).toMatch(/requires TLS and proxy TLS verification/);
+			expect(existsSync(networkMarker)).toBe(false);
+		}
+	);
+
 	it('redacts a failed fetch before Git stderr reaches the caller', () => {
 		const secret = 'DUMMY_FETCH_QUERY_SECRET';
 		const url = `http://127.0.0.1:1/repo.git?token=${secret}`;
@@ -3760,23 +3902,38 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 			`http.${upstream}.proxy`,
 			'http://DUMMY_PROXY_SECRET@proxy.example'
 		]);
+		git(fork, [
+			'config',
+			'--local',
+			'remote.upstream.proxy',
+			'http://DUMMY_REMOTE_PROXY_SECRET@remote-proxy.example'
+		]);
 		const wrapper = installGitWrapper(tmp);
 		const credentialLog = join(tmp, 'transport-windows-credential.log');
 		const httpLog = join(tmp, 'transport-windows-http.log');
 		const networkLog = join(tmp, 'transport-windows-network.log');
+		const effectiveAuthLog = join(tmp, 'transport-windows-effective-auth.log');
 		const r = run(fork, ['--json', 'shared/pristine.ts'], {
 			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
 			REAL_GIT: realGitPath(),
 			NODE_ENV: 'test',
 			UPSTREAM_REPORT_TEST_WINDOWS_SAFETY: '1',
 			TRANSPORT_CREDENTIAL_LOG: credentialLog,
+			TRANSPORT_EFFECTIVE_AUTH_LOG: effectiveAuthLog,
 			TRANSPORT_HTTP_LOG: httpLog,
 			TRANSPORT_NETWORK_LOG: networkLog
 		});
 		expect(r.status, r.stderr).toBe(0);
+		const effectiveAuth = readFileSync(effectiveAuthLog, 'utf8');
+		expect(effectiveAuth).toContain('DUMMY_HELPER_SECRET');
+		expect(effectiveAuth).toContain('DUMMY_HEADER_SECRET');
+		expect(effectiveAuth).toContain('DUMMY_PROXY_SECRET');
+		expect(effectiveAuth).toContain('DUMMY_REMOTE_PROXY_SECRET');
 		expect(readFileSync(credentialLog, 'utf8')).not.toContain('DUMMY_HELPER_SECRET');
 		expect(readFileSync(httpLog, 'utf8')).not.toContain('DUMMY_HEADER_SECRET');
-		expect(readFileSync(networkLog, 'utf8')).not.toContain('DUMMY_PROXY_SECRET');
+		const temporaryNetwork = readFileSync(networkLog, 'utf8');
+		expect(temporaryNetwork).not.toContain('DUMMY_PROXY_SECRET');
+		expect(temporaryNetwork).not.toContain('DUMMY_REMOTE_PROXY_SECRET');
 	});
 
 	itWithGitWrapper('does not copy unscoped HTTP authentication to a marker-selected host', () => {
@@ -4073,6 +4230,40 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(readFileSync(processLog, 'utf8').trim().split('\n')).toHaveLength(2);
 	});
 
+	itWithGitWrapper('keeps a local remote bound after its symlink is retargeted', () => {
+		const upstreamLink = join(tmp, 'upstream-link');
+		symlinkSync(upstream, upstreamLink);
+		const decoy = join(tmp, 'retargeted-upstream');
+		mkdirSync(decoy);
+		init(decoy);
+		write(decoy, 'decoy.ts', 'export const decoy = true;\n');
+		git(decoy, ['add', '-A']);
+		git(decoy, ['commit', '-qm', 'add decoy parent']);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: upstreamLink }));
+		git(fork, ['commit', '-qam', 'set symlinked parent']);
+		git(fork, ['remote', 'set-url', 'upstream', upstreamLink]);
+		const retargeted = join(tmp, 'remote-link-retargeted');
+
+		const r = run(fork, ['--fetch', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			RETARGET_REMOTE_LINK: upstreamLink,
+			RETARGET_REMOTE_TARGET: decoy,
+			RETARGET_REMOTE_EXPECTED: realpathSync(upstream),
+			RETARGET_REMOTE_MARKER: retargeted
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(retargeted)).toBe(true);
+		const parsed = JSON.parse(r.stdout) as { upstreamRef: string };
+		expect(parsed.upstreamRef).toBe(git(upstream, ['rev-parse', 'HEAD']));
+		expect(parsed.upstreamRef).not.toBe(git(decoy, ['rev-parse', 'HEAD']));
+	});
+
 	it('keeps trailing whitespace significant in local repository paths', () => {
 		const spacedUpstream = `${upstream} `;
 		git(tmp, ['clone', '-q', upstream, spacedUpstream]);
@@ -4180,9 +4371,10 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		git(fork, ['remote', 'set-url', 'upstream', remote]);
 
 		const r = run(fork, ['--json']);
-		expect(r.status).toBe(0);
-		expect(r.stdout).not.toContain('DUMMY_QUERY_SECRET');
-		expect(r.stdout).toContain('repo.git?***');
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain('DUMMY_QUERY_SECRET');
+		expect(r.stderr).toContain('repo.git?***');
+		expect(r.stderr).toMatch(/credential-free remote/);
 	});
 
 	it('redacts credentials carried in a remote fragment', () => {
@@ -4192,9 +4384,10 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		git(fork, ['remote', 'set-url', 'upstream', remote]);
 
 		const r = run(fork, ['--json']);
-		expect(r.status).toBe(0);
-		expect(r.stdout).not.toContain('DUMMY_FRAGMENT_SECRET');
-		expect(r.stdout).toContain('repo.git#***');
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain('DUMMY_FRAGMENT_SECRET');
+		expect(r.stderr).toContain('repo.git#***');
+		expect(r.stderr).toMatch(/credential-free remote/);
 	});
 
 	it('redacts a multiline remote query string', () => {

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -152,6 +152,28 @@ function installGitWrapper(root: string): string {
 		wrapper,
 		`#!/bin/sh
 command_line=" $* "
+if [ -n "$REF_BACKING_RACE_PATH" ] && [ ! -e "$REF_BACKING_RACE_MARKER" ]; then
+  case "$command_line" in
+    *" ls-remote "*)
+      for arg in "$@"; do
+        case "$arg" in
+          upstream-report-*)
+            remote_url=$("$REAL_GIT" config --get "remote.$arg.url") || continue
+            if [ "$remote_url" = "$REF_BACKING_RACE_REMOTE" ]; then
+              touch -t 203001010101 "$REF_BACKING_RACE_PATH" || exit $?
+              : > "$REF_BACKING_RACE_MARKER"
+            fi
+            ;;
+        esac
+      done
+      ;;
+  esac
+fi
+if [ -n "$TRANSPORT_SSH_COMMAND_LOG" ]; then
+  case "$command_line" in
+    *" ls-remote "*|*" fetch "*) printf '%s\n' "$GIT_SSH_COMMAND" >> "$TRANSPORT_SSH_COMMAND_LOG" ;;
+  esac
+fi
 if [ -n "$EXPLICIT_ABA_PATH" ] && [ ! -e "$EXPLICIT_ABA_MARKER" ]; then
   case "$command_line" in
     *" ls-files -z --full-name --cached --others --exclude-standard -- "*)
@@ -3288,15 +3310,18 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		git(fork, ['commit', '-qam', 'fix shared path']);
 		git(fork, ['remote', 'remove', 'upstream']);
 		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+		const sshCommandLog = join(tmp, 'transport-ssh-command.log');
 
 		const r = run(fork, ['--base', 'origin/main', '--fetch', '--json', 'shared/pristine.ts'], {
 			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
 			REAL_GIT: realGitPath(),
 			FAKE_FETCH_SUCCESS: '1',
-			FAKE_REMOTE_MAIN_SHA: git(upstream, ['rev-parse', 'HEAD'])
+			FAKE_REMOTE_MAIN_SHA: git(upstream, ['rev-parse', 'HEAD']),
+			TRANSPORT_SSH_COMMAND_LOG: sshCommandLog
 		});
 
 		expect(r.status, r.stderr).toBe(0);
+		expect(readFileSync(sshCommandLog, 'utf8')).toContain('ssh -F none');
 		expect(git(fork, ['remote', 'get-url', 'upstream'])).toBe(sshUrl);
 	});
 
@@ -4663,6 +4688,83 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		});
 		expect(r.status, r.stderr).toBe(0);
 		expect(readFileSync(processLog, 'utf8').trim().split('\n')).toHaveLength(2);
+	});
+
+	itWithPosixPaths('rejects a filesystem-symlinked local main ref', () => {
+		const remote = join(tmp, 'symlinked-main-ref.git');
+		mkdirSync(remote);
+		git(remote, ['init', '--bare', '-q']);
+		const branchRef = realpathSync(
+			git(fork, ['rev-parse', '--path-format=absolute', '--git-path', 'refs/heads/main'])
+		);
+		symlinkSync(branchRef, join(remote, 'refs', 'heads', 'main'));
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: remote }));
+		git(fork, ['commit', '-qam', 'set symlinked-ref parent']);
+		git(fork, ['remote', 'set-url', 'upstream', remote]);
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toContain('loose main ref is a filesystem symlink');
+	});
+
+	itWithPosixPaths('rejects a filesystem-symlinked packed-refs file', () => {
+		const remote = join(tmp, 'symlinked-packed-refs.git');
+		mkdirSync(remote);
+		git(remote, ['init', '--bare', '-q']);
+		const commonDir = realpathSync(
+			git(fork, ['rev-parse', '--path-format=absolute', '--git-common-dir'])
+		);
+		const ownedPackedRefs = join(commonDir, 'owned-packed-refs');
+		writeFileSync(
+			ownedPackedRefs,
+			`# pack-refs with: peeled fully-peeled sorted\n${git(fork, ['rev-parse', 'HEAD'])} refs/heads/main\n`
+		);
+		symlinkSync(ownedPackedRefs, join(remote, 'packed-refs'));
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: remote }));
+		git(fork, ['commit', '-qam', 'set symlinked-packed parent']);
+		git(fork, ['remote', 'set-url', 'upstream', remote]);
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toContain('packed refs is a filesystem symlink');
+	});
+
+	itWithGitWrapper('fences in-place changes to local ref backing files', () => {
+		const remote = join(tmp, 'ref-backing-race.git');
+		git(tmp, ['clone', '-q', '--bare', upstream, remote]);
+		const mainRef = join(remote, 'refs', 'heads', 'main');
+		mkdirSync(join(mainRef, '..'), { recursive: true });
+		writeFileSync(mainRef, `${git(upstream, ['rev-parse', 'HEAD'])}\n`);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: remote }));
+		git(fork, ['commit', '-qam', 'set ref-race parent']);
+		git(fork, ['remote', 'set-url', 'upstream', remote]);
+		const raceMarker = join(tmp, 'ref-backing-raced');
+
+		const r = run(fork, ['--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			REF_BACKING_RACE_PATH: mainRef,
+			REF_BACKING_RACE_REMOTE: realpathSync(remote),
+			REF_BACKING_RACE_MARKER: raceMarker
+		});
+
+		expect(existsSync(raceMarker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/local upstream path|local remote/i);
 	});
 
 	it('rejects a local wrapper whose .git file points into this repository', () => {
@@ -6791,6 +6893,30 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		const r = run(fork, []);
 		expect(r.status).not.toBe(2);
 		expect(r.stderr).toMatch(/url\.\*\.insteadOf/);
+		expect(r.stderr).not.toContain('IS the upstream template');
+	});
+
+	it('rejects an SSH command override before template self-detection', () => {
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(
+			fork,
+			'.upstream-sync.json',
+			JSON.stringify({
+				...marker,
+				upstreamUrl: 'https://github.com/stickerdaniel/saas-starter.git'
+			})
+		);
+		git(fork, ['commit', '-qam', 'record GitHub parent']);
+		git(fork, ['remote', 'set-url', 'origin', 'git@github.com:stickerdaniel/saas-starter.git']);
+		git(fork, ['config', 'core.sshCommand', 'ssh -o HostName=mirror.example']);
+
+		const r = run(fork, []);
+
+		expect(r.status).not.toBe(2);
+		expect(r.stderr).toContain('core.sshCommand');
 		expect(r.stderr).not.toContain('IS the upstream template');
 	});
 

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -254,6 +254,22 @@ if [ -n "$REPLACE_REMOTE_STORAGE_PATH" ] && [ ! -e "$REPLACE_REMOTE_STORAGE_MARK
       ;;
   esac
 fi
+if [ -n "$UPSTREAM_TRANSPORT_SECRET" ]; then
+  case "$command_line" in
+    *" ls-remote "*|*" fetch "*)
+      for arg in "$@"; do
+        case "$arg" in
+          upstream-report-*)
+            remote_url=$("$REAL_GIT" config --get "remote.$arg.url") || continue
+            case "$remote_url" in
+              *"$UPSTREAM_TRANSPORT_SECRET"*) : > "$UPSTREAM_TRANSPORT_SECRET_MARKER" ;;
+            esac
+            ;;
+        esac
+      done
+      ;;
+  esac
+fi
 if [ -n "$TRANSPORT_CREDENTIAL_LOG" ]; then
   case "$command_line" in
     *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-all credential.helper > "$TRANSPORT_CREDENTIAL_LOG" ;;
@@ -3295,17 +3311,22 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		git(fork, ['commit', '-qam', 'set SCP query parent']);
 		git(fork, ['remote', 'set-url', 'upstream', unsafeUrl]);
 		const seen = join(tmp, 'scp-query-secret-in-argv');
+		const transport = join(tmp, 'scp-query-transport');
 
 		const r = run(fork, ['--fetch', '--json'], {
 			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
 			REAL_GIT: realGitPath(),
 			CHILD_ARG_SECRET: secret,
-			CHILD_ARG_MARKER: seen
+			CHILD_ARG_MARKER: seen,
+			UPSTREAM_TRANSPORT_SECRET: secret,
+			UPSTREAM_TRANSPORT_SECRET_MARKER: transport
 		});
 
 		expect(r.status).not.toBe(0);
+		expect(r.stderr).toContain('userinfo, a query, or a fragment');
 		expect(r.stderr).not.toContain(secret);
 		expect(existsSync(seen)).toBe(false);
+		expect(existsSync(transport)).toBe(false);
 	});
 
 	itWithGitWrapper('keeps SCP-style usernames out of shared remote creation', () => {

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -2328,7 +2328,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 			});
 			expect(r.status).not.toBe(0);
 			expect(r.stdout).not.toContain('Nothing to report upstream');
-			expect(r.stderr).toContain('changed while this report started');
+			expect(r.stderr).toMatch(/changed while this report started|points at .*but .*names/);
 		}
 	);
 
@@ -3454,23 +3454,24 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		const r = run(fork, ['--fetch']);
 		expect(r.status).toBe(0);
 		expect(r.stdout).toMatch(/>> pristine\s+shared\/pristine\.ts/);
-		expect(r.stdout).not.toContain('product/only-here.ts');
-		expect(r.stdout).toContain('1 of 2 changed files need a look');
+		expect(r.stdout).toMatch(/>> unmeasured\s+product\/only-here\.ts/);
+		expect(r.stdout).toContain('2 of 2 changed files need a look');
 		expect(r.stdout).not.toContain('Nothing to report upstream');
 	});
 
-	it('says plainly when nothing template-derived changed', () => {
+	it('keeps a root-only change visible in the human report', () => {
 		write(fork, 'product/only-here.ts', 'export const product = false;\n');
-		git(fork, ['commit', '-qam', 'fork only']);
+		git(fork, ['commit', '-qam', 'fork-owned change']);
 
 		const r = run(fork, ['--fetch']);
 		expect(r.status).toBe(0);
-		expect(r.stdout).toContain('Nothing to report upstream');
+		expect(r.stdout).toMatch(/>> unmeasured\s+product\/only-here\.ts/);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
 	});
 
 	it('accepts an explicit path in any form git understands', () => {
-		// `./x`, a directory and a redundant separator all miss an exact lookup
-		// against the upstream file set, and a miss reads as fork-only.
+		// `./x`, a directory and a redundant separator must all reach the same
+		// exact upstream lookup.
 		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 43;\n');
 		git(fork, ['commit', '-qam', 'fix']);
 

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -695,8 +695,8 @@ function init(root: string, objectFormat: 'sha1' | 'sha256' = 'sha1'): void {
 
 describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 	let tmp: string;
-	let upstream: string;
-	let fork: string;
+	let upstream!: string;
+	let fork!: string;
 
 	beforeEach(() => {
 		tmp = mkdtempSync(join(tmpdir(), 'upstream-relevance-'));
@@ -3144,7 +3144,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		git(fork, ['commit', '-qam', 'fork block']);
 		const r = run(fork, ['--json']);
 		const parsed = JSON.parse(r.stdout) as {
-			verdicts: Array<{ path: string; relevance: string; report: boolean }>;
+			verdicts: Array<{ path: string; relevance: string; report: boolean; overlap?: number }>;
 		};
 		const v = parsed.verdicts.find((x) => x.path === 'shared/rewritten.ts');
 		expect(v?.relevance).toBe('diverged');
@@ -3237,6 +3237,13 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 
 		const r = run(fork, ['--bsae', 'shared/pristine.ts']);
 		expect(r.status).not.toBe(0);
+	});
+
+	it('refuses an empty explicit path', () => {
+		const r = run(fork, ['']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toContain('Path arguments must not be empty');
+		expect(r.stdout).not.toContain('Nothing to report upstream');
 	});
 
 	it('refuses an explicit path that does not exist', () => {
@@ -4623,6 +4630,33 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		markBase(fork);
 		write(fork, path, 'export const changed = true;\n');
 		git(fork, ['commit', '-qam', 'edit large shared path']);
+
+		const r = run(fork, ['--fetch', '--json', path], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_SIMILARITY_REPRESENTATION_LIMIT: '100'
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === path);
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/bounded similarity representation/);
+	});
+
+	it('charges every split line against the overlap representation budget', () => {
+		const path = 'shared/split-heavy-overlap.ts';
+		write(upstream, path, `${'}\n'.repeat(30)}`);
+		write(fork, path, `${'{\n'.repeat(30)}`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add split-heavy shared path']);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add divergent split-heavy path']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		markBase(fork);
+		write(fork, path, 'changed();\n');
+		git(fork, ['commit', '-qam', 'edit split-heavy path']);
 
 		const r = run(fork, ['--fetch', '--json', path], {
 			NODE_ENV: 'test',

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -36,6 +36,27 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 const itWithGitWrapper = it.runIf(process.platform !== 'win32');
 const itWithPosixPaths = it.runIf(process.platform !== 'win32');
 
+// Reftable ref storage only exists from Git 2.45 onwards, so the fixture that
+// needs it cannot be built on older toolchains.
+const itWithReftable = it.runIf(reftableSupported());
+
+function reftableSupported(): boolean {
+	const probe = mkdtempSync(join(tmpdir(), 'upstream-relevance-reftable-probe-'));
+	try {
+		return (
+			spawnSync(
+				'git',
+				['init', '--bare', '-q', '--ref-format=reftable', join(probe, 'probe.git')],
+				{
+					encoding: 'utf8'
+				}
+			).status === 0
+		);
+	} finally {
+		rmSync(probe, { recursive: true, force: true });
+	}
+}
+
 const SCRIPT = resolve(
 	process.cwd(),
 	'.agents/skills/upstream-report/scripts/upstream-relevance.ts'
@@ -4737,6 +4758,23 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 
 		expect(r.status).not.toBe(0);
 		expect(r.stderr).toContain('packed refs is a filesystem symlink');
+	});
+
+	itWithReftable('rejects a local remote using reftable ref storage', () => {
+		const remote = join(tmp, 'reftable-upstream.git');
+		git(tmp, ['clone', '-q', '--bare', '--ref-format=reftable', upstream, remote]);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: remote }));
+		git(fork, ['commit', '-qam', 'set reftable parent']);
+		git(fork, ['remote', 'set-url', 'upstream', remote]);
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toContain('reftable ref storage are not supported');
 	});
 
 	itWithGitWrapper('fences in-place changes to local ref backing files', () => {

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -20,6 +20,7 @@ import {
 	readFileSync,
 	readdirSync,
 	realpathSync,
+	renameSync,
 	rmSync,
 	statSync,
 	symlinkSync,
@@ -151,6 +152,23 @@ function installGitWrapper(root: string): string {
 		wrapper,
 		`#!/bin/sh
 command_line=" $* "
+if [ -n "$EXPLICIT_ABA_PATH" ] && [ ! -e "$EXPLICIT_ABA_MARKER" ]; then
+  case "$command_line" in
+    *" ls-files -z --full-name --cached --others --exclude-standard -- "*)
+      saved="$EXPLICIT_ABA_MARKER.saved"
+      output_file="$EXPLICIT_ABA_MARKER.output"
+      error_file="$EXPLICIT_ABA_MARKER.error"
+      mv "$EXPLICIT_ABA_PATH" "$saved" || exit $?
+      "$REAL_GIT" "$@" > "$output_file" 2> "$error_file"
+      rc=$?
+      mv "$saved" "$EXPLICIT_ABA_PATH" || exit $?
+      : > "$EXPLICIT_ABA_MARKER"
+      cat "$output_file"
+      cat "$error_file" >&2
+      exit "$rc"
+      ;;
+  esac
+fi
 if [ -n "$TRANSPORT_ALIAS_CONFIG_LOG" ]; then
   case "$command_line" in
     *" fetch "*)
@@ -211,6 +229,24 @@ if [ -n "$RETARGET_REMOTE_LINK" ] && [ ! -e "$RETARGET_REMOTE_MARKER" ]; then
               rm "$RETARGET_REMOTE_LINK" || exit $?
               ln -s "$RETARGET_REMOTE_TARGET" "$RETARGET_REMOTE_LINK" || exit $?
               : > "$RETARGET_REMOTE_MARKER"
+            fi
+            ;;
+        esac
+      done
+      ;;
+  esac
+fi
+if [ -n "$REPLACE_REMOTE_STORAGE_PATH" ] && [ ! -e "$REPLACE_REMOTE_STORAGE_MARKER" ]; then
+  case "$command_line" in
+    *" ls-remote "*)
+      for arg in "$@"; do
+        case "$arg" in
+          upstream-report-*)
+            remote_url=$("$REAL_GIT" config --get "remote.$arg.url") || continue
+            if [ "$remote_url" = "$REPLACE_REMOTE_STORAGE_PATH" ]; then
+              mv "$REPLACE_REMOTE_STORAGE_PATH" "$REPLACE_REMOTE_STORAGE_MARKER.saved" || exit $?
+              mv "$REPLACE_REMOTE_STORAGE_WITH" "$REPLACE_REMOTE_STORAGE_PATH" || exit $?
+              : > "$REPLACE_REMOTE_STORAGE_MARKER"
             fi
             ;;
         esac
@@ -772,6 +808,14 @@ function write(root: string, rel: string, content: string): void {
 	const full = join(root, rel);
 	mkdirSync(join(full, '..'), { recursive: true });
 	writeFileSync(full, content);
+}
+
+function writeScratchOwner(dir: string, owner: number): void {
+	writeFileSync(join(dir, 'owner'), String(owner));
+	writeFileSync(
+		join(dir, '.upstream-relevance-scratch.json'),
+		JSON.stringify({ magic: 'upstream-relevance-scratch', version: 1, owner })
+	);
 }
 
 function init(root: string, objectFormat: 'sha1' | 'sha256' = 'sha1'): void {
@@ -3240,6 +3284,30 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(git(fork, ['remote', 'get-url', 'upstream'])).toBe(sshUrl);
 	});
 
+	itWithGitWrapper('rejects query secrets in username-less SCP remotes before transport', () => {
+		const secret = 'DUMMY_SCP_QUERY_SECRET';
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		const unsafeUrl = `example.invalid:owner/template.git?access_token=${secret}`;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: unsafeUrl }));
+		git(fork, ['commit', '-qam', 'set SCP query parent']);
+		git(fork, ['remote', 'set-url', 'upstream', unsafeUrl]);
+		const seen = join(tmp, 'scp-query-secret-in-argv');
+
+		const r = run(fork, ['--fetch', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			CHILD_ARG_SECRET: secret,
+			CHILD_ARG_MARKER: seen
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain(secret);
+		expect(existsSync(seen)).toBe(false);
+	});
+
 	itWithGitWrapper('keeps SCP-style usernames out of shared remote creation', () => {
 		const secret = 'DUMMY_SCP_CREATION_SECRET';
 		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
@@ -3304,6 +3372,27 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stdout).not.toContain('Nothing to report upstream');
 		expect(r.stderr).toContain('skip-worktree');
 		expect(r.stderr).toContain('shared/pristine.ts');
+	});
+
+	itWithGitWrapper('refuses an explicit directory that changes during expansion', () => {
+		write(fork, 'explicit-scope/tracked.ts', 'export const tracked = true;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add explicit scope']);
+		markBase(fork);
+		const target = join(fork, 'explicit-scope/untracked.ts');
+		writeFileSync(target, 'export const untracked = true;\n');
+		const marker = join(tmp, 'explicit-expansion-aba');
+
+		const r = run(fork, ['--fetch', '--json', 'explicit-scope'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			EXPLICIT_ABA_PATH: target,
+			EXPLICIT_ABA_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toContain('Explicit path expansion changed during this report');
 	});
 
 	it('refuses an explicit path hidden by an index flag', () => {
@@ -3748,7 +3837,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stderr).toMatch(/\.upstream-sync\.json changed in the selected commit range/);
 	});
 
-	itWithGitWrapper('deduplicates explicit pathspecs before enumeration', () => {
+	itWithGitWrapper('deduplicates explicit pathspecs across both enumeration reads', () => {
 		const enumerationLog = join(tmp, 'path-enumeration.log');
 		const r = run(fork, ['--fetch', '--json', 'shared', 'shared', './shared'], {
 			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
@@ -3756,7 +3845,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 			PATH_ENUMERATION_LOG: enumerationLog
 		});
 		expect(r.status, r.stderr).toBe(0);
-		expect(readFileSync(enumerationLog, 'utf8').trim().split('\n')).toHaveLength(3);
+		expect(readFileSync(enumerationLog, 'utf8').trim().split('\n')).toHaveLength(6);
 	});
 
 	itWithGitWrapper('bounds aggregate explicit path expansion before reading later trees', () => {
@@ -4555,6 +4644,54 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(readFileSync(processLog, 'utf8').trim().split('\n')).toHaveLength(2);
 	});
 
+	it('rejects a local wrapper whose .git file points into this repository', () => {
+		const wrapper = join(tmp, 'external-upstream-wrapper');
+		mkdirSync(wrapper);
+		writeFileSync(
+			join(wrapper, '.git'),
+			`gitdir: ${git(fork, ['rev-parse', '--path-format=absolute', '--git-dir'])}\n`
+		);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: wrapper }));
+		git(fork, ['commit', '-qam', 'set wrapped local parent']);
+		git(fork, ['remote', 'set-url', 'upstream', wrapper]);
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/inside a checkout or Git directory owned by this repository/);
+	});
+
+	itWithGitWrapper('rejects local Git storage replaced after validation', () => {
+		const decoy = join(tmp, 'replacement-source');
+		mkdirSync(decoy);
+		init(decoy);
+		write(decoy, 'decoy.ts', 'export const decoy = true;\n');
+		git(decoy, ['add', '-A']);
+		git(decoy, ['commit', '-qm', 'add replacement commit']);
+		const replacement = join(tmp, 'replacement.git');
+		git(tmp, ['clone', '-q', '--bare', decoy, replacement]);
+		const storage = realpathSync(
+			git(upstream, ['rev-parse', '--path-format=absolute', '--git-common-dir'])
+		);
+		const marker = join(tmp, 'remote-storage-replaced');
+
+		const r = run(fork, ['--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			REPLACE_REMOTE_STORAGE_PATH: storage,
+			REPLACE_REMOTE_STORAGE_WITH: replacement,
+			REPLACE_REMOTE_STORAGE_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/local upstream path|local remote/i);
+	});
+
 	itWithGitWrapper('keeps a local remote bound after its symlink is retargeted', () => {
 		const upstreamLink = join(tmp, 'upstream-link');
 		symlinkSync(upstream, upstreamLink);
@@ -4578,7 +4715,9 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 			REAL_GIT: realGitPath(),
 			RETARGET_REMOTE_LINK: upstreamLink,
 			RETARGET_REMOTE_TARGET: decoy,
-			RETARGET_REMOTE_EXPECTED: realpathSync(upstream),
+			RETARGET_REMOTE_EXPECTED: realpathSync(
+				git(upstream, ['rev-parse', '--path-format=absolute', '--git-common-dir'])
+			),
 			RETARGET_REMOTE_MARKER: retargeted
 		});
 
@@ -5325,7 +5464,10 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(check).toContain('statSync(current)');
 		expect(check).toContain('sameFileIdentity(rootStatsEntry, currentStats)');
 		expect(source).toContain('pathResolvesInsideOwnedRoot(tempPath, ownedRoots)');
-		expect(source).toContain('pathResolvesInsideOwnedRoot(remotePath, ownedRepositoryPaths)');
+		expect(source).toContain('pathResolvesInsideOwnedRoot(path, ownedRepositoryPaths)');
+		expect(source).toContain(
+			'pathResolvesInsideOwnedRoot(realpathSync(dir), ownedRepositoryPaths)'
+		);
 	});
 
 	it('pins executable-bit detection after the POSIX capability check', () => {
@@ -6454,6 +6596,25 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stderr).toMatch(/different repository/i);
 	});
 
+	it('never sweeps a checkout beneath the temporary root', () => {
+		const protectedCheckout = join(tmp, 'upstream-relevance-index-project');
+		renameSync(fork, protectedCheckout);
+		fork = protectedCheckout;
+		writeScratchOwner(fork, 999999999);
+		const old = new Date(Date.now() - 3 * 60 * 60 * 1000);
+		utimesSync(fork, old, old);
+
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			TMPDIR: tmp,
+			TMP: tmp,
+			TEMP: tmp
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(fork)).toBe(true);
+		expect(existsSync(join(fork, '.git'))).toBe(true);
+	});
+
 	it('sweeps up an index copy an earlier run left behind', () => {
 		// SIGTERM and SIGHUP do not reach the exit listener, and a handler for them
 		// is worse than the leak: this script sits inside execFileSync almost the
@@ -6463,7 +6624,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		// previous run can have died.
 		const leftover = mkdtempSync(join(tmpdir(), 'upstream-relevance-index-'));
 		writeFileSync(join(leftover, 'index'), 'stale');
-		writeFileSync(join(leftover, 'owner'), '999999999');
+		writeScratchOwner(leftover, 999999999);
 		const old = new Date(Date.now() - 3 * 60 * 60 * 1000);
 		utimesSync(leftover, old, old);
 
@@ -6489,7 +6650,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 	it('does not sweep an old index copy owned by a live report', () => {
 		const active = mkdtempSync(join(tmpdir(), 'upstream-relevance-index-'));
 		writeFileSync(join(active, 'index'), 'in use');
-		writeFileSync(join(active, 'owner'), String(process.pid));
+		writeScratchOwner(active, process.pid);
 		const old = new Date(Date.now() - 3 * 60 * 60 * 1000);
 		utimesSync(active, old, old);
 

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -188,6 +188,11 @@ if [ -n "$TRANSPORT_UNSCOPED_HTTP_LOG" ]; then
     *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-all http.extraheader > "$TRANSPORT_UNSCOPED_HTTP_LOG" || : ;;
   esac
 fi
+if [ -n "$TRANSPORT_NETWORK_LOG" ]; then
+  case "$command_line" in
+    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-regexp '^http\\..*\\.(sslcainfo|proxy)$' > "$TRANSPORT_NETWORK_LOG" || : ;;
+  esac
+fi
 if [ -n "$CAT_FILE_CHECK_LOG" ]; then
   case "$command_line" in
     *" cat-file --batch-check=%(objectname) %(objecttype) %(objectsize) "*) printf '%s\n' "$command_line" >> "$CAT_FILE_CHECK_LOG" ;;
@@ -312,6 +317,16 @@ fi
 if [ "$SLOW_UPSTREAM_OBJECT_CHECK" = "1" ]; then
   case "$command_line" in
     *" cat-file --batch-check=%(objectname) %(objecttype) ") exec sleep 3600 ;;
+  esac
+fi
+if [ "$SLOW_BLOB_SIZE_CHECK" = "1" ]; then
+  case "$command_line" in
+    *" cat-file --batch-check=%(objectname) %(objecttype) %(objectsize) "*) exec sleep 3600 ;;
+  esac
+fi
+if [ "$SLOW_BLOB_READ" = "1" ]; then
+  case "$command_line" in
+    *" cat-file --batch "*) exec sleep 3600 ;;
   esac
 fi
 if [ "$SLOW_ROOT_HISTORY" = "1" ]; then
@@ -1573,6 +1588,29 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/only-here.ts');
 		expect(verdict?.relevance).toBe('unmeasured');
 		expect(verdict?.note).toMatch(/upstream history did not complete/);
+	});
+
+	itWithGitWrapper.each([
+		['blob size inspection', 'SLOW_BLOB_SIZE_CHECK'],
+		['blob content inspection', 'SLOW_BLOB_READ']
+	])('times out stalled %s', (_label, slowVariable) => {
+		write(fork, 'shared/rewritten.ts', 'export const changed = true;\n');
+		git(fork, ['commit', '-qam', 'edit diverged path before blob stall']);
+
+		const r = run(fork, ['--json', 'shared/rewritten.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			[slowVariable]: '1',
+			UPSTREAM_REPORT_TEST_HISTORY_TIMEOUT_MS: '50'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'shared/rewritten.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/blob is absent/);
 	});
 
 	itWithGitWrapper('times out a stalled repository root walk', () => {
@@ -3601,6 +3639,22 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		}
 	);
 
+	itWithGitWrapper('copies URL-scoped CA and proxy settings into the private transport', () => {
+		git(fork, ['config', '--local', `http.${upstream}.sslCAInfo`, '/private/company-ca.pem']);
+		git(fork, ['config', '--local', `http.${upstream}.proxy`, 'http://proxy.example']);
+		const wrapper = installGitWrapper(tmp);
+		const networkLog = join(tmp, 'transport-network.log');
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			TRANSPORT_NETWORK_LOG: networkLog
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const config = readFileSync(networkLog, 'utf8');
+		expect(config).toContain('/private/company-ca.pem');
+		expect(config).toContain('http://proxy.example');
+	});
+
 	itWithGitWrapper('does not copy unscoped HTTP authentication to a marker-selected host', () => {
 		git(fork, ['config', '--local', 'http.extraHeader', 'Authorization: Bearer DUMMY_HEADER']);
 		const wrapper = installGitWrapper(tmp);
@@ -3616,7 +3670,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 
 	it('keeps copied authentication values out of child-process arguments', () => {
 		const source = readFileSync(SCRIPT, 'utf8');
-		const start = source.indexOf('function copyTransportAuthentication(');
+		const start = source.indexOf('function copyTransportConfiguration(');
 		const end = source.indexOf('// Enough for a whole repository', start);
 		const copy = source.slice(start, end);
 		expect(copy).toContain('appendTransportConfig(');

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -1,0 +1,5616 @@
+// Integration cover for the git-facing half of the detector.
+//
+// The pure helpers are unit-tested next door, but they were never the risk. The
+// risk is the wiring around them: a base that silently becomes HEAD, a ref that
+// belongs to another repository, a rename that loses its source, a first run
+// that writes config into a shared checkout. Every one of those ends in a
+// confident "nothing to report", which is the one answer that costs something
+// real: a template fix that no other fork ever receives.
+//
+// So these run the actual script against throwaway repositories built here,
+// with a local path as "upstream". Nothing touches the network or this
+// repository. The convention follows scripts/git-context.staged-files.test.ts.
+
+import { spawnSync } from 'node:child_process';
+import {
+	chmodSync,
+	existsSync,
+	mkdtempSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	realpathSync,
+	rmSync,
+	statSync,
+	symlinkSync,
+	utimesSync,
+	writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// POSIX executable wrappers, symlinks and control-byte filenames are gated.
+// The detector and ordinary repository fixtures still run on native Windows.
+const itWithGitWrapper = it.runIf(process.platform !== 'win32');
+const itWithPosixPaths = it.runIf(process.platform !== 'win32');
+
+const SCRIPT = resolve(
+	process.cwd(),
+	'.agents/skills/upstream-report/scripts/upstream-relevance.ts'
+);
+const TEST_FILE = resolve(
+	process.cwd(),
+	'.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts'
+);
+const NULL_GIT_CONFIG = process.platform === 'win32' ? 'NUL' : '/dev/null';
+
+const FIXTURE_GIT_VARS = [
+	'GIT_DIR',
+	'GIT_WORK_TREE',
+	'GIT_INDEX_FILE',
+	'GIT_OBJECT_DIRECTORY',
+	'GIT_COMMON_DIR',
+	'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+	'GIT_CEILING_DIRECTORIES',
+	'GIT_CONFIG',
+	'GIT_CONFIG_GLOBAL',
+	'GIT_CONFIG_SYSTEM',
+	'GIT_CONFIG_NOSYSTEM',
+	'GIT_CONFIG_PARAMETERS',
+	'GIT_NAMESPACE',
+	'GIT_ALLOW_PROTOCOL',
+	'GIT_PROTOCOL_FROM_USER',
+	'GIT_SSH',
+	'GIT_SSH_COMMAND',
+	'GIT_SSH_VARIANT',
+	'GIT_PROXY_COMMAND',
+	'GIT_LITERAL_PATHSPECS',
+	'GIT_NOGLOB_PATHSPECS',
+	'GIT_GLOB_PATHSPECS',
+	'GIT_ICASE_PATHSPECS'
+];
+
+function fixtureGitEnv(extra?: Record<string, string>): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	const scrubbed = new Set(FIXTURE_GIT_VARS.map((key) => key.toUpperCase()));
+	for (const key of Object.keys(env)) {
+		const normalized = key.toUpperCase();
+		if (
+			scrubbed.has(normalized) ||
+			/^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/.test(normalized) ||
+			normalized.startsWith('GIT_TRACE')
+		) {
+			delete env[key];
+		}
+	}
+	env.GIT_GRAFT_FILE = join(tmpdir(), 'upstream-relevance-test-no-grafts');
+	env.GIT_CONFIG_NOSYSTEM = '1';
+	env.GIT_CONFIG_GLOBAL = NULL_GIT_CONFIG;
+	env.GIT_CONFIG_SYSTEM = NULL_GIT_CONFIG;
+	return { ...env, ...extra };
+}
+
+function git(cwd: string, args: string[], env?: Record<string, string>): string {
+	const r = spawnSync('git', args, {
+		cwd,
+		encoding: 'utf-8',
+		env: fixtureGitEnv(env)
+	});
+	if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+	return r.stdout.trim();
+}
+
+function gitOptional(cwd: string, args: string[]): string {
+	return spawnSync('git', args, {
+		cwd,
+		encoding: 'utf-8',
+		env: fixtureGitEnv()
+	}).stdout.trim();
+}
+
+function gitInput(cwd: string, args: string[], input: string | Buffer): string {
+	const r = spawnSync('git', args, { cwd, encoding: 'utf-8', input, env: fixtureGitEnv() });
+	if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+	return r.stdout.trim();
+}
+
+function advertiseOriginMain(cwd: string, ref: string): void {
+	const origin = git(cwd, ['remote', 'get-url', 'origin']);
+	git(cwd, ['push', '-q', '--force', origin, `${ref}:refs/heads/main`]);
+}
+
+function markBase(cwd: string): void {
+	advertiseOriginMain(cwd, 'HEAD');
+	git(cwd, ['fetch', '-q']);
+}
+
+function realGitPath(): string {
+	const r = spawnSync('/bin/sh', ['-c', 'command -v git'], { encoding: 'utf-8' });
+	if (r.status !== 0) throw new Error('git is not on PATH');
+	return r.stdout.trim();
+}
+
+function copyObject(source: string, target: string, type: 'commit' | 'tree', sha: string): void {
+	const read = spawnSync('git', ['cat-file', type, sha], { cwd: source, env: fixtureGitEnv() });
+	if (read.status !== 0) throw new Error(`could not read ${type} ${sha}`);
+	const write = spawnSync('git', ['hash-object', '-w', '-t', type, '--stdin'], {
+		cwd: target,
+		input: read.stdout,
+		env: fixtureGitEnv()
+	});
+	if (write.status !== 0) throw new Error(`could not copy ${type} ${sha}`);
+	expect(write.stdout.toString().trim()).toBe(sha);
+}
+
+function installGitWrapper(root: string): string {
+	const dir = join(root, 'git-wrapper');
+	mkdirSync(dir);
+	const wrapper = join(dir, 'git');
+	writeFileSync(
+		wrapper,
+		`#!/bin/sh
+if [ "$FAKE_FETCH_SUCCESS" = "1" ]; then
+  for arg in "$@"; do
+    [ "$arg" = "fetch" ] && exit 0
+  done
+fi
+command_line=" $* "
+if [ -n "$FAKE_REMOTE_MAIN_SHA" ]; then
+  case "$command_line" in
+    *" ls-remote "*" refs/heads/main "*) printf '%s\trefs/heads/main\n' "$FAKE_REMOTE_MAIN_SHA"; exit 0 ;;
+  esac
+fi
+if [ -n "$CHILD_ARG_SECRET" ]; then
+  for arg in "$@"; do
+    case "$arg" in
+      *"$CHILD_ARG_SECRET"*) : > "$CHILD_ARG_MARKER" ;;
+    esac
+  done
+fi
+if [ -n "$FETCH_COMMAND_LOG" ]; then
+  case "$command_line" in
+    *" fetch "*) printf '%s\n' "$command_line" >> "$FETCH_COMMAND_LOG" ;;
+  esac
+fi
+if [ -n "$TRANSPORT_CREDENTIAL_LOG" ]; then
+  case "$command_line" in
+    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-all credential.helper > "$TRANSPORT_CREDENTIAL_LOG" ;;
+  esac
+fi
+if [ -n "$TRANSPORT_HTTP_LOG" ]; then
+  case "$command_line" in
+    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-regexp '^http\\..*\\.extraheader$' > "$TRANSPORT_HTTP_LOG" || : ;;
+  esac
+fi
+if [ -n "$TRANSPORT_UNSCOPED_HTTP_LOG" ]; then
+  case "$command_line" in
+    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-all http.extraheader > "$TRANSPORT_UNSCOPED_HTTP_LOG" || : ;;
+  esac
+fi
+if [ -n "$CAT_FILE_CHECK_LOG" ]; then
+  case "$command_line" in
+    *" cat-file --batch-check=%(objectname) %(objecttype) %(objectsize) "*) printf '%s\n' "$command_line" >> "$CAT_FILE_CHECK_LOG" ;;
+  esac
+fi
+if [ -n "$FAKE_GIT_VERSION" ]; then
+  case "$command_line" in
+    *" version "*) printf 'git version %s\n' "$FAKE_GIT_VERSION"; exit 0 ;;
+  esac
+fi
+if [ -n "$CASE_SCRUB_MARKER" ]; then
+  if [ -n "\${git_dir+x}" ] || [ -n "\${git_work_tree+x}" ] || [ -n "\${git_ssh_command+x}" ] || [ -n "\${git_config_count+x}" ]; then
+    : > "$CASE_SCRUB_MARKER"
+    exit 97
+  fi
+fi
+if [ -n "$TRANSPORT_REWRITE_REPO" ]; then
+  case "$command_line" in
+    *" config --null --get-regexp ^url\\..*\\.insteadof$ "*)
+      "$REAL_GIT" "$@"
+      rc=$?
+      checks=0
+      [ ! -e "$TRANSPORT_REWRITE_CHECKS" ] || read -r checks < "$TRANSPORT_REWRITE_CHECKS"
+      checks=$((checks + 1))
+      printf '%s\n' "$checks" > "$TRANSPORT_REWRITE_CHECKS"
+      if [ "$checks" -eq 4 ]; then
+        env -u GIT_INDEX_FILE -u GIT_DIR -u GIT_OBJECT_DIRECTORY -u GIT_SHALLOW_FILE -u GIT_CONFIG_GLOBAL -u GIT_CONFIG_SYSTEM "$REAL_GIT" -C "$TRANSPORT_REWRITE_REPO" config "url.$TRANSPORT_REWRITE_TARGET.insteadOf" "$TRANSPORT_REWRITE_URL" || exit $?
+        : > "$TRANSPORT_REWRITE_MARKER.added"
+      fi
+      exit $rc
+      ;;
+    *" ls-remote "*)
+      "$REAL_GIT" "$@"
+      rc=$?
+      reads=0
+      [ ! -e "$TRANSPORT_REWRITE_READS" ] || read -r reads < "$TRANSPORT_REWRITE_READS"
+      reads=$((reads + 1))
+      printf '%s\n' "$reads" > "$TRANSPORT_REWRITE_READS"
+      if [ "$reads" -eq 2 ]; then
+        env -u GIT_INDEX_FILE -u GIT_DIR -u GIT_OBJECT_DIRECTORY -u GIT_SHALLOW_FILE -u GIT_CONFIG_GLOBAL -u GIT_CONFIG_SYSTEM "$REAL_GIT" -C "$TRANSPORT_REWRITE_REPO" config --unset-all "url.$TRANSPORT_REWRITE_TARGET.insteadOf" || exit $?
+        : > "$TRANSPORT_REWRITE_MARKER"
+      fi
+      exit $rc
+      ;;
+  esac
+fi
+if [ -n "$PATH_ENUMERATION_LOG" ]; then
+  case "$command_line" in
+    *" ls-files -z --full-name --cached --others --exclude-standard -- "*|*" ls-tree -z --full-name --name-only -r "*)
+      printf '%s\n' "$command_line" >> "$PATH_ENUMERATION_LOG"
+      ;;
+  esac
+fi
+if [ -n "$SCRATCH_INDEX_PATH_MARKER" ] && [ -n "$GIT_INDEX_FILE" ] && [ ! -e "$SCRATCH_INDEX_PATH_MARKER" ]; then
+  printf '%s\n' "$GIT_INDEX_FILE" > "$SCRATCH_INDEX_PATH_MARKER"
+fi
+if [ -n "$RETARGET_TMPDIR_LINK" ] && [ ! -e "$RETARGET_TMPDIR_MARKER" ]; then
+  case "$command_line" in
+    *" rev-parse --path-format=absolute --git-dir "*)
+      output=$("$REAL_GIT" "$@") || exit $?
+      rm "$RETARGET_TMPDIR_LINK" || exit $?
+      ln -s "$RETARGET_TMPDIR_TARGET" "$RETARGET_TMPDIR_LINK" || exit $?
+      : > "$RETARGET_TMPDIR_MARKER"
+      printf '%s\n' "$output"
+      exit 0
+      ;;
+  esac
+fi
+if [ -n "$REMOVE_SCRATCH_INDEX_MARKER" ] && [ ! -e "$REMOVE_SCRATCH_INDEX_MARKER" ]; then
+  case "$command_line" in
+    *" ls-files -v -z "*)
+      [ -n "$GIT_INDEX_FILE" ] || exit 1
+      rm -f "$GIT_INDEX_FILE" || exit $?
+      : > "$REMOVE_SCRATCH_INDEX_MARKER"
+      ;;
+  esac
+fi
+if [ -n "$STAGE_PRIVATE_INDEX_AFTER_COPY" ] && [ ! -e "$PRIVATE_INDEX_RACE_MARKER" ]; then
+  case "$command_line" in
+    *" config --null --get-all remote.upstream.url "*)
+      output_file="$PRIVATE_INDEX_RACE_MARKER.output"
+      "$REAL_GIT" "$@" > "$output_file" || exit $?
+      [ -n "$GIT_INDEX_FILE" ] || exit 1
+      "$REAL_GIT" update-index --add --cacheinfo "100644,$STAGE_PRIVATE_BLOB_SHA,$STAGE_PRIVATE_INDEX_AFTER_COPY" || exit $?
+      : > "$PRIVATE_INDEX_RACE_MARKER"
+      cat "$output_file"
+      rm -f "$output_file"
+      exit 0
+      ;;
+  esac
+fi
+if [ "$PARTIAL_INVALID_HISTORY" = "1" ]; then
+  case "$command_line" in
+    *" log --format= --raw -z "*) printf '\\303'; exit 1 ;;
+  esac
+fi
+if [ "$SLOW_STATUS" = "1" ]; then
+  case "$command_line" in
+    *" status --porcelain=v2 "*) exec sleep 3600 ;;
+  esac
+fi
+if [ "$SLOW_CHANGED_DIFF" = "1" ]; then
+  case "$command_line" in
+    *" diff --ignore-submodules=none --name-status -M "*) exec sleep 3600 ;;
+  esac
+fi
+if [ "$SLOW_CAPTURED_DIFF" = "1" ]; then
+  case "$command_line" in
+    *" diff --no-index "*) exec sleep 3600 ;;
+  esac
+fi
+if [ "$SLOW_HISTORY_LOG" = "1" ]; then
+  case "$command_line" in
+    *" log --format=%H --follow "*) sleep 2 ;;
+  esac
+fi
+if [ "$SLOW_UPSTREAM_HISTORY_LOG" = "1" ]; then
+  case "$command_line" in
+    *" log --format= --raw "*) sleep 2 ;;
+  esac
+fi
+if [ "$SLOW_UPSTREAM_OBJECT_CHECK" = "1" ]; then
+  case "$command_line" in
+    *" cat-file --batch-check=%(objectname) %(objecttype) ") exec sleep 3600 ;;
+  esac
+fi
+if [ "$SLOW_ROOT_HISTORY" = "1" ]; then
+  case "$command_line" in
+    *" rev-list --max-parents=0 "*) sleep 2 ;;
+  esac
+fi
+if [ "$SLOW_TREE_SCAN" = "1" ]; then
+  case "$command_line" in
+    *" ls-tree -r -z "*) exec sleep 3600 ;;
+  esac
+fi
+if [ -n "$ADD_SHALLOW_AFTER_CHECK_SHA" ] && [ ! -e "$SHALLOW_RACE_MARKER" ]; then
+  case "$command_line" in
+    *" status --porcelain=v2 -z --untracked-files=all --ignore-submodules=none "*)
+      "$REAL_GIT" "$@"
+      rc=$?
+      shallow="$CALLER_SHALLOW_PATH"
+      [ -n "$shallow" ] || shallow=$("$REAL_GIT" rev-parse --git-path shallow) || exit $?
+      printf '%s\n' "$ADD_SHALLOW_AFTER_CHECK_SHA" > "$shallow" || exit $?
+      : > "$SHALLOW_RACE_MARKER"
+      exit $rc
+      ;;
+  esac
+fi
+if [ -n "$ADD_SHALLOW_ABA_SHA" ]; then
+  if [ ! -e "$SHALLOW_ABA_MARKER.added" ]; then
+    case "$command_line" in
+      *" status --porcelain=v2 -z --untracked-files=all --ignore-submodules=none "*)
+        "$REAL_GIT" "$@"
+        rc=$?
+        printf '%s\n' "$ADD_SHALLOW_ABA_SHA" > "$CALLER_SHALLOW_PATH" || exit $?
+        : > "$SHALLOW_ABA_MARKER.added"
+        exit $rc
+        ;;
+    esac
+  elif [ ! -e "$SHALLOW_ABA_MARKER" ]; then
+    case "$command_line" in
+      *" rev-list --max-parents=0 "*)
+        output=$("$REAL_GIT" "$@") || exit $?
+        rm -f "$CALLER_SHALLOW_PATH" || exit $?
+        : > "$SHALLOW_ABA_MARKER"
+        printf '%s\n' "$output"
+        exit 0
+        ;;
+    esac
+  fi
+fi
+if [ -n "$REJECT_REV_LIST_Z_MARKER" ]; then
+  case "$command_line" in
+    *" rev-list --objects -z "*)
+      : > "$REJECT_REV_LIST_Z_MARKER"
+      exit 129
+      ;;
+  esac
+fi
+if [ -n "$FAIL_CAPTURED_DIFF_MARKER" ] && [ ! -e "$FAIL_CAPTURED_DIFF_MARKER" ]; then
+  case "$command_line" in
+    *" diff --no-index "*)
+      printf '%s\n' 'diff --git a/a b/b' '--- a/a' '+++ b/b' '@@ -1 +1 @@' '-old' '+new'
+      : > "$FAIL_CAPTURED_DIFF_MARKER"
+      exit 2
+      ;;
+  esac
+fi
+if [ -n "$UPSTREAM_AFTER_ORIGIN_SHA" ]; then
+  case "$command_line" in
+    *" ls-remote "*" refs/heads/main "*)
+      if [ ! -e "$UPSTREAM_AFTER_ORIGIN_SEEN" ]; then
+        : > "$UPSTREAM_AFTER_ORIGIN_SEEN"
+      elif [ ! -e "$UPSTREAM_AFTER_ORIGIN_MARKER" ]; then
+        output=$("$REAL_GIT" "$@") || exit $?
+        env -u GIT_INDEX_FILE -u GIT_DIR -u GIT_OBJECT_DIRECTORY -u GIT_SHALLOW_FILE -u GIT_CONFIG_GLOBAL -u GIT_CONFIG_SYSTEM "$REAL_GIT" -C "$UPSTREAM_AFTER_ORIGIN_REPO" update-ref refs/remotes/upstream/main "$UPSTREAM_AFTER_ORIGIN_SHA" || exit $?
+        : > "$UPSTREAM_AFTER_ORIGIN_MARKER"
+        printf '%s\n' "$output"
+        exit 0
+      fi
+      ;;
+  esac
+fi
+if [ -n "$FETCH_REF_SWAP_SHA" ] && [ ! -e "$FETCH_REF_SWAP_MARKER" ]; then
+  case "$command_line" in
+    *" fetch "*)
+      "$REAL_GIT" "$@"
+      rc=$?
+      env -u GIT_INDEX_FILE -u GIT_DIR -u GIT_OBJECT_DIRECTORY -u GIT_SHALLOW_FILE -u GIT_CONFIG_GLOBAL -u GIT_CONFIG_SYSTEM "$REAL_GIT" -C "$FETCH_REF_SWAP_REPO" update-ref refs/remotes/upstream/main "$FETCH_REF_SWAP_SHA" || exit $?
+      : > "$FETCH_REF_SWAP_MARKER"
+      exit $rc
+      ;;
+  esac
+fi
+if [ -n "$FETCH_URL_SWAP_REMOTE" ] && [ ! -e "$FETCH_URL_SWAP_MARKER" ]; then
+  case "$command_line" in
+    *" fetch "*)
+      "$REAL_GIT" "$@"
+      rc=$?
+      env -u GIT_INDEX_FILE -u GIT_DIR -u GIT_OBJECT_DIRECTORY -u GIT_SHALLOW_FILE -u GIT_CONFIG_GLOBAL -u GIT_CONFIG_SYSTEM "$REAL_GIT" -C "$FETCH_URL_SWAP_REPO" remote set-url upstream "$FETCH_URL_SWAP_REMOTE" || exit $?
+      : > "$FETCH_URL_SWAP_MARKER"
+      exit $rc
+      ;;
+  esac
+fi
+if [ -n "$ADD_REMOTE_SWAP_REMOTE" ] && [ ! -e "$ADD_REMOTE_SWAP_MARKER" ]; then
+  case "$command_line" in
+    *" remote add upstream "*)
+      "$REAL_GIT" "$@"
+      rc=$?
+      "$REAL_GIT" remote set-url upstream "$ADD_REMOTE_SWAP_REMOTE" || exit $?
+      : > "$ADD_REMOTE_SWAP_MARKER"
+      exit $rc
+      ;;
+  esac
+fi
+if [ -n "$OVERLAP_ABA_PATH" ] && [ ! -e "$OVERLAP_ABA_MARKER" ]; then
+  case "$command_line" in
+    *" diff --ignore-submodules=none --unified=3 "*|*" diff --no-index --unified=3 "*)
+      saved="$OVERLAP_ABA_MARKER.saved"
+      cp "$OVERLAP_ABA_PATH" "$saved" || exit $?
+      cp "$OVERLAP_ABA_REPLACEMENT" "$OVERLAP_ABA_PATH" || exit $?
+      output_file="$OVERLAP_ABA_MARKER.output"
+      "$REAL_GIT" "$@" > "$output_file"
+      rc=$?
+      cp "$saved" "$OVERLAP_ABA_PATH" || exit $?
+      rm -f "$saved"
+      : > "$OVERLAP_ABA_MARKER"
+      cat "$output_file"
+      rm -f "$output_file"
+      exit $rc
+      ;;
+  esac
+fi
+if [ -n "$ORIGIN_RACE_SHA" ] && [ ! -e "$ORIGIN_RACE_MARKER" ]; then
+  case "$command_line" in
+    *" cat-file --batch "*)
+      "$REAL_GIT" --git-dir="$ORIGIN_RACE_REMOTE" update-ref refs/heads/main "$ORIGIN_RACE_SHA" || exit $?
+      env -u GIT_INDEX_FILE "$REAL_GIT" update-ref -m "fetch origin: forced-update" refs/remotes/origin/main "$ORIGIN_RACE_SHA" || exit $?
+      : > "$ORIGIN_RACE_MARKER"
+      ;;
+  esac
+fi
+if [ "$SLOW_LS_REMOTE" = "1" ]; then
+  case "$command_line" in
+    *" ls-remote "*) sleep 2 ;;
+  esac
+fi
+if [ -n "$STAGE_AFTER_INDEX_COPY" ] && [ ! -e "$INDEX_RACE_MARKER" ]; then
+  case "$command_line" in
+    *" config --null --get-all remote.upstream.url "*)
+      output_file="$INDEX_RACE_MARKER.output"
+      "$REAL_GIT" "$@" > "$output_file" || exit $?
+      env -u GIT_INDEX_FILE "$REAL_GIT" update-index --add --cacheinfo "100644,$STAGE_BLOB_SHA,$STAGE_AFTER_INDEX_COPY" || exit $?
+      : > "$INDEX_RACE_MARKER"
+      cat "$output_file"
+      rm -f "$output_file"
+      exit 0
+      ;;
+  esac
+fi
+if [ -n "$REPLACE_AFTER_CONTENT_PATH" ] && [ ! -e "$CONTENT_RACE_MARKER" ]; then
+  case "$command_line" in
+    *" cat-file --batch "*)
+      output_file="$CONTENT_RACE_MARKER.output"
+      "$REAL_GIT" "$@" > "$output_file" || exit $?
+      cp "$REPLACEMENT_CONTENT" "$REPLACE_AFTER_CONTENT_PATH" || exit $?
+      : > "$CONTENT_RACE_MARKER"
+      cat "$output_file"
+      rm -f "$output_file"
+      exit 0
+      ;;
+  esac
+fi
+if [ "$FETCH_AFTER_REFLOG" = "1" ] && [ ! -e "$FETCH_MARKER" ]; then
+  case "$command_line" in
+    *" reflog show "*" refs/remotes/upstream/main "*)
+      output_file="$FETCH_MARKER.output"
+      "$REAL_GIT" "$@" > "$output_file" || exit $?
+      "$REAL_GIT" fetch -q upstream || exit $?
+      : > "$FETCH_MARKER"
+      cat "$output_file"
+      rm -f "$output_file"
+      exit 0
+      ;;
+  esac
+fi
+if [ -n "$FETCH_AFTER_TREE_SHA" ] && [ ! -e "$FETCH_MARKER" ]; then
+  case "$command_line" in
+    *" ls-tree -r -z $FETCH_AFTER_TREE_SHA "*)
+      output_file="$FETCH_MARKER.output"
+      "$REAL_GIT" "$@" > "$output_file" || exit $?
+      "$REAL_GIT" fetch -q upstream || exit $?
+      : > "$FETCH_MARKER"
+      cat "$output_file"
+      rm -f "$output_file"
+      exit 0
+      ;;
+  esac
+fi
+if [ -n "$REMOVE_AFTER_UNTRACKED" ] && [ ! -e "$REMOVE_MARKER" ]; then
+  case "$command_line" in
+    *" ls-files --others "*)
+      output_file="$REMOVE_MARKER.output"
+      "$REAL_GIT" "$@" > "$output_file" || exit $?
+      rm -f "$REMOVE_AFTER_UNTRACKED" || exit $?
+      : > "$REMOVE_MARKER"
+      cat "$output_file"
+      rm -f "$output_file"
+      exit 0
+      ;;
+  esac
+fi
+if [ -n "$ADD_AFTER_UNTRACKED" ] && [ ! -e "$LOCAL_CHANGE_MARKER" ]; then
+  case "$command_line" in
+    *" ls-files --others "*)
+      output_file="$LOCAL_CHANGE_MARKER.output"
+      "$REAL_GIT" "$@" > "$output_file" || exit $?
+      printf 'lateFile();\n' > "$ADD_AFTER_UNTRACKED" || exit $?
+      cp "$REPLACEMENT_MARKER" "$UPSTREAM_MARKER" || exit $?
+      : > "$LOCAL_CHANGE_MARKER"
+      cat "$output_file"
+      rm -f "$output_file"
+      exit 0
+      ;;
+  esac
+fi
+if [ -n "$SWAP_REMOTE" ] && [ ! -e "$SWAP_MARKER" ]; then
+  case "$command_line" in
+    *" config --null --get-all remote.upstream.url "*)
+      output_file="$SWAP_MARKER.output"
+      "$REAL_GIT" "$@" > "$output_file" || exit $?
+      "$REAL_GIT" remote set-url upstream "$SWAP_REMOTE" || exit $?
+      "$REAL_GIT" fetch -q upstream || exit $?
+      : > "$SWAP_MARKER"
+      cat "$output_file"
+      rm -f "$output_file"
+      exit 0
+      ;;
+  esac
+fi
+if [ -n "$ABA_DECOY_REMOTE" ] && [ ! -e "$ABA_REMOTE_MARKER" ]; then
+  case "$command_line" in
+    *" fetch "*)
+      env -u GIT_DIR -u GIT_OBJECT_DIRECTORY -u GIT_SHALLOW_FILE -u GIT_CONFIG_GLOBAL -u GIT_CONFIG_SYSTEM "$REAL_GIT" -C "$ABA_REPO" remote set-url upstream "$ABA_DECOY_REMOTE" || exit $?
+      "$REAL_GIT" "$@"
+      rc=$?
+      env -u GIT_DIR -u GIT_OBJECT_DIRECTORY -u GIT_SHALLOW_FILE -u GIT_CONFIG_GLOBAL -u GIT_CONFIG_SYSTEM "$REAL_GIT" -C "$ABA_REPO" remote set-url upstream "$ABA_EXPECTED_REMOTE" || exit $?
+      : > "$ABA_REMOTE_MARKER"
+      exit $rc
+      ;;
+  esac
+fi
+if [ -n "$ABA_WORKTREE_PATH" ] && [ ! -e "$ABA_WORKTREE_MARKER" ]; then
+  case "$command_line" in
+    *" diff --ignore-submodules=none --name-status -M -z $ABA_HEAD "*)
+      saved="$ABA_WORKTREE_MARKER.saved"
+      cp "$ABA_WORKTREE_PATH" "$saved" || exit $?
+      cp "$ABA_HEAD_CONTENT" "$ABA_WORKTREE_PATH" || exit $?
+      output_file="$ABA_WORKTREE_MARKER.output"
+      "$REAL_GIT" "$@" > "$output_file"
+      rc=$?
+      cp "$saved" "$ABA_WORKTREE_PATH" || exit $?
+      rm -f "$saved"
+      : > "$ABA_WORKTREE_MARKER"
+      cat "$output_file"
+      rm -f "$output_file"
+      exit $rc
+      ;;
+  esac
+fi
+if [ -n "$ABA_CAPTURE_PATH" ]; then
+  if [ ! -e "$ABA_CAPTURE_MARKER.swapped" ]; then
+    case "$command_line" in
+      *" cat-file --batch "*)
+        output_file="$ABA_CAPTURE_MARKER.output"
+        "$REAL_GIT" "$@" > "$output_file"
+        rc=$?
+        cp "$ABA_CAPTURE_REPLACEMENT" "$ABA_CAPTURE_PATH" || exit $?
+        : > "$ABA_CAPTURE_MARKER.swapped"
+        cat "$output_file"
+        rm -f "$output_file"
+        exit $rc
+        ;;
+    esac
+  elif [ ! -e "$ABA_CAPTURE_MARKER" ]; then
+    case "$command_line" in
+      *" status --porcelain=v2 -z --untracked-files=all --ignore-submodules=none "*)
+        cp "$ABA_CAPTURE_ORIGINAL" "$ABA_CAPTURE_PATH" || exit $?
+        : > "$ABA_CAPTURE_MARKER"
+        ;;
+    esac
+  fi
+fi
+if [ -n "$INDEX_ABA_PATH" ]; then
+  if [ ! -e "$INDEX_ABA_MARKER.swapped" ]; then
+    case "$command_line" in
+      *" rev-parse --show-object-format "*)
+        output=$("$REAL_GIT" "$@") || exit $?
+        cp "$INDEX_ABA_ORDINARY" "$INDEX_ABA_PATH" || exit $?
+        : > "$INDEX_ABA_MARKER.swapped"
+        printf '%s\n' "$output"
+        exit 0
+        ;;
+    esac
+  elif [ ! -e "$INDEX_ABA_MARKER" ]; then
+    case "$command_line" in
+      *" status --porcelain=v2 -z --untracked-files=all --ignore-submodules=none "*)
+        cp "$INDEX_ABA_SPLIT" "$INDEX_ABA_PATH" || exit $?
+        : > "$INDEX_ABA_MARKER"
+        ;;
+    esac
+  fi
+fi
+exec "$REAL_GIT" "$@"
+`
+	);
+	chmodSync(wrapper, 0o755);
+	return dir;
+}
+
+/** Index copies left by one detector process, identified by its owner file. */
+function leakedIndexCopies(owner: number): string[] {
+	return readdirSync(tmpdir())
+		.filter((name) => name.startsWith('upstream-relevance-index-'))
+		.filter((name) => {
+			try {
+				return Number(readFileSync(join(tmpdir(), name, 'owner'), 'utf8')) === owner;
+			} catch {
+				return false;
+			}
+		})
+		.sort();
+}
+
+function run(
+	cwd: string,
+	args: string[],
+	env?: Record<string, string>
+): { pid: number; status: number; stdout: string; stderr: string } {
+	const r = spawnSync('bun', [SCRIPT, ...args], {
+		cwd,
+		encoding: 'utf-8',
+		env: fixtureGitEnv(env),
+		timeout: 30_000,
+		killSignal: 'SIGKILL'
+	});
+	return { pid: r.pid, status: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function verdicts(cwd: string, args: string[] = []): Record<string, string> {
+	const effective = args.includes('--fetch') ? args : ['--fetch', ...args];
+	const r = run(cwd, ['--json', ...effective]);
+	expect(r.status, `script failed: ${r.stderr}`).toBe(0);
+	const parsed = JSON.parse(r.stdout) as { verdicts: Array<{ path: string; relevance: string }> };
+	return Object.fromEntries(parsed.verdicts.map((v) => [v.path, v.relevance]));
+}
+
+function verdictsWithScore(
+	cwd: string,
+	args: string[] = []
+): Record<string, { relevance: string; overlap?: number }> {
+	const effective = args.includes('--fetch') ? args : ['--fetch', ...args];
+	const r = run(cwd, ['--json', ...effective]);
+	expect(r.status, `script failed: ${r.stderr}`).toBe(0);
+	const parsed = JSON.parse(r.stdout) as {
+		verdicts: Array<{ path: string; relevance: string; overlap?: number }>;
+	};
+	return Object.fromEntries(parsed.verdicts.map((v) => [v.path, v]));
+}
+
+function write(root: string, rel: string, content: string): void {
+	const full = join(root, rel);
+	mkdirSync(join(full, '..'), { recursive: true });
+	writeFileSync(full, content);
+}
+
+function init(root: string, objectFormat: 'sha1' | 'sha256' = 'sha1'): void {
+	git(root, ['init', '-q', '-b', 'main', `--object-format=${objectFormat}`]);
+	git(root, ['config', 'user.email', 'test@example.com']);
+	git(root, ['config', 'user.name', 'Test']);
+	git(root, ['config', 'commit.gpgsign', 'false']);
+}
+
+describe('upstream-relevance (integration)', () => {
+	let tmp: string;
+	let upstream: string;
+	let fork: string;
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), 'upstream-relevance-'));
+
+		// A miniature template.
+		upstream = join(tmp, 'template');
+		mkdirSync(upstream);
+		init(upstream);
+		write(upstream, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 2;\n');
+		write(
+			upstream,
+			'shared/rewritten.ts',
+			'export const template1 = 1;\nexport const template2 = 2;\nexport const template3 = 3;\nexport const template4 = 4;\nexport const template5 = 5;\nexport const template6 = 6;\nexport const template7 = 7;\nexport const template8 = 8;\n'
+		);
+		// A NUL byte is what makes git call it binary and emit no hunks at all.
+		write(upstream, 'shared/binary.bin', 'template\u0000payload');
+		write(upstream, 'shared/encöded.ts', 'export const t = 1;\nexport const u = 2;\n');
+		// Only the template has this spelling; the fork carries the lowercase one,
+		// which the case-fold test relies on. The two cannot coexist in one
+		// working tree on a case-insensitive filesystem, so they live one per repo.
+		write(upstream, 'shared/Config.ts', 'export const config = 1;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'template']);
+		const upstreamBase = git(upstream, ['rev-parse', 'HEAD']);
+
+		// A fork of it: same paths, plus its own, with one file already rewritten.
+		fork = join(tmp, 'fork');
+		mkdirSync(fork);
+		init(fork);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 2;\n');
+		// Template section on top, a block this fork appended underneath. Editing
+		// deep inside the fork block must not read as an edit to template code.
+		write(
+			fork,
+			'shared/rewritten.ts',
+			'export const template1 = 1;\nexport const template2 = 2;\nexport const template3 = 3;\nexport const template4 = 4;\nexport const template5 = 5;\nexport const template6 = 6;\nexport const template7 = 7;\nexport const template8 = 8;\nexport const forkOnly1 = 1;\nexport const forkOnly2 = 2;\nexport const forkOnly3 = 3;\nexport const forkOnly4 = 4;\nexport const forkOnly5 = 5;\nexport const forkOnly6 = 6;\nexport const forkOnly7 = 7;\nexport const forkOnly8 = 8;\n'
+		);
+		// Already diverged from the template at the base, so editing it exercises
+		// the binary path instead of the pristine one.
+		write(fork, 'shared/binary.bin', 'fork\u0000payload');
+		write(fork, 'shared/encöded.ts', 'export const t = 1;\nexport const u = 2;\n');
+		write(fork, 'product/only-here.ts', 'export const product = true;\n');
+		write(
+			fork,
+			'.upstream-sync.json',
+			JSON.stringify({ upstreamUrl: upstream, forkPoint: upstreamBase, lastSynced: upstreamBase })
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'fork base']);
+		// `origin` is the fork's own remote and must differ from the template, or
+		// the script correctly refuses to run at all.
+		const origin = join(tmp, 'fork-origin.git');
+		mkdirSync(origin);
+		git(origin, ['init', '--bare', '-q']);
+		git(fork, ['remote', 'add', 'origin', origin]);
+		git(fork, ['remote', 'add', 'upstream', upstream]);
+		git(fork, ['fetch', '-q', 'upstream']);
+		// `origin/main` must exist for the default base; point it at the fork's
+		// own base commit the way a real remote trunk would be.
+		markBase(fork);
+	});
+
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	it('isolates fixture Git commands from user and system config', () => {
+		const env = fixtureGitEnv();
+		expect(env.GIT_CONFIG_NOSYSTEM).toBe('1');
+		expect(env.GIT_CONFIG_GLOBAL).toBe(NULL_GIT_CONFIG);
+		expect(env.GIT_CONFIG_SYSTEM).toBe(NULL_GIT_CONFIG);
+	});
+
+	it('keeps fixture Git commands inside their temporary repository', () => {
+		const safe = join(tmp, 'safe-fixture');
+		mkdirSync(safe);
+		const oldDir = process.env.GIT_DIR;
+		const oldTree = process.env.GIT_WORK_TREE;
+		process.env.GIT_DIR = join(upstream, '.git');
+		process.env.GIT_WORK_TREE = upstream;
+		try {
+			init(safe);
+			write(safe, 'safe.ts', 'export const safe = true;\n');
+			git(safe, ['add', '-A']);
+			git(safe, ['commit', '-qm', 'safe fixture']);
+		} finally {
+			if (oldDir === undefined) delete process.env.GIT_DIR;
+			else process.env.GIT_DIR = oldDir;
+			if (oldTree === undefined) delete process.env.GIT_WORK_TREE;
+			else process.env.GIT_WORK_TREE = oldTree;
+		}
+
+		expect(existsSync(join(safe, '.git'))).toBe(true);
+		expect(git(safe, ['show', 'HEAD:safe.ts'])).toContain('safe = true');
+	});
+
+	it('scrubs command-scope config from fixture Git calls', () => {
+		const keys = ['GIT_CONFIG_COUNT', 'GIT_CONFIG_KEY_0', 'GIT_CONFIG_VALUE_0', 'GIT_TRACE2_EVENT'];
+		const previous = new Map(keys.map((key) => [key, process.env[key]]));
+		process.env.GIT_CONFIG_COUNT = '1';
+		process.env.GIT_CONFIG_KEY_0 = 'commit.gpgsign';
+		process.env.GIT_CONFIG_VALUE_0 = 'true';
+		process.env.GIT_TRACE2_EVENT = join(tmp, 'fixture-trace.json');
+		try {
+			const env = fixtureGitEnv();
+			for (const key of keys) expect(env[key]).toBeUndefined();
+		} finally {
+			for (const [key, value] of previous) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+		}
+	});
+
+	it('scrubs a namespace that redirects local remote advertisements', () => {
+		const decoyUpstream = git(upstream, ['rev-parse', 'HEAD']);
+		write(upstream, 'shared/namespaced.ts', 'export const namespaceSafe = 1;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add ordinary upstream namespace path']);
+		git(upstream, ['update-ref', 'refs/namespaces/decoy/refs/heads/main', decoyUpstream]);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, 'shared/namespaced.ts', 'export const namespaceSafe = 1;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'copy namespace path']);
+		markBase(fork);
+		write(fork, 'shared/namespaced.ts', 'export const namespaceSafe = 2;\n');
+		git(fork, ['commit', '-qam', 'edit namespace path']);
+
+		const origin = git(fork, ['remote', 'get-url', 'origin']);
+		git(origin, [
+			'update-ref',
+			'refs/namespaces/decoy/refs/heads/main',
+			git(fork, ['rev-parse', 'refs/remotes/origin/main'])
+		]);
+		const r = run(fork, ['--fetch', '--json', 'shared/namespaced.ts'], {
+			GIT_NAMESPACE: 'decoy'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('pristine');
+	});
+
+	itWithGitWrapper('scrubs Git environment names case-insensitively', () => {
+		const marker = join(tmp, 'case-insensitive-env-leak');
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			CASE_SCRUB_MARKER: marker,
+			git_dir: join(tmp, 'wrong-git-dir'),
+			git_work_tree: join(tmp, 'wrong-worktree'),
+			git_ssh_command: join(tmp, 'wrong-ssh'),
+			git_config_count: '1',
+			git_config_key_0: 'core.fileMode',
+			git_config_value_0: 'false'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(marker)).toBe(false);
+	});
+
+	itWithPosixPaths('scrubs inherited protocol permission before reading the marker URL', () => {
+		const executed = join(tmp, 'ext-protocol-executed');
+		const helper = join(tmp, 'ext-protocol-helper');
+		writeFileSync(helper, `#!/bin/sh\n: > "${executed}"\nexit 1\n`);
+		chmodSync(helper, 0o755);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as {
+			forkPoint: string;
+			lastSynced: string;
+		};
+		const url = `ext::${helper}`;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+		git(fork, ['commit', '-qam', 'set ext parent']);
+		git(fork, ['remote', 'set-url', 'upstream', url]);
+
+		const r = run(fork, ['--fetch', '--json'], {
+			GIT_ALLOW_PROTOCOL: 'ext:file',
+			GIT_PROTOCOL_FROM_USER: '1'
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(existsSync(executed)).toBe(false);
+	});
+
+	it('refuses a relative temporary directory before writing or sweeping', () => {
+		const victim = join(fork, 'upstream-relevance-index-victim');
+		mkdirSync(victim);
+		writeFileSync(join(victim, 'keep'), 'unrelated');
+		const old = new Date(Date.now() - 3 * 60 * 60 * 1000);
+		utimesSync(victim, old, old);
+
+		const r = run(fork, ['--json'], { TMPDIR: '.' });
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/temporary directory must be an absolute path/);
+		expect(existsSync(victim)).toBe(true);
+		expect(
+			readdirSync(fork).filter((name) => name.startsWith('upstream-relevance-index-'))
+		).toEqual(['upstream-relevance-index-victim']);
+	});
+
+	it('refuses an absolute temporary directory inside the repository', () => {
+		const inside = join(fork, 'detector-temp');
+		mkdirSync(inside);
+
+		const r = run(fork, ['--json'], { TMPDIR: inside });
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/temporary directory resolves inside this repository/);
+		expect(readdirSync(inside)).toEqual([]);
+	});
+
+	it('refuses shared repository storage as a linked-worktree temp directory', () => {
+		const linked = join(tmp, 'linked-worktree');
+		git(fork, ['worktree', 'add', '-q', '-b', 'linked-test', linked, 'HEAD']);
+
+		const r = run(linked, ['--json'], { TMPDIR: join(fork, '.git') });
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/shared Git storage/);
+	});
+
+	it('refuses a temporary directory inside a sibling linked worktree', () => {
+		const sibling = join(tmp, 'sibling-worktree');
+		git(fork, ['worktree', 'add', '-q', '-b', 'sibling-test', sibling, 'HEAD']);
+		const insideSibling = join(sibling, 'detector-temp');
+		mkdirSync(insideSibling);
+
+		const r = run(fork, ['--json'], { TMPDIR: insideSibling });
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/temporary directory resolves inside this repository/);
+		expect(readdirSync(insideSibling)).toEqual([]);
+	});
+
+	it('refuses an unknown primary checkout from a separate Git directory', () => {
+		const primary = join(tmp, 'separate-primary');
+		const storage = join(tmp, 'separate-storage');
+		const linked = join(tmp, 'separate-linked');
+		git(tmp, ['clone', '-q', `--separate-git-dir=${storage}`, fork, primary]);
+		git(primary, ['worktree', 'add', '-q', '-b', 'separate-linked', linked, 'HEAD']);
+		const insidePrimary = join(primary, 'detector-temp');
+		mkdirSync(insidePrimary);
+
+		const r = run(linked, ['--json'], { TMPDIR: insidePrimary });
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/cannot identify the primary checkout/);
+		expect(readdirSync(insidePrimary)).toEqual([]);
+	});
+
+	itWithPosixPaths('uses the validated temp root after its symlink is retargeted', () => {
+		const safeTemp = join(tmp, 'safe-temp');
+		const repositoryTemp = join(fork, 'retargeted-temp');
+		const tempLink = join(tmp, 'temp-link');
+		const retargeted = join(tmp, 'temp-retargeted');
+		const scratchPath = join(tmp, 'scratch-index-path');
+		mkdirSync(safeTemp);
+		mkdirSync(repositoryTemp);
+		symlinkSync(safeTemp, tempLink);
+
+		const r = run(fork, ['--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			TMPDIR: tempLink,
+			RETARGET_TMPDIR_LINK: tempLink,
+			RETARGET_TMPDIR_TARGET: repositoryTemp,
+			RETARGET_TMPDIR_MARKER: retargeted,
+			SCRATCH_INDEX_PATH_MARKER: scratchPath
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(retargeted)).toBe(true);
+		expect(readFileSync(scratchPath, 'utf8').startsWith(`${realpathSync(safeTemp)}/`)).toBe(true);
+		expect(readdirSync(repositoryTemp)).toEqual([]);
+	});
+
+	it('refuses a missing Git index', () => {
+		rmSync(join(fork, '.git', 'index'));
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/requires an existing Git index/);
+	});
+
+	it('keeps core.splitIndex from activating on the scratch index', () => {
+		git(fork, ['config', 'core.splitIndex', 'true']);
+		const changedStat = new Date(Date.now() + 2_000);
+		utimesSync(join(fork, 'shared/pristine.ts'), changedStat, changedStat);
+		const before = readdirSync(join(fork, '.git')).filter((name) =>
+			name.startsWith('sharedindex.')
+		);
+
+		const r = run(fork, ['--fetch', '--json']);
+
+		expect(r.status, r.stderr).toBe(0);
+		expect(
+			readdirSync(join(fork, '.git')).filter((name) => name.startsWith('sharedindex.'))
+		).toEqual(before);
+	});
+
+	it('classifies an edit to untouched template code as pristine', () => {
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'fix']);
+		expect(verdicts(fork)['shared/pristine.ts']).toBe('pristine');
+	});
+
+	it('reports a template file copied to a new path and customised here', () => {
+		// The silent negative that three earlier rounds left standing. Blob
+		// identity only recognises a copy nobody edited, and the name rung only a
+		// relocation that kept its name; a template file copied to a
+		// product-specific path and customised in the same commit matches neither
+		// and was hidden entirely. Measured on this repository, an email template
+		// was a 59% copy of the template's own and classified fork-only, so an
+		// accessibility fix made in it would never have been offered upstream.
+		write(
+			fork,
+			'product/derived.ts',
+			'export const template1 = 1;\nexport const template2 = 2;\nexport const template3 = 3;\nexport const template4 = 4;\nexport const template5 = 5;\nexport const template6 = 6;\nexport const template7 = 7;\nexport const template8 = 8;\nexport const forkExtra1 = 1;\nexport const forkExtra2 = 2;\n'
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'copy and customise']);
+
+		const v = verdicts(fork);
+		expect(v['product/derived.ts']).toBe('unmeasured');
+		const r = run(fork, []);
+		expect(r.stdout).toContain('shared/rewritten.ts');
+	});
+
+	it('keeps a wholly new file visible for design judgment', () => {
+		// The rung has to stay a measurement. A threshold low enough to flag every
+		// file sharing a shape would restore by noise exactly what the score
+		// avoids by design: a report nobody reads.
+		write(
+			fork,
+			'product/unrelated.ts',
+			'export function unrelated(): void {\n\tqueueDaphneJob();\n}\n'
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add unrelated']);
+
+		expect(verdicts(fork)['product/unrelated.ts']).toBe('unmeasured');
+	});
+
+	it('keeps base ancestry after the working tree rewrites the copy', () => {
+		const shared = Array.from({ length: 10 }, (_, i) => `export const ancestor${i} = ${i};`);
+		write(upstream, 'shared/ancestry-source.ts', `${shared.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add ancestry source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(
+			fork,
+			'product/derived-after-edit.ts',
+			`${[...shared.slice(0, 6), 'forkOne();', 'forkTwo();', 'forkThree();', 'forkFour();'].join('\n')}\n`
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add customised copy']);
+		markBase(fork);
+
+		write(fork, 'product/derived-after-edit.ts', 'completelyDifferent();\nfromTheCurrentEdit();\n');
+		git(fork, ['commit', '-qam', 'rewrite after base']);
+		expect(verdicts(fork)['product/derived-after-edit.ts']).toBe('unmeasured');
+	});
+
+	it('keeps exact upstream ancestry from an intermediate feature commit', () => {
+		const source = Array.from({ length: 6 }, (_, i) => `export const inherited${i} = ${i};`);
+		write(upstream, 'shared/intermediate-source.ts', `${source.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add intermediate source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(fork, 'product/intermediate-copy.ts', 'originalForkOnly();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add fork-owned base']);
+		markBase(fork);
+		write(fork, 'product/intermediate-copy.ts', `${source.join('\n')}\n`);
+		git(fork, ['commit', '-qam', 'copy exact source']);
+		write(fork, 'product/intermediate-copy.ts', 'completelyDifferent();\nfinalRewrite();\n');
+		git(fork, ['commit', '-qam', 'rewrite copied source']);
+
+		for (const env of [undefined, { GIT_LITERAL_PATHSPECS: '1' }]) {
+			const r = run(fork, ['--fetch', '--json'], env);
+			expect(r.status, `script failed: ${r.stderr}`).toBe(0);
+			const parsed = JSON.parse(r.stdout) as {
+				verdicts: Array<{ path: string; relevance: string }>;
+			};
+			expect(
+				parsed.verdicts.find((v) => v.path === 'product/intermediate-copy.ts')?.relevance
+			).toBe('unmeasured');
+		}
+	});
+
+	it('keeps exact upstream ancestry from before the selected base', () => {
+		const source = Array.from({ length: 6 }, (_, i) => `export const oldInherited${i} = ${i};`);
+		write(upstream, 'shared/old-source.ts', `${source.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add old source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(fork, 'product/historical-copy.ts', `${source.join('\n')}\n`);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'copy exact source']);
+		write(fork, 'product/historical-copy.ts', 'forkRewriteOne();\nforkRewriteTwo();\n');
+		git(fork, ['commit', '-qam', 'rewrite before base']);
+		markBase(fork);
+		write(fork, 'product/historical-copy.ts', 'forkRewriteOne();\nfeatureEdit();\n');
+		git(fork, ['commit', '-qam', 'edit rewritten copy']);
+
+		expect(verdicts(fork)['product/historical-copy.ts']).toBe('unmeasured');
+	});
+
+	it('follows exact ancestry across a historical rename', () => {
+		const source = Array.from({ length: 8 }, (_, i) => `export const renamedInherited${i} = ${i};`);
+		write(upstream, 'shared/rename-source.ts', `${source.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add rename source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(fork, 'product/legacy-copy.ts', `${source.join('\n')}\n`);
+		write(
+			fork,
+			'product/decoy-before.ts',
+			`${source.map((_, i) => `decoyBefore${i}();`).join('\n')}\n`
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'copy exact rename source']);
+		git(fork, ['config', 'diff.renameLimit', '1']);
+		git(fork, ['mv', 'product/legacy-copy.ts', 'product/renamed-copy.ts']);
+		git(fork, ['mv', 'product/decoy-before.ts', 'product/decoy-after.ts']);
+		write(
+			fork,
+			'product/renamed-copy.ts',
+			`${[...source.slice(0, 3), 'forkFour();', 'forkFive();', 'forkSix();', 'forkSeven();', 'forkEight();'].join('\n')}\n`
+		);
+		write(
+			fork,
+			'product/decoy-after.ts',
+			`${['decoyBefore0();', 'decoyBefore1();', 'decoyAfter2();', 'decoyAfter3();'].join('\n')}\n`
+		);
+		git(fork, ['commit', '-qam', 'rename and customize copy']);
+		markBase(fork);
+		write(
+			fork,
+			'product/renamed-copy.ts',
+			`${[...source.slice(0, 2), 'featureEdit();', 'forkFour();', 'forkFive();', 'forkSix();', 'forkSeven();', 'forkEight();'].join('\n')}\n`
+		);
+		git(fork, ['commit', '-qam', 'edit renamed copy']);
+
+		const r = run(fork, ['--fetch', '--json', '--all']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/renamed-copy.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/content is upstream elsewhere/);
+	});
+
+	it('follows ancestry through a merge-created rename', () => {
+		const source = Array.from({ length: 12 }, (_, i) => `mergeInheritedToken${i}();`);
+		write(upstream, 'shared/merge-source.ts', `${source.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add merge source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, 'product/merge-source.ts', `${source.join('\n')}\n`);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'copy merge source']);
+		git(fork, ['checkout', '-q', '-b', 'merge-side']);
+		write(fork, 'product/side-unrelated.ts', 'sideUnrelated();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'diverge merge side']);
+		git(fork, ['checkout', '-q', 'main']);
+		write(fork, 'product/merge-unrelated.ts', 'mergeUnrelated();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'diverge before merge']);
+		git(fork, ['merge', '--no-ff', '--no-commit', '-q', 'merge-side']);
+		git(fork, ['mv', 'product/merge-source.ts', 'product/renamed-product.ts']);
+		write(
+			fork,
+			'product/renamed-product.ts',
+			`${[...source.slice(0, 2), ...Array.from({ length: 10 }, (_, i) => `mergeForkRewrite${i}();`)].join('\n')}\n`
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'rename while merging']);
+		markBase(fork);
+		write(
+			fork,
+			'product/renamed-product.ts',
+			`${[source[0]!, 'mergeFeatureEdit();', ...Array.from({ length: 10 }, (_, i) => `mergeForkRewrite${i}();`)].join('\n')}\n`
+		);
+		git(fork, ['commit', '-qam', 'edit merge-created destination']);
+
+		const r = run(fork, ['--fetch', '--json', '--all']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/renamed-product.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/content is upstream elsewhere/);
+	});
+
+	it('keeps a blobless inexact rename unmeasured', () => {
+		const source = Array.from({ length: 12 }, (_, i) => `bloblessRenameSource${i}();`);
+		write(fork, 'product/blobless-source.ts', `${source.join('\n')}\n`);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add blobless rename source']);
+		const oldBlob = git(fork, ['rev-parse', 'HEAD:product/blobless-source.ts']);
+		git(fork, ['mv', 'product/blobless-source.ts', 'product/blobless-renamed.ts']);
+		write(
+			fork,
+			'product/blobless-renamed.ts',
+			`${[...source.slice(0, 4), ...Array.from({ length: 8 }, (_, i) => `bloblessRewrite${i}();`)].join('\n')}\n`
+		);
+		git(fork, ['commit', '-qam', 'rename and rewrite blobless source']);
+
+		const origin = git(fork, ['remote', 'get-url', 'origin']);
+		git(origin, ['config', 'uploadpack.allowFilter', 'true']);
+		git(origin, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
+		git(fork, ['push', '-q', '--force', 'origin', 'HEAD:main']);
+		const clone = join(tmp, 'blobless-clone');
+		git(tmp, ['clone', '-q', '--filter=blob:none', `file://${origin}`, clone]);
+		git(clone, ['remote', 'add', 'upstream', upstream]);
+		git(clone, ['fetch', '-q', 'upstream']);
+		const missing = spawnSync('git', ['cat-file', '-e', oldBlob], {
+			cwd: clone,
+			env: fixtureGitEnv({ GIT_NO_LAZY_FETCH: '1' })
+		});
+		expect(missing.status).not.toBe(0);
+
+		const r = run(clone, [
+			'--base',
+			'HEAD',
+			'--fetch',
+			'--json',
+			'--all',
+			'product/blobless-renamed.ts'
+		]);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/blobless-renamed.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/local history is incomplete/);
+	});
+
+	it('follows exact ancestry across a historical copy', () => {
+		const source = Array.from({ length: 8 }, (_, i) => `copyTemplateToken${i}();`);
+		for (const repo of [upstream, fork]) {
+			write(repo, 'shared/copy-source.ts', `${source.join('\n')}\n`);
+			git(repo, ['add', '-A']);
+			git(repo, ['commit', '-qm', 'add copy source']);
+		}
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(
+			fork,
+			'product/copied-and-customized.ts',
+			`${[...source.slice(0, 3), 'copyForkThree();', 'copyForkFour();', 'copyForkFive();', 'copyForkSix();', 'copyForkSeven();'].join('\n')}\n`
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'copy and customize source']);
+		markBase(fork);
+		write(
+			fork,
+			'product/copied-and-customized.ts',
+			`${[...source.slice(0, 2), 'copyFeatureEdit();', 'copyForkThree();', 'copyForkFour();', 'copyForkFive();', 'copyForkSix();', 'copyForkSeven();'].join('\n')}\n`
+		);
+		git(fork, ['commit', '-qam', 'edit customized copy']);
+
+		const r = run(fork, ['--fetch', '--json', '--all']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find(
+			(entry) => entry.path === 'product/copied-and-customized.ts'
+		);
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/content is upstream elsewhere/);
+	});
+
+	it('keeps exact ancestry after the source leaves the upstream tip', () => {
+		const source = Array.from({ length: 6 }, (_, i) => `export const removedUpstream${i} = ${i};`);
+		write(upstream, 'shared/removed-source.ts', `${source.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add removable source']);
+		write(fork, 'product/removed-source-copy.ts', `${source.join('\n')}\n`);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'copy exact source']);
+		write(fork, 'product/removed-source-copy.ts', 'alphaForkOnly();\nbetaForkOnly();\n');
+		git(fork, ['commit', '-qam', 'rewrite before base']);
+		markBase(fork);
+		write(upstream, 'shared/removed-source.ts', 'zuluTemplate();\nyankeeTemplate();\n');
+		git(upstream, ['commit', '-qam', 'rewrite upstream source']);
+		write(fork, 'product/removed-source-copy.ts', 'alphaForkOnly();\ngammaFeature();\n');
+		git(fork, ['commit', '-qam', 'edit rewritten copy']);
+
+		const r = run(fork, ['--fetch', '--json', '--all']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find(
+			(entry) => entry.path === 'product/removed-source-copy.ts'
+		);
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/content is upstream elsewhere/);
+	});
+
+	it('compares text with historical upstream blobs', () => {
+		const source = Array.from({ length: 8 }, (_, i) => `historicalTemplateToken${i}();`);
+		write(upstream, 'shared/historical-text-source.ts', `${source.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add historical text source']);
+		write(
+			fork,
+			'product/historical-text-copy.ts',
+			`${[...source.slice(0, 5), 'customFive();', 'customSix();', 'customSeven();'].join('\n')}\n`
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add customized historical copy']);
+		markBase(fork);
+		write(upstream, 'shared/historical-text-source.ts', 'newTemplateOne();\nnewTemplateTwo();\n');
+		git(upstream, ['commit', '-qam', 'replace historical text source']);
+		write(
+			fork,
+			'product/historical-text-copy.ts',
+			`${[...source.slice(0, 5), 'featureEdit();', 'customSix();', 'customSeven();'].join('\n')}\n`
+		);
+		git(fork, ['commit', '-qam', 'edit customized historical copy']);
+
+		const r = run(fork, ['--fetch', '--json', '--all']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find(
+			(entry) => entry.path === 'product/historical-text-copy.ts'
+		);
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toContain('shared/historical-text-source.ts');
+	});
+
+	it('bounds widened historical blob reads', () => {
+		for (let i = 0; i < 12; i++) {
+			write(
+				upstream,
+				`history/scale-${i}.scale`,
+				`${Array.from({ length: 10 }, (_, line) => `upstreamScale${i}Token${line}();`).join('\n')}\n`
+			);
+		}
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add blob scale history']);
+		write(
+			fork,
+			'product/scale-copy.scale',
+			`${[
+				...Array.from({ length: 8 }, (_, line) => `upstreamScale0Token${line}();`),
+				'localScaleEight();',
+				'localScaleNine();'
+			].join('\n')}\n`
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add scale comparison']);
+
+		const r = run(fork, ['--fetch', '--json', '--all'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_BLOB_OUTPUT_LIMIT: '2048'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/scale-copy.scale');
+		expect(verdict?.note).toContain('history/scale-0.scale');
+	});
+
+	it('bounds retained historical similarity data', () => {
+		const source = Array.from({ length: 10 }, (_, i) => `boundedSimilarityToken${i}();`);
+		write(upstream, 'history/z-bounded-source.ts', `${source.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add bounded similarity source']);
+		for (let i = 0; i < 6; i++) {
+			write(
+				upstream,
+				`history/filler-${i}.ts`,
+				`${Array.from({ length: 10 }, (_, line) => `boundedFiller${i}Token${line}();`).join('\n')}\n`
+			);
+		}
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add bounded similarity fillers']);
+		write(
+			fork,
+			'product/local-bounded-copy.ts',
+			`${[...source.slice(0, 8), 'localBoundedEight();', 'localBoundedNine();'].join('\n')}\n`
+		);
+
+		const r = run(fork, ['--fetch', '--json', '--all'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_BLOB_OUTPUT_LIMIT: '4096'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/local-bounded-copy.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/one or more upstream blobs are absent/);
+	});
+
+	it('bounds retained local historical blobs', () => {
+		const inherited = Array.from({ length: 12 }, (_, i) => `boundedLocalHistoryToken${i}();`);
+		write(upstream, 'history/local-history-source.ts', `${inherited.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add local history source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(
+			fork,
+			'product/local-history-copy.ts',
+			`${[...inherited.slice(0, 8), 'localHistoryEight();', 'localHistoryNine();', 'localHistoryTen();', 'localHistoryEleven();'].join('\n')}\n`
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'copy bounded local history source']);
+		for (let revision = 0; revision < 6; revision++) {
+			write(
+				fork,
+				'product/local-history-copy.ts',
+				`${Array.from({ length: 8 }, (_, line) => `localRevision${revision}Token${line}();`).join('\n')}\n`
+			);
+			git(fork, ['commit', '-qam', `rewrite local history ${revision}`]);
+		}
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/local-history-copy.ts'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_BLOB_OUTPUT_LIMIT: '2048'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/local-history-copy.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/bounded local-history capture/);
+	});
+
+	it('bounds local history process count', () => {
+		write(fork, 'product/history-operation-limit.ts', 'historyOperationOne();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add operation-limited history']);
+		markBase(fork);
+		write(fork, 'product/history-operation-limit.ts', 'historyOperationTwo();\n');
+		git(fork, ['commit', '-qam', 'rewrite operation-limited history']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/history-operation-limit.ts'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_HISTORY_OPERATION_LIMIT: '1'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find(
+			(entry) => entry.path === 'product/history-operation-limit.ts'
+		);
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/local history is incomplete/);
+	});
+
+	itWithGitWrapper('times out a stalled local history command', () => {
+		write(fork, 'product/history-timeout.ts', 'historyTimeoutOne();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add history timeout path']);
+		markBase(fork);
+		write(fork, 'product/history-timeout.ts', 'historyTimeoutTwo();\n');
+		git(fork, ['commit', '-qam', 'rewrite history timeout path']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/history-timeout.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			SLOW_HISTORY_LOG: '1',
+			UPSTREAM_REPORT_TEST_HISTORY_TIMEOUT_MS: '50'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/history-timeout.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/local history is incomplete/);
+	});
+
+	itWithGitWrapper('times out stalled working-tree status inspection', () => {
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			SLOW_STATUS: '1',
+			UPSTREAM_REPORT_TEST_WORKTREE_TIMEOUT_MS: '50'
+		});
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/Git operation timed out/);
+	});
+
+	itWithGitWrapper('times out stalled changed-path diff inspection', () => {
+		const r = run(fork, ['--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			SLOW_CHANGED_DIFF: '1',
+			UPSTREAM_REPORT_TEST_DIFF_TIMEOUT_MS: '50'
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/Git operation timed out/);
+	});
+
+	itWithGitWrapper('times out a stalled upstream history walk', () => {
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'edit fork path']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/only-here.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			SLOW_UPSTREAM_HISTORY_LOG: '1',
+			UPSTREAM_REPORT_TEST_HISTORY_TIMEOUT_MS: '50'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/only-here.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/upstream history did not complete/);
+	});
+
+	itWithGitWrapper('treats a truncated UTF-8 history record as incomplete', () => {
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'edit fork path before partial history']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/only-here.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			PARTIAL_INVALID_HISTORY: '1'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/only-here.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/upstream history did not complete/);
+	});
+
+	itWithGitWrapper('times out stalled upstream object typing', () => {
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'edit fork path before object stall']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/only-here.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			SLOW_UPSTREAM_OBJECT_CHECK: '1',
+			UPSTREAM_REPORT_TEST_HISTORY_TIMEOUT_MS: '50'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/only-here.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/upstream history did not complete/);
+	});
+
+	itWithGitWrapper('times out a stalled repository root walk', () => {
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'edit fork root path']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/only-here.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			SLOW_ROOT_HISTORY: '1',
+			UPSTREAM_REPORT_TEST_HISTORY_TIMEOUT_MS: '50'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/only-here.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/root history did not complete/);
+	});
+
+	itWithGitWrapper('times out a stalled repository tree scan', () => {
+		const r = run(fork, ['--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			SLOW_TREE_SCAN: '1',
+			UPSTREAM_REPORT_TEST_HISTORY_TIMEOUT_MS: '50'
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/Git operation timed out/);
+	});
+
+	itWithGitWrapper('does not require rev-list NUL output introduced in Git 2.50', () => {
+		write(fork, 'product/portable-history.ts', 'forkOwnedHistoryOne();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add portable history path']);
+		markBase(fork);
+		write(fork, 'product/portable-history.ts', 'forkOwnedHistoryTwo();\n');
+		git(fork, ['commit', '-qam', 'edit portable history path']);
+		const marker = join(tmp, 'rev-list-z-rejected');
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/portable-history.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			REJECT_REV_LIST_Z_MARKER: marker
+		});
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(marker)).toBe(false);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/portable-history.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/entered local history after repository creation/);
+	});
+
+	it('keeps absent paths unmeasured when local history is shallow', () => {
+		const source = Array.from({ length: 6 }, (_, i) => `export const shallowInherited${i} = ${i};`);
+		write(upstream, 'shared/shallow-source.ts', `${source.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add shallow source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, 'product/shallow-copy.ts', `${source.join('\n')}\n`);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'copy exact source']);
+		write(fork, 'product/shallow-copy.ts', 'forkRewriteOne();\nforkRewriteTwo();\n');
+		git(fork, ['commit', '-qam', 'rewrite before boundary']);
+		const boundary = git(fork, ['rev-parse', 'HEAD']);
+		markBase(fork);
+		writeFileSync(join(fork, '.git', 'shallow'), `${boundary}\n`);
+		write(fork, 'product/shallow-copy.ts', 'forkRewriteOne();\nfeatureEdit();\n');
+		git(fork, ['commit', '-qam', 'edit after shallow boundary']);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/shallow-copy.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/history is shallow/);
+	});
+
+	itWithGitWrapper('rejects a shallow boundary added after the completeness check', () => {
+		write(fork, 'product/shallow-race.ts', 'shallowRaceOne();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add shallow race history']);
+		markBase(fork);
+		write(fork, 'product/shallow-race.ts', 'shallowRaceTwo();\n');
+		git(fork, ['commit', '-qam', 'edit shallow race history']);
+		const marker = join(tmp, 'shallow-boundary-raced');
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/shallow-race.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			ADD_SHALLOW_AFTER_CHECK_SHA: git(fork, ['rev-parse', 'HEAD']),
+			CALLER_SHALLOW_PATH: join(fork, '.git', 'shallow'),
+			SHALLOW_RACE_MARKER: marker
+		});
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/shallow boundary.*changed/);
+	});
+
+	itWithGitWrapper('pins local history through a shallow-boundary ABA race', () => {
+		write(fork, 'product/shallow-aba.ts', 'shallowAbaOne();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add shallow ABA path']);
+		const boundary = git(fork, ['rev-parse', 'HEAD']);
+		markBase(fork);
+		write(fork, 'product/shallow-aba.ts', 'shallowAbaTwo();\n');
+		git(fork, ['commit', '-qam', 'edit shallow ABA path']);
+		const marker = join(tmp, 'shallow-boundary-aba');
+		const shallowPath = join(fork, '.git', 'shallow');
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/shallow-aba.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			ADD_SHALLOW_ABA_SHA: boundary,
+			CALLER_SHALLOW_PATH: shallowPath,
+			SHALLOW_ABA_MARKER: marker
+		});
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(marker)).toBe(true);
+		expect(existsSync(shallowPath)).toBe(false);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/shallow-aba.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/entered local history after repository creation/);
+	});
+
+	it('keeps staged ancestry when an unstaged edit replaces it', () => {
+		const shared = Array.from({ length: 10 }, (_, i) => `export const stagedAncestor${i} = ${i};`);
+		write(upstream, 'shared/staged-source.ts', `${shared.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add staged source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(
+			fork,
+			'product/staged-derived.ts',
+			`${[...shared.slice(0, 6), 'forkA();', 'forkB();', 'forkC();', 'forkD();'].join('\n')}\n`
+		);
+		git(fork, ['add', 'product/staged-derived.ts']);
+		write(fork, 'product/staged-derived.ts', 'unrelatedWorktree();\nmoreUnrelatedWorktree();\n');
+
+		expect(verdicts(fork)['product/staged-derived.ts']).toBe('unmeasured');
+	});
+
+	itWithPosixPaths('keeps filtered unstaged bytes from proving fork ownership', () => {
+		const canonical = 'export const upstreamCanonical = true;\n';
+		write(upstream, 'shared/filter-source.ts', canonical);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add filter source']);
+		const filter = join(tmp, 'canonical-filter');
+		writeFileSync(filter, `#!/bin/sh\nprintf '${canonical}'\n`);
+		chmodSync(filter, 0o755);
+		write(fork, '.gitattributes', 'product/filtered.ts filter=canonical\n');
+		write(fork, 'product/filtered.ts', 'forkOnlyBase();\nmoreForkOnlyBase();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add filtered fork path']);
+		git(fork, ['config', 'filter.canonical.clean', filter]);
+		markBase(fork);
+		const raw = 'rawWorkingCopyWithAQuiteDifferentLength();\nanotherRawLineWithMoreText();\n';
+		write(fork, 'product/filtered.ts', raw);
+		const canonicalSha = gitInput(
+			fork,
+			['hash-object', '--path=product/filtered.ts', '--stdin'],
+			raw
+		);
+		expect(canonicalSha).toBe(git(upstream, ['rev-parse', 'HEAD:shared/filter-source.ts']));
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/filtered.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/clean filters/);
+	});
+
+	it('finds a template port whose extension changed', () => {
+		const shared = Array.from({ length: 10 }, (_, i) => `const portable${i} = ${i};`);
+		write(upstream, 'shared/portable.js', `${shared.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add portable script']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(
+			fork,
+			'product/ported.ts',
+			`${[...shared.slice(0, 7), 'const typedA: number = 1;', 'const typedB: number = 2;', 'const typedC: number = 3;'].join('\n')}\n`
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'port script to typescript']);
+
+		expect(verdicts(fork)['product/ported.ts']).toBe('unmeasured');
+	});
+
+	it('surfaces a comparison blocked by a missing upstream blob', () => {
+		const shared = Array.from({ length: 8 }, (_, i) => `export const missing${i} = ${i};`);
+		write(upstream, 'missing-source.ts', `${shared.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add unavailable source']);
+		const tip = git(upstream, ['rev-parse', 'HEAD']);
+		const tree = git(upstream, ['rev-parse', 'HEAD^{tree}']);
+		const blob = git(upstream, ['rev-parse', 'HEAD:missing-source.ts']);
+		copyObject(upstream, fork, 'tree', tree);
+		copyObject(upstream, fork, 'commit', tip);
+		git(fork, [
+			'update-ref',
+			'-m',
+			'fetch upstream: storing head',
+			'refs/remotes/upstream/main',
+			tip
+		]);
+		expect(
+			spawnSync('git', ['cat-file', '-e', blob], {
+				cwd: fork,
+				env: fixtureGitEnv({ GIT_NO_LAZY_FETCH: '1' })
+			}).status
+		).not.toBe(0);
+
+		write(
+			fork,
+			'product/missing-derived.ts',
+			`${[...shared.slice(0, 5), 'forkMissingA();', 'forkMissingB();', 'forkMissingC();'].join('\n')}\n`
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add copy of unavailable source']);
+
+		expect(verdicts(fork)['product/missing-derived.ts']).toBe('unmeasured');
+	});
+
+	itWithGitWrapper.each(['true', 'yes', 'on', '1'])(
+		'requires Git 2.45 when promisor is spelled %s',
+		(value) => {
+			git(fork, ['config', 'remote.origin.promisor', value]);
+			const r = run(fork, ['--json', 'shared/pristine.ts'], {
+				PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+				REAL_GIT: realGitPath(),
+				FAKE_GIT_VERSION: '2.43.0'
+			});
+			expect(r.status).not.toBe(0);
+			expect(r.stderr).toMatch(/Git 2\.45 or newer.*partial-clone/);
+		}
+	);
+
+	itWithGitWrapper('requires Git 2.45 for a valueless promisor declaration', () => {
+		const config = join(fork, '.git', 'config');
+		writeFileSync(config, `${readFileSync(config, 'utf8')}\n[remote "valueless"]\n\tpromisor\n`);
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			FAKE_GIT_VERSION: '2.43.0'
+		});
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/Git 2\.45 or newer.*partial-clone/);
+	});
+
+	it('classifies a fork-only path as fork-only', () => {
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'edit']);
+		expect(verdicts(fork)['product/only-here.ts']).toBe('fork-only');
+	});
+
+	it('keeps a low-similarity port added after repository creation unmeasured', () => {
+		const inherited = Array.from(
+			{ length: 10 },
+			(_, i) => `export const inheritedPortLine${i} = calculateInheritedPortValue(${i});`
+		);
+		write(upstream, 'shared/late-port-source.js', `${inherited.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add late port source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		const port = [
+			...inherited.slice(0, 4),
+			...Array.from({ length: 6 }, (_, i) => `// ${'z'.repeat(80 + i)}`)
+		];
+		write(fork, 'product/late-port.ts', `${port.join('\n')}\n`);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add late low-similarity port']);
+		markBase(fork);
+		write(fork, 'product/late-port.ts', `${port.join('\n')}\nconst featureFix = true;\n`);
+		git(fork, ['commit', '-qam', 'fix late port']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/late-port.ts']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/late-port.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/entered local history after repository creation/);
+	});
+
+	it('keeps imported root paths unmeasured', () => {
+		const imported = join(tmp, 'imported-history');
+		mkdirSync(imported);
+		init(imported);
+		write(imported, 'product/imported-port.ts', 'export const importedPort = true;\n');
+		git(imported, ['add', '-A']);
+		git(imported, ['commit', '-qm', 'add imported root path']);
+		git(fork, ['fetch', '-q', imported, 'main']);
+		git(fork, [
+			'merge',
+			'-q',
+			'--allow-unrelated-histories',
+			'--no-ff',
+			'FETCH_HEAD',
+			'-m',
+			'import unrelated history'
+		]);
+		markBase(fork);
+		write(fork, 'product/imported-port.ts', 'export const importedPort = false;\n');
+		git(fork, ['commit', '-qam', 'fix imported path']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/imported-port.ts']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/imported-port.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/multiple root commits/);
+	});
+
+	it('keeps a case-folded marker provenance path visible after upstream deletes it', () => {
+		const provenanceUpstream = join(tmp, 'provenance-template');
+		mkdirSync(provenanceUpstream);
+		init(provenanceUpstream);
+		write(
+			provenanceUpstream,
+			'Legacy/Template-Port.ts',
+			'export const inheritedOne = 1;\nexport const inheritedTwo = 2;\n'
+		);
+		git(provenanceUpstream, ['add', '-A']);
+		git(provenanceUpstream, ['commit', '-qm', 'template with legacy path']);
+		const forkPoint = git(provenanceUpstream, ['rev-parse', 'HEAD']);
+
+		const provenanceFork = join(tmp, 'provenance-fork');
+		mkdirSync(provenanceFork);
+		init(provenanceFork);
+		write(
+			provenanceFork,
+			'legacy/template-port.ts',
+			'// zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\n' +
+				'// yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\n'
+		);
+		write(
+			provenanceFork,
+			'.upstream-sync.json',
+			JSON.stringify({
+				upstreamUrl: provenanceUpstream,
+				forkPoint,
+				lastSynced: forkPoint
+			})
+		);
+		git(provenanceFork, ['add', '-A']);
+		git(provenanceFork, ['commit', '-qm', 'content-copy root']);
+		const provenanceOrigin = join(tmp, 'provenance-origin.git');
+		mkdirSync(provenanceOrigin);
+		git(provenanceOrigin, ['init', '--bare', '-q']);
+		git(provenanceFork, ['remote', 'add', 'origin', provenanceOrigin]);
+		git(provenanceFork, ['remote', 'add', 'upstream', provenanceUpstream]);
+		git(provenanceFork, ['fetch', '-q', 'upstream']);
+		markBase(provenanceFork);
+
+		git(provenanceUpstream, ['rm', '-q', 'Legacy/Template-Port.ts']);
+		git(provenanceUpstream, ['commit', '-qm', 'remove legacy path']);
+		write(
+			provenanceFork,
+			'legacy/template-port.ts',
+			'// zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\n' +
+				'// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n'
+		);
+		git(provenanceFork, ['commit', '-qam', 'fix retained legacy path']);
+
+		const r = run(provenanceFork, ['--fetch', '--json', '--all', 'legacy/template-port.ts']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'legacy/template-port.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/marker provenance|\.upstream-sync\.json provenance/);
+	});
+
+	it('keeps absences unmeasured after upstream rewrites its history', () => {
+		git(upstream, ['checkout', '-q', '--orphan', 'rewritten-main']);
+		git(upstream, ['rm', '-q', '-rf', '.']);
+		write(upstream, 'rewritten-root.txt', 'upstream history was replaced\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'replace upstream history']);
+		git(upstream, ['branch', '-M', 'main']);
+
+		write(
+			fork,
+			'shared/rewritten.ts',
+			'export const retainedTemplatePort = false;\nexport const localFix = true;\n'
+		);
+		git(fork, ['commit', '-qam', 'fix retained template file']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'shared/rewritten.ts']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'shared/rewritten.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/provenance is not reachable/);
+	});
+
+	it('refuses to run when the base is missing instead of reporting an empty diff', () => {
+		// The failure this exists for: without `origin/main` an earlier version
+		// fell back to HEAD, so `HEAD...HEAD` was empty and a branch full of
+		// template fixes reported "nothing to report upstream", exit 0.
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'fix']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/origin/main']);
+
+		const r = run(fork, []);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+		expect(r.stderr).toMatch(/origin\/main/);
+	});
+
+	it('refuses a base that shares no history with HEAD', () => {
+		// `upstream/main` is a real unrelated root in this fixture, which is what
+		// a template fork looks like. Enumeration runs from the merge base, so
+		// without one it enumerates nothing and reads as a clean report.
+		const r = run(fork, ['--base', 'refs/remotes/upstream/main']);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+		// The script's own refusal. Letting git fail on its own would pass this
+		// too, and would not say the run stopped for the right reason.
+		expect(r.stderr).toContain('Refusing to compare unrelated histories');
+	});
+
+	it('refuses multiple best merge bases instead of choosing one', () => {
+		const root = git(fork, ['rev-parse', 'HEAD']);
+		git(fork, ['checkout', '-q', '-b', 'criss-a', root]);
+		write(fork, 'product/criss-cross.ts', 'export const side = "a";\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add side a']);
+		const sideA = git(fork, ['rev-parse', 'HEAD']);
+		const treeA = git(fork, ['rev-parse', `${sideA}^{tree}`]);
+
+		git(fork, ['checkout', '-q', '-b', 'criss-b', root]);
+		write(fork, 'product/criss-cross.ts', 'export const side = "b";\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add side b']);
+		const sideB = git(fork, ['rev-parse', 'HEAD']);
+		const treeB = git(fork, ['rev-parse', `${sideB}^{tree}`]);
+
+		const head = gitInput(fork, ['commit-tree', treeA, '-p', sideA, '-p', sideB], 'keep side a\n');
+		const main = gitInput(fork, ['commit-tree', treeB, '-p', sideB, '-p', sideA], 'keep side b\n');
+		git(fork, ['checkout', '-q', '--detach', head]);
+		advertiseOriginMain(fork, main);
+		git(fork, ['update-ref', '-m', 'fetch origin: fast-forward', 'refs/remotes/origin/main', main]);
+
+		const r = run(fork, ['--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+		expect(r.stderr).toMatch(/multiple best merge bases/);
+	});
+
+	it('ignores inherited graft files when validating base ancestry', () => {
+		const head = git(fork, ['rev-parse', 'HEAD']);
+		const emptyTree = gitInput(fork, ['mktree'], '');
+		const unrelated = git(fork, ['commit-tree', emptyTree, '-m', 'unrelated base']);
+		advertiseOriginMain(fork, unrelated);
+		git(fork, [
+			'update-ref',
+			'-m',
+			'fetch origin: fast-forward',
+			'refs/remotes/origin/main',
+			unrelated
+		]);
+		const graft = join(tmp, 'grafts');
+		writeFileSync(graft, `${unrelated} ${head}\n`);
+
+		const r = run(fork, ['--json'], { GIT_GRAFT_FILE: graft });
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+		expect(r.stderr).toContain('Refusing to compare unrelated histories');
+	});
+
+	it('ignores repository-local graft files', () => {
+		const head = git(fork, ['rev-parse', 'HEAD']);
+		const emptyTree = gitInput(fork, ['mktree'], '');
+		const unrelated = git(fork, ['commit-tree', emptyTree, '-m', 'unrelated base']);
+		advertiseOriginMain(fork, unrelated);
+		git(fork, [
+			'update-ref',
+			'-m',
+			'fetch origin: fast-forward',
+			'refs/remotes/origin/main',
+			unrelated
+		]);
+		writeFileSync(join(fork, '.git', 'info', 'grafts'), `${unrelated} ${head}\n`);
+
+		const r = run(fork, ['--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+		expect(r.stderr).toContain('Refusing to compare unrelated histories');
+	});
+
+	it('does not trust a planted graft at the former shared temporary path', () => {
+		const head = git(fork, ['rev-parse', 'HEAD']);
+		const emptyTree = gitInput(fork, ['mktree'], '');
+		const unrelated = git(fork, ['commit-tree', emptyTree, '-m', 'unrelated base']);
+		advertiseOriginMain(fork, unrelated);
+		git(fork, [
+			'update-ref',
+			'-m',
+			'fetch origin: fast-forward',
+			'refs/remotes/origin/main',
+			unrelated
+		]);
+		const controlledTmp = join(tmp, 'controlled-tmp');
+		mkdirSync(controlledTmp);
+		writeFileSync(join(controlledTmp, 'upstream-relevance-no-grafts'), `${unrelated} ${head}\n`);
+
+		const r = run(fork, ['--json'], { TMPDIR: controlledTmp });
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+		expect(r.stderr).toContain('Refusing to compare unrelated histories');
+	});
+
+	it('refuses an unresolvable explicit base', () => {
+		const escape = String.fromCharCode(27);
+		const bidi = String.fromCharCode(0x202e);
+		const base = `refs/remotes/origin/${escape}[2J${bidi}does-not-exist`;
+		const r = run(fork, ['--base', base, 'shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/does not resolve/i);
+		expect(r.stderr).not.toContain(escape);
+		expect(r.stderr).not.toContain(bidi);
+		expect(r.stderr).toContain('\\u001b[2J\\u202edoes-not-exist');
+	});
+
+	it('refuses an origin that resolves to the current checkout', () => {
+		git(fork, ['remote', 'set-url', 'origin', fork]);
+		git(fork, [
+			'update-ref',
+			'-m',
+			'fetch origin: fast-forward',
+			'refs/remotes/origin/main',
+			'HEAD'
+		]);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'committed change hidden by self origin']);
+		git(fork, [
+			'update-ref',
+			'-m',
+			'fetch origin: fast-forward',
+			'refs/remotes/origin/main',
+			'HEAD'
+		]);
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/origin URL resolves inside a checkout/);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+	});
+
+	it('refuses origin URLs owned by a sibling worktree', () => {
+		const sibling = join(tmp, 'origin-sibling');
+		git(fork, ['worktree', 'add', '-q', '-b', 'origin-sibling', sibling, 'HEAD']);
+		const siblingGitDir = git(sibling, ['rev-parse', '--path-format=absolute', '--git-dir']);
+
+		for (const url of [sibling, siblingGitDir]) {
+			git(fork, ['remote', 'set-url', 'origin', url]);
+			const r = run(fork, ['--json']);
+			expect(r.status).not.toBe(0);
+			expect(r.stderr).toMatch(/origin URL resolves inside a checkout or Git directory owned/);
+		}
+	});
+
+	it('refuses a marker upstream owned by a sibling worktree', () => {
+		const sibling = join(tmp, 'upstream-sibling');
+		git(fork, ['worktree', 'add', '-q', '-b', 'upstream-sibling', sibling, 'HEAD']);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: sibling }));
+		git(fork, ['commit', '-qam', 'point marker at sibling']);
+		git(fork, ['remote', 'set-url', 'upstream', sibling]);
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/marker upstream URL resolves inside a checkout/);
+	});
+
+	it('refuses a repository-contained Git bundle as marker upstream', () => {
+		const decoy = join(tmp, 'bundle-decoy');
+		git(tmp, ['clone', '-q', upstream, decoy]);
+		git(decoy, ['config', 'user.email', 'test@example.com']);
+		git(decoy, ['config', 'user.name', 'Test']);
+		git(decoy, ['rm', '-q', 'shared/pristine.ts']);
+		git(decoy, ['commit', '-qm', 'remove shared path']);
+		const bundle = join(fork, 'forged.bundle');
+		git(decoy, ['bundle', 'create', bundle, 'main']);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: 'forged.bundle' }));
+		git(fork, ['add', '.upstream-sync.json', 'forged.bundle']);
+		git(fork, ['commit', '-qm', 'add forged parent bundle']);
+		markBase(fork);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'fix shared path']);
+		git(fork, ['remote', 'remove', 'upstream']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/marker upstream URL resolves inside a checkout/);
+	});
+
+	it('refuses when the upstream remote points somewhere else than the marker', () => {
+		// Squatting on the conventional `upstream` name is common, and a parent fork
+		// is the usual case. Classifying against the wrong tree yields a full set
+		// of plausible wrong verdicts, so it has to be fatal instead of quiet.
+		const other = join(tmp, 'other');
+		mkdirSync(other);
+		init(other);
+		write(other, 'unrelated.ts', 'export const x = 1;\n');
+		git(other, ['add', '-A']);
+		git(other, ['commit', '-qm', 'other']);
+		git(fork, ['remote', 'set-url', 'upstream', other]);
+
+		const r = run(fork, ['shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/different repository/i);
+	});
+
+	it.skipIf(process.platform === 'win32')(
+		'aborts when another worktree swaps the shared upstream remote during startup',
+		() => {
+			const other = join(tmp, 'other-upstream');
+			mkdirSync(other);
+			init(other);
+			write(other, 'other.ts', 'export const other = 1;\n');
+			git(other, ['add', '-A']);
+			git(other, ['commit', '-qm', 'other upstream']);
+
+			const wrapper = installGitWrapper(tmp);
+			const r = run(fork, ['shared/pristine.ts'], {
+				PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+				REAL_GIT: realGitPath(),
+				SWAP_REMOTE: other,
+				SWAP_MARKER: join(tmp, 'remote-swapped')
+			});
+			expect(r.status).not.toBe(0);
+			expect(r.stdout).not.toContain('Nothing to report upstream');
+			expect(r.stderr).toContain('changed while this report started');
+		}
+	);
+
+	itWithGitWrapper('binds an allowed fetch to the checked upstream URL', () => {
+		const decoy = join(tmp, 'fetch-decoy');
+		mkdirSync(decoy);
+		init(decoy);
+		write(decoy, 'decoy.ts', 'export const decoy = true;\n');
+		git(decoy, ['add', '-A']);
+		git(decoy, ['commit', '-qm', 'decoy']);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 91;\n');
+		git(fork, ['commit', '-qam', 'fix shared file']);
+
+		const wrapper = installGitWrapper(tmp);
+		const marker = join(tmp, 'remote-aba');
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			ABA_REPO: fork,
+			ABA_DECOY_REMOTE: decoy,
+			ABA_EXPECTED_REMOTE: upstream,
+			ABA_REMOTE_MARKER: marker
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(marker)).toBe(true);
+		expect(git(fork, ['remote', 'get-url', 'upstream'])).toBe(upstream);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('pristine');
+	});
+
+	itWithPosixPaths('ignores an upstream upload-pack that redirects the checked URL', () => {
+		const decoy = join(tmp, 'upload-pack-decoy');
+		mkdirSync(decoy);
+		init(decoy);
+		write(decoy, 'decoy.ts', 'export const decoy = true;\n');
+		git(decoy, ['add', '-A']);
+		git(decoy, ['commit', '-qm', 'add upload-pack decoy']);
+		const marker = join(tmp, 'custom-upload-pack-used');
+		const uploadPack = join(tmp, 'custom-upload-pack');
+		writeFileSync(
+			uploadPack,
+			`#!/bin/sh\nprintf 'used\\n' >> "${marker}"\nexec git-upload-pack "${decoy}"\n`
+		);
+		chmodSync(uploadPack, 0o755);
+		git(fork, ['config', 'remote.upstream.uploadpack', uploadPack]);
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(marker)).toBe(false);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ relevance: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('pristine');
+	});
+
+	itWithPosixPaths('refuses an SSH command that redirects the checked URL', () => {
+		const markerBefore = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as {
+			forkPoint: string;
+		};
+		const decoy = join(tmp, 'ssh-command-decoy.git');
+		mkdirSync(decoy);
+		git(decoy, ['init', '--bare', '-q']);
+		git(upstream, ['push', '-q', decoy, `${markerBefore.forkPoint}:refs/heads/main`]);
+
+		write(upstream, 'product/only-here.ts', 'export const product = true;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add product path upstream']);
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'fix product path']);
+
+		const markerUrl = 'ssh://example.invalid/template.git';
+		write(
+			fork,
+			'.upstream-sync.json',
+			JSON.stringify({
+				upstreamUrl: markerUrl,
+				forkPoint: markerBefore.forkPoint,
+				lastSynced: markerBefore.forkPoint
+			})
+		);
+		git(fork, ['commit', '-qam', 'set SSH upstream marker']);
+		git(fork, ['remote', 'set-url', 'upstream', markerUrl]);
+		const used = join(tmp, 'ssh-command-used');
+		const sshCommand = join(tmp, 'redirect-ssh');
+		writeFileSync(
+			sshCommand,
+			`#!/bin/sh\nprintf 'used\\n' >> "${used}"\nexec git-upload-pack "${decoy}"\n`
+		);
+		chmodSync(sshCommand, 0o755);
+		git(fork, ['config', 'core.sshCommand', sshCommand]);
+		git(fork, ['config', 'ssh.variant', 'simple']);
+
+		const r = run(fork, ['--fetch', '--json', '--all']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/core\.sshCommand/);
+		expect(existsSync(used)).toBe(false);
+	});
+
+	itWithPosixPaths('scrubs an inherited SSH command from trusted reads', () => {
+		const markerBefore = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as {
+			forkPoint: string;
+		};
+		const decoy = join(tmp, 'inherited-ssh-decoy.git');
+		mkdirSync(decoy);
+		git(decoy, ['init', '--bare', '-q']);
+		git(upstream, ['push', '-q', decoy, `${markerBefore.forkPoint}:refs/heads/main`]);
+		const markerUrl = 'ssh://example.invalid/template.git';
+		write(
+			fork,
+			'.upstream-sync.json',
+			JSON.stringify({
+				upstreamUrl: markerUrl,
+				forkPoint: markerBefore.forkPoint,
+				lastSynced: markerBefore.forkPoint
+			})
+		);
+		git(fork, ['commit', '-qam', 'set inherited SSH marker']);
+		git(fork, ['remote', 'set-url', 'upstream', markerUrl]);
+		git(fork, ['config', 'ssh.variant', 'simple']);
+		const used = join(tmp, 'inherited-ssh-used');
+		const sshCommand = join(tmp, 'inherited-redirect-ssh');
+		writeFileSync(
+			sshCommand,
+			`#!/bin/sh\nprintf 'used\\n' >> "${used}"\nexec git-upload-pack "${decoy}"\n`
+		);
+		chmodSync(sshCommand, 0o755);
+
+		const r = run(fork, ['--fetch', '--json'], {
+			GIT_SSH_COMMAND: sshCommand,
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_TIMEOUT_MS: '1000'
+		});
+		expect(r.status).not.toBe(0);
+		expect(existsSync(used)).toBe(false);
+	});
+
+	it('refuses a URL rewrite that redirects the marker transport', () => {
+		const markerUrl = 'https://example.invalid/template.git';
+		const decoy = join(tmp, 'instead-of-decoy');
+		mkdirSync(decoy);
+		init(decoy);
+		write(decoy, 'decoy.ts', 'export const decoy = true;\n');
+		git(decoy, ['add', '-A']);
+		git(decoy, ['commit', '-qm', 'add instead-of decoy']);
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: markerUrl }));
+		git(fork, ['commit', '-qam', 'set network-style upstream marker']);
+		git(fork, ['remote', 'set-url', 'upstream', markerUrl]);
+		git(fork, ['config', `url.${decoy}.insteadOf`, markerUrl]);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/url\.\*\.insteadOf/);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+	});
+
+	itWithGitWrapper('isolates network reads from a transport rewrite ABA race', () => {
+		const markerBefore = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as {
+			forkPoint: string;
+		};
+		const decoy = join(tmp, 'transport-rewrite-decoy.git');
+		mkdirSync(decoy);
+		git(decoy, ['init', '--bare', '-q']);
+		git(upstream, ['push', '-q', decoy, `${markerBefore.forkPoint}:refs/heads/main`]);
+		write(upstream, 'product/only-here.ts', 'export const product = true;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add product path upstream']);
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'fix product path']);
+
+		const marker = join(tmp, 'transport-rewrite-aba');
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/only-here.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			TRANSPORT_REWRITE_REPO: fork,
+			TRANSPORT_REWRITE_URL: upstream,
+			TRANSPORT_REWRITE_TARGET: decoy,
+			TRANSPORT_REWRITE_CHECKS: join(tmp, 'transport-rewrite-checks'),
+			TRANSPORT_REWRITE_READS: join(tmp, 'transport-rewrite-reads'),
+			TRANSPORT_REWRITE_MARKER: marker
+		});
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(marker)).toBe(true);
+		expect(git(fork, ['config', '--list'])).not.toContain(decoy);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('pristine');
+	});
+
+	it('refuses a symbolic upstream tracking ref before fetching', () => {
+		const mainBefore = git(fork, ['rev-parse', 'refs/heads/main']);
+		git(fork, ['symbolic-ref', 'refs/remotes/upstream/main', 'refs/heads/main']);
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/symbolic ref/);
+		expect(git(fork, ['rev-parse', 'refs/heads/main'])).toBe(mainBefore);
+	});
+
+	itWithGitWrapper('refuses to overwrite a concurrent upstream ref update', () => {
+		const expected = git(upstream, ['rev-parse', 'HEAD']);
+		write(upstream, 'shared/ref-swap-decoy.ts', 'decoyRef();\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add ref swap decoy']);
+		const decoy = git(upstream, ['rev-parse', 'HEAD']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		git(upstream, ['reset', '--hard', '-q', expected]);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		const wrapper = installGitWrapper(tmp);
+		const marker = join(tmp, 'fetch-ref-swap');
+		const r = run(fork, ['--fetch', '--json', '--all'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			FETCH_REF_SWAP_REPO: fork,
+			FETCH_REF_SWAP_SHA: decoy,
+			FETCH_REF_SWAP_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/tracking ref changed while this report fetched objects/);
+		expect(git(fork, ['rev-parse', 'refs/remotes/upstream/main'])).toBe(decoy);
+	});
+
+	itWithGitWrapper('does not write a fetched ref after the shared upstream URL changes', () => {
+		const decoy = join(tmp, 'fetch-url-swap-decoy');
+		mkdirSync(decoy);
+		init(decoy);
+		write(decoy, 'decoy.ts', 'export const decoy = true;\n');
+		git(decoy, ['add', '-A']);
+		git(decoy, ['commit', '-qm', 'add URL swap decoy']);
+		const refBefore = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		const fetchRecordBefore = gitOptional(fork, ['config', '--get', 'upstreamReport.lastFetch']);
+		const marker = join(tmp, 'fetch-url-swap');
+
+		const r = run(fork, ['--fetch', '--json', '--all'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			FETCH_URL_SWAP_REPO: fork,
+			FETCH_URL_SWAP_REMOTE: decoy,
+			FETCH_URL_SWAP_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/upstream URL changed while this report fetched objects/);
+		expect(git(fork, ['rev-parse', 'refs/remotes/upstream/main'])).toBe(refBefore);
+		expect(gitOptional(fork, ['config', '--get', 'upstreamReport.lastFetch'])).toBe(
+			fetchRecordBefore
+		);
+	});
+
+	it('does not overwrite FETCH_HEAD during an allowed fetch', () => {
+		const fetchHead = join(fork, '.git', 'FETCH_HEAD');
+		writeFileSync(fetchHead, 'caller-owned fetch state\n');
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+		expect(r.status, r.stderr).toBe(0);
+		expect(readFileSync(fetchHead, 'utf8')).toBe('caller-owned fetch state\n');
+	});
+
+	it('writes no git state when the upstream copy is missing', () => {
+		git(fork, ['remote', 'remove', 'upstream']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+		const refsBefore = git(fork, ['for-each-ref', '--format=%(refname)']);
+		const indexBefore = statSync(join(fork, '.git', 'index')).mtimeMs;
+
+		const r = run(fork, ['shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/UNKNOWN/);
+		// The point: asking the question must not add the remote or reach the
+		// network. Both are shared state in a repository with linked worktrees.
+		expect(git(fork, ['remote']).split('\n').filter(Boolean)).not.toContain('upstream');
+		expect(git(fork, ['for-each-ref', '--format=%(refname)'])).toBe(refsBefore);
+		expect(statSync(join(fork, '.git', 'index')).mtimeMs).toBe(indexBefore);
+		expect(leakedIndexCopies(r.pid)).toEqual([]);
+	});
+
+	itWithPosixPaths('does not resolve a symlink when asking what a file resembles', () => {
+		// git stores a symlink as the target path, a string, so reading through
+		// the link compares a file the repository does not hold. Pointed outside
+		// the tree it reads whatever the branch aimed it at, and the branch is
+		// what every other decision here refuses to trust. Here the target is a
+		// near-copy of a template file, so following the link reports a match
+		// that exists nowhere in this repository.
+		const outside = join(tmp, 'outside.ts');
+		// Two of its three lines are shared/pristine.ts, so following the link
+		// clears the resemblance threshold and reports a match.
+		writeFileSync(outside, 'export const a = 1;\nexport const b = 2;\nexport const c = 3;\n');
+		symlinkSync(outside, join(fork, 'product/link.ts'));
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add a link']);
+
+		const r = run(fork, ['--fetch', '--json', 'product/link.ts']);
+		expect(r.status).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ relevance: string; note?: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('unmeasured');
+		expect(parsed.verdicts[0]?.note).toContain('design judgment');
+	});
+
+	itWithPosixPaths('does not follow a symlink in an intermediate directory', () => {
+		write(fork, 'product/linked/derived.ts', 'forkOnlyA();\nforkOnlyB();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add tracked product file']);
+		markBase(fork);
+
+		const outside = join(tmp, 'outside-directory');
+		mkdirSync(outside);
+		write(outside, 'derived.ts', 'export const a = 1;\nexport const b = 2;\nexternal();\n');
+		rmSync(join(fork, 'product/linked'), { recursive: true });
+		symlinkSync(outside, join(fork, 'product/linked'));
+
+		const r = run(fork, ['--json', 'product/linked/derived.ts']);
+		expect(r.status, `script failed: ${r.stderr}`).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((item) => item.path === 'product/linked/derived.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toContain('parent "product/linked" is a symlink');
+	});
+
+	it('surfaces binary resemblance instead of decoding it as line text', () => {
+		const source = Buffer.alloc(256, 0x61);
+		source[10] = 0;
+		const copy = Buffer.from(source);
+		copy[255] = 0x62;
+		writeFileSync(join(upstream, 'shared/source.blob'), source);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add binary source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		writeFileSync(join(fork, 'product/derived.blob'), copy);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add binary copy']);
+
+		expect(verdicts(fork)['product/derived.blob']).toBe('unmeasured');
+	});
+
+	it.each([
+		['one short line', 'on\n', 'off\n'],
+		['single-character lines', 'a\nb\nc\n', 'a\nb\nd\n']
+	])('keeps compact %s unmeasured', (_name, upstreamText, forkText) => {
+		write(upstream, 'shared/compact-source.txt', upstreamText);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add compact source']);
+		write(fork, 'product/compact-copy.txt', forkText);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add compact copy']);
+
+		expect(verdicts(fork)['product/compact-copy.txt']).toBe('unmeasured');
+	});
+
+	it('finds a multiline copy transformed over an existing fork path', () => {
+		const source = Array.from({ length: 8 }, (_, i) => `performTask${i}();`);
+		write(upstream, 'shared/transformed-source.ts', `${source.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add transform source']);
+		write(fork, 'product/transformed-copy.ts', 'originalForkOnly();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add fork-owned base']);
+		markBase(fork);
+		write(
+			fork,
+			'product/transformed-copy.ts',
+			`${source.map((line) => `await ${line}`).join('\n')}\n`
+		);
+		git(fork, ['commit', '-qam', 'replace with transformed copy']);
+
+		expect(verdicts(fork)['product/transformed-copy.ts']).toBe('unmeasured');
+	});
+
+	it('finds a multiline upstream copy minified to one line', () => {
+		const source = Array.from(
+			{ length: 10 },
+			(_, i) => `export const preservedIdentifier${i} = calculatePreservedValue(${i});`
+		);
+		write(upstream, 'shared/minified-source.ts', `${source.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add minified source']);
+		write(fork, 'product/minified-copy.ts', 'originalForkOnly();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add fork-owned base']);
+		markBase(fork);
+		write(fork, 'product/minified-copy.ts', `${source.join('')}extraForkCall();\n`);
+		git(fork, ['commit', '-qam', 'replace with minified copy']);
+
+		expect(verdicts(fork)['product/minified-copy.ts']).toBe('unmeasured');
+	});
+
+	it('finds a one-line derived file after a small edit', () => {
+		write(upstream, 'shared/minified.js', 'const inherited=1;const shared=2;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add minified source']);
+
+		write(fork, 'product/derived.js', 'const inherited=1;const shared=3;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add minified copy']);
+
+		expect(verdicts(fork)['product/derived.js']).toBe('unmeasured');
+	});
+
+	it('keeps NUL-free invalid UTF-8 with a newline unmeasured', () => {
+		writeFileSync(
+			join(upstream, 'shared/source.bytes'),
+			Buffer.from([0xff, 0x41, 0x42, 0x43, 0x0a])
+		);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add binary source']);
+
+		writeFileSync(join(fork, 'product/derived.bytes'), Buffer.from([0xff, 0x41, 0x42, 0x44, 0x0a]));
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add binary copy']);
+
+		expect(verdicts(fork)['product/derived.bytes']).toBe('unmeasured');
+	});
+
+	it('keeps a multiline Latin-1 source unmeasured', () => {
+		const source = [
+			'export const café = 1;',
+			'export const inheritedA = 1;',
+			'export const inheritedB = 2;',
+			'export const inheritedC = 3;',
+			'export const inheritedD = 4;',
+			'export const inheritedE = 5;'
+		].join('\n');
+		writeFileSync(join(upstream, 'shared/latin-source.ts'), Buffer.from(`${source}\n`, 'latin1'));
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add latin1 source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(
+			fork,
+			'product/utf8-copy.ts',
+			`${source}\nexport const forkOnlyA = 1;\nexport const forkOnlyB = 2;\n`
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'convert copied source to utf8']);
+
+		expect(verdicts(fork)['product/utf8-copy.ts']).toBe('unmeasured');
+	});
+
+	it('keeps cross-extension invalid UTF-8 evidence unmeasured', () => {
+		const source = [
+			'const café = 1;',
+			'const inheritedA = 1;',
+			'const inheritedB = 2;',
+			'const inheritedC = 3;',
+			'const inheritedD = 4;',
+			'const inheritedE = 5;'
+		].join('\n');
+		writeFileSync(join(upstream, 'shared/legacy-port.js'), Buffer.from(`${source}\n`, 'latin1'));
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add cross-extension latin1 source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(fork, 'product/modern-port.ts', `${source}\nconst forkOnlyA = 1;\n`);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'port latin1 source to typescript']);
+		markBase(fork);
+		write(
+			fork,
+			'product/modern-port.ts',
+			`${source}\nconst forkOnlyA = 1;\nconst forkOnlyB = 2;\n`
+		);
+		git(fork, ['commit', '-qam', 'edit typescript port']);
+
+		expect(verdicts(fork)['product/modern-port.ts']).toBe('unmeasured');
+	});
+
+	it('decodes UTF-16 text under an unlisted extension', () => {
+		const source = 'const inheritedUtf16Source = true;\nconst inheritedUtf16Value = 2;\n';
+		writeFileSync(
+			join(upstream, 'shared/Localizable.strings'),
+			Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(source, 'utf16le')])
+		);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add cross-extension utf16 source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(fork, 'product/only-here.ts', `${source}const forkOnlyA = 1;\n`);
+		git(fork, ['commit', '-qam', 'port utf16 source to typescript']);
+		markBase(fork);
+		write(fork, 'product/only-here.ts', `${source}const forkOnlyA = 1;\nconst forkOnlyB = 2;\n`);
+		git(fork, ['commit', '-qam', 'edit utf16 typescript port']);
+
+		expect(verdicts(fork)['product/only-here.ts']).toBe('unmeasured');
+	});
+
+	it('decodes BOM-prefixed UTF-16 without NUL bytes', () => {
+		const source = '漢字漢字漢字漢字漢字漢字漢字漢字';
+		const encoded = Buffer.from(source, 'utf16le');
+		expect(encoded.includes(0)).toBe(false);
+		const utf16Upstream = join(tmp, 'utf16-bom-upstream');
+		mkdirSync(utf16Upstream);
+		init(utf16Upstream);
+		writeFileSync(
+			join(utf16Upstream, 'Localizable.strings'),
+			Buffer.concat([Buffer.from([0xff, 0xfe]), encoded])
+		);
+		git(utf16Upstream, ['add', '-A']);
+		git(utf16Upstream, ['commit', '-qm', 'add UTF-16 source']);
+		const forkPoint = git(utf16Upstream, ['rev-parse', 'HEAD']);
+		const utf16Fork = join(tmp, 'utf16-bom-fork');
+		mkdirSync(utf16Fork);
+		init(utf16Fork);
+		write(utf16Fork, 'product/port.ts', source);
+		write(
+			utf16Fork,
+			'.upstream-sync.json',
+			JSON.stringify({ upstreamUrl: utf16Upstream, forkPoint, lastSynced: forkPoint })
+		);
+		git(utf16Fork, ['add', '-A']);
+		git(utf16Fork, ['commit', '-qm', 'create UTF-16 fork']);
+		const origin = join(tmp, 'utf16-bom-origin.git');
+		mkdirSync(origin);
+		git(origin, ['init', '--bare', '-q']);
+		git(utf16Fork, ['remote', 'add', 'origin', origin]);
+		git(utf16Fork, ['remote', 'add', 'upstream', utf16Upstream]);
+		git(utf16Fork, ['fetch', '-q', 'upstream']);
+		markBase(utf16Fork);
+		write(utf16Fork, 'product/port.ts', `${source}仮名`);
+		git(utf16Fork, ['commit', '-qam', 'edit UTF-16 port']);
+
+		const r = run(utf16Fork, ['--fetch', '--json', '--all', 'product/port.ts']);
+
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('unmeasured');
+		expect(parsed.verdicts[0]?.note).toMatch(/mostly matches upstream/);
+	});
+
+	it('adds the remote when --fetch is asked to recover a fresh clone', () => {
+		// The documented recovery from a clone that has never seen the template.
+		// Without the remote add, --fetch has nothing to fetch and the advice the
+		// error gives is a dead end. The neighbouring no-write test cannot catch
+		// that: it deliberately omits --fetch, and the refresh test starts from a
+		// fixture that already has the remote.
+		git(fork, ['remote', 'remove', 'upstream']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+
+		const r = run(fork, ['--fetch', 'shared/pristine.ts']);
+		expect(r.status, `script failed: ${r.stderr}`).toBe(0);
+		expect(git(fork, ['remote']).split('\n').filter(Boolean)).toContain('upstream');
+		expect(git(fork, ['rev-parse', '--verify', 'refs/remotes/upstream/main'])).toBeTruthy();
+	});
+
+	itWithGitWrapper(
+		'does not bind fetched objects to a remote changed during initial creation',
+		() => {
+			const decoy = join(tmp, 'remote-add-race-decoy');
+			mkdirSync(decoy);
+			init(decoy);
+			write(decoy, 'decoy.ts', 'export const decoy = true;\n');
+			git(decoy, ['add', '-A']);
+			git(decoy, ['commit', '-qm', 'add remote-add decoy']);
+			git(fork, ['remote', 'remove', 'upstream']);
+			git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+			const marker = join(tmp, 'remote-add-swapped');
+
+			const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts'], {
+				PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+				REAL_GIT: realGitPath(),
+				ADD_REMOTE_SWAP_REMOTE: decoy,
+				ADD_REMOTE_SWAP_MARKER: marker
+			});
+
+			expect(existsSync(marker)).toBe(true);
+			expect(r.status).not.toBe(0);
+			expect(r.stderr).toMatch(/upstream URL changed while this report fetched objects/);
+			expect(git(fork, ['remote', 'get-url', 'upstream'])).toBe(decoy);
+			expect(
+				gitOptional(fork, ['rev-parse', '--verify', '--quiet', 'refs/remotes/upstream/main'])
+			).toBe('');
+			expect(gitOptional(fork, ['config', '--get', 'upstreamReport.lastFetch'])).toBe('');
+		}
+	);
+
+	it('refuses a fetched remote that has no main branch', () => {
+		const trunk = join(tmp, 'trunk-template');
+		mkdirSync(trunk);
+		init(trunk);
+		write(trunk, 'trunk.ts', 'export const trunk = 1;\n');
+		git(trunk, ['add', '-A']);
+		git(trunk, ['commit', '-qm', 'trunk template']);
+		git(trunk, ['branch', '-m', 'trunk']);
+
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: trunk }));
+		git(fork, ['commit', '-qam', 'set trunk parent']);
+		git(fork, ['remote', 'remove', 'upstream']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+		const r = run(fork, ['--fetch']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toContain('Could not fetch refs/heads/main');
+		expect(r.stderr).not.toContain('already exists');
+		expect(gitOptional(fork, ['config', '--get', 'remote.upstream.url'])).toBe('');
+		expect(
+			gitOptional(fork, ['rev-parse', '--verify', '--quiet', 'refs/remotes/upstream/main'])
+		).toBe('');
+		expect(gitOptional(fork, ['config', '--get', 'upstreamReport.lastFetch'])).toBe('');
+	});
+
+	it.skipIf(process.platform === 'win32')(
+		'redacts a credential when a fresh fetch creates no main ref',
+		() => {
+			const secret = 's3cr3t-fetch-token';
+			write(
+				fork,
+				'.upstream-sync.json',
+				JSON.stringify({ upstreamUrl: `https://${secret}@example.invalid/template.git` })
+			);
+			git(fork, ['remote', 'remove', 'upstream']);
+			git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+			const wrapper = installGitWrapper(tmp);
+			const r = run(fork, ['--fetch', 'shared/pristine.ts'], {
+				PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+				REAL_GIT: realGitPath(),
+				FAKE_FETCH_SUCCESS: '1'
+			});
+			expect(r.status).not.toBe(0);
+			expect(r.stderr).not.toContain(secret);
+			expect(r.stderr).not.toContain('already exists');
+		}
+	);
+
+	itWithGitWrapper('creates a missing remote from a standard SSH URL', () => {
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		const sshUrl = 'ssh://git@github.com/stickerdaniel/saas-starter.git';
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: sshUrl }));
+		git(fork, ['commit', '-qam', 'set SSH parent']);
+		markBase(fork);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'fix shared path']);
+		git(fork, ['remote', 'remove', 'upstream']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+
+		const r = run(fork, ['--base', 'origin/main', '--fetch', '--json', 'shared/pristine.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			FAKE_FETCH_SUCCESS: '1',
+			FAKE_REMOTE_MAIN_SHA: git(upstream, ['rev-parse', 'HEAD'])
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		expect(git(fork, ['remote', 'get-url', 'upstream'])).toBe(sshUrl);
+	});
+
+	itWithGitWrapper('keeps SCP-style usernames out of shared remote creation', () => {
+		const secret = 'DUMMY_SCP_CREATION_SECRET';
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		const unsafeUrl = `${secret}@example.invalid:owner/template.git`;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: unsafeUrl }));
+		git(fork, ['commit', '-qam', 'set SCP parent']);
+		markBase(fork);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'fix shared path']);
+		git(fork, ['remote', 'remove', 'upstream']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+		const seen = join(tmp, 'scp-secret-in-argv');
+
+		const r = run(fork, ['--base', 'origin/main', '--fetch', '--json', 'shared/pristine.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			FAKE_FETCH_SUCCESS: '1',
+			FAKE_REMOTE_MAIN_SHA: git(upstream, ['rev-parse', 'HEAD']),
+			CHILD_ARG_SECRET: secret,
+			CHILD_ARG_MARKER: seen
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain(secret);
+		expect(existsSync(seen)).toBe(false);
+		expect(gitOptional(fork, ['remote', 'get-url', 'upstream'])).toBe('');
+	});
+
+	it('collects an edit that exists only in the index', () => {
+		// Staging and then restoring the working tree leaves the change in the
+		// index alone. The staged collector is the only one that can see it: the
+		// worktree diff finds nothing, and the committed range has not moved.
+		// Staging without restoring, which is what the neighbouring test does,
+		// leaves the same bytes on disk and keeps that collector redundant.
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['add', 'shared/pristine.ts']);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 2;\n');
+
+		expect(verdicts(fork)['shared/pristine.ts']).toBe('pristine');
+	});
+
+	it('refuses automatic discovery with assume-unchanged entries', () => {
+		git(fork, ['update-index', '--assume-unchanged', 'shared/pristine.ts']);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+
+		const r = run(fork, []);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+		expect(r.stderr).toContain('assume-unchanged');
+		expect(r.stderr).toContain('shared/pristine.ts');
+	});
+
+	it('refuses automatic discovery with skip-worktree entries', () => {
+		git(fork, ['update-index', '--skip-worktree', 'shared/pristine.ts']);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+
+		const r = run(fork, []);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+		expect(r.stderr).toContain('skip-worktree');
+		expect(r.stderr).toContain('shared/pristine.ts');
+	});
+
+	it('refuses an explicit path hidden by an index flag', () => {
+		git(fork, ['update-index', '--skip-worktree', 'product/only-here.ts']);
+
+		const r = run(fork, ['--fetch', '--json', 'product/only-here.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+		expect(r.stderr).toContain('skip-worktree');
+		expect(r.stderr).toContain('product/only-here.ts');
+	});
+
+	it('classifies an explicit staged deletion introduced after the base', () => {
+		write(fork, 'product/feature-file.ts', 'featureFile();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add feature file']);
+		git(fork, ['rm', '-q', 'product/feature-file.ts']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/feature-file.ts']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as { verdicts: Array<{ path: string }> };
+		expect(parsed.verdicts.map((verdict) => verdict.path)).toContain('product/feature-file.ts');
+	});
+
+	it('resolves a path argument against the directory it was typed in', () => {
+		// An agent runs from wherever it is working. Resolving arguments after the
+		// chdir to the repository root reinterprets them against a directory the
+		// caller never meant, and an argument that matches nothing is fatal, so
+		// the run dies on a path that was correct when written.
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'fix']);
+
+		const r = run(join(fork, 'product'), ['--json', '../shared/pristine.ts']);
+		expect(r.status, `script failed: ${r.stderr}`).toBe(0);
+		const parsed = JSON.parse(r.stdout) as { verdicts: Array<{ path: string }> };
+		expect(parsed.verdicts.map((v) => v.path)).toEqual(['shared/pristine.ts']);
+	});
+
+	it('resolves a deleted relative path against the caller directory', () => {
+		git(fork, ['rm', '-q', 'shared/pristine.ts']);
+		git(fork, ['commit', '-qm', 'delete shared file']);
+
+		const r = run(join(fork, 'shared'), ['--json', 'pristine.ts']);
+		expect(r.status, `script failed: ${r.stderr}`).toBe(0);
+		const parsed = JSON.parse(r.stdout) as { verdicts: Array<{ path: string; relevance: string }> };
+		expect(parsed.verdicts).toEqual([
+			expect.objectContaining({ path: 'shared/pristine.ts', relevance: 'pristine' })
+		]);
+	});
+
+	it.skipIf(process.platform === 'win32')(
+		'keeps a literal backslash in an explicit POSIX path',
+		() => {
+			const path = 'shared/a\\b.ts';
+			for (const repo of [upstream, fork]) {
+				write(repo, path, 'export const slash = 1;\n');
+				git(repo, ['add', '-A']);
+				git(repo, ['commit', '-qm', 'add backslash path']);
+			}
+			git(fork, ['fetch', '-q', 'upstream']);
+			markBase(fork);
+			write(fork, path, 'export const slash = 2;\n');
+
+			expect(verdicts(fork, [path])[path]).toBe('pristine');
+		}
+	);
+
+	it('does not close a one-day-old run with a clean bill of health', () => {
+		// The age warning and the closing sentence must use the same threshold.
+		// Two days was enough for this template to add seven paths, so a clean
+		// verdict cannot survive a copy that is already two days old.
+		const old = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+		const tip = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+		git(
+			fork,
+			['update-ref', '-m', 'fetch upstream: storing head', 'refs/remotes/upstream/main', tip],
+			{
+				GIT_COMMITTER_DATE: old
+			}
+		);
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'edit']);
+
+		const r = run(fork, []);
+		expect(r.status).toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream.');
+		expect(r.stdout).toContain('--fetch');
+
+		const json = run(fork, ['--json']);
+		expect(json.status).toBe(0);
+		expect((JSON.parse(json.stdout) as { upstreamStale: boolean }).upstreamStale).toBe(true);
+	});
+
+	it('keeps both the source and the destination path of a rename', () => {
+		// Moving template code to a fork-only path is exactly the change worth
+		// reporting, and `--name-only` prints only the destination, which is
+		// fork-only, so the whole move disappears. `--name-status` is what keeps
+		// both halves; `-M` beside it only decides whether git calls the pair a
+		// rename or a delete plus an add, and either spelling yields both paths.
+		git(fork, ['mv', 'shared/pristine.ts', 'product/moved.ts']);
+		git(fork, ['commit', '-qm', 'move']);
+		const v = verdicts(fork);
+		expect(Object.keys(v)).toContain('shared/pristine.ts');
+		expect(v['shared/pristine.ts']).toBe('pristine');
+		// The destination answers too, or dropping `-M` would leave this green:
+		// a rename then reads as one deletion plus one addition, and the source
+		// still appears.
+		expect(Object.keys(v)).toContain('product/moved.ts');
+	});
+
+	it('sees an untracked new file at a path upstream also has', () => {
+		git(fork, ['rm', '-q', 'shared/pristine.ts']);
+		git(fork, ['commit', '-qm', 'drop']);
+		markBase(fork);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const reAdded = true;\n');
+
+		const v = verdicts(fork);
+		expect(v['shared/pristine.ts']).toBe('unmeasured');
+	});
+
+	it('surfaces a changed shared binary instead of scoring it zero', () => {
+		write(fork, 'shared/binary.bin', 'fork\u0000other');
+		git(fork, ['commit', '-qam', 'binary']);
+		expect(verdicts(fork)['shared/binary.bin']).toBe('unmeasured');
+	});
+
+	it('refuses Git paths that are not valid UTF-8', () => {
+		const first = gitInput(fork, ['hash-object', '-w', '--stdin'], 'export const a = 1;\n');
+		const second = gitInput(fork, ['hash-object', '-w', '--stdin'], 'forkOnly();\n');
+		const records = Buffer.concat([
+			Buffer.from(`100644 ${first} 0\tproduct/`),
+			Buffer.from([0xfe]),
+			Buffer.from('.ts\0'),
+			Buffer.from(`100644 ${second} 0\tproduct/`),
+			Buffer.from([0xff]),
+			Buffer.from('.ts\0')
+		]);
+		gitInput(fork, ['update-index', '-z', '--index-info'], records);
+		git(fork, ['commit', '-qm', 'add raw paths']);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/pathname.*not valid UTF-8/);
+	});
+
+	it('keeps invalid UTF-8 shared content unmeasured', () => {
+		writeFileSync(join(upstream, 'shared/invalid-text.ts'), Buffer.from([0xff, 0x20, 0x41]));
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add invalid source']);
+		writeFileSync(join(fork, 'shared/invalid-text.ts'), Buffer.from([0xff, 0x20, 0x42]));
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add diverged invalid source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		markBase(fork);
+		writeFileSync(join(fork, 'shared/invalid-text.ts'), Buffer.from([0xff, 0x20, 0x43]));
+		git(fork, ['commit', '-qam', 'edit invalid source']);
+
+		expect(verdicts(fork, ['shared/invalid-text.ts'])['shared/invalid-text.ts']).toBe('unmeasured');
+	});
+
+	it('handles a non-ASCII shared path', () => {
+		// git quotes these by default ("enc\303\266ded"), and the quoted form then
+		// fails when handed back to rev-parse, so the file silently ends up
+		// unmeasured: a wrong answer that looks like a cautious one.
+		write(fork, 'shared/encöded.ts', 'export const t = 1;\nexport const u = 99;\n');
+		git(fork, ['commit', '-qam', 'edit encoded']);
+
+		expect(verdicts(fork)['shared/encöded.ts']).toBe('pristine');
+	});
+
+	it('scores a change inside a fork-added block at zero, and still reports it', () => {
+		write(
+			fork,
+			'shared/rewritten.ts',
+			'export const template1 = 1;\nexport const template2 = 2;\nexport const template3 = 3;\nexport const template4 = 4;\nexport const template5 = 5;\nexport const template6 = 6;\nexport const template7 = 7;\nexport const template8 = 8;\nexport const forkOnly1 = 1;\nexport const forkOnly2 = 2;\nexport const forkOnly3 = 3;\nexport const forkOnly4 = 4;\nexport const forkOnly5 = 99;\nexport const forkOnly6 = 6;\nexport const forkOnly7 = 7;\nexport const forkOnly8 = 8;\n'
+		);
+		git(fork, ['commit', '-qam', 'fork block']);
+		const r = run(fork, ['--json']);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; report: boolean }>;
+		};
+		const v = parsed.verdicts.find((x) => x.path === 'shared/rewritten.ts');
+		expect(v?.relevance).toBe('diverged');
+		// Zero is the honest score: nothing this change replaced exists upstream.
+		// It is not grounds for silence, because the same score is produced by a
+		// fix to a template line the fork had renamed.
+		expect(v?.overlap).toBe(0);
+		expect(v?.report).toBe(true);
+	});
+
+	it('reports a diverged file whose change replaced an actual upstream line', () => {
+		// The positive counterpart to the case above, and the one whose absence
+		// let a broken wiring stay green: with no test that a diverged file can
+		// ever be reported, an implementation feeding empty upstream content to
+		// every comparison would pass the whole suite.
+		const lines = Array.from({ length: 8 }, (_, i) => `export const template${i + 1} = ${i + 1};`);
+		lines[2] = 'export const template3 = 3333;';
+		write(
+			fork,
+			'shared/rewritten.ts',
+			lines.join('\n') +
+				'\n' +
+				Array.from({ length: 8 }, (_, i) => `export const forkOnly${i + 1} = ${i + 1};`).join(
+					'\n'
+				) +
+				'\n'
+		);
+		git(fork, ['commit', '-qam', 'fix template line']);
+		const r = run(fork, ['--json']);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; report: boolean; overlap?: number }>;
+		};
+		const v = parsed.verdicts.find((x) => x.path === 'shared/rewritten.ts');
+		expect(v?.relevance).toBe('diverged');
+		expect(v?.overlap).toBe(1);
+		expect(v?.report).toBe(true);
+	});
+
+	it('collects an unstaged edit to a tracked file', () => {
+		// Every other case commits first, so removing the working-tree collector
+		// entirely would leave the suite green.
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 77;\n');
+		expect(verdicts(fork)['shared/pristine.ts']).toBe('pristine');
+	});
+
+	it('collects a staged edit to a tracked file', () => {
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 78;\n');
+		git(fork, ['add', 'shared/pristine.ts']);
+		expect(verdicts(fork)['shared/pristine.ts']).toBe('pristine');
+	});
+
+	it('scores a staged diverged edit after the worktree is restored', () => {
+		const path = join(fork, 'shared/rewritten.ts');
+		const original = readFileSync(path, 'utf8');
+		writeFileSync(path, original.replace('template8 = 8', 'template8 = 88'));
+		git(fork, ['add', 'shared/rewritten.ts']);
+		writeFileSync(path, original);
+
+		const verdict = verdictsWithScore(fork, ['shared/rewritten.ts'])['shared/rewritten.ts'];
+		expect(verdict?.relevance).toBe('diverged');
+		expect(verdict?.overlap).toBe(1);
+	});
+
+	it('refuses an unknown option instead of treating its value as a path', () => {
+		// `--bsae origin/main` parsed as a boolean flag plus a positional, and a
+		// positional replaces the entire automatic file list. The run then checked
+		// the literal path "origin/main", found nothing, and exited zero.
+		const r = run(fork, ['--bsae', 'origin/main']);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+	});
+
+	it('escapes controls in an unknown-option diagnostic', () => {
+		const escape = String.fromCharCode(27);
+		const r = run(fork, [`--bad${escape}[2J`]);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain(escape);
+		expect(r.stderr).toContain('\\u001b[2J');
+		expect(r.stderr).not.toContain('TypeError');
+	});
+
+	it('refuses an unknown option even when its value is a real path', () => {
+		// The sharper version of the case above. With a nonexistent value the path
+		// check catches it, so that test passes whether or not parsing is strict.
+		// Here the stray value IS a real file, so only strict parsing objects.
+		// Otherwise the run silently narrows to that one file and exits zero.
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'fix']);
+
+		const r = run(fork, ['--bsae', 'shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+	});
+
+	it('refuses an explicit path that does not exist', () => {
+		const r = run(fork, ['shared/typo.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+	});
+
+	it('refuses a tracking ref with no remote behind it', () => {
+		// An orphan `upstream/main` left by a former parent fork classifies every
+		// path the real template has but that one lacks as fork-only: silent, and
+		// wrong. Ref presence alone is not evidence of provenance.
+		// `git remote remove` deletes the tracking refs too, so it cannot build
+		// this case. Dropping the config section leaves the ref stranded, which is
+		// exactly what a repointed or abandoned remote leaves behind.
+		git(fork, ['config', '--remove-section', 'remote.upstream']);
+		expect(git(fork, ['rev-parse', '--verify', '--quiet', 'refs/remotes/upstream/main'])).not.toBe(
+			''
+		);
+
+		const r = run(fork, ['shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/no `upstream` remote is configured/);
+	});
+
+	it('fails when a collector cannot run instead of reporting clean', () => {
+		// A malformed inherited config made every `git diff` fail; each returned
+		// an empty string, and four empty lists read as a clean tree.
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 55;\n');
+		git(fork, ['commit', '-qam', 'fix']);
+		git(fork, ['config', 'diff.renames', 'not-a-valid-value']);
+
+		const r = run(fork, []);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+	});
+
+	itWithPosixPaths('escapes terminal controls in the human report', () => {
+		const escape = String.fromCharCode(27);
+		const path = `shared/${escape}[2J${escape}[HNothing to report upstream.ts`;
+		write(upstream, path, 'export const safe = 1;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add controlled path']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, path, 'export const safe = 1;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add controlled path']);
+		markBase(fork);
+		write(fork, path, 'export const safe = 2;\n');
+		git(fork, ['commit', '-qam', 'edit controlled path']);
+
+		const r = run(fork, ['--fetch', path]);
+		expect(r.status).toBe(0);
+		expect(r.stdout).not.toContain(escape);
+		expect(r.stdout).toContain('\\u001b[2J\\u001b[HNothing to report upstream.ts');
+	});
+
+	itWithPosixPaths('escapes bidirectional controls in human and JSON reports', () => {
+		const bidi = String.fromCharCode(0x202e);
+		const path = `shared/${bidi}reordered.ts`;
+		write(upstream, path, 'export const bidiSafe = 1;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add bidi path']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, path, 'export const bidiSafe = 1;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add bidi path']);
+		markBase(fork);
+		write(fork, path, 'export const bidiSafe = 2;\n');
+		git(fork, ['commit', '-qam', 'edit bidi path']);
+
+		const human = run(fork, ['--fetch', path]);
+		expect(human.status, human.stderr).toBe(0);
+		expect(human.stdout).not.toContain(bidi);
+		expect(human.stdout).toContain('\\u202ereordered.ts');
+
+		const json = run(fork, ['--fetch', '--json', path]);
+		expect(json.status, json.stderr).toBe(0);
+		expect(json.stdout).not.toContain(bidi);
+		expect(json.stdout).toContain('\\u202ereordered.ts');
+		const parsed = JSON.parse(json.stdout) as { verdicts: Array<{ path: string }> };
+		expect(parsed.verdicts[0]?.path).toBe(path);
+	});
+
+	itWithPosixPaths('escapes C1 and Unicode line controls in human and JSON reports', () => {
+		const csi = String.fromCharCode(0x009b);
+		const lineSeparator = String.fromCharCode(0x2028);
+		const path = `shared/${csi}31m${lineSeparator}Nothing to report upstream.ts`;
+		write(upstream, path, 'export const controlSafe = 1;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add controlled path']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, path, 'export const controlSafe = 1;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add controlled path']);
+		markBase(fork);
+		write(fork, path, 'export const controlSafe = 2;\n');
+		git(fork, ['commit', '-qam', 'edit controlled path']);
+
+		const human = run(fork, ['--fetch', path]);
+		expect(human.status, human.stderr).toBe(0);
+		expect(human.stdout).not.toContain(csi);
+		expect(human.stdout).not.toContain(lineSeparator);
+		expect(human.stdout).toContain('\\u009b31m\\u2028Nothing to report upstream.ts');
+
+		const json = run(fork, ['--fetch', '--json', path]);
+		expect(json.status, json.stderr).toBe(0);
+		expect(json.stdout).not.toContain(csi);
+		expect(json.stdout).not.toContain(lineSeparator);
+		expect(json.stdout).toContain('\\u009b31m\\u2028Nothing to report upstream.ts');
+	});
+
+	it('renders a human report that marks what to read', () => {
+		// Every other assertion reads --json, so a renderer that dropped every
+		// marker, or printed "Nothing to report upstream" unconditionally, would
+		// leave the whole suite green while showing an agent the wrong answer.
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 42;\n');
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'both']);
+
+		const r = run(fork, ['--fetch']);
+		expect(r.status).toBe(0);
+		expect(r.stdout).toMatch(/>> pristine\s+shared\/pristine\.ts/);
+		expect(r.stdout).not.toContain('product/only-here.ts');
+		expect(r.stdout).toContain('1 of 2 changed files need a look');
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+	});
+
+	it('says plainly when nothing template-derived changed', () => {
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'fork only']);
+
+		const r = run(fork, ['--fetch']);
+		expect(r.status).toBe(0);
+		expect(r.stdout).toContain('Nothing to report upstream');
+	});
+
+	it('accepts an explicit path in any form git understands', () => {
+		// `./x`, a directory and a redundant separator all miss an exact lookup
+		// against the upstream file set, and a miss reads as fork-only.
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 43;\n');
+		git(fork, ['commit', '-qam', 'fix']);
+
+		for (const form of ['./shared/pristine.ts', 'shared//pristine.ts', 'shared']) {
+			const v = verdicts(fork, [form]);
+			expect(v['shared/pristine.ts'], `form ${form}`).toBe('pristine');
+		}
+	});
+
+	it('refuses explicit paths when the parent marker changed in the commit range', () => {
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, detectorFixture: true }));
+		git(fork, ['commit', '-qam', 'change parent marker']);
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/\.upstream-sync\.json changed in the selected commit range/);
+	});
+
+	itWithGitWrapper('deduplicates explicit pathspecs before enumeration', () => {
+		const enumerationLog = join(tmp, 'path-enumeration.log');
+		const r = run(fork, ['--fetch', '--json', 'shared', 'shared', './shared'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			PATH_ENUMERATION_LOG: enumerationLog
+		});
+		expect(r.status, r.stderr).toBe(0);
+		expect(readFileSync(enumerationLog, 'utf8').trim().split('\n')).toHaveLength(3);
+	});
+
+	it('bounds aggregate explicit path expansion', () => {
+		const r = run(fork, ['--fetch', '--json', '--all', '.'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_PATH_LIMIT: '1'
+		});
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/matched more than 1 files/);
+	});
+
+	it('bounds aggregate automatic path discovery', () => {
+		write(fork, 'product/automatic-one.ts', 'automaticOne();\n');
+		write(fork, 'product/automatic-two.ts', 'automaticTwo();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add automatic paths']);
+
+		const r = run(fork, ['--json'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_PATH_LIMIT: '1'
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/Automatic discovery found more than 1 changed paths/);
+	});
+
+	it('refuses staged marker bytes that differ from the working tree', () => {
+		const stagedParent = join(tmp, 'staged-parent');
+		mkdirSync(stagedParent);
+		init(stagedParent);
+		write(stagedParent, 'inherited.ts', 'stagedParentInheritance();\n');
+		git(stagedParent, ['add', '-A']);
+		git(stagedParent, ['commit', '-qm', 'add inherited file']);
+
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: stagedParent }));
+		write(fork, 'inherited.ts', 'stagedParentInheritance();\n');
+		git(fork, ['add', '.upstream-sync.json', 'inherited.ts']);
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: upstream }));
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'inherited.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/must be committed and clean/);
+	});
+
+	it('refuses an ignored untracked upstream marker', () => {
+		git(fork, ['rm', '-q', '.upstream-sync.json']);
+		git(fork, ['commit', '-qm', 'remove upstream marker']);
+		writeFileSync(join(fork, '.git', 'info', 'exclude'), '.upstream-sync.json\n');
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: upstream }));
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/exists but is not tracked/);
+	});
+
+	it('refuses an oversized upstream marker before allocating its bytes', () => {
+		write(fork, '.upstream-sync.json', `${' '.repeat(1024 * 1024)}x`);
+		git(fork, ['commit', '-qam', 'oversize marker']);
+
+		const r = run(fork, ['--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/input limit/);
+	});
+
+	it('refuses a marker that cannot be parsed instead of assuming the default template', () => {
+		// A fork of a fork names its own parent here. Falling back silently would
+		// classify it against the wrong repository, and with --fetch would pull it.
+		write(fork, '.upstream-sync.json', '{ not valid json');
+		git(fork, ['commit', '-qam', 'break marker']);
+
+		const r = run(fork, ['shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/not valid JSON/);
+	});
+
+	it('escapes controls copied into a malformed-marker diagnostic', () => {
+		const escape = String.fromCharCode(27);
+		write(fork, '.upstream-sync.json', `{"upstreamUrl":"ok"}${escape}[31m`);
+		git(fork, ['commit', '-qam', 'add malformed marker control']);
+
+		const r = run(fork, ['shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain(escape);
+		expect(r.stderr).toContain('\\u001b');
+	});
+
+	itWithPosixPaths('refuses a dangling upstream marker symlink', () => {
+		rmSync(join(fork, '.upstream-sync.json'));
+		symlinkSync('../missing-upstream-marker.json', join(fork, '.upstream-sync.json'));
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/must be a regular file/);
+	});
+
+	itWithPosixPaths('refuses a clean tracked upstream marker symlink', () => {
+		const target = join(tmp, 'external-upstream-marker.json');
+		writeFileSync(target, JSON.stringify({ upstreamUrl: upstream }));
+		rmSync(join(fork, '.upstream-sync.json'));
+		symlinkSync(target, join(fork, '.upstream-sync.json'));
+		git(fork, ['add', '.upstream-sync.json']);
+		git(fork, ['commit', '-qm', 'track marker symlink']);
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/must be a regular file/);
+	});
+
+	it.each([
+		['null URL', { upstreamUrl: null }],
+		['false URL', { upstreamUrl: false }],
+		['short fork point', { upstreamUrl: upstream, forkPoint: 'abc' }],
+		['numeric last synced', { upstreamUrl: upstream, lastSynced: 42 }],
+		['array root', []]
+	])('refuses a marker with %s', (_name, marker) => {
+		write(fork, '.upstream-sync.json', JSON.stringify(marker));
+
+		const r = run(fork, ['--fetch', 'shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(
+			/must (?:contain a JSON object|be a non-empty string|be full commit SHAs)/
+		);
+	});
+
+	it('redacts a failed fetch before Git stderr reaches the caller', () => {
+		const secret = 'DUMMY_FETCH_QUERY_SECRET';
+		const url = `http://127.0.0.1:1/repo.git?token=${secret}`;
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: url }));
+		git(fork, ['commit', '-qam', 'set unreachable parent']);
+		git(fork, ['remote', 'set-url', 'upstream', url]);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain(secret);
+		expect(r.stderr).toContain('repo.git?***');
+	});
+
+	itWithGitWrapper('disables maintenance in the private transport repository', () => {
+		const wrapper = installGitWrapper(tmp);
+		const fetchLog = join(tmp, 'fetch-command.log');
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			FETCH_COMMAND_LOG: fetchLog
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const commands = readFileSync(fetchLog, 'utf8');
+		expect(commands).toContain(' --no-auto-maintenance ');
+	});
+
+	itWithGitWrapper('copies credential helpers into the private transport config', () => {
+		const helper = '!credential-probe "quoted" C:\\tools';
+		git(fork, ['config', '--local', 'credential.helper', helper]);
+		const wrapper = installGitWrapper(tmp);
+		const credentialLog = join(tmp, 'transport-credential.log');
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			TRANSPORT_CREDENTIAL_LOG: credentialLog
+		});
+		expect(r.status, r.stderr).toBe(0);
+		expect(readFileSync(credentialLog, 'utf8').trim()).toBe(helper);
+	});
+
+	itWithGitWrapper(
+		'copies URL-scoped HTTP authentication into the private transport config',
+		() => {
+			git(fork, [
+				'config',
+				'--local',
+				`http.${upstream}.extraHeader`,
+				'Authorization: Bearer DUMMY_SCOPED_HEADER'
+			]);
+			const wrapper = installGitWrapper(tmp);
+			const httpLog = join(tmp, 'transport-http.log');
+			const r = run(fork, ['--json', 'shared/pristine.ts'], {
+				PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+				REAL_GIT: realGitPath(),
+				TRANSPORT_HTTP_LOG: httpLog
+			});
+			expect(r.status, r.stderr).toBe(0);
+			expect(readFileSync(httpLog, 'utf8')).toContain('Authorization: Bearer DUMMY_SCOPED_HEADER');
+		}
+	);
+
+	itWithGitWrapper('does not copy unscoped HTTP authentication to a marker-selected host', () => {
+		git(fork, ['config', '--local', 'http.extraHeader', 'Authorization: Bearer DUMMY_HEADER']);
+		const wrapper = installGitWrapper(tmp);
+		const httpLog = join(tmp, 'transport-unscoped-http.log');
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			TRANSPORT_UNSCOPED_HTTP_LOG: httpLog
+		});
+		expect(r.status, r.stderr).toBe(0);
+		expect(readFileSync(httpLog, 'utf8')).toBe('');
+	});
+
+	it('keeps copied authentication values out of child-process arguments', () => {
+		const source = readFileSync(SCRIPT, 'utf8');
+		const start = source.indexOf('function copyTransportAuthentication(');
+		const end = source.indexOf('// Enough for a whole repository', start);
+		const copy = source.slice(start, end);
+		expect(copy).toContain('appendTransportConfig(');
+		expect(copy).not.toContain('execFileSync(');
+		expect(source).toContain('chmodSync(transportConfigPath, 0o600)');
+	});
+
+	itWithGitWrapper('keeps remote URLs out of detector Git arguments', () => {
+		const secret = 'DUMMY_REMOTE_ARG_SECRET';
+		const secretUpstream = join(tmp, `template?token=${secret}`);
+		git(tmp, ['clone', '-q', upstream, secretUpstream]);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: secretUpstream }));
+		git(fork, ['commit', '-qam', 'set private parent path']);
+		git(fork, ['remote', 'set-url', 'upstream', secretUpstream]);
+		const seen = join(tmp, 'remote-secret-in-argv');
+
+		const r = run(fork, ['--fetch', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			CHILD_ARG_SECRET: secret,
+			CHILD_ARG_MARKER: seen
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(seen)).toBe(false);
+	});
+
+	it('fetches through a private SHA-256 transport repository', () => {
+		const shaUpstream = join(tmp, 'sha256-template');
+		mkdirSync(shaUpstream);
+		init(shaUpstream, 'sha256');
+		write(shaUpstream, 'shared/template.ts', 'export const template = 1;\n');
+		git(shaUpstream, ['add', '-A']);
+		git(shaUpstream, ['commit', '-qm', 'template']);
+		const forkPoint = git(shaUpstream, ['rev-parse', 'HEAD']);
+
+		const shaFork = join(tmp, 'sha256-fork');
+		mkdirSync(shaFork);
+		init(shaFork, 'sha256');
+		write(shaFork, 'shared/template.ts', 'export const template = 1;\n');
+		write(
+			shaFork,
+			'.upstream-sync.json',
+			JSON.stringify({ upstreamUrl: shaUpstream, forkPoint, lastSynced: forkPoint })
+		);
+		git(shaFork, ['add', '-A']);
+		git(shaFork, ['commit', '-qm', 'fork base']);
+		const shaOrigin = join(tmp, 'sha256-origin.git');
+		mkdirSync(shaOrigin);
+		git(shaOrigin, ['init', '--bare', '-q', '--object-format=sha256']);
+		git(shaFork, ['remote', 'add', 'origin', shaOrigin]);
+		git(shaFork, ['remote', 'add', 'upstream', shaUpstream]);
+		git(shaFork, ['fetch', '-q', 'upstream']);
+		markBase(shaFork);
+		write(shaFork, 'shared/template.ts', 'export const template = 2;\n');
+		git(shaFork, ['commit', '-qam', 'fix template path']);
+
+		const r = run(shaFork, ['--fetch', '--json', 'shared/template.ts']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('pristine');
+	});
+
+	it('refreshes a stale ref when --fetch is given', () => {
+		// The orphan-ref error suggests --fetch, so --fetch must actually fetch.
+		// It used to be skipped whenever a ref already existed, leaving the stale
+		// tree in place and every verdict computed from it unchanged.
+		write(upstream, 'shared/newly-added-upstream.ts', 'export const fresh = 1;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'new upstream file']);
+		write(fork, 'shared/newly-added-upstream.ts', 'export const fresh = 1;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'same file here']);
+
+		// A no-fetch run can use the old tree to find ties, but it cannot use an
+		// absent path to rule one out. Only this run's fetch earns fork-only.
+		const stale = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		const before = run(fork, ['--json']);
+		expect(before.status).toBe(0);
+		const beforeVerdicts = JSON.parse(before.stdout) as {
+			verdicts: Array<{ path: string; relevance: string }>;
+		};
+		expect(
+			beforeVerdicts.verdicts.find((v) => v.path === 'shared/newly-added-upstream.ts')?.relevance
+		).toBe('unmeasured');
+		expect(verdicts(fork, ['--fetch'])['shared/newly-added-upstream.ts']).not.toBe('fork-only');
+		// The verdict has to change because the copy advanced. Special-casing an
+		// absent path whenever --fetch is present would satisfy the line above.
+		expect(git(fork, ['rev-parse', 'refs/remotes/upstream/main'])).not.toBe(stale);
+	});
+
+	it('reports a deleted template file, in any spelling of its path', () => {
+		// Deleting template code is worth reporting, and the deletion branch of the
+		// path handling used to keep the caller's raw spelling: `./shared/x.ts`
+		// then missed the exact upstream lookup and came back fork-only.
+		git(fork, ['rm', '-q', 'shared/pristine.ts']);
+		git(fork, ['commit', '-qm', 'delete template file']);
+
+		for (const form of ['shared/pristine.ts', './shared/pristine.ts']) {
+			const v = verdicts(fork, [form]);
+			expect(v['shared/pristine.ts'], `form ${form}`).toBe('pristine');
+		}
+	});
+
+	it('calls a case-only difference ambiguous instead of fork-only', () => {
+		// The template has `shared/Config.ts`; this fork writes `shared/config.ts`.
+		// macOS and Windows treat those as one file and git treats them as two, so
+		// an exact-lookup miss is not evidence the template lacks the file, and
+		// answering fork-only would be a silent negative on the same file.
+		write(fork, 'shared/config.ts', 'export const config = 2;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'case variant']);
+
+		const v = verdicts(fork, ['shared/config.ts']);
+		expect(v['shared/config.ts']).toBe('unmeasured');
+	});
+
+	it('does not call a file fork-only when upstream renamed it away', () => {
+		// The path is gone upstream and the content is not. A fork that still
+		// carries the template's spelling and fixes a template bug in it would be
+		// suppressed by an exact-path lookup, which is the silent negative this
+		// whole file exists to prevent.
+		git(upstream, ['mv', 'shared/pristine.ts', 'shared/renamed.ts']);
+		git(upstream, ['commit', '-qm', 'rename upstream']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'fix the old path']);
+
+		const v = verdicts(fork, ['shared/pristine.ts']);
+		expect(v['shared/pristine.ts']).toBe('unmeasured');
+	});
+
+	it('does not call a fork copy of template code fork-only', () => {
+		// The fork copied an inherited file to a product path, then fixed an
+		// inherited bug in the copy. `-M` finds renames and not copies, so only
+		// the fork-specific destination is classified, and its path is absent
+		// upstream.
+		write(fork, 'product/copied.ts', 'export const a = 1;\nexport const b = 2;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'copy template code']);
+		markBase(fork);
+
+		write(fork, 'product/copied.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'fix the copy']);
+
+		const v = verdicts(fork, ['product/copied.ts']);
+		expect(v['product/copied.ts']).toBe('unmeasured');
+	});
+
+	itWithPosixPaths('treats pathspec-looking explicit arguments and diffs literally', () => {
+		const path = ':(literal)shared.ts';
+		write(upstream, path, 'export const inherited = 1;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add literal path']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, path, 'export const inherited = 1;\nexport const forkOnly = 1;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add fork version']);
+		markBase(fork);
+		write(fork, path, 'export const forkOnly = 1;\n');
+		git(fork, ['commit', '-qam', 'remove inherited line']);
+
+		const scored = verdictsWithScore(fork, [path]);
+		expect(scored[path]?.relevance).toBe('diverged');
+		expect(scored[path]?.overlap).toBe(1);
+	});
+
+	it('refuses when one explicit path matches and another does not', () => {
+		// A valid neighbour used to cover a typo: git drops the unmatched argument
+		// without a word, the combined list is still non-empty, and the run exits
+		// zero having never looked at the file the caller meant.
+		const r = run(fork, ['product/only-here.ts', 'shared/pristnie.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+		expect(r.stderr).toContain('shared/pristnie.ts');
+	});
+
+	it('sees a submodule change through per-submodule ignore=all', () => {
+		// Inherited config that suppresses a whole class of change is the same
+		// failure as a broken diff: all three collectors drop the path and the run
+		// exits zero. `update-index --cacheinfo` builds the gitlink without a real
+		// submodule checkout, which is enough for git to diff it.
+		const first = git(upstream, ['rev-parse', 'HEAD']);
+		for (const repo of [upstream, fork]) {
+			write(
+				repo,
+				'.gitmodules',
+				'[submodule "dep"]\n\tpath = vendor/dep\n\turl = ../dep.git\n\tignore = all\n'
+			);
+			git(repo, ['update-index', '--add', `--cacheinfo`, `160000,${first},vendor/dep`]);
+			git(repo, ['commit', '-qm', 'add gitlink']);
+		}
+		git(fork, ['fetch', '-q', 'upstream']);
+		markBase(fork);
+		git(fork, ['config', 'submodule.dep.ignore', 'all']);
+
+		const second = git(fork, ['rev-parse', 'HEAD']);
+		git(fork, ['update-index', `--cacheinfo`, `160000,${second},vendor/dep`]);
+		git(fork, ['commit', '-qm', 'move the gitlink']);
+
+		const v = verdicts(fork);
+		expect(Object.keys(v)).toContain('vendor/dep');
+	});
+
+	it('keeps a dirty unchanged gitlink unmeasured', () => {
+		const dependency = join(tmp, 'gitlink-dependency');
+		mkdirSync(dependency);
+		init(dependency);
+		write(dependency, 'tracked.txt', 'clean dependency\n');
+		git(dependency, ['add', '-A']);
+		git(dependency, ['commit', '-qm', 'add dependency file']);
+		const dependencySha = git(dependency, ['rev-parse', 'HEAD']);
+
+		for (const repo of [upstream, fork]) {
+			write(
+				repo,
+				'.gitmodules',
+				`[submodule "dirty"]\n\tpath = vendor/dirty\n\turl = ${dependency}\n`
+			);
+			git(repo, ['update-index', '--add', '--cacheinfo', `160000,${dependencySha},vendor/dirty`]);
+			git(repo, ['commit', '-qm', 'add dirty gitlink']);
+		}
+		git(fork, ['fetch', '-q', 'upstream']);
+		markBase(fork);
+		mkdirSync(join(fork, 'vendor'), { recursive: true });
+		git(fork, ['-c', 'protocol.file.allow=always', 'clone', '-q', dependency, 'vendor/dirty']);
+		write(fork, 'vendor/dirty/tracked.txt', 'dirty dependency\n');
+
+		const r = run(fork, ['--fetch', '--json', 'vendor/dirty']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('unmeasured');
+		expect(parsed.verdicts[0]?.note).toMatch(/gitlink|not a regular file/);
+	});
+
+	itWithGitWrapper('batches current upstream blob reads across changed paths', () => {
+		const paths = Array.from({ length: 3 }, (_, index) => `shared/batched-${index}.ts`);
+		for (const [index, path] of paths.entries()) {
+			write(upstream, path, `export const templateBatch${index} = true;\n`);
+			write(fork, path, `export const forkBatch${index} = true;\n`);
+		}
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add batched upstream paths']);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add divergent batched paths']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		markBase(fork);
+		for (const [index, path] of paths.entries()) {
+			write(fork, path, `export const forkBatch${index} = false;\n`);
+		}
+		git(fork, ['commit', '-qam', 'edit batched paths']);
+		const processLog = join(tmp, 'cat-file-checks.log');
+
+		const r = run(fork, ['--fetch', '--json', ...paths], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			CAT_FILE_CHECK_LOG: processLog
+		});
+		expect(r.status, r.stderr).toBe(0);
+		expect(readFileSync(processLog, 'utf8').trim().split('\n')).toHaveLength(2);
+	});
+
+	it('keeps trailing whitespace significant in local repository paths', () => {
+		const spacedUpstream = `${upstream} `;
+		git(tmp, ['clone', '-q', upstream, spacedUpstream]);
+		git(spacedUpstream, ['config', 'user.email', 'test@example.com']);
+		git(spacedUpstream, ['config', 'user.name', 'Test']);
+		write(spacedUpstream, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 50;\n');
+		git(spacedUpstream, ['commit', '-qam', 'change spaced parent']);
+		git(fork, ['remote', 'set-url', 'upstream', spacedUpstream]);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 50;\n');
+		git(fork, ['commit', '-qam', 'match spaced parent']);
+		markBase(fork);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 51;\n');
+		git(fork, ['commit', '-qam', 'edit shared path']);
+
+		const r = run(fork, ['--json', 'shared/pristine.ts']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/different repository/);
+	});
+
+	it('keeps .git significant in local repository paths', () => {
+		const decoy = `${upstream}.git`;
+		mkdirSync(decoy);
+		init(decoy);
+		write(decoy, 'decoy.ts', 'export const decoy = true;\n');
+		git(decoy, ['add', '-A']);
+		git(decoy, ['commit', '-qm', 'decoy']);
+		git(fork, ['remote', 'set-url', 'upstream', decoy]);
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/different repository/);
+	});
+
+	it('keeps non-git SSH identities distinct', () => {
+		write(
+			fork,
+			'.upstream-sync.json',
+			JSON.stringify({ upstreamUrl: 'ssh://alice@example.invalid/~/template.git' })
+		);
+		git(fork, ['commit', '-qam', 'set SSH parent']);
+		git(fork, ['remote', 'set-url', 'upstream', 'ssh://bob@example.invalid/~/template.git']);
+
+		const r = run(fork, []);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/different repository/);
+	});
+
+	it('escapes controls in remote diagnostics', () => {
+		const escape = String.fromCharCode(27);
+		const upstreamUrl = `https://example.invalid/${escape}[2Jtemplate.git`;
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl }));
+		git(fork, ['commit', '-qam', 'set control-character parent']);
+		git(fork, ['remote', 'set-url', 'upstream', 'https://example.invalid/other.git']);
+
+		const r = run(fork, []);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain(escape);
+		expect(r.stderr).toContain('\\u001b[2J');
+	});
+
+	it('keeps a credential out of the remote-mismatch diagnostic', () => {
+		// `git remote get-url` returns the URL exactly as configured, tokens and
+		// all, and this diagnostic is the one place it reaches a terminal, an
+		// agent transcript or a CI log.
+		git(fork, [
+			'remote',
+			'set-url',
+			'upstream',
+			'https://user@example.com:DUMMY_DOUBLE_AT_SECRET@github.com/owner/x.git'
+		]);
+
+		const r = run(fork, []);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain('DUMMY_DOUBLE_AT_SECRET');
+		expect(r.stderr).not.toContain('user@example.com');
+		expect(r.stderr).toContain('***@github.com');
+	});
+
+	it('redacts scheme userinfo that contains whitespace', () => {
+		const remote = 'https://user\nDUMMY_MULTILINE_USERINFO@example.invalid/repo.git';
+		git(fork, ['remote', 'set-url', 'upstream', remote]);
+
+		const r = run(fork, []);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain('DUMMY_MULTILINE_USERINFO');
+		expect(r.stderr).not.toContain('user');
+		expect(r.stderr).toContain('https://***@example.invalid');
+	});
+
+	it('redacts SCP-style remote userinfo', () => {
+		git(fork, ['remote', 'set-url', 'upstream', 'DUMMY_SCP_SECRET@example.invalid:owner/repo.git']);
+
+		const r = run(fork, ['shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain('DUMMY_SCP_SECRET');
+		expect(r.stderr).toContain('***@example.invalid');
+	});
+
+	it('redacts credentials carried in a remote query string', () => {
+		const remote = 'https://example.invalid/repo.git?access_token=DUMMY_QUERY_SECRET';
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: remote }));
+		git(fork, ['commit', '-qam', 'set query-string parent']);
+		git(fork, ['remote', 'set-url', 'upstream', remote]);
+
+		const r = run(fork, ['--json']);
+		expect(r.status).toBe(0);
+		expect(r.stdout).not.toContain('DUMMY_QUERY_SECRET');
+		expect(r.stdout).toContain('repo.git?***');
+	});
+
+	it('redacts credentials carried in a remote fragment', () => {
+		const remote = 'https://example.invalid/repo.git#access_token=DUMMY_FRAGMENT_SECRET';
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: remote }));
+		git(fork, ['commit', '-qam', 'set fragment remote']);
+		git(fork, ['remote', 'set-url', 'upstream', remote]);
+
+		const r = run(fork, ['--json']);
+		expect(r.status).toBe(0);
+		expect(r.stdout).not.toContain('DUMMY_FRAGMENT_SECRET');
+		expect(r.stdout).toContain('repo.git#***');
+	});
+
+	it('redacts a multiline remote query string', () => {
+		const remote =
+			'https://example.invalid/repo.git?access_token=DUMMY_MULTILINE_SECRET\ncontinued=1';
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: remote }));
+		git(fork, ['commit', '-qam', 'set multiline parent']);
+
+		const r = run(fork, []);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain('DUMMY_MULTILINE_SECRET');
+		expect(r.stderr).toContain('repo.git?***');
+	});
+
+	it('pins full stat checks when repository config weakens them', async () => {
+		const path = join(fork, 'shared/pristine.ts');
+		const cachedTime = new Date(Math.floor((Date.now() - 60_000) / 1_000) * 1_000);
+		utimesSync(path, cachedTime, cachedTime);
+		git(fork, ['update-index', '--refresh']);
+		await new Promise((resolve) => setTimeout(resolve, 1_100));
+		writeFileSync(path, 'export const a = 1;\nexport const b = 3;\n');
+		utimesSync(path, cachedTime, cachedTime);
+		git(fork, ['config', 'core.trustctime', 'false']);
+		git(fork, ['config', 'core.checkStat', 'minimal']);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string }>;
+		};
+		expect(parsed.verdicts.find((entry) => entry.path === 'shared/pristine.ts')?.relevance).toBe(
+			'pristine'
+		);
+	});
+
+	itWithGitWrapper('rejects partial output from a failed captured diff', () => {
+		write(upstream, 'shared/captured-failure.ts', 'upstreamOne();\nupstreamTwo();\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add captured diff fixture']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, 'shared/captured-failure.ts', 'forkBaseOne();\nforkBaseTwo();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add diverged captured path']);
+		markBase(fork);
+		write(fork, 'shared/captured-failure.ts', 'forkAfterOne();\nforkAfterTwo();\n');
+		git(fork, ['commit', '-qam', 'rewrite diverged captured path']);
+		const marker = join(tmp, 'captured-diff-failed');
+
+		const r = run(fork, ['--fetch', '--json', 'shared/captured-failure.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			FAIL_CAPTURED_DIFF_MARKER: marker
+		});
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'shared/captured-failure.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/diff command failed before completing/);
+	});
+
+	itWithGitWrapper('times out a stalled captured diff', () => {
+		write(upstream, 'shared/captured-timeout.ts', 'upstreamOne();\nupstreamTwo();\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add captured timeout fixture']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, 'shared/captured-timeout.ts', 'forkBaseOne();\nforkBaseTwo();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add diverged timeout path']);
+		markBase(fork);
+		write(fork, 'shared/captured-timeout.ts', 'forkAfterOne();\nforkAfterTwo();\n');
+		git(fork, ['commit', '-qam', 'rewrite diverged timeout path']);
+
+		const r = run(fork, ['--fetch', '--json', 'shared/captured-timeout.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			SLOW_CAPTURED_DIFF: '1',
+			UPSTREAM_REPORT_TEST_DIFF_TIMEOUT_MS: '50'
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'shared/captured-timeout.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/diff command failed before completing/);
+	});
+
+	it("leaves the caller's index alone when a stat-only change is pending", () => {
+		// A worktree diff refreshes the index when the stat data moved and the
+		// content did not, which takes index.lock in the caller's repository.
+		// Measured on git 2.55: GIT_OPTIONAL_LOCKS=0 stops that for `git status`
+		// and not for `git diff`, so the run reads through a private copy.
+		const indexPath = join(fork, '.git', 'index');
+		// A settling run first, so the index carries current stat data and the
+		// only mismatch left is the one this test creates.
+		run(fork, ['--json']);
+		const before = statSync(indexPath).mtimeMs;
+		// Same bytes, stat data moved well clear of the cached values. Rewriting
+		// the file is not enough on its own: within the same second git reads the
+		// entry as racily clean and may leave the index alone, which passes this
+		// test for the wrong reason.
+		const stale = new Date(Date.now() - 60_000);
+		utimesSync(join(fork, 'shared/pristine.ts'), stale, stale);
+		const r = run(fork, ['--json']);
+
+		expect(r.status).toBe(0);
+		expect(statSync(indexPath).mtimeMs).toBe(before);
+	});
+
+	itWithPosixPaths('matches a path holding a tab against the upstream tree', () => {
+		// `ls-tree` without `-z` quotes a path containing a tab, a newline or a
+		// backslash even under core.quotePath=false, while the changed-file
+		// collectors return the raw bytes. The two spellings miss each other and
+		// the file classifies fork-only.
+		const tabbed = 'shared/ta\tb.ts';
+		for (const repo of [upstream, fork]) {
+			write(repo, tabbed, 'export const t = 1;\n');
+			git(repo, ['add', '-A']);
+			git(repo, ['commit', '-qm', 'tabbed path']);
+		}
+		git(fork, ['fetch', '-q', 'upstream']);
+		markBase(fork);
+
+		write(fork, tabbed, 'export const t = 99;\n');
+		git(fork, ['commit', '-qam', 'edit the tabbed path']);
+
+		const v = verdicts(fork);
+		expect(v[tabbed]).toBe('pristine');
+	});
+
+	it('parses hunks when repository config forces color', () => {
+		git(fork, ['config', 'color.ui', 'always']);
+		write(
+			fork,
+			'shared/rewritten.ts',
+			'export const changed = 99;\nexport const template2 = 2;\nexport const template3 = 3;\nexport const template4 = 4;\nexport const template5 = 5;\nexport const template6 = 6;\nexport const template7 = 7;\nexport const template8 = 8;\nexport const forkOnly1 = 1;\nexport const forkOnly2 = 2;\nexport const forkOnly3 = 3;\nexport const forkOnly4 = 4;\nexport const forkOnly5 = 5;\nexport const forkOnly6 = 6;\nexport const forkOnly7 = 7;\nexport const forkOnly8 = 8;\n'
+		);
+		git(fork, ['commit', '-qam', 'edit template line']);
+
+		expect(verdictsWithScore(fork)['shared/rewritten.ts']?.overlap).toBe(1);
+	});
+
+	it('scores a tracked glob-looking filename literally', () => {
+		const path = 'shared/[ab].ts';
+		write(upstream, path, 'export const inherited = 1;\n');
+		write(upstream, 'shared/a.ts', 'export const neighbor = 1;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add glob-looking path']);
+		write(fork, path, 'export const inherited = 1;\nexport const forkOnly = 1;\n');
+		write(fork, 'shared/a.ts', 'export const neighbor = 1;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add fork versions']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		markBase(fork);
+		write(fork, path, 'export const forkOnly = 1;\n');
+		git(fork, ['commit', '-qam', 'remove inherited line']);
+
+		const scored = verdictsWithScore(fork, [path]);
+		expect(scored[path]?.relevance).toBe('diverged');
+		expect(scored[path]?.overlap).toBe(1);
+	});
+
+	it('prints the highest-scoring shared file first', () => {
+		// The skill tells the reader to start at the top. Paths arrive
+		// alphabetised, so without a rank the 0% file sits above the 100% one.
+		// Both files are diverged at the base; they differ in where the change
+		// landed. `aaa` replaces lines this fork added, `zzz` replaces template
+		// lines that are still upstream.
+		write(upstream, 'shared/aaa.ts', 'export const up1 = 1;\nexport const up2 = 2;\n');
+		write(
+			upstream,
+			'shared/zzz.ts',
+			'export const tpl1 = 1;\nexport const tpl2 = 2;\nexport const tpl3 = 3;\n'
+		);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'two shared files']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(
+			fork,
+			'shared/aaa.ts',
+			'export const up1 = 1;\nexport const up2 = 2;\nexport const fork1 = 1;\nexport const fork2 = 2;\nexport const fork3 = 3;\n'
+		);
+		write(
+			fork,
+			'shared/zzz.ts',
+			'export const tpl1 = 1;\nexport const tpl2 = 2;\nexport const tpl3 = 3;\nexport const fork9 = 9;\n'
+		);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'fork versions']);
+		markBase(fork);
+
+		// Removes only fork-added lines: nothing of what it replaced is upstream.
+		write(fork, 'shared/aaa.ts', 'export const up1 = 1;\nexport const up2 = 2;\n');
+		// Removes template lines that upstream still carries.
+		write(fork, 'shared/zzz.ts', 'export const changed = 9;\nexport const fork9 = 9;\n');
+		git(fork, ['commit', '-qam', 'edit both']);
+
+		const scored = verdictsWithScore(fork);
+		expect(scored['shared/aaa.ts']?.overlap).toBe(0);
+		expect(scored['shared/zzz.ts']?.overlap).toBe(1);
+
+		const r = run(fork, []);
+		expect(r.status).toBe(0);
+		const order = r.stdout
+			.split('\n')
+			.filter((l) => l.includes('diverged'))
+			.map((l) => l.trim());
+		expect(order.length).toBe(2);
+		expect(order[0]).toContain('shared/zzz.ts');
+		expect(order[1]).toContain('shared/aaa.ts');
+	});
+
+	it('reports the age of the local upstream copy on every run', () => {
+		// A fork-only verdict from a copy that predates an upstream file is wrong
+		// and invisible. The age is the only thing that lets a reader doubt it, so
+		// it is not held back for a staleness threshold.
+		const r = run(fork, []);
+		expect(r.status).toBe(0);
+		expect(r.stdout).toContain('Local upstream copy:');
+	});
+
+	it('does not call a relocated template file fork-only', () => {
+		// The fork had already customised its copy, so blob identity finds
+		// nothing, and upstream then renamed the file away. That file is the one
+		// most likely to still carry a template bug, and an exact-path lookup
+		// suppresses it.
+		write(fork, 'shared/relocated.ts', 'export const t = 1;\nexport const forkOnly = 2;\n');
+		write(upstream, 'shared/other/relocated.ts', 'export const t = 1;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'customised copy']);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'upstream keeps it elsewhere']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		markBase(fork);
+
+		write(fork, 'shared/relocated.ts', 'export const t = 99;\nexport const forkOnly = 2;\n');
+		git(fork, ['commit', '-qam', 'fix it here']);
+
+		const v = verdicts(fork, ['shared/relocated.ts']);
+		expect(v['shared/relocated.ts']).toBe('unmeasured');
+	});
+
+	it('keeps a name the template uses more than once out of the report', () => {
+		// `types.ts` and `index.ts` sit in a dozen upstream directories. Matching
+		// on those would flag most of this fork's own files and make the report
+		// too noisy to read, which is the same as not running it.
+		for (const dir of ['shared/one', 'shared/two']) {
+			write(upstream, `${dir}/types.ts`, 'export type A = 1;\n');
+		}
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'two files of one name']);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		write(fork, 'product/types.ts', 'export type P = 1;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'a product file of that name']);
+
+		const r = run(fork, ['--fetch', '--json', 'product/types.ts']);
+		expect(r.status).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ relevance: string; note?: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('unmeasured');
+		expect(parsed.verdicts[0]?.note).toContain('design judgment');
+	});
+
+	it('does not call a file pristine when only its mode matches upstream', () => {
+		// One blob is shared by a regular file and a symlink to that text, and by
+		// an executable and a non-executable copy. Pristine claims the fork never
+		// touched the file, which is wrong when it changed what the file is.
+		git(fork, ['update-index', '--chmod=+x', 'shared/pristine.ts']);
+		git(fork, ['commit', '-qm', 'make it executable']);
+		markBase(fork);
+
+		const v = verdicts(fork, ['shared/pristine.ts']);
+		expect(v['shared/pristine.ts']).toBe('unmeasured');
+	});
+
+	itWithPosixPaths('refuses a filesystem where Git cannot verify file modes', () => {
+		git(fork, ['config', 'core.fileMode', 'false']);
+
+		const r = run(fork, ['--fetch', '--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/filesystem does not preserve executable bits/);
+	});
+
+	it('measures the age of the copy from the fetch, not the tip commit', () => {
+		// A template that committed yesterday and was fetched a month ago is a
+		// month behind, and the tip's commit date says one day. Every path added
+		// upstream in that month reads as fork-only.
+		const old = '2026-01-02T03:04:05+00:00';
+		const tip = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+		git(
+			fork,
+			['update-ref', '-m', 'fetch upstream: storing head', 'refs/remotes/upstream/main', tip],
+			{
+				GIT_COMMITTER_DATE: old
+			}
+		);
+
+		const r = run(fork, ['--json']);
+		expect(r.status).toBe(0);
+		const parsed = JSON.parse(r.stdout) as { upstreamAgeDays: number; upstreamAgeFrom: string };
+		expect(parsed.upstreamAgeFrom).toBe('fetch');
+		// The fixture's tip was committed seconds ago; only the reflog is old.
+		expect(parsed.upstreamAgeDays).toBeGreaterThan(30);
+
+		const human = run(fork, []);
+		expect(human.status, human.stderr).toBe(0);
+		expect(human.stdout).toContain('bun run upstream:report -- --fetch');
+		expect(human.stdout).not.toContain('Run `git fetch upstream`');
+	});
+
+	it('marks a successful no-op --fetch as fresh for this run', () => {
+		const old = '2026-01-02T03:04:05+00:00';
+		const tip = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+		git(
+			fork,
+			['update-ref', '-m', 'fetch upstream: storing head', 'refs/remotes/upstream/main', tip],
+			{ GIT_COMMITTER_DATE: old }
+		);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status, `script failed: ${r.stderr}`).toBe(0);
+		const parsed = JSON.parse(r.stdout) as { upstreamAgeDays: number; upstreamAgeFrom: string };
+		expect(parsed.upstreamAgeFrom).toBe('fetch');
+		expect(parsed.upstreamAgeDays).toBe(0);
+
+		const later = run(fork, ['--json']);
+		expect(later.status, later.stderr).toBe(0);
+		const laterParsed = JSON.parse(later.stdout) as {
+			upstreamAgeDays: number;
+			upstreamAgeFrom: string;
+		};
+		expect(laterParsed.upstreamAgeFrom).toBe('fetch');
+		expect(laterParsed.upstreamAgeDays).toBe(0);
+	});
+
+	it('recognises a pull reflog entry as the fetch that refreshed the copy', () => {
+		const old = '2026-01-02T03:04:05+00:00';
+		const tip = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+		git(
+			fork,
+			['update-ref', '-m', 'pull upstream main: storing head', 'refs/remotes/upstream/main', tip],
+			{ GIT_COMMITTER_DATE: old }
+		);
+
+		const r = run(fork, ['--json']);
+		expect(r.status).toBe(0);
+		const parsed = JSON.parse(r.stdout) as { upstreamAgeDays: number; upstreamAgeFrom: string };
+		expect(parsed.upstreamAgeFrom).toBe('fetch');
+		expect(parsed.upstreamAgeDays).toBeGreaterThan(30);
+	});
+
+	it('does not let a later non-fetch ref write pass for a fetch', () => {
+		// A remote-tracking reflog records every write to the ref, not only
+		// fetches: update-ref, a push that advanced it, a restore script. Reading
+		// the newest entry and calling it a fetch reported a month-old copy as
+		// fetched today, and a path upstream added in that month stays hidden as
+		// fork-only with no freshness warning to contradict it.
+		const old = '2026-01-02T03:04:05+00:00';
+		const tip = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		// The old fetch has to land on a different commit than the restore, or git
+		// writes no reflog entry for the second write and the fixture silently
+		// stops containing the case: update-ref to a value the ref already holds
+		// is a no-op down to the log, which is how this guard first passed against
+		// its own mutation.
+		const elsewhere = git(fork, ['rev-parse', 'HEAD']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+		git(
+			fork,
+			['update-ref', '-m', 'fetch upstream: storing head', 'refs/remotes/upstream/main', elsewhere],
+			{ GIT_COMMITTER_DATE: old }
+		);
+		// Today, something that is not a fetch moves the ref to where it belongs.
+		git(fork, ['update-ref', '-m', 'restore stale ref', 'refs/remotes/upstream/main', tip]);
+
+		const r = run(fork, ['--json']);
+		expect(r.status).toBe(0);
+		const parsed = JSON.parse(r.stdout) as { upstreamAgeDays: number; upstreamAgeFrom: string };
+		expect(parsed.upstreamAgeFrom).toBe('tip commit');
+		expect(parsed.upstreamAgeDays).toBeLessThan(2);
+	});
+
+	it('says so when the reflog holds no fetch at all', () => {
+		// Falling back to the tip's commit date is fine; claiming it was a fetch
+		// is not, because the reader calibrates how much to trust a clean report
+		// on exactly that word.
+		const tip = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+		git(fork, ['update-ref', '-m', 'restore stale ref', 'refs/remotes/upstream/main', tip]);
+
+		const r = run(fork, ['--json']);
+		expect(r.status).toBe(0);
+		const parsed = JSON.parse(r.stdout) as { upstreamAgeFrom: string };
+		expect(parsed.upstreamAgeFrom).toBe('tip commit');
+	});
+
+	itWithGitWrapper('rejects an untracked path that disappears after enumeration', () => {
+		write(
+			fork,
+			'product/disappearing.ts',
+			'export const a = 1;\nexport const b = 2;\nproductOnly();\n'
+		);
+		const wrapper = installGitWrapper(tmp);
+		const marker = join(tmp, 'removed-after-untracked');
+		const r = run(fork, ['--fetch', '--json'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			REMOVE_AFTER_UNTRACKED: join(fork, 'product/disappearing.ts'),
+			REMOVE_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/working tree changed during this report/);
+	});
+
+	itWithGitWrapper('keeps an unstaged path seen before a working-tree ABA', () => {
+		const path = join(fork, 'shared/pristine.ts');
+		const headContent = join(tmp, 'pristine-head.ts');
+		writeFileSync(headContent, 'export const a = 1;\nexport const b = 2;\n');
+		writeFileSync(path, 'export const a = 1;\nexport const b = 92;\n');
+		const marker = join(tmp, 'worktree-aba');
+		const r = run(fork, ['--fetch', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			ABA_WORKTREE_PATH: path,
+			ABA_HEAD_CONTENT: headContent,
+			ABA_WORKTREE_MARKER: marker,
+			ABA_HEAD: git(fork, ['rev-parse', 'HEAD'])
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(marker)).toBe(true);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string }>;
+		};
+		expect(
+			parsed.verdicts.find((verdict) => verdict.path === 'shared/pristine.ts')?.relevance
+		).toBe('pristine');
+	});
+
+	itWithGitWrapper('classifies from the bytes captured with the fingerprint', () => {
+		const source = Array.from({ length: 6 }, (_, i) => `export const captured${i} = ${i};`);
+		write(upstream, 'shared/captured-source.ts', `${source.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add captured source']);
+		write(fork, 'product/captured-copy.ts', 'forkOnlyBase();\nmoreForkOnlyBase();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add fork-owned base']);
+		markBase(fork);
+		const path = join(fork, 'product/captured-copy.ts');
+		writeFileSync(path, `${source.join('\n')}\n`);
+		const original = join(tmp, 'captured-original.ts');
+		const replacement = join(tmp, 'captured-replacement.ts');
+		writeFileSync(original, `${source.join('\n')}\n`);
+		writeFileSync(replacement, 'temporaryForkOnly();\nanotherTemporaryLine();\n');
+		const marker = join(tmp, 'capture-aba');
+
+		const r = run(fork, ['--fetch', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			ABA_CAPTURE_PATH: path,
+			ABA_CAPTURE_ORIGINAL: original,
+			ABA_CAPTURE_REPLACEMENT: replacement,
+			ABA_CAPTURE_MARKER: marker
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(marker)).toBe(true);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/captured-copy.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/mostly matches upstream/);
+	});
+
+	itWithGitWrapper('scores shared paths from captured bytes', () => {
+		const path = join(fork, 'shared/rewritten.ts');
+		const original = readFileSync(path, 'utf8');
+		writeFileSync(path, original.replace('template8 = 8', 'template8 = 99'));
+		const baseline = verdictsWithScore(fork, ['shared/rewritten.ts'])['shared/rewritten.ts'];
+		const replacement = join(tmp, 'overlap-replacement.ts');
+		writeFileSync(replacement, original.replace('forkOnly8 = 8', 'forkOnly8 = 99'));
+		const marker = join(tmp, 'overlap-aba');
+
+		const r = run(fork, ['--fetch', '--json', 'shared/rewritten.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			OVERLAP_ABA_PATH: path,
+			OVERLAP_ABA_REPLACEMENT: replacement,
+			OVERLAP_ABA_MARKER: marker
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(marker)).toBe(true);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; overlap?: number }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'shared/rewritten.ts');
+		expect(verdict?.overlap).toBe(baseline?.overlap);
+	});
+
+	it('binds working-tree bytes to a checked file descriptor', () => {
+		const source = readFileSync(SCRIPT, 'utf8');
+		const start = source.indexOf('function workingTreeContent(');
+		const end = source.indexOf('function fingerprintContent(', start);
+		const capture = source.slice(start, end);
+		const identityCheck = capture.indexOf('sameFileIdentity(initial, opened)');
+		const boundedRead = capture.indexOf('readSync(');
+
+		expect(identityCheck).toBeGreaterThan(0);
+		expect(boundedRead).toBeGreaterThan(identityCheck);
+		expect(capture).toContain('opened.size > maxBytes');
+	});
+
+	it('binds marker inspection and bytes to one file descriptor', () => {
+		const source = readFileSync(SCRIPT, 'utf8');
+		const start = source.indexOf('function readUpstreamMarker(');
+		const end = source.indexOf('function requireCleanUpstreamMarker(', start);
+		const markerRead = source.slice(start, end);
+		const open = markerRead.indexOf('openSync(');
+		const identity = markerRead.indexOf('sameFileIdentity(opened, atPath)');
+		const read = markerRead.indexOf('readSync(');
+		const finalIdentity = markerRead.indexOf('sameFileIdentity(opened, afterPath)');
+
+		expect(open).toBeGreaterThan(0);
+		expect(identity).toBeGreaterThan(open);
+		expect(read).toBeGreaterThan(identity);
+		expect(finalIdentity).toBeGreaterThan(read);
+	});
+
+	it('binds the selected marker to committed HEAD before shared Git writes', () => {
+		const source = readFileSync(SCRIPT, 'utf8');
+		const start = source.indexOf('const marker = readUpstreamMarker(root);');
+		const markerAtHead = source.indexOf('requireMarkerAtHead(head, marker);', start);
+		const upstreamWrite = source.indexOf('ensureUpstream(root, upstreamUrl', start);
+		expect(markerAtHead).toBeGreaterThan(start);
+		expect(upstreamWrite).toBeGreaterThan(markerAtHead);
+	});
+
+	it('bounds and caches source-bag preprocessing', () => {
+		const source = readFileSync(SCRIPT, 'utf8');
+		const start = source.indexOf('function sourceBag(');
+		const end = source.indexOf('/**\n * The upstream file this content most resembles.', start);
+		const preparation = source.slice(start, end);
+		const budget = preparation.indexOf('content.length > upstream.similarityOperationsRemaining');
+		const bag = preparation.indexOf('bagOf(text)');
+
+		expect(preparation).toContain('sourceBags.get(content)');
+		expect(budget).toBeGreaterThan(0);
+		expect(bag).toBeGreaterThan(budget);
+	});
+
+	it('gives each detector subprocess a hard test timeout', () => {
+		const source = readFileSync(TEST_FILE, 'utf8');
+		const start = source.indexOf('function run(');
+		const end = source.indexOf('function verdicts(', start);
+		expect(source.slice(start, end)).toContain('timeout: 30_000');
+	});
+
+	it('isolates leftover cleanup failures to one temporary directory', () => {
+		const source = readFileSync(SCRIPT, 'utf8');
+		const start = source.indexOf('function sweepLeftovers(');
+		const end = source.indexOf('function ensureScratchIndexExists(', start);
+		const sweep = source.slice(start, end);
+		const loop = sweep.indexOf('for (const name of names)');
+		const perEntryCatch = sweep.indexOf('Another report may remove its directory', loop);
+		expect(loop).toBeGreaterThan(0);
+		expect(perEntryCatch).toBeGreaterThan(loop);
+	});
+
+	it('bounds the similarity representation of large single-line text', () => {
+		write(fork, 'product/large-minified.js', `${'minifiedToken'.repeat(128)}\n`);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/large-minified.js'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_SIMILARITY_LIMIT: '1024'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/large-minified.js');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/bounded similarity size/);
+	});
+
+	it('bounds the overlap map for a shared upstream path', () => {
+		const path = 'shared/large-overlap.ts';
+		write(
+			upstream,
+			path,
+			`${Array.from({ length: 30 }, (_, index) => `export const upstream${index} = ${index};`).join('\n')}\n`
+		);
+		write(
+			fork,
+			path,
+			`${Array.from({ length: 30 }, (_, index) => `export const fork${index} = ${index};`).join('\n')}\n`
+		);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add large shared path']);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add divergent large shared path']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		markBase(fork);
+		write(fork, path, 'export const changed = true;\n');
+		git(fork, ['commit', '-qam', 'edit large shared path']);
+
+		const r = run(fork, ['--fetch', '--json', path], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_SIMILARITY_REPRESENTATION_LIMIT: '100'
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === path);
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/bounded similarity representation/);
+	});
+
+	it('charges reused upstream blobs once against the representation budget', () => {
+		const target = 'targetOne();\ntargetTwo();\ntargetThree();\ntargetFour();\n';
+		write(upstream, 'shared/reused-target.rare', target);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add reusable target']);
+		const duplicate = 'duplicateOne();\nduplicateTwo();\n';
+		for (let index = 0; index < 5; index++) {
+			write(upstream, `shared/duplicate-${index}.rare`, duplicate);
+		}
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'reuse one filler blob']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(
+			fork,
+			'product/reused-probe.rare',
+			'targetOne();\ntargetTwo();\ntargetThree();\nlocalFour();\n'
+		);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/reused-probe.rare'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_SIMILARITY_REPRESENTATION_LIMIT: '550'
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts[0];
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toContain('mostly matches upstream\'s "shared/reused-target.rare"');
+	});
+
+	it('charges four bytes per retained character gram', () => {
+		write(upstream, 'shared/gram-source.rare', `sharedLine();\n${'x'.repeat(180)}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add gram-heavy source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, 'product/gram-probe.rare', 'sharedLine();\nlocalLine();\n');
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/gram-probe.rare'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_SIMILARITY_REPRESENTATION_LIMIT: '300'
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		expect(parsed.verdicts[0]?.note).toMatch(/bounded similarity representation/);
+	});
+
+	it('bounds retained upstream similarity maps and grams', () => {
+		write(
+			upstream,
+			'shared/representation-source.rare',
+			`${Array.from({ length: 30 }, (_, i) => `uniqueUpstreamLine${i}();`).join('\n')}\n`
+		);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add representation-heavy source']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, 'product/representation-probe.rare', 'forkProbeOne();\nforkProbeTwo();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add representation probe']);
+		markBase(fork);
+		write(fork, 'product/representation-probe.rare', 'forkProbeOne();\nforkProbeThree();\n');
+		git(fork, ['commit', '-qam', 'edit representation probe']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/representation-probe.rare'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_SIMILARITY_REPRESENTATION_LIMIT: '500'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find(
+			(entry) => entry.path === 'product/representation-probe.rare'
+		);
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/bounded similarity representation/);
+	});
+
+	it('bounds similarity work across changed paths and upstream history', () => {
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'edit product path']);
+
+		const r = run(fork, ['--fetch', '--json', '--all', 'product/only-here.ts'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_SIMILARITY_OPERATION_LIMIT: '0'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/only-here.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/bounded operation count/);
+	});
+
+	it('keeps aggregate working-tree capture bounded', () => {
+		write(fork, 'product/capture-a.ts', 'captureAlphaToken();\ncaptureAlphaToken();\n');
+		write(fork, 'product/capture-b.ts', 'captureBetaToken();\ncaptureBetaToken();\n');
+
+		const r = run(fork, ['--fetch', '--json', '--all'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_CAPTURE_LIMIT: '64'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/capture-b.ts');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/bounded capture size/);
+	});
+
+	itWithPosixPaths('counts symlink targets against aggregate working-tree capture', () => {
+		symlinkSync('a'.repeat(40), join(fork, 'product/capture-link-a'));
+		symlinkSync('b'.repeat(40), join(fork, 'product/capture-link-b'));
+
+		const r = run(fork, ['--fetch', '--json', '--all'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_CAPTURE_LIMIT: '64'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/capture-link-b');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/bounded capture size/);
+	});
+
+	itWithGitWrapper('refuses a disappearing private scratch index', () => {
+		write(fork, 'product/staged-only.ts', 'stagedOnly();\n');
+		git(fork, ['add', 'product/staged-only.ts']);
+		rmSync(join(fork, 'product/staged-only.ts'));
+		const indexPath = join(fork, '.git', 'index');
+		const indexBefore = readFileSync(indexPath);
+		const marker = join(tmp, 'scratch-index-removed');
+
+		const r = run(fork, ['--fetch', '--json', '--all'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			REMOVE_SCRATCH_INDEX_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/scratch index disappeared/);
+		expect(readFileSync(indexPath)).toEqual(indexBefore);
+	});
+
+	itWithGitWrapper('rejects changed entries in the private scratch index', () => {
+		const upstreamBlob = git(fork, ['rev-parse', 'refs/remotes/upstream/main:shared/pristine.ts']);
+		const marker = join(tmp, 'private-index-race-staged');
+		const r = run(fork, ['--fetch', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			STAGE_PRIVATE_INDEX_AFTER_COPY: 'product/private-index-race.ts',
+			STAGE_PRIVATE_BLOB_SHA: upstreamBlob,
+			PRIVATE_INDEX_RACE_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/scratch index entries changed/);
+	});
+
+	itWithGitWrapper('rejects staging that races the scratch-index copy', () => {
+		write(fork, 'product/staged-race.ts', 'unrelatedWorkingCopy();\n');
+		const upstreamBlob = git(fork, ['rev-parse', 'refs/remotes/upstream/main:shared/pristine.ts']);
+		const marker = join(tmp, 'index-race-staged');
+		const r = run(fork, ['--fetch', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			STAGE_AFTER_INDEX_COPY: 'product/staged-race.ts',
+			STAGE_BLOB_SHA: upstreamBlob,
+			INDEX_RACE_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/index.*changed during this report/);
+	});
+
+	itWithGitWrapper('rejects working content that changes without a status change', () => {
+		write(fork, 'product/content-race.ts', 'unrelatedA();\nunrelatedB();\n');
+		const replacement = join(tmp, 'replacement-content.ts');
+		writeFileSync(replacement, 'export const a = 1;\nexport const b = 2;\nproductOnly();\n');
+		const marker = join(tmp, 'content-race-replaced');
+		const r = run(fork, ['--fetch', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			REPLACE_AFTER_CONTENT_PATH: join(fork, 'product/content-race.ts'),
+			REPLACEMENT_CONTENT: replacement,
+			CONTENT_RACE_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/working tree changed during this report/);
+	});
+
+	itWithGitWrapper('rejects local state that changes after enumeration', () => {
+		const replacement = join(tmp, 'replacement-marker.json');
+		writeFileSync(replacement, JSON.stringify({ upstreamUrl: join(tmp, 'other-parent') }));
+		const marker = join(tmp, 'local-state-changed');
+		const r = run(fork, ['--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			ADD_AFTER_UNTRACKED: join(fork, 'product/late.ts'),
+			REPLACEMENT_MARKER: replacement,
+			UPSTREAM_MARKER: join(fork, '.upstream-sync.json'),
+			LOCAL_CHANGE_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/working tree changed during this report/);
+	});
+
+	itWithGitWrapper('rejects an upstream ref that moves after the snapshot check', () => {
+		write(upstream, 'shared/arrived-during-report.ts', 'export const fresh = 1;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'advance during report']);
+		write(fork, 'shared/arrived-during-report.ts', 'export const fresh = 1;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add same path']);
+
+		const wrapper = installGitWrapper(tmp);
+		const marker = join(tmp, 'fetched-after-reflog');
+		const r = run(fork, ['--json'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			FETCH_AFTER_REFLOG: '1',
+			FETCH_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toContain('changed while this report started');
+	});
+
+	itWithGitWrapper('rejects an upstream ref that moves while the pinned tree is read', () => {
+		const pinned = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		write(upstream, 'shared/arrived-during-tree-read.ts', 'export const fresh = 1;\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'advance during tree read']);
+		write(fork, 'shared/arrived-during-tree-read.ts', 'export const fresh = 1;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add same path']);
+
+		const wrapper = installGitWrapper(tmp);
+		const marker = join(tmp, 'fetched-after-tree-read');
+		const r = run(fork, ['--json'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			FETCH_AFTER_TREE_SHA: pinned,
+			FETCH_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toContain('changed during this report');
+	});
+
+	it('does not reuse fetch evidence after the upstream URL changes', () => {
+		const fetched = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+		expect(fetched.status, fetched.stderr).toBe(0);
+		expect(git(fork, ['config', '--get', 'upstreamReport.lastFetch']).split(' ')).toHaveLength(3);
+		const replacement = join(tmp, 'replacement-upstream');
+		mkdirSync(replacement);
+		init(replacement);
+		write(replacement, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 3;\n');
+		git(replacement, ['add', '-A']);
+		git(replacement, ['commit', '-qm', 'replacement upstream']);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: replacement }));
+		git(fork, ['commit', '-qam', 'replace upstream URL']);
+		git(fork, ['remote', 'set-url', 'upstream', replacement]);
+		markBase(fork);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 77;\n');
+		git(fork, ['commit', '-qam', 'fix shared file']);
+
+		const r = run(fork, ['--json', 'shared/pristine.ts']);
+		expect(r.status).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('unmeasured');
+		expect(parsed.verdicts[0]?.note).toMatch(/no provenance from the configured upstream/);
+	});
+
+	itWithGitWrapper('uses a URL-bound fetch record while upstream is unavailable', () => {
+		const fetched = run(fork, ['--base', 'origin/main', '--fetch', '--json', 'shared/pristine.ts']);
+		expect(fetched.status, fetched.stderr).toBe(0);
+		const r = run(fork, ['--base', 'origin/main', '--json', 'shared/pristine.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			SLOW_LS_REMOTE: '1',
+			UPSTREAM_REPORT_TEST_TIMEOUT_MS: '50'
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+	});
+
+	it('does not let another remote populate upstream verdicts', () => {
+		const decoy = join(tmp, 'decoy');
+		mkdirSync(decoy);
+		init(decoy);
+		write(decoy, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 2;\n');
+		git(decoy, ['add', '-A']);
+		git(decoy, ['commit', '-qm', 'decoy']);
+		write(upstream, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 3;\n');
+		git(upstream, ['commit', '-qam', 'advance real upstream']);
+		git(fork, ['remote', 'add', 'decoy', decoy]);
+		git(fork, ['fetch', '-q', 'decoy', '+refs/heads/main:refs/remotes/upstream/main']);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 77;\n');
+		git(fork, ['commit', '-qam', 'fix shared file']);
+
+		const r = run(fork, ['--json', 'shared/pristine.ts']);
+		expect(r.status).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('unmeasured');
+		expect(parsed.verdicts[0]?.note).toMatch(/no provenance from the configured upstream/);
+	});
+
+	it('does not measure divergence against another remote', () => {
+		const decoy = join(tmp, 'diverged-decoy');
+		mkdirSync(decoy);
+		init(decoy);
+		write(decoy, 'shared/pristine.ts', 'decoyOne();\ndecoyTwo();\n');
+		git(decoy, ['add', '-A']);
+		git(decoy, ['commit', '-qm', 'diverged decoy']);
+		git(fork, ['remote', 'add', 'decoy', decoy]);
+		git(fork, ['fetch', '-q', 'decoy', '+refs/heads/main:refs/remotes/upstream/main']);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 77;\n');
+		git(fork, ['commit', '-qam', 'fix shared file']);
+
+		const r = run(fork, ['--json', 'shared/pristine.ts']);
+		expect(r.status).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('unmeasured');
+		expect(parsed.verdicts[0]?.note).toMatch(/no provenance from the configured upstream/);
+	});
+
+	it('does not trust another upstream branch as upstream main', () => {
+		git(upstream, ['checkout', '-q', '-b', 'topic']);
+		write(upstream, 'topic-only.ts', 'topicOnly();\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'advance topic']);
+		git(upstream, ['checkout', '-q', 'main']);
+		write(upstream, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 3;\n');
+		git(upstream, ['commit', '-qam', 'advance upstream main']);
+		git(fork, ['fetch', '-q', 'upstream', '+refs/heads/topic:refs/remotes/upstream/main']);
+		const subject = git(fork, [
+			'reflog',
+			'show',
+			'-1',
+			'--format=%gs',
+			'refs/remotes/upstream/main'
+		]);
+		expect(subject).toContain('refs/heads/topic:refs/remotes/upstream/main');
+		expect(gitOptional(fork, ['config', '--get', 'upstreamReport.lastFetch'])).toBe('');
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 77;\n');
+		git(fork, ['commit', '-qam', 'fix shared file']);
+
+		const r = run(fork, ['--json', 'shared/pristine.ts']);
+		expect(r.status).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('unmeasured');
+		expect(parsed.verdicts[0]?.note).toMatch(/no provenance from the configured upstream/);
+	});
+
+	it('rejects an origin/main self-reference the remote does not advertise', () => {
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 78;\n');
+		git(fork, ['commit', '-qam', 'committed change']);
+		git(fork, ['update-ref', 'refs/remotes/origin/main', 'HEAD']);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/origin\/main.*does not match/);
+	});
+
+	it('accepts origin/main provenance from an ordinary fetch without a remote argument', () => {
+		write(fork, 'product/base-marker.ts', 'export const baseMarker = true;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'advance fork base']);
+		advertiseOriginMain(fork, 'HEAD');
+		git(fork, ['fetch', '-q']);
+		const subject = git(fork, ['reflog', 'show', '-1', '--format=%gs', 'refs/remotes/origin/main']);
+		expect(subject).toMatch(/^fetch -q:/);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 79;\n');
+		git(fork, ['commit', '-qam', 'fix shared path']);
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status, r.stderr).toBe(0);
+	});
+
+	it('accepts origin/main updated by a successful push', () => {
+		write(fork, 'product/pushed-base.ts', 'export const pushedBase = true;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'advance pushed base']);
+		git(fork, ['push', '-q', 'origin', 'HEAD:refs/heads/main']);
+		const subject = git(fork, ['reflog', 'show', '-1', '--format=%gs', 'refs/remotes/origin/main']);
+		expect(subject).toBe('update by push');
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 80;\n');
+		git(fork, ['commit', '-qam', 'fix after pushed base']);
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status, r.stderr).toBe(0);
+	});
+
+	it.each([
+		['option with value', ['fetch', '--depth', '1', 'origin', 'main']],
+		['server option with value', ['fetch', '--server-option', 'x=y', 'origin', 'main']],
+		['full refspec', ['fetch', 'origin', 'refs/heads/main:refs/remotes/origin/main']],
+		['forced full refspec', ['fetch', 'origin', '+refs/heads/main:refs/remotes/origin/main']]
+	])('accepts origin/main provenance from a real fetch with %s', (_name, fetchArgs) => {
+		write(fork, 'product/fetch-base.ts', 'export const fetchBase = true;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'advance fetch base']);
+		advertiseOriginMain(fork, 'HEAD');
+		git(fork, ['update-ref', '-d', 'refs/remotes/origin/main']);
+		git(fork, fetchArgs);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 88;\n');
+		git(fork, ['commit', '-qam', 'fix after fetched base']);
+
+		const r = run(fork, ['--json', 'shared/pristine.ts']);
+
+		expect(r.status, r.stderr).toBe(0);
+	});
+
+	it('accepts a fetch of main alongside additional refs', () => {
+		const base = git(fork, ['rev-parse', 'refs/remotes/origin/main']);
+		const elsewhere = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		git(fork, ['update-ref', 'refs/remotes/origin/main', elsewhere, base]);
+		git(fork, [
+			'update-ref',
+			'-m',
+			'fetch origin refs/heads/topic:refs/remotes/origin/topic main: fast-forward',
+			'refs/remotes/origin/main',
+			base,
+			elsewhere
+		]);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 79;\n');
+		git(fork, ['commit', '-qam', 'fix shared path']);
+
+		const r = run(fork, ['--json']);
+		expect(r.status, r.stderr).toBe(0);
+	});
+
+	it('rejects an untrusted origin/main inside the feature history', () => {
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 82;\n');
+		git(fork, ['commit', '-qam', 'shared feature commit']);
+		const truncatedBase = git(fork, ['rev-parse', 'HEAD']);
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'later product commit']);
+		git(fork, [
+			'update-ref',
+			'-m',
+			'fetch origin topic: storing head',
+			'refs/remotes/origin/main',
+			truncatedBase
+		]);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/origin\/main.*does not match/);
+	});
+
+	it('does not trust a manually packed origin/main', () => {
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 83;\n');
+		git(fork, ['commit', '-qam', 'committed change']);
+		git(fork, ['update-ref', '-m', 'local rewrite', 'refs/remotes/origin/main', 'HEAD']);
+		git(fork, ['pack-refs', '--all', '--prune']);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/origin\/main.*does not match/);
+	});
+
+	it('rejects origin/main populated from another origin branch', () => {
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 81;\n');
+		git(fork, ['commit', '-qam', 'committed change']);
+		git(fork, [
+			'update-ref',
+			'-m',
+			'fetch origin topic: storing head',
+			'refs/remotes/origin/main',
+			'HEAD'
+		]);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/origin\/main.*does not match/);
+	});
+
+	it('rejects a real default fetch that maps origin topic to origin/main', () => {
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 84;\n');
+		git(fork, ['commit', '-qam', 'committed change']);
+		const misleadingOrigin = join(tmp, 'topic-origin.git');
+		mkdirSync(misleadingOrigin);
+		git(misleadingOrigin, ['init', '--bare', '-q']);
+		git(fork, ['push', '-q', misleadingOrigin, 'HEAD:refs/heads/topic']);
+		git(fork, ['remote', 'set-url', 'origin', misleadingOrigin]);
+		git(fork, ['config', '--unset-all', 'remote.origin.fetch']);
+		git(fork, [
+			'config',
+			'--add',
+			'remote.origin.fetch',
+			'+refs/heads/topic:refs/remotes/origin/main'
+		]);
+		git(fork, ['fetch', '-q', 'origin']);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/origin\/main.*not mapped exclusively/);
+	});
+
+	itWithGitWrapper('times out a stalled origin provenance check', () => {
+		const wrapper = installGitWrapper(tmp);
+		const r = run(fork, ['--json'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_TIMEOUT_MS: '100',
+			SLOW_LS_REMOTE: '1'
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/Git operation timed out/);
+	});
+
+	itWithGitWrapper('rechecks upstream after final origin validation', () => {
+		const expected = git(upstream, ['rev-parse', 'HEAD']);
+		write(upstream, 'shared/late-upstream.ts', 'lateUpstream();\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add late upstream state']);
+		const replacement = git(upstream, ['rev-parse', 'HEAD']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		git(upstream, ['reset', '--hard', '-q', expected]);
+		git(fork, ['fetch', '-q', 'upstream']);
+
+		const wrapper = installGitWrapper(tmp);
+		const seen = join(tmp, 'origin-validated-once');
+		const marker = join(tmp, 'upstream-after-origin');
+		const r = run(fork, ['--json'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			UPSTREAM_AFTER_ORIGIN_REPO: fork,
+			UPSTREAM_AFTER_ORIGIN_SHA: replacement,
+			UPSTREAM_AFTER_ORIGIN_SEEN: seen,
+			UPSTREAM_AFTER_ORIGIN_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/tracking ref changed during this report/);
+	});
+
+	itWithGitWrapper('rejects origin/main moving during classification', () => {
+		write(fork, 'shared/origin-base.ts', 'originBase();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'advance validated origin base']);
+		markBase(fork);
+		const rewind = git(fork, ['rev-parse', 'HEAD^']);
+		write(fork, 'product/after-origin-base.ts', 'featureAfterOriginBase();\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add feature after origin base']);
+
+		const wrapper = installGitWrapper(tmp);
+		const marker = join(tmp, 'origin-race');
+		const r = run(fork, ['--fetch', '--json'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			ORIGIN_RACE_SHA: rewind,
+			ORIGIN_RACE_REMOTE: git(fork, ['remote', 'get-url', 'origin']),
+			ORIGIN_RACE_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/changed during base validation/);
+	});
+
+	it('rejects origin/main after the origin URL changes', () => {
+		const otherOrigin = join(tmp, 'other-origin');
+		mkdirSync(otherOrigin);
+		init(otherOrigin);
+		write(otherOrigin, 'other.ts', 'export const otherOrigin = true;\n');
+		git(otherOrigin, ['add', '-A']);
+		git(otherOrigin, ['commit', '-qm', 'other origin']);
+		git(fork, ['remote', 'set-url', 'origin', otherOrigin]);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/currently configured origin URL/);
+	});
+
+	it('rejects an origin URL rewritten to the feature HEAD', () => {
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'fix shared file']);
+		const configuredOrigin = git(fork, ['config', '--get', 'remote.origin.url']);
+		git(fork, ['config', `url.${fork}.insteadOf`, configuredOrigin]);
+		git(fork, ['fetch', '-q', 'origin']);
+		expect(git(fork, ['rev-parse', 'origin/main'])).toBe(git(fork, ['rev-parse', 'HEAD']));
+
+		const r = run(fork, ['--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+		expect(r.stderr).toMatch(/url\.\*\.insteadOf/);
+	});
+
+	it('accepts origin/main fetched with an explicit main argument', () => {
+		write(fork, 'shared/new-base.ts', 'export const newBase = true;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'advance origin base']);
+		const origin = git(fork, ['remote', 'get-url', 'origin']);
+		git(fork, ['push', '-q', '--force', origin, 'HEAD:refs/heads/main']);
+		git(fork, ['fetch', '-q', 'origin', 'main']);
+		write(fork, 'product/after-base.ts', 'export const afterBase = true;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add feature after fetched base']);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status, r.stderr).toBe(0);
+	});
+
+	it('rejects an origin refspec that excludes main', () => {
+		git(fork, ['config', '--add', 'remote.origin.fetch', '^refs/heads/main']);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/origin\/main.*not mapped exclusively/);
+	});
+
+	it('ignores inherited Git trace output paths', () => {
+		const trace = join(tmp, 'inherited-git-trace.log');
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts'], {
+			GIT_TRACE: trace,
+			GIT_TRACE2_EVENT: join(tmp, 'inherited-git-trace-event.log')
+		});
+		expect(r.status, r.stderr).toBe(0);
+		expect(existsSync(trace)).toBe(false);
+		expect(existsSync(join(tmp, 'inherited-git-trace-event.log'))).toBe(false);
+	});
+
+	it('ignores inherited command-scope Git config', () => {
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 85;\n');
+		git(fork, ['commit', '-qam', 'fix shared file']);
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts'], {
+			GIT_CONFIG_COUNT: '1',
+			GIT_CONFIG_KEY_0: 'remote.origin.fetch',
+			GIT_CONFIG_VALUE_0: '+refs/heads/topic:refs/remotes/origin/main'
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('pristine');
+	});
+
+	it('ignores legacy command-scope Git config', () => {
+		const hidden = 'product/legacy-hidden.ts';
+		write(fork, hidden, 'export const inheritedCopy = true;\n');
+		const excludes = join(tmp, 'legacy-excludes');
+		writeFileSync(excludes, `${hidden}\n`);
+
+		const r = run(fork, ['--fetch', '--json'], {
+			GIT_CONFIG_PARAMETERS: `'core.excludesFile'='${excludes}'`
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string }>;
+		};
+		expect(parsed.verdicts.find((verdict) => verdict.path === hidden)?.relevance).toBe(
+			'unmeasured'
+		);
+	});
+
+	it('ignores replacement refs while reading the pinned upstream tree', () => {
+		const upstreamTip = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		const emptyTree = gitInput(fork, ['mktree'], '');
+		const emptyCommit = git(fork, ['commit-tree', emptyTree, '-m', 'empty replacement']);
+		git(fork, ['replace', upstreamTip, emptyCommit]);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 79;\n');
+		git(fork, ['commit', '-qam', 'fix shared file']);
+
+		expect(verdicts(fork, ['shared/pristine.ts'])['shared/pristine.ts']).toBe('pristine');
+	});
+
+	it('refuses an index with unresolved merge stages', () => {
+		const ours = gitInput(fork, ['hash-object', '-w', '--stdin'], 'fork content\n');
+		const theirs = git(fork, ['rev-parse', 'refs/remotes/upstream/main:shared/pristine.ts']);
+		gitInput(
+			fork,
+			['update-index', '--index-info'],
+			`100644 ${ours} 2\tproduct/conflict.ts\n100644 ${theirs} 3\tproduct/conflict.ts\n`
+		);
+
+		const r = run(fork, ['--fetch', '--json', 'product/conflict.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/unresolved merge stages/);
+		expect(r.stderr).toContain('product/conflict.ts');
+	});
+
+	itWithPosixPaths('escapes controls in unresolved-index diagnostics', () => {
+		const escape = String.fromCharCode(27);
+		const path = `product/${escape}[2J${escape}]0;spoofed${String.fromCharCode(7)}.ts`;
+		const ours = gitInput(fork, ['hash-object', '-w', '--stdin'], 'ours\n');
+		const theirs = gitInput(fork, ['hash-object', '-w', '--stdin'], 'theirs\n');
+		gitInput(
+			fork,
+			['update-index', '-z', '--index-info'],
+			Buffer.concat([
+				Buffer.from(`100644 ${ours} 2\t${path}\0`),
+				Buffer.from(`100644 ${theirs} 3\t${path}\0`)
+			])
+		);
+
+		const r = run(fork, ['--fetch', '--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain(escape);
+		expect(r.stderr).not.toContain(String.fromCharCode(7));
+		expect(r.stderr).toContain('\\u001b[2J');
+	});
+
+	it('case-folds a unique filename after relocation', () => {
+		write(fork, 'product/config.ts', 'export const productConfig = 99;\n');
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'relocate config']);
+
+		const r = run(fork, ['--fetch', '--json', 'product/config.ts']);
+		expect(r.status).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('unmeasured');
+		expect(parsed.verdicts[0]?.note).toContain('shared/Config.ts');
+	});
+
+	it('copies an index written in version 4 format', () => {
+		git(fork, ['update-index', '--index-version', '4']);
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 80;\n');
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+		expect(r.status, `script failed: ${r.stderr}`).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('pristine');
+	});
+
+	it('does not touch a split index backing file', () => {
+		git(fork, ['config', 'core.splitIndex', 'true']);
+		git(fork, ['update-index', '--split-index']);
+		const gitDir = resolve(fork, git(fork, ['rev-parse', '--git-dir']));
+		const shared = readdirSync(gitDir).find((name) => name.startsWith('sharedindex.'));
+		expect(shared).toBeDefined();
+		const backing = join(gitDir, shared!);
+		const old = new Date('2020-01-02T03:04:05Z');
+		utimesSync(backing, old, old);
+		const before = statSync(backing).mtimeMs;
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/split index/);
+		expect(statSync(backing).mtimeMs).toBe(before);
+	});
+
+	itWithGitWrapper('checks split-index state from the copied bytes', () => {
+		const indexPath = join(fork, '.git', 'index');
+		const ordinary = join(tmp, 'ordinary-index');
+		writeFileSync(ordinary, readFileSync(indexPath));
+		git(fork, ['config', 'core.splitIndex', 'true']);
+		git(fork, ['update-index', '--split-index']);
+		const split = join(tmp, 'split-index');
+		writeFileSync(split, readFileSync(indexPath));
+		const gitDir = resolve(fork, git(fork, ['rev-parse', '--git-dir']));
+		const shared = readdirSync(gitDir).find((name) => name.startsWith('sharedindex.'));
+		expect(shared).toBeDefined();
+		const backing = join(gitDir, shared!);
+		const old = new Date('2020-01-02T03:04:05Z');
+		utimesSync(backing, old, old);
+		const before = statSync(backing).mtimeMs;
+		const marker = join(tmp, 'index-aba');
+
+		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			INDEX_ABA_PATH: indexPath,
+			INDEX_ABA_ORDINARY: ordinary,
+			INDEX_ABA_SPLIT: split,
+			INDEX_ABA_MARKER: marker
+		});
+
+		expect(existsSync(`${marker}.swapped`)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/split index/);
+		expect(statSync(backing).mtimeMs).toBe(before);
+	});
+
+	itWithGitWrapper(
+		'accepts the standard GitHub HTTPS and SSH spellings as one repository',
+		() => {
+			const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+				string,
+				unknown
+			>;
+			write(
+				fork,
+				'.upstream-sync.json',
+				JSON.stringify({
+					...marker,
+					upstreamUrl: 'https://github.com/stickerdaniel/saas-starter.git'
+				})
+			);
+			git(fork, ['commit', '-qam', 'record GitHub parent']);
+			markBase(fork);
+			write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+			git(fork, ['commit', '-qam', 'edit shared path']);
+			const wrapper = installGitWrapper(tmp);
+			const upstreamSha = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+
+			for (const remote of [
+				'git@github.com:stickerdaniel/saas-starter.git',
+				'git@github.com:stickerdaniel/saas-starter',
+				'ssh://git@github.com/stickerdaniel/saas-starter',
+				'https://github.com/StickerDaniel/SaaS-Starter',
+				'https://github.com/stickerdaniel/saas-starter/'
+			]) {
+				git(fork, ['remote', 'set-url', 'upstream', remote]);
+				const r = run(fork, ['--base', 'origin/main', '--json', 'shared/pristine.ts'], {
+					PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+					REAL_GIT: realGitPath(),
+					FAKE_REMOTE_MAIN_SHA: upstreamSha
+				});
+				expect(r.status, `${remote}: ${r.stderr}`).toBe(0);
+				const parsed = JSON.parse(r.stdout) as {
+					verdicts: Array<{ path: string; relevance: string }>;
+				};
+				expect(parsed.verdicts[0]).toEqual({
+					path: 'shared/pristine.ts',
+					relevance: 'pristine',
+					report: true
+				});
+			}
+		},
+		15_000
+	);
+
+	it.each([
+		['ssh://git@h/owner/template.git', 'git@h:owner/template.git'],
+		['https://h/owner/template.git', 'https://h/owner/template']
+	])('keeps distinct Git server paths separate: %s and %s', (markerUrl, remoteUrl) => {
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: markerUrl }));
+		git(fork, ['commit', '-qam', 'set exact parent address']);
+		git(fork, ['remote', 'set-url', 'upstream', remoteUrl]);
+
+		const r = run(fork, []);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/different repository/i);
+	});
+
+	it('sweeps up an index copy an earlier run left behind', () => {
+		// SIGTERM and SIGHUP do not reach the exit listener, and a handler for them
+		// is worse than the leak: this script sits inside execFileSync almost the
+		// whole run, a JS handler cannot run until the event loop turns, and
+		// installing one only replaces the default disposition, so the run stops
+		// answering SIGTERM at all. Cleaning up on the way in covers every way the
+		// previous run can have died.
+		const leftover = mkdtempSync(join(tmpdir(), 'upstream-relevance-index-'));
+		writeFileSync(join(leftover, 'index'), 'stale');
+		writeFileSync(join(leftover, 'owner'), '999999999');
+		const old = new Date(Date.now() - 3 * 60 * 60 * 1000);
+		utimesSync(leftover, old, old);
+
+		// And two directories the detector cannot prove it owns.
+		const fresh = mkdtempSync(join(tmpdir(), 'upstream-relevance-index-'));
+		writeFileSync(join(fresh, 'index'), 'in use');
+		const unrelated = mkdtempSync(join(tmpdir(), 'upstream-relevance-index-'));
+		writeFileSync(join(unrelated, 'keep'), 'unrelated');
+		utimesSync(unrelated, old, old);
+
+		try {
+			expect(run(fork, ['--json']).status).toBe(0);
+			expect(existsSync(leftover)).toBe(false);
+			expect(existsSync(fresh)).toBe(true);
+			expect(existsSync(unrelated)).toBe(true);
+		} finally {
+			rmSync(fresh, { recursive: true, force: true });
+			rmSync(unrelated, { recursive: true, force: true });
+			rmSync(leftover, { recursive: true, force: true });
+		}
+	});
+
+	it('does not sweep an old index copy owned by a live report', () => {
+		const active = mkdtempSync(join(tmpdir(), 'upstream-relevance-index-'));
+		writeFileSync(join(active, 'index'), 'in use');
+		writeFileSync(join(active, 'owner'), String(process.pid));
+		const old = new Date(Date.now() - 3 * 60 * 60 * 1000);
+		utimesSync(active, old, old);
+
+		try {
+			expect(run(fork, ['--json']).status).toBe(0);
+			expect(existsSync(active)).toBe(true);
+		} finally {
+			rmSync(active, { recursive: true, force: true });
+		}
+	});
+
+	it('rejects an origin rewrite before template self-detection', () => {
+		const decoy = join(tmp, 'self-detection-decoy');
+		mkdirSync(decoy);
+		init(decoy);
+		write(decoy, 'decoy.ts', 'export const decoy = true;\n');
+		git(decoy, ['add', '-A']);
+		git(decoy, ['commit', '-qm', 'add self-detection decoy']);
+		git(fork, ['remote', 'set-url', 'origin', upstream]);
+		git(fork, ['config', `url.${decoy}.insteadOf`, upstream]);
+
+		const r = run(fork, []);
+		expect(r.status).not.toBe(2);
+		expect(r.stderr).toMatch(/url\.\*\.insteadOf/);
+		expect(r.stderr).not.toContain('IS the upstream template');
+	});
+
+	it('detects the template across standard GitHub HTTPS and SSH spellings', () => {
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(
+			fork,
+			'.upstream-sync.json',
+			JSON.stringify({
+				...marker,
+				upstreamUrl: 'https://github.com/stickerdaniel/saas-starter.git'
+			})
+		);
+		git(fork, ['commit', '-qam', 'record GitHub parent']);
+		git(fork, ['remote', 'set-url', 'origin', 'git@github.com:stickerdaniel/saas-starter.git']);
+
+		const r = run(fork, []);
+
+		expect(r.status).toBe(2);
+		expect(r.stderr).toContain('IS the upstream template');
+	});
+
+	it('refuses to classify the template against itself', () => {
+		// The skill ships to the template too, where every fork inherits it. There
+		// the repository IS upstream, so there is nothing to report and every
+		// verdict would be a comparison with itself.
+		git(fork, ['remote', 'set-url', 'origin', upstream]);
+
+		const r = run(fork, []);
+		expect(r.status).toBe(2);
+		expect(r.stderr).toContain('IS the upstream template');
+	});
+});

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -190,7 +190,7 @@ if [ -n "$TRANSPORT_UNSCOPED_HTTP_LOG" ]; then
 fi
 if [ -n "$TRANSPORT_NETWORK_LOG" ]; then
   case "$command_line" in
-    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-regexp '^http\\..*\\.(sslcainfo|proxy)$' > "$TRANSPORT_NETWORK_LOG" || : ;;
+    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-regexp '^(http\\..*(sslcainfo|proxy)|remote\\..*\\.proxy)$' > "$TRANSPORT_NETWORK_LOG" || : ;;
   esac
 fi
 if [ -n "$CAT_FILE_CHECK_LOG" ]; then
@@ -873,7 +873,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(existsSync(marker)).toBe(false);
 	});
 
-	itWithPosixPaths('scrubs inherited protocol permission before reading the marker URL', () => {
+	itWithPosixPaths('intersects inherited protocol permission with safe transports', () => {
 		const executed = join(tmp, 'ext-protocol-executed');
 		const helper = join(tmp, 'ext-protocol-helper');
 		writeFileSync(helper, `#!/bin/sh\n: > "${executed}"\nexit 1\n`);
@@ -894,6 +894,17 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 
 		expect(r.status).not.toBe(0);
 		expect(existsSync(executed)).toBe(false);
+	});
+
+	it('preserves an inherited protocol allowlist that excludes local remotes', () => {
+		const r = run(fork, ['--json', 'shared/pristine.ts'], { GIT_ALLOW_PROTOCOL: 'https' });
+		expect(r.status).not.toBe(0);
+	});
+
+	it('preserves restrictive protocol configuration', () => {
+		git(fork, ['config', '--local', 'protocol.file.allow', 'never']);
+		const r = run(fork, ['--json', 'shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
 	});
 
 	it('refuses a relative temporary directory before writing or sweeping', () => {
@@ -1877,10 +1888,48 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stderr).toMatch(/Git 2\.45 or newer.*partial-clone/);
 	});
 
-	it('classifies a fork-only path as fork-only', () => {
-		write(fork, 'product/only-here.ts', 'export const product = false;\n');
-		git(fork, ['commit', '-qam', 'edit']);
-		expect(verdicts(fork)['product/only-here.ts']).toBe('fork-only');
+	it('keeps a low-similarity bootstrap port unmeasured', () => {
+		const inherited = Array.from(
+			{ length: 10 },
+			(_, index) => `BOOTSTRAP_TEMPLATE_TOKEN_${index}_${'q'.repeat(40 + index)}`
+		);
+		write(upstream, 'shared/bootstrap-source.rare', `${inherited.join('\n')}\n`);
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '--amend', '-qm', 'template with bootstrap source']);
+		const upstreamRoot = git(upstream, ['rev-parse', 'HEAD']);
+		git(fork, ['fetch', '-q', 'upstream', '+main:refs/remotes/upstream/main']);
+
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(
+			fork,
+			'.upstream-sync.json',
+			JSON.stringify({ ...marker, forkPoint: upstreamRoot, lastSynced: upstreamRoot })
+		);
+		const port = [
+			...inherited.slice(0, 4),
+			...Array.from(
+				{ length: 6 },
+				(_, index) => `BOOTSTRAP_FORK_TOKEN_${index}_${'z'.repeat(80 + index)}`
+			)
+		];
+		write(fork, 'product/bootstrap-port.rare', `${port.join('\n')}\n`);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '--amend', '-qm', 'fork base with bootstrap port']);
+		markBase(fork);
+		write(fork, 'product/bootstrap-port.rare', `${port.join('\n')}\nBOOTSTRAP_FIX_TOKEN\n`);
+		git(fork, ['commit', '-qam', 'fix bootstrap port']);
+
+		const r = run(fork, ['--fetch', '--json', 'product/bootstrap-port.rare']);
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/bootstrap-port.rare');
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/bootstrap-time relocation or customization/);
 	});
 
 	it('keeps a low-similarity port added after repository creation unmeasured', () => {
@@ -3456,13 +3505,18 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(readFileSync(enumerationLog, 'utf8').trim().split('\n')).toHaveLength(3);
 	});
 
-	it('bounds aggregate explicit path expansion', () => {
+	itWithGitWrapper('bounds aggregate explicit path expansion before reading later trees', () => {
+		const enumerationLog = join(tmp, 'bounded-path-enumeration.log');
 		const r = run(fork, ['--fetch', '--json', '--all', '.'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			PATH_ENUMERATION_LOG: enumerationLog,
 			NODE_ENV: 'test',
 			UPSTREAM_REPORT_TEST_PATH_LIMIT: '1'
 		});
 		expect(r.status).not.toBe(0);
 		expect(r.stderr).toMatch(/matched more than 1 files/);
+		expect(readFileSync(enumerationLog, 'utf8').trim().split('\n')).toHaveLength(1);
 	});
 
 	it('bounds aggregate automatic path discovery', () => {
@@ -3562,6 +3616,24 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stderr).toMatch(/must be a regular file/);
 	});
 
+	itWithPosixPaths('rejects a Windows marker symlink from the index before target access', () => {
+		const target = join(tmp, 'unreadable-upstream-marker.json');
+		writeFileSync(target, JSON.stringify({ upstreamUrl: upstream }));
+		chmodSync(target, 0o000);
+		rmSync(join(fork, '.upstream-sync.json'));
+		symlinkSync(target, join(fork, '.upstream-sync.json'));
+		git(fork, ['add', '.upstream-sync.json']);
+		git(fork, ['commit', '-qm', 'track Windows marker symlink']);
+
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_WINDOWS_SAFETY: '1'
+		});
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/must be a regular file/);
+		expect(r.stderr).not.toMatch(/could not be opened/);
+	});
+
 	it.each([
 		['null URL', { upstreamUrl: null }],
 		['false URL', { upstreamUrl: false }],
@@ -3653,6 +3725,57 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		const config = readFileSync(networkLog, 'utf8');
 		expect(config).toContain('/private/company-ca.pem');
 		expect(config).toContain('http://proxy.example');
+	});
+
+	itWithGitWrapper('copies global CA and proxy settings plus the matching remote proxy', () => {
+		git(fork, ['config', '--local', 'http.sslCAInfo', '/private/global-ca.pem']);
+		git(fork, ['config', '--local', 'http.proxy', 'http://global-proxy.example']);
+		git(fork, ['config', '--local', 'remote.upstream.proxy', 'http://upstream-proxy.example']);
+		const wrapper = installGitWrapper(tmp);
+		const networkLog = join(tmp, 'transport-global-network.log');
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			TRANSPORT_NETWORK_LOG: networkLog
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const config = readFileSync(networkLog, 'utf8');
+		expect(config).toContain('/private/global-ca.pem');
+		expect(config).toContain('http://global-proxy.example');
+		expect(config).toContain('http://upstream-proxy.example');
+	});
+
+	itWithGitWrapper('keeps secret-bearing HTTP config out of Windows temporary files', () => {
+		git(fork, ['config', '--local', 'credential.helper', '!echo DUMMY_HELPER_SECRET']);
+		git(fork, [
+			'config',
+			'--local',
+			`http.${upstream}.extraHeader`,
+			'Authorization: Bearer DUMMY_HEADER_SECRET'
+		]);
+		git(fork, [
+			'config',
+			'--local',
+			`http.${upstream}.proxy`,
+			'http://DUMMY_PROXY_SECRET@proxy.example'
+		]);
+		const wrapper = installGitWrapper(tmp);
+		const credentialLog = join(tmp, 'transport-windows-credential.log');
+		const httpLog = join(tmp, 'transport-windows-http.log');
+		const networkLog = join(tmp, 'transport-windows-network.log');
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			PATH: `${wrapper}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_WINDOWS_SAFETY: '1',
+			TRANSPORT_CREDENTIAL_LOG: credentialLog,
+			TRANSPORT_HTTP_LOG: httpLog,
+			TRANSPORT_NETWORK_LOG: networkLog
+		});
+		expect(r.status, r.stderr).toBe(0);
+		expect(readFileSync(credentialLog, 'utf8')).not.toContain('DUMMY_HELPER_SECRET');
+		expect(readFileSync(httpLog, 'utf8')).not.toContain('DUMMY_HEADER_SECRET');
+		expect(readFileSync(networkLog, 'utf8')).not.toContain('DUMMY_PROXY_SECRET');
 	});
 
 	itWithGitWrapper('does not copy unscoped HTTP authentication to a marker-selected host', () => {
@@ -3751,8 +3874,8 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		git(fork, ['add', '-A']);
 		git(fork, ['commit', '-qm', 'same file here']);
 
-		// A no-fetch run can use the old tree to find ties, but it cannot use an
-		// absent path to rule one out. Only this run's fetch earns fork-only.
+		// A no-fetch run sees the old tree. Fetching must replace that absence
+		// explanation with the newly observed shared path.
 		const stale = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
 		const before = run(fork, ['--json']);
 		expect(before.status).toBe(0);
@@ -3762,9 +3885,16 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(
 			beforeVerdicts.verdicts.find((v) => v.path === 'shared/newly-added-upstream.ts')?.relevance
 		).toBe('unmeasured');
-		expect(verdicts(fork, ['--fetch'])['shared/newly-added-upstream.ts']).not.toBe('fork-only');
-		// The verdict has to change because the copy advanced. Special-casing an
-		// absent path whenever --fetch is present would satisfy the line above.
+		const after = run(fork, ['--fetch', '--json']);
+		expect(after.status, after.stderr).toBe(0);
+		const afterVerdicts = JSON.parse(after.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		expect(
+			afterVerdicts.verdicts.find((v) => v.path === 'shared/newly-added-upstream.ts')?.note
+		).toMatch(/added here at a path upstream also has/);
+		// The explanation has to change because the copy advanced. Special-casing
+		// an absent path whenever --fetch is present would satisfy only the status.
 		expect(git(fork, ['rev-parse', 'refs/remotes/upstream/main'])).not.toBe(stale);
 	});
 
@@ -4283,7 +4413,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 	});
 
 	it('reports the age of the local upstream copy on every run', () => {
-		// A fork-only verdict from a copy that predates an upstream file is wrong
+		// Hiding a copy that predates an upstream file is wrong
 		// and invisible. The age is the only thing that lets a reader doubt it, so
 		// it is not held back for a staleness threshold.
 		const r = run(fork, []);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -5644,6 +5644,28 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(verdict?.note).toMatch(/bounded similarity size/);
 	});
 
+	it('bounds the completed diff before building changed-region arrays', () => {
+		const path = 'shared/rewritten.ts';
+		write(
+			fork,
+			path,
+			`${Array.from({ length: 20 }, (_, index) => `export const changed${index} = ${index};`).join('\n')}\n`
+		);
+
+		const r = run(fork, ['--fetch', '--json', path], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_CHANGED_REGION_LIMIT: '2000'
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		const verdict = parsed.verdicts.find((entry) => entry.path === path);
+		expect(verdict?.relevance).toBe('unmeasured');
+		expect(verdict?.note).toMatch(/bounded changed-region representation/);
+	});
+
 	it('bounds the overlap map for a shared upstream path', () => {
 		const path = 'shared/large-overlap.ts';
 		write(

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -693,7 +693,7 @@ function init(root: string, objectFormat: 'sha1' | 'sha256' = 'sha1'): void {
 	git(root, ['config', 'commit.gpgsign', 'false']);
 }
 
-describe('upstream-relevance (integration)', () => {
+describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 	let tmp: string;
 	let upstream: string;
 	let fork: string;

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -150,16 +150,25 @@ function installGitWrapper(root: string): string {
 	writeFileSync(
 		wrapper,
 		`#!/bin/sh
+command_line=" $* "
+if [ -n "$TRANSPORT_ALIAS_CONFIG_LOG" ]; then
+  case "$command_line" in
+    *" fetch "*)
+      for arg in "$@"; do
+        case "$arg" in
+          upstream-report-*)
+            remote_url=$("$REAL_GIT" config --get "remote.$arg.url") || continue
+            { printf '%s\n' "$remote_url"; "$REAL_GIT" config --get-urlmatch http.pinnedPubkey "$remote_url" || :; "$REAL_GIT" config --get "remote.$arg.proxy" || :; } > "$TRANSPORT_ALIAS_CONFIG_LOG"
+            ;;
+        esac
+      done
+      ;;
+  esac
+fi
 if [ "$FAKE_FETCH_SUCCESS" = "1" ]; then
   for arg in "$@"; do
     [ "$arg" = "fetch" ] && exit 0
   done
-fi
-command_line=" $* "
-if [ -n "$TRANSPORT_ALIAS_CONFIG_LOG" ]; then
-  case "$command_line" in
-    *" ls-remote "*) "$REAL_GIT" config --get-regexp '^(http\\..*\\.pinnedpubkey|remote\\..*\\.proxy)$' > "$TRANSPORT_ALIAS_CONFIG_LOG" || : ;;
-  esac
 fi
 if [ -n "$FAKE_REMOTE_MAIN_SHA" ]; then
   case "$command_line" in
@@ -6045,15 +6054,17 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		const upstreamSha = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
 		const networkLog = join(tmp, 'github-alias-transport.log');
 
-		const r = run(fork, ['--base', 'origin/main', '--json'], {
+		const r = run(fork, ['--fetch', '--base', 'origin/main', '--json'], {
 			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
 			REAL_GIT: realGitPath(),
+			FAKE_FETCH_SUCCESS: '1',
 			FAKE_REMOTE_MAIN_SHA: upstreamSha,
 			TRANSPORT_ALIAS_CONFIG_LOG: networkLog
 		});
 
 		expect(r.status, r.stderr).toBe(0);
 		const config = readFileSync(networkLog, 'utf8');
+		expect(config).toContain(configured);
 		expect(config).toContain('sha256//DUMMY_PIN');
 		expect(config).toContain('http://proxy.example');
 	});

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -170,6 +170,14 @@ if [ "$FAKE_FETCH_SUCCESS" = "1" ]; then
     [ "$arg" = "fetch" ] && exit 0
   done
 fi
+if [ -n "$TRANSPORT_CONFIG_RACE_REPO" ] && [ ! -e "$TRANSPORT_CONFIG_RACE_MARKER" ]; then
+  case "$command_line" in
+    *" ls-remote "*)
+      env -u GIT_INDEX_FILE -u GIT_DIR -u GIT_OBJECT_DIRECTORY -u GIT_SHALLOW_FILE -u GIT_CONFIG_COUNT "$REAL_GIT" -C "$TRANSPORT_CONFIG_RACE_REPO" config remote.upstream.proxy "$TRANSPORT_CONFIG_RACE_PROXY" || exit $?
+      : > "$TRANSPORT_CONFIG_RACE_MARKER"
+      ;;
+  esac
+fi
 if [ -n "$FAKE_REMOTE_MAIN_SHA" ]; then
   case "$command_line" in
     *" ls-remote "*" refs/heads/main "*) printf '%s\trefs/heads/main\n' "$FAKE_REMOTE_MAIN_SHA"; exit 0 ;;
@@ -218,7 +226,7 @@ fi
 if [ -n "$TRANSPORT_EFFECTIVE_AUTH_LOG" ]; then
   case "$command_line" in
     *" ls-remote "*)
-      { "$REAL_GIT" config --get-all credential.helper || :; "$REAL_GIT" config --get-regexp '^(http\\..*\\.(extraheader|proxy)|remote\\..*\\.proxy)$' || :; } > "$TRANSPORT_EFFECTIVE_AUTH_LOG"
+      { "$REAL_GIT" config --get-all credential.helper || :; "$REAL_GIT" config --get-regexp '^(http\\.(proxy|.*\\.(extraheader|proxy))|remote\\..*\\.proxy)$' || :; } > "$TRANSPORT_EFFECTIVE_AUTH_LOG"
       ;;
   esac
 fi
@@ -234,7 +242,7 @@ if [ -n "$TRANSPORT_UNSCOPED_HTTP_LOG" ]; then
 fi
 if [ -n "$TRANSPORT_NETWORK_LOG" ]; then
   case "$command_line" in
-    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-regexp '^(http\\..*(pinnedpubkey|sslcainfo|sslcapath|proxy|proxysslcainfo)|remote\\..*\\.(proxy|proxyauthmethod))$' > "$TRANSPORT_NETWORK_LOG" || : ;;
+    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-regexp '^(http\\..*(pinnedpubkey|schannelusesslcainfo|sslcainfo|sslcapath|proxy|proxysslcainfo)|remote\\..*\\.(proxy|proxyauthmethod))$' > "$TRANSPORT_NETWORK_LOG" || : ;;
   esac
 fi
 if [ -n "$TLS_CONFIG_RACE_REPO" ] && [ ! -e "$TLS_CONFIG_RACE_MARKER" ]; then
@@ -2375,6 +2383,22 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stderr).toMatch(/marker upstream URL resolves inside a checkout/);
 	});
 
+	it('rejects file colon paths that Git parses as SCP syntax', () => {
+		const url = `file:${upstream}`;
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+		git(fork, ['commit', '-qam', 'set ambiguous file colon parent']);
+		git(fork, ['remote', 'set-url', 'upstream', url]);
+
+		const r = run(fork, ['--fetch', '--base', 'HEAD', '--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/canonical file:\/\/\/absolute\/path form/);
+	});
+
 	it('rejects hosted file URLs before Windows can resolve a UNC path', () => {
 		const url = 'file://attacker.example/share/repo.git';
 		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
@@ -4033,6 +4057,21 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(existsSync(networkMarker)).toBe(false);
 	});
 
+	itWithGitWrapper('rejects remote proxy configuration races', () => {
+		git(fork, ['config', '--local', 'remote.upstream.proxy', 'http://proxy-a.example']);
+		const marker = join(tmp, 'transport-config-raced');
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			TRANSPORT_CONFIG_RACE_REPO: fork,
+			TRANSPORT_CONFIG_RACE_PROXY: 'http://proxy-b.example',
+			TRANSPORT_CONFIG_RACE_MARKER: marker
+		});
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/Git transport configuration changed during this report/);
+	});
+
 	it('redacts a failed fetch before Git stderr reaches the caller', () => {
 		const secret = 'DUMMY_FETCH_QUERY_SECRET';
 		const url = `http://127.0.0.1:1/repo.git?token=${secret}`;
@@ -4111,7 +4150,9 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 	});
 
 	itWithGitWrapper('copies global CA and proxy settings plus the matching remote proxy', () => {
+		git(fork, ['config', '--local', 'http.sslBackend', 'schannel']);
 		git(fork, ['config', '--local', 'http.sslCAInfo', '/private/global-ca.pem']);
+		git(fork, ['config', '--local', 'http.schannelUseSSLCAInfo', 'true']);
 		git(fork, ['config', '--local', 'http.sslCAPath', '/private/global-ca-directory']);
 		git(fork, ['config', '--local', 'http.proxySSLCAInfo', '/private/proxy-ca.pem']);
 		git(fork, ['config', '--local', 'http.proxy', 'http://global-proxy.example']);
@@ -4127,6 +4168,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.status, r.stderr).toBe(0);
 		const config = readFileSync(networkLog, 'utf8');
 		expect(config).toContain('/private/global-ca.pem');
+		expect(config).toMatch(/http.schannelusesslcainfo true/i);
 		expect(config).toContain('/private/global-ca-directory');
 		expect(config).toContain('/private/proxy-ca.pem');
 		expect(config).toContain('http://global-proxy.example');
@@ -4195,6 +4237,28 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		const temporaryNetwork = readFileSync(networkLog, 'utf8');
 		expect(temporaryNetwork).not.toContain('DUMMY_PROXY_SECRET');
 		expect(temporaryNetwork).not.toContain('DUMMY_REMOTE_PROXY_SECRET');
+	});
+
+	itWithGitWrapper('keeps scheme-less proxy credentials out of Windows temporary files', () => {
+		git(fork, [
+			'config',
+			'--local',
+			'http.proxy',
+			'DUMMY_PROXY_USER:DUMMY_PROXY_PASSWORD@proxy.example:8080'
+		]);
+		const effectiveLog = join(tmp, 'transport-windows-schemeless-effective.log');
+		const networkLog = join(tmp, 'transport-windows-schemeless-file.log');
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_WINDOWS_SAFETY: '1',
+			TRANSPORT_EFFECTIVE_AUTH_LOG: effectiveLog,
+			TRANSPORT_NETWORK_LOG: networkLog
+		});
+		expect(r.status, r.stderr).toBe(0);
+		expect(readFileSync(effectiveLog, 'utf8')).toContain('DUMMY_PROXY_PASSWORD');
+		expect(readFileSync(networkLog, 'utf8')).not.toContain('DUMMY_PROXY_PASSWORD');
 	});
 
 	itWithGitWrapper('does not copy unscoped HTTP authentication to a marker-selected host', () => {
@@ -4546,6 +4610,23 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stderr).toMatch(/different repository/);
 	});
 
+	itWithPosixPaths('preserves trailing whitespace in the checkout root', () => {
+		const spaced = join(tmp, 'checkout ');
+		git(tmp, ['clone', '-q', fork, spaced]);
+		git(spaced, ['config', 'user.email', 'test@example.com']);
+		git(spaced, ['config', 'user.name', 'Test']);
+		git(spaced, ['remote', 'add', 'upstream', upstream]);
+		git(spaced, ['fetch', '-q', 'upstream']);
+		const trimmed = join(tmp, 'checkout');
+		mkdirSync(trimmed);
+		init(trimmed);
+
+		const r = run(spaced, ['--base', 'HEAD', '--json']);
+
+		expect(r.status, r.stderr).toBe(0);
+		expect(JSON.parse(r.stdout)).toMatchObject({ upstreamUrl: upstream });
+	});
+
 	it('keeps .git significant in local repository paths', () => {
 		const decoy = `${upstream}.git`;
 		mkdirSync(decoy);
@@ -4564,7 +4645,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		write(
 			fork,
 			'.upstream-sync.json',
-			JSON.stringify({ upstreamUrl: 'ssh://alice@example.invalid/~/template.git' })
+			JSON.stringify({ upstreamUrl: 'ssh://git@example.invalid/~/template.git' })
 		);
 		git(fork, ['commit', '-qam', 'set SSH parent']);
 		git(fork, ['remote', 'set-url', 'upstream', 'ssh://bob@example.invalid/~/template.git']);
@@ -4623,6 +4704,34 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.status).not.toBe(0);
 		expect(r.stderr).not.toContain('DUMMY_SCP_SECRET');
 		expect(r.stderr).toContain('***@example.invalid');
+	});
+
+	it('rejects secret-bearing suffixes in SCP-style remotes', () => {
+		const secret = 'DUMMY_SCP_SUFFIX_SECRET';
+		const remote = `git@example.invalid:owner/repo.git?access_token=${secret}`;
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: remote }));
+		git(fork, ['commit', '-qam', 'set secret-bearing SCP parent']);
+		git(fork, ['remote', 'set-url', 'upstream', remote]);
+
+		const r = run(fork, ['--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain(secret);
+		expect(r.stderr).toContain('?***');
+		expect(r.stderr).toMatch(/credential-free remote/);
+	});
+
+	it('rejects marker credentials even when the configured remote is clean', () => {
+		const secret = 'DUMMY_MARKER_ALIAS_SECRET';
+		const clean = 'https://example.invalid/owner/repo.git';
+		const marked = `https://user:${secret}@example.invalid/owner/repo.git`;
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: marked }));
+		git(fork, ['commit', '-qam', 'set credential-bearing marker alias']);
+		git(fork, ['remote', 'set-url', 'upstream', clean]);
+
+		const r = run(fork, ['--json']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain(secret);
+		expect(r.stderr).toMatch(/credential-free remote/);
 	});
 
 	it('redacts credentials carried in a remote query string', () => {
@@ -5208,6 +5317,26 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(capture).toContain('opened.size > maxBytes');
 	});
 
+	it('checks owned roots by filesystem identity as well as spelling', () => {
+		const source = readFileSync(SCRIPT, 'utf8');
+		const start = source.indexOf('function pathResolvesInsideOwnedRoot(');
+		const end = source.indexOf('function statFingerprint(', start);
+		const check = source.slice(start, end);
+		expect(check).toContain('statSync(current)');
+		expect(check).toContain('sameFileIdentity(rootStatsEntry, currentStats)');
+		expect(source).toContain('pathResolvesInsideOwnedRoot(tempPath, ownedRoots)');
+		expect(source).toContain('pathResolvesInsideOwnedRoot(remotePath, ownedRepositoryPaths)');
+	});
+
+	it('pins executable-bit detection after the POSIX capability check', () => {
+		const source = readFileSync(SCRIPT, 'utf8');
+		const start = source.indexOf('const PINNED_CONFIG = [');
+		const end = source.indexOf('];', start);
+		const config = source.slice(start, end);
+		expect(config).toContain("process.platform === 'win32'");
+		expect(config).toContain("'core.fileMode=true'");
+	});
+
 	it('binds marker inspection and bytes to one file descriptor', () => {
 		const source = readFileSync(SCRIPT, 'utf8');
 		const start = source.indexOf('function readUpstreamMarker(');
@@ -5461,6 +5590,30 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(cachedRead).toBeGreaterThan(candidateCharge);
 		expect(similar).toContain('for (const candidate of upstream.blobKeys)');
 		expect(similar).toContain('takeSimilarityOperations(upstream, 1)');
+	});
+
+	it('bounds retained upstream history metadata', () => {
+		write(upstream, 'shared/history-record-a.ts', 'historyRecordA();\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add first history record']);
+		write(upstream, 'shared/history-record-b.ts', 'historyRecordB();\n');
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add second history record']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		write(fork, 'product/only-here.ts', 'export const product = false;\n');
+		git(fork, ['commit', '-qam', 'edit fork-only path for history bound']);
+
+		const r = run(fork, ['--fetch', '--json', 'product/only-here.ts'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_HISTORY_RECORD_LIMIT: '1'
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		expect(parsed.verdicts[0]?.relevance).toBe('unmeasured');
+		expect(parsed.verdicts[0]?.note).toMatch(/upstream history did not complete/);
 	});
 
 	it('keeps aggregate working-tree capture bounded', () => {

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -291,6 +291,14 @@ if [ -n "$TRANSPORT_REWRITE_REPO" ]; then
       ;;
   esac
 fi
+if [ -n "$MUTATE_AFTER_CAPTURE_PATH" ] && [ ! -e "$MUTATE_AFTER_CAPTURE_MARKER" ]; then
+  case "$command_line" in
+    *" ls-tree -r -z "*)
+      printf '%s' "$MUTATE_AFTER_CAPTURE_CONTENT" > "$MUTATE_AFTER_CAPTURE_PATH" || exit $?
+      : > "$MUTATE_AFTER_CAPTURE_MARKER"
+      ;;
+  esac
+fi
 if [ -n "$PATH_ENUMERATION_LOG" ]; then
   case "$command_line" in
     *" diff --ignore-submodules=none --name-status -M -z "*|*" ls-files --others --exclude-standard -z "*|*" ls-files -z --full-name --cached --others --exclude-standard -- "*|*" ls-tree -z --full-name --name-only -r "*)
@@ -2367,8 +2375,66 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stderr).toMatch(/marker upstream URL resolves inside a checkout/);
 	});
 
+	it('rejects hosted file URLs before Windows can resolve a UNC path', () => {
+		const url = 'file://attacker.example/share/repo.git';
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+		git(fork, ['commit', '-qam', 'set hosted file parent']);
+		git(fork, ['remote', 'set-url', 'upstream', url]);
+
+		const r = run(fork, ['--json'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_WINDOWS_SAFETY: '1'
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/Hosted file URLs are network transports/);
+	});
+
+	it('rejects raw UNC remotes before local path resolution', () => {
+		const url = String.raw`\\attacker.example\share\repo.git`;
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+		git(fork, ['commit', '-qam', 'set UNC parent']);
+		git(fork, ['remote', 'set-url', 'upstream', url]);
+
+		const r = run(fork, ['--json'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_WINDOWS_SAFETY: '1'
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/UNC paths are network transports/);
+	});
+
+	it('rejects Windows drive-relative remotes before SCP parsing', () => {
+		const url = 'C:.';
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+		git(fork, ['commit', '-qam', 'set drive-relative parent']);
+		git(fork, ['remote', 'set-url', 'upstream', url]);
+
+		const r = run(fork, ['--json'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_WINDOWS_SAFETY: '1'
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/Windows drive-relative paths/);
+	});
+
 	itWithPosixPaths('rejects Git-compatible file URLs that lack one canonical local path', () => {
-		const url = `file://example.invalid${fork}`;
+		const encodedPath = fork.replace(/^\/([^/]+)\//, '/$1%2F');
+		const url = `file://${encodedPath}`;
 		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
 			string,
 			unknown
@@ -3833,6 +3899,30 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		);
 	});
 
+	itWithGitWrapper('rejects forced HTTPS helper syntax before transport', () => {
+		const secret = 'DUMMY_NESTED_HELPER_SECRET';
+		const url = `https::https://user:${secret}@example.invalid/repo.git`;
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+		git(fork, ['commit', '-qam', 'set forced HTTPS helper parent']);
+		git(fork, ['remote', 'set-url', 'upstream', url]);
+		const networkMarker = join(tmp, 'forced-helper-network-command');
+
+		const r = run(fork, ['--fetch', '--base', 'HEAD', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NETWORK_COMMAND_MARKER: networkMarker
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).not.toContain(secret);
+		expect(r.stderr).toMatch(/Forced Git remote-helper syntax/);
+		expect(existsSync(networkMarker)).toBe(false);
+	});
+
 	itWithGitWrapper('rejects credential-bearing HTTPS before starting its helper', () => {
 		const secret = 'DUMMY_REMOTE_CREDENTIAL';
 		const url = `https://user:${secret}@example.invalid/repo.git`;
@@ -4622,6 +4712,37 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(verdict?.note).toMatch(/diff command failed before completing/);
 	});
 
+	it('bounds aggregate shared-path diff commands', () => {
+		const paths = ['shared/diff-budget-a.ts', 'shared/diff-budget-b.ts'];
+		for (const [index, path] of paths.entries()) {
+			write(upstream, path, `upstream${index}One();\nupstream${index}Two();\n`);
+			write(fork, path, `fork${index}One();\nfork${index}Two();\n`);
+		}
+		git(upstream, ['add', '-A']);
+		git(upstream, ['commit', '-qm', 'add diff budget fixtures']);
+		git(fork, ['add', '-A']);
+		git(fork, ['commit', '-qm', 'add diverged diff budget paths']);
+		git(fork, ['fetch', '-q', 'upstream']);
+		markBase(fork);
+		for (const [index, path] of paths.entries()) {
+			write(fork, path, `fork${index}AfterOne();\nfork${index}AfterTwo();\n`);
+		}
+		git(fork, ['commit', '-qam', 'edit diff budget paths']);
+
+		const r = run(fork, ['--fetch', '--json', ...paths], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_DIFF_OPERATION_LIMIT: '1'
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		const parsed = JSON.parse(r.stdout) as {
+			verdicts: Array<{ path: string; relevance: string; note?: string }>;
+		};
+		expect(
+			parsed.verdicts.some((verdict) => verdict.note?.includes('bounded diff command count'))
+		).toBe(true);
+	});
+
 	itWithGitWrapper('times out a stalled captured diff', () => {
 		write(upstream, 'shared/captured-timeout.ts', 'upstreamOne();\nupstreamTwo();\n');
 		git(upstream, ['add', '-A']);
@@ -5320,6 +5441,28 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(verdict?.note).toMatch(/bounded operation count/);
 	});
 
+	it('charges candidate traversal even when upstream text is unavailable', () => {
+		const source = readFileSync(SCRIPT, 'utf8');
+		const cacheStart = source.indexOf('function cacheBags(');
+		const cacheEnd = source.indexOf('const POTENTIAL_TEXT_EXTENSIONS', cacheStart);
+		const cache = source.slice(cacheStart, cacheEnd);
+		const searchStart = source.indexOf('function searchSimilar(');
+		const searchEnd = source.indexOf('type SourceBag', searchStart);
+		const search = source.slice(searchStart, searchEnd);
+		const similarStart = source.indexOf('function similarTo(');
+		const similarEnd = source.indexOf('interface ContentSet', similarStart);
+		const similar = source.slice(similarStart, similarEnd);
+		const candidateLoop = search.indexOf('for (const key of candidates)');
+		const candidateCharge = search.indexOf('takeSimilarityOperations(upstream, 1)', candidateLoop);
+		const cachedRead = search.indexOf('upstream.bags.get(key)', candidateLoop);
+
+		expect(cache).toContain('takeSimilarityOperations(upstream, 1)');
+		expect(candidateCharge).toBeGreaterThan(candidateLoop);
+		expect(cachedRead).toBeGreaterThan(candidateCharge);
+		expect(similar).toContain('for (const candidate of upstream.blobKeys)');
+		expect(similar).toContain('takeSimilarityOperations(upstream, 1)');
+	});
+
 	it('keeps aggregate working-tree capture bounded', () => {
 		write(fork, 'product/capture-a.ts', 'captureAlphaToken();\ncaptureAlphaToken();\n');
 		write(fork, 'product/capture-b.ts', 'captureBetaToken();\ncaptureBetaToken();\n');
@@ -5335,6 +5478,33 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		const verdict = parsed.verdicts.find((entry) => entry.path === 'product/capture-b.ts');
 		expect(verdict?.relevance).toBe('unmeasured');
 		expect(verdict?.note).toMatch(/bounded capture size/);
+	});
+
+	itWithGitWrapper('fences bytes after aggregate capture is exhausted', () => {
+		const first = 'product/capture-fence-a.ts';
+		const second = 'product/capture-fence-b.ts';
+		write(fork, first, 'export const first = 1;\n');
+		write(fork, second, 'export const value = 1;\n');
+		git(fork, ['add', first, second]);
+		git(fork, ['commit', '-qm', 'add capture fence paths']);
+		markBase(fork);
+		write(fork, first, 'export const first = 123456789012345678901234567890;\n');
+		write(fork, second, 'export const value = 2;\n');
+		const marker = join(tmp, 'capture-fence-mutated');
+
+		const r = run(fork, ['--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_CAPTURE_LIMIT: '64',
+			MUTATE_AFTER_CAPTURE_PATH: join(fork, second),
+			MUTATE_AFTER_CAPTURE_CONTENT: 'export const value = 3;\n',
+			MUTATE_AFTER_CAPTURE_MARKER: marker
+		});
+
+		expect(existsSync(marker)).toBe(true);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/working tree changed during this report/);
 	});
 
 	itWithPosixPaths('counts symlink targets against aggregate working-tree capture', () => {

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -4686,6 +4686,52 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stderr).toMatch(/inside a checkout or Git directory owned by this repository/);
 	});
 
+	it('rejects a C-quoted alternate that resolves into this repository', () => {
+		const remote = join(tmp, 'quoted-alternate-remote.git');
+		mkdirSync(remote);
+		git(remote, ['init', '--bare', '-q']);
+		const objectDir = join(remote, 'objects');
+		const ownedObjects = realpathSync(
+			git(fork, ['rev-parse', '--path-format=absolute', '--git-path', 'objects'])
+		);
+		const entry = JSON.stringify(ownedObjects);
+		mkdirSync(resolve(objectDir, entry), { recursive: true });
+		writeFileSync(join(objectDir, 'info', 'alternates'), `${entry}\n`);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: remote }));
+		git(fork, ['commit', '-qam', 'set quoted-alternate parent']);
+		git(remote, ['update-ref', 'refs/heads/main', git(fork, ['rev-parse', 'HEAD'])]);
+		git(fork, ['remote', 'set-url', 'upstream', remote]);
+
+		const r = run(fork, ['--fetch', '--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/inside a checkout or Git directory owned by this repository/);
+	});
+
+	it('ignores comment lines in local alternates files', () => {
+		const remote = join(tmp, 'commented-alternate-remote.git');
+		git(tmp, ['clone', '-q', '--bare', upstream, remote]);
+		const ownedObjects = realpathSync(
+			git(fork, ['rev-parse', '--path-format=absolute', '--git-path', 'objects'])
+		);
+		writeFileSync(join(remote, 'objects', 'info', 'alternates'), `#${ownedObjects}\n`);
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: remote }));
+		git(fork, ['commit', '-qam', 'set commented-alternate parent']);
+		git(fork, ['remote', 'set-url', 'upstream', remote]);
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status, r.stderr).toBe(0);
+	});
+
 	it('rejects repository-owned object storage behind nested alternates', () => {
 		const remote = join(tmp, 'nested-alternate-remote.git');
 		mkdirSync(remote);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -220,7 +220,15 @@ if [ -n "$TRANSPORT_UNSCOPED_HTTP_LOG" ]; then
 fi
 if [ -n "$TRANSPORT_NETWORK_LOG" ]; then
   case "$command_line" in
-    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-regexp '^(http\\..*(sslcainfo|proxy)|remote\\..*\\.proxy)$' > "$TRANSPORT_NETWORK_LOG" || : ;;
+    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-regexp '^(http\\..*(sslcainfo|sslcapath|proxy|proxysslcainfo)|remote\\..*\\.(proxy|proxyauthmethod))$' > "$TRANSPORT_NETWORK_LOG" || : ;;
+  esac
+fi
+if [ -n "$TLS_CONFIG_RACE_REPO" ] && [ ! -e "$TLS_CONFIG_RACE_MARKER" ]; then
+  case "$command_line" in
+    *" config --type=bool --get-urlmatch http.sslVerify "*)
+      env -u GIT_INDEX_FILE -u GIT_DIR -u GIT_OBJECT_DIRECTORY -u GIT_SHALLOW_FILE -u GIT_CONFIG_COUNT -u GIT_CONFIG_KEY_0 -u GIT_CONFIG_VALUE_0 "$REAL_GIT" -C "$TLS_CONFIG_RACE_REPO" config http.sslVerify true || exit $?
+      : > "$TLS_CONFIG_RACE_MARKER"
+      ;;
   esac
 fi
 if [ -n "$CAT_FILE_CHECK_LOG" ]; then
@@ -234,7 +242,7 @@ if [ -n "$FAKE_GIT_VERSION" ]; then
   esac
 fi
 if [ -n "$CASE_SCRUB_MARKER" ]; then
-  if [ -n "\${git_dir+x}" ] || [ -n "\${git_work_tree+x}" ] || [ -n "\${git_ssh_command+x}" ] || [ -n "\${git_config_count+x}" ]; then
+  if [ -n "\${git_dir+x}" ] || [ -n "\${git_work_tree+x}" ] || [ -n "\${git_ssh_command+x}" ] || [ -n "\${git_ssl_no_verify+x}" ] || [ -n "\${git_config_count+x}" ]; then
     : > "$CASE_SCRUB_MARKER"
     exit 97
   fi
@@ -271,7 +279,7 @@ if [ -n "$TRANSPORT_REWRITE_REPO" ]; then
 fi
 if [ -n "$PATH_ENUMERATION_LOG" ]; then
   case "$command_line" in
-    *" ls-files -z --full-name --cached --others --exclude-standard -- "*|*" ls-tree -z --full-name --name-only -r "*)
+    *" diff --ignore-submodules=none --name-status -M -z "*|*" ls-files --others --exclude-standard -z "*|*" ls-files -z --full-name --cached --others --exclude-standard -- "*|*" ls-tree -z --full-name --name-only -r "*)
       printf '%s\n' "$command_line" >> "$PATH_ENUMERATION_LOG"
       ;;
   esac
@@ -470,6 +478,11 @@ if [ -n "$ADD_REMOTE_SWAP_REMOTE" ] && [ ! -e "$ADD_REMOTE_SWAP_MARKER" ]; then
       ;;
   esac
 fi
+if [ "$FAIL_FETCH_RECORD" = "1" ]; then
+  case "$command_line" in
+    *" config --local upstreamReport.lastFetch "*) exit 91 ;;
+  esac
+fi
 if [ -n "$OVERLAP_ABA_PATH" ] && [ ! -e "$OVERLAP_ABA_MARKER" ]; then
   case "$command_line" in
     *" diff --ignore-submodules=none --unified=3 "*|*" diff --no-index --unified=3 "*)
@@ -556,7 +569,7 @@ if [ -n "$FETCH_AFTER_TREE_SHA" ] && [ ! -e "$FETCH_MARKER" ]; then
 fi
 if [ -n "$REMOVE_AFTER_UNTRACKED" ] && [ ! -e "$REMOVE_MARKER" ]; then
   case "$command_line" in
-    *" ls-files --others "*)
+    *" ls-files --others --exclude-standard -z "*)
       output_file="$REMOVE_MARKER.output"
       "$REAL_GIT" "$@" > "$output_file" || exit $?
       rm -f "$REMOVE_AFTER_UNTRACKED" || exit $?
@@ -569,7 +582,7 @@ if [ -n "$REMOVE_AFTER_UNTRACKED" ] && [ ! -e "$REMOVE_MARKER" ]; then
 fi
 if [ -n "$ADD_AFTER_UNTRACKED" ] && [ ! -e "$LOCAL_CHANGE_MARKER" ]; then
   case "$command_line" in
-    *" ls-files --others "*)
+    *" ls-files --others --exclude-standard -z "*)
       output_file="$LOCAL_CHANGE_MARKER.output"
       "$REAL_GIT" "$@" > "$output_file" || exit $?
       printf 'lateFile();\n' > "$ADD_AFTER_UNTRACKED" || exit $?
@@ -895,6 +908,7 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 			git_dir: join(tmp, 'wrong-git-dir'),
 			git_work_tree: join(tmp, 'wrong-worktree'),
 			git_ssh_command: join(tmp, 'wrong-ssh'),
+			git_ssl_no_verify: '1',
 			git_config_count: '1',
 			git_config_key_0: 'core.fileMode',
 			git_config_value_0: 'false'
@@ -2945,6 +2959,50 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 	});
 
 	itWithGitWrapper(
+		'rolls back a new remote after the fetched ref loses its compare-and-swap',
+		() => {
+			git(fork, ['remote', 'remove', 'upstream']);
+			git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+			const decoy = git(fork, ['rev-parse', 'HEAD']);
+			const raceMarker = join(tmp, 'initial-ref-race');
+
+			const r = run(fork, ['--fetch', '--json'], {
+				PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+				REAL_GIT: realGitPath(),
+				FETCH_REF_SWAP_REPO: fork,
+				FETCH_REF_SWAP_SHA: decoy,
+				FETCH_REF_SWAP_MARKER: raceMarker
+			});
+
+			expect(existsSync(raceMarker)).toBe(true);
+			expect(r.status).not.toBe(0);
+			expect(r.stderr).toMatch(/newly added remote was rolled back/);
+			expect(gitOptional(fork, ['config', '--get', 'remote.upstream.url'])).toBe('');
+			expect(git(fork, ['rev-parse', 'refs/remotes/upstream/main'])).toBe(decoy);
+			expect(gitOptional(fork, ['config', '--get', 'upstreamReport.lastFetch'])).toBe('');
+		}
+	);
+
+	itWithGitWrapper('rolls back a new remote and ref when fetch recording fails', () => {
+		git(fork, ['remote', 'remove', 'upstream']);
+		git(fork, ['update-ref', '-d', 'refs/remotes/upstream/main']);
+
+		const r = run(fork, ['--fetch', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			FAIL_FETCH_RECORD: '1'
+		});
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/tracking ref was rolled back/);
+		expect(gitOptional(fork, ['config', '--get', 'remote.upstream.url'])).toBe('');
+		expect(
+			gitOptional(fork, ['rev-parse', '--verify', '--quiet', 'refs/remotes/upstream/main'])
+		).toBe('');
+		expect(gitOptional(fork, ['config', '--get', 'upstreamReport.lastFetch'])).toBe('');
+	});
+
+	itWithGitWrapper(
 		'does not bind fetched objects to a remote changed during initial creation',
 		() => {
 			const decoy = join(tmp, 'remote-add-race-decoy');
@@ -3580,19 +3638,24 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(readFileSync(enumerationLog, 'utf8').trim().split('\n')).toHaveLength(1);
 	});
 
-	it('bounds aggregate automatic path discovery', () => {
+	itWithGitWrapper('bounds aggregate automatic path discovery as paths are decoded', () => {
 		write(fork, 'product/automatic-one.ts', 'automaticOne();\n');
 		write(fork, 'product/automatic-two.ts', 'automaticTwo();\n');
 		git(fork, ['add', '-A']);
 		git(fork, ['commit', '-qm', 'add automatic paths']);
+		const enumerationLog = join(tmp, 'automatic-path-enumeration.log');
 
 		const r = run(fork, ['--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			PATH_ENUMERATION_LOG: enumerationLog,
 			NODE_ENV: 'test',
 			UPSTREAM_REPORT_TEST_PATH_LIMIT: '1'
 		});
 
 		expect(r.status).not.toBe(0);
 		expect(r.stderr).toMatch(/Automatic discovery found more than 1 changed paths/);
+		expect(readFileSync(enumerationLog, 'utf8').trim().split('\n')).toHaveLength(1);
 	});
 
 	it('refuses staged marker bytes that differ from the working tree', () => {
@@ -3620,6 +3683,20 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: upstream }));
 
 		const r = run(fork, ['--fetch', '--json', 'shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/exists but is not tracked/);
+	});
+
+	it('refuses an ignored untracked upstream marker in Windows safety mode', () => {
+		git(fork, ['rm', '-q', '.upstream-sync.json']);
+		git(fork, ['commit', '-qm', 'remove Windows upstream marker']);
+		writeFileSync(join(fork, '.git', 'info', 'exclude'), '.upstream-sync.json\n');
+		write(fork, '.upstream-sync.json', JSON.stringify({ upstreamUrl: upstream }));
+
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			NODE_ENV: 'test',
+			UPSTREAM_REPORT_TEST_WINDOWS_SAFETY: '1'
+		});
 		expect(r.status).not.toBe(0);
 		expect(r.stderr).toMatch(/exists but is not tracked/);
 	});
@@ -3793,6 +3870,34 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		}
 	);
 
+	itWithGitWrapper('checks TLS policy from the private transport snapshot', () => {
+		const url = 'https://example.invalid/repo.git';
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+		git(fork, ['commit', '-qam', 'set raced HTTPS parent']);
+		git(fork, ['remote', 'set-url', 'upstream', url]);
+		git(fork, ['config', '--local', 'http.sslVerify', 'false']);
+		const raceMarker = join(tmp, 'tls-config-raced');
+		const networkMarker = join(tmp, 'tls-race-network-command');
+
+		const r = run(fork, ['--fetch', '--base', 'HEAD', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			TLS_CONFIG_RACE_REPO: fork,
+			TLS_CONFIG_RACE_MARKER: raceMarker,
+			NETWORK_COMMAND_MARKER: networkMarker
+		});
+
+		expect(existsSync(raceMarker)).toBe(true);
+		expect(git(fork, ['config', '--get', 'http.sslVerify'])).toBe('true');
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/requires TLS and proxy TLS verification/);
+		expect(existsSync(networkMarker)).toBe(false);
+	});
+
 	it('redacts a failed fetch before Git stderr reaches the caller', () => {
 		const secret = 'DUMMY_FETCH_QUERY_SECRET';
 		const url = `http://127.0.0.1:1/repo.git?token=${secret}`;
@@ -3872,8 +3977,11 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 
 	itWithGitWrapper('copies global CA and proxy settings plus the matching remote proxy', () => {
 		git(fork, ['config', '--local', 'http.sslCAInfo', '/private/global-ca.pem']);
+		git(fork, ['config', '--local', 'http.sslCAPath', '/private/global-ca-directory']);
+		git(fork, ['config', '--local', 'http.proxySSLCAInfo', '/private/proxy-ca.pem']);
 		git(fork, ['config', '--local', 'http.proxy', 'http://global-proxy.example']);
 		git(fork, ['config', '--local', 'remote.upstream.proxy', 'http://upstream-proxy.example']);
+		git(fork, ['config', '--local', 'remote.upstream.proxyAuthMethod', 'basic']);
 		const wrapper = installGitWrapper(tmp);
 		const networkLog = join(tmp, 'transport-global-network.log');
 		const r = run(fork, ['--json', 'shared/pristine.ts'], {
@@ -3884,8 +3992,26 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.status, r.stderr).toBe(0);
 		const config = readFileSync(networkLog, 'utf8');
 		expect(config).toContain('/private/global-ca.pem');
+		expect(config).toContain('/private/global-ca-directory');
+		expect(config).toContain('/private/proxy-ca.pem');
 		expect(config).toContain('http://global-proxy.example');
 		expect(config).toContain('http://upstream-proxy.example');
+		expect(config).toMatch(/remote\..*\.proxyauthmethod basic/i);
+	});
+
+	itWithGitWrapper('preserves an empty remote proxy override', () => {
+		git(fork, ['config', '--local', 'http.proxy', 'http://global-proxy.example']);
+		git(fork, ['config', '--local', 'remote.upstream.proxy', '']);
+		const networkLog = join(tmp, 'transport-empty-remote-proxy.log');
+		const r = run(fork, ['--json', 'shared/pristine.ts'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			TRANSPORT_NETWORK_LOG: networkLog
+		});
+		expect(r.status, r.stderr).toBe(0);
+		const config = readFileSync(networkLog, 'utf8');
+		expect(config).toContain('http.proxy http://global-proxy.example');
+		expect(config).toMatch(/^remote\..*\.proxy\s*$/m);
 	});
 
 	itWithGitWrapper('keeps secret-bearing HTTP config out of Windows temporary files', () => {

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -156,6 +156,11 @@ if [ "$FAKE_FETCH_SUCCESS" = "1" ]; then
   done
 fi
 command_line=" $* "
+if [ -n "$TRANSPORT_ALIAS_CONFIG_LOG" ]; then
+  case "$command_line" in
+    *" ls-remote "*) "$REAL_GIT" config --get-regexp '^(http\\..*\\.pinnedpubkey|remote\\..*\\.proxy)$' > "$TRANSPORT_ALIAS_CONFIG_LOG" || : ;;
+  esac
+fi
 if [ -n "$FAKE_REMOTE_MAIN_SHA" ]; then
   case "$command_line" in
     *" ls-remote "*" refs/heads/main "*) printf '%s\trefs/heads/main\n' "$FAKE_REMOTE_MAIN_SHA"; exit 0 ;;
@@ -220,7 +225,7 @@ if [ -n "$TRANSPORT_UNSCOPED_HTTP_LOG" ]; then
 fi
 if [ -n "$TRANSPORT_NETWORK_LOG" ]; then
   case "$command_line" in
-    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-regexp '^(http\\..*(sslcainfo|sslcapath|proxy|proxysslcainfo)|remote\\..*\\.(proxy|proxyauthmethod))$' > "$TRANSPORT_NETWORK_LOG" || : ;;
+    *" ls-remote "*) "$REAL_GIT" config --file "$GIT_DIR/config" --get-regexp '^(http\\..*(pinnedpubkey|sslcainfo|sslcapath|proxy|proxysslcainfo)|remote\\..*\\.(proxy|proxyauthmethod))$' > "$TRANSPORT_NETWORK_LOG" || : ;;
   esac
 fi
 if [ -n "$TLS_CONFIG_RACE_REPO" ] && [ ! -e "$TLS_CONFIG_RACE_MARKER" ]; then
@@ -979,6 +984,21 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		git(fork, ['config', '--local', 'protocol.file.allow', 'never']);
 		const r = run(fork, ['--json', 'shared/pristine.ts']);
 		expect(r.status).not.toBe(0);
+	});
+
+	it('preserves a global protocol.allow restriction', () => {
+		git(fork, ['config', '--local', 'protocol.allow', 'never']);
+		const r = run(fork, ['--json', 'shared/pristine.ts']);
+		expect(r.status).not.toBe(0);
+	});
+
+	it('preserves the overriding semantics of an inherited protocol allowlist', () => {
+		git(fork, ['config', '--local', 'protocol.file.allow', 'never']);
+		const r = run(fork, ['--base', 'HEAD', '--json'], {
+			GIT_ALLOW_PROTOCOL: 'file',
+			GIT_PROTOCOL_FROM_USER: 'false'
+		});
+		expect(r.status, r.stderr).toBe(0);
 	});
 
 	it('refuses a relative temporary directory before writing or sweeping', () => {
@@ -2336,6 +2356,22 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 
 		expect(r.status).not.toBe(0);
 		expect(r.stderr).toMatch(/marker upstream URL resolves inside a checkout/);
+	});
+
+	itWithPosixPaths('rejects Git-compatible file URLs that lack one canonical local path', () => {
+		const url = `file://example.invalid${fork}`;
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: url }));
+		git(fork, ['commit', '-qam', 'set ambiguous file URL parent']);
+		git(fork, ['remote', 'set-url', 'upstream', url]);
+
+		const r = run(fork, ['--fetch', '--base', 'HEAD', '--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/file URL cannot be resolved to one canonical local path/);
 	});
 
 	it('refuses a repository-contained Git bundle as marker upstream', () => {
@@ -5992,6 +6028,34 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.status).not.toBe(0);
 		expect(r.stderr).toMatch(/split index/);
 		expect(statSync(backing).mtimeMs).toBe(before);
+	});
+
+	itWithGitWrapper('keeps scoped transport config on the configured GitHub spelling', () => {
+		const configured = 'https://github.com/StickerDaniel/SaaS-Starter.git';
+		const markerUrl = 'https://github.com/stickerdaniel/saas-starter';
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: markerUrl }));
+		git(fork, ['commit', '-qam', 'record GitHub alias parent']);
+		git(fork, ['remote', 'set-url', 'upstream', configured]);
+		git(fork, ['config', '--local', `http.${configured}.pinnedPubkey`, 'sha256//DUMMY_PIN']);
+		git(fork, ['config', '--local', 'remote.upstream.proxy', 'http://proxy.example']);
+		const upstreamSha = git(fork, ['rev-parse', 'refs/remotes/upstream/main']);
+		const networkLog = join(tmp, 'github-alias-transport.log');
+
+		const r = run(fork, ['--base', 'origin/main', '--json'], {
+			PATH: `${installGitWrapper(tmp)}:${process.env.PATH ?? ''}`,
+			REAL_GIT: realGitPath(),
+			FAKE_REMOTE_MAIN_SHA: upstreamSha,
+			TRANSPORT_ALIAS_CONFIG_LOG: networkLog
+		});
+
+		expect(r.status, r.stderr).toBe(0);
+		const config = readFileSync(networkLog, 'utf8');
+		expect(config).toContain('sha256//DUMMY_PIN');
+		expect(config).toContain('http://proxy.example');
 	});
 
 	itWithGitWrapper(

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -6794,6 +6794,25 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stderr).not.toContain('IS the upstream template');
 	});
 
+	it('does not let a branch marker redefine the fork as its own template', () => {
+		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
+			string,
+			unknown
+		>;
+		const origin = git(fork, ['remote', 'get-url', 'origin']);
+		write(fork, '.upstream-sync.json', JSON.stringify({ ...marker, upstreamUrl: origin }));
+		write(fork, 'shared/pristine.ts', 'export const a = 1;\nexport const b = 99;\n');
+		git(fork, ['commit', '-qam', 'redirect parent to fork origin']);
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status).not.toBe(2);
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toContain('Refusing branch-controlled template self-detection');
+		expect(r.stderr).not.toContain('IS the upstream template');
+		expect(r.stdout).not.toContain('Nothing to report upstream');
+	});
+
 	it('detects the template across standard GitHub HTTPS and SSH spellings', () => {
 		const marker = JSON.parse(readFileSync(join(fork, '.upstream-sync.json'), 'utf8')) as Record<
 			string,

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+import { changedRegionLines, classifyVerdict, regionOverlap } from './upstream-relevance';
+
+describe('changedRegionLines', () => {
+	it('keeps removed and context lines, drops additions', () => {
+		const diff = [
+			'diff --git a/x.ts b/x.ts',
+			'--- a/x.ts',
+			'+++ b/x.ts',
+			'@@ -1,4 +1,4 @@',
+			' const before = 1;',
+			'-const wrong = 2;',
+			'+const right = 3;',
+			' const after = 4;'
+		].join('\n');
+		expect(changedRegionLines(diff)).toEqual([
+			{ removed: ['const wrong = 2;'], context: ['const before = 1;', 'const after = 4;'] }
+		]);
+	});
+
+	it('ignores the file headers that look like removals and additions', () => {
+		// `--- a/x` and `+++ b/x` sit before the first @@ and are excluded by
+		// position, not by prefix. See the next test for why that matters.
+		const diff = ['--- a/x.ts', '+++ b/x.ts', '@@ -1 +1 @@', '-a', '+b'].join('\n');
+		expect(changedRegionLines(diff)).toEqual([{ removed: ['a'], context: [] }]);
+	});
+
+	it('keeps a removed line whose own content starts with two dashes', () => {
+		// Removing `--flag` reaches the parser as `---flag`. Filtering that as a
+		// file header discards the only evidence a one-line change has, and the
+		// file then scores zero overlap and is silently dismissed.
+		const diff = ['@@ -1 +1 @@', '---flag', '+--other'].join('\n');
+		expect(changedRegionLines(diff)).toEqual([{ removed: ['--flag'], context: [] }]);
+	});
+
+	it('reads every hunk of a multi-hunk diff', () => {
+		const diff = [
+			'@@ -1,2 +1,2 @@',
+			' one',
+			'-two',
+			'+TWO',
+			'@@ -20,2 +20,2 @@',
+			' twenty',
+			'-twentyone'
+		].join('\n');
+		expect(changedRegionLines(diff)).toEqual([
+			{ removed: ['two'], context: ['one'] },
+			{ removed: ['twentyone'], context: ['twenty'] }
+		]);
+	});
+});
+
+describe('regionOverlap', () => {
+	const upstream = ['export function greet(name) {', '\treturn `hello ${name}`;', '}'].join('\n');
+
+	it('scores an edit to untouched template code as fully overlapping', () => {
+		expect(
+			regionOverlap(
+				[{ removed: ['export function greet(name) {', '\treturn `hello ${name}`;'], context: [] }],
+				upstream
+			)
+		).toBe(1);
+	});
+
+	it('scores an edit to fork-only code inside a shared file as zero', () => {
+		expect(
+			regionOverlap(
+				[{ removed: ['const forkOnlyThing = buildDaphneThing();'], context: [] }],
+				upstream
+			)
+		).toBe(0);
+	});
+
+	it('ignores indentation, so reformatted code still matches', () => {
+		expect(
+			regionOverlap([{ removed: ['            return `hello ${name}`;'], context: [] }], upstream)
+		).toBe(1);
+	});
+
+	it('does not let braces and blank lines inflate the score', () => {
+		// A region of pure punctuation matches any file ever written. Counting it
+		// would mark every fork-only edit as upstream-relevant. Dropping it leaves
+		// nothing to measure, which is "unmeasured" and gets a glance. It is not a
+		// confident 100%, and not a confident 0 either.
+		expect(regionOverlap([{ removed: ['}', '', '  '], context: [] }], upstream)).toBeNull();
+	});
+
+	it('still scores a region that mixes punctuation with real lines', () => {
+		expect(regionOverlap([{ removed: ['}', 'const forkOnly = 1;'], context: [] }], upstream)).toBe(
+			0
+		);
+		expect(
+			regionOverlap([{ removed: ['}', '\treturn `hello ${name}`;'], context: [] }], upstream)
+		).toBe(1);
+	});
+
+	it('counts a repeated line only as often as upstream actually has it', () => {
+		const twice = 'value = 1;\nvalue = 1;\nother = 2;';
+		expect(
+			regionOverlap([{ removed: ['value = 1;', 'value = 1;', 'value = 1;'], context: [] }], twice)
+		).toBeCloseTo(2 / 3);
+	});
+
+	it('reports "not measured" for an empty region, never zero', () => {
+		// Zero means "measured, and none of it is upstream", a definitive
+		// negative. Nothing to measure is a different answer and must not
+		// collapse into it, or a binary file reads as proof of irrelevance.
+		expect(regionOverlap([], upstream)).toBeNull();
+		expect(regionOverlap([{ removed: [], context: [] }], upstream)).toBeNull();
+		expect(regionOverlap([{ removed: ['', ' '], context: [] }], upstream)).toBeNull();
+	});
+});
+
+describe('classifyVerdict', () => {
+	it('stays quiet when the caller says the path is not upstream', () => {
+		// Only about this helper. `verdictFor` reaches it with existsUpstream true
+		// for several paths that are absent by exact spelling: a case-only
+		// difference, content that is upstream under another name, and a name the
+		// template carries exactly once.
+		expect(
+			classifyVerdict({
+				path: 'src/lib/daphne/voice.ts',
+				existsUpstream: false,
+				baseMatchesUpstream: false
+			})
+		).toEqual({ path: 'src/lib/daphne/voice.ts', relevance: 'fork-only', report: false });
+	});
+
+	it('always reports an edit to a file the fork had never touched', () => {
+		// The strongest signal in the whole detector: pristine template code that
+		// needed fixing here needs fixing in every other fork too.
+		const v = classifyVerdict({
+			path: 'src/lib/emails/components/layout/EmailFooter.svelte',
+			existsUpstream: true,
+			baseMatchesUpstream: true
+		});
+		expect(v.relevance).toBe('pristine');
+		expect(v.report).toBe(true);
+	});
+
+	it('reports every shared file that changed, whatever its overlap', () => {
+		// The overlap ranks; it does not gate. Line matching cannot tell a
+		// fork-only line from a template line this fork had renamed, so any
+		// threshold drops real findings. Measured: a 20% gate hid the one genuine
+		// upstream bug on the branch that carried it, at 15%.
+		for (const overlap of [0, 0.15, 0.5, 1]) {
+			const v = classifyVerdict({
+				path: 'a',
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap
+			});
+			expect(v.relevance).toBe('diverged');
+			expect(v.report, `overlap ${overlap} must still be reported`).toBe(true);
+			expect(v.overlap).toBe(overlap);
+		}
+	});
+
+	it('surfaces a shared file it could not measure instead of dismissing it', () => {
+		// A binary file, a mode-only change or a submodule yields no comparable
+		// text. Reporting it costs a glance; dismissing it loses the finding.
+		const v = classifyVerdict({
+			path: 'static/favicon.ico',
+			existsUpstream: true,
+			baseMatchesUpstream: false,
+			overlap: null,
+			unmeasuredNote: 'binary file, no text to compare'
+		});
+		expect(v.relevance).toBe('unmeasured');
+		expect(v.report).toBe(true);
+		expect(v.note).toContain('binary');
+	});
+
+	it('treats an absent overlap the same as an explicitly null one', () => {
+		expect(
+			classifyVerdict({ path: 'a', existsUpstream: true, baseMatchesUpstream: false }).relevance
+		).toBe('unmeasured');
+	});
+});
+
+describe('regionOverlap weighting', () => {
+	const upstream = 'export const templateLine = 1;\nother();\n';
+
+	it('lets a removed template line decide, whatever the context around it', () => {
+		// The finding this exists for: a one-line fix to template code sits inside
+		// a fork-added block, so it carries six lines of fork-only context. Scoring
+		// all seven gave 14%, under the threshold, and the fix was dropped: the
+		// exact silent false negative the detector is meant to prevent.
+		const overlap = regionOverlap(
+			[
+				{
+					removed: ['export const templateLine = 1;'],
+					context: ['forkA();', 'forkB();', 'forkC();', 'forkD();', 'forkE();', 'forkF();']
+				}
+			],
+			upstream
+		);
+		expect(overlap).toBe(1);
+	});
+
+	it('falls back to context only when the change removed nothing', () => {
+		expect(regionOverlap([{ removed: [], context: ['other();'] }], upstream)).toBe(1);
+		expect(regionOverlap([{ removed: [], context: ['forkOnly();'] }], upstream)).toBe(0);
+	});
+
+	it('does not let context rescue a removal that is absent upstream', () => {
+		expect(
+			regionOverlap(
+				[{ removed: ['forkOnlyRemoved();'], context: ['export const templateLine = 1;'] }],
+				upstream
+			)
+		).toBe(0);
+	});
+
+	it('scores each hunk on its own, so a removal elsewhere cannot bury an insertion', () => {
+		// One file, two hunks: a fork-only line deleted in one place, and a guard
+		// inserted beside template code in another. Pooling them threw away the
+		// second hunk's context entirely (the rule is removed-lines-if-any, and
+		// the first hunk supplied one), scoring the file 0% and sorting the most
+		// upstream-shaped file on the branch below every trivial one.
+		const forkRemoval = { removed: ['forkOnlyCleanup();'], context: [] };
+		const upstreamInsertion = { removed: [], context: ['export const templateLine = 1;'] };
+		expect(regionOverlap([forkRemoval, upstreamInsertion], upstream)).toBe(1);
+		expect(regionOverlap([upstreamInsertion, forkRemoval], upstream)).toBe(1);
+	});
+
+	it('keeps one hunk from consuming the matches another needs', () => {
+		// One tally shared across hunks lets a weak hunk spend the only copy of a
+		// line a strong one needed. Here the first hunk matches a third of itself
+		// and takes the line the second hunk consists of entirely: sharing scores
+		// the file 33%, and the hunk that made it worth reading is gone.
+		const weak = { removed: ['other();', 'forkA();', 'forkB();'], context: [] };
+		const strong = { removed: ['other();'], context: [] };
+		expect(regionOverlap([weak, strong], upstream)).toBe(1);
+	});
+});

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
@@ -246,3 +246,22 @@ describe('regionOverlap weighting', () => {
 		expect(regionOverlap([weak, strong], upstream)).toBe(1);
 	});
 });
+
+describe('integration test routing', () => {
+	it('keeps repository-spawning tests out of the unit job', () => {
+		const root = resolve(import.meta.dirname, '../../../..');
+		const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
+			scripts: Record<string, string>;
+		};
+		const viteConfig = readFileSync(resolve(root, 'vite.config.ts'), 'utf8');
+		const workflow = readFileSync(resolve(root, '.github/workflows/static-checks.yml'), 'utf8');
+		const integrationPath =
+			'.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts';
+
+		expect(viteConfig).toContain(`'${integrationPath}'`);
+		expect(packageJson.scripts['test:upstream-report']).toContain(
+			'.agents/skills/upstream-report/scripts/vitest.config.ts'
+		);
+		expect(workflow).toContain('run: bun run test:upstream-report');
+	});
+});

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
@@ -262,6 +262,7 @@ describe('integration test routing', () => {
 		expect(packageJson.scripts['test:upstream-report']).toContain(
 			'.agents/skills/upstream-report/scripts/vitest.config.ts'
 		);
+		expect(packageJson.scripts.test).toContain('bun run test:upstream-report');
 		expect(workflow).toContain('run: bun run test:upstream-report');
 	});
 });

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
@@ -112,18 +112,19 @@ describe('regionOverlap', () => {
 });
 
 describe('classifyVerdict', () => {
-	it('stays quiet when the caller says the path is not upstream', () => {
-		// Only about this helper. `verdictFor` reaches it with existsUpstream true
-		// for several paths that are absent by exact spelling: a case-only
-		// difference, content that is upstream under another name, and a name the
-		// template carries exactly once.
+	it('keeps an absent path visible when ownership is not proven', () => {
 		expect(
 			classifyVerdict({
 				path: 'src/lib/daphne/voice.ts',
 				existsUpstream: false,
 				baseMatchesUpstream: false
 			})
-		).toEqual({ path: 'src/lib/daphne/voice.ts', relevance: 'fork-only', report: false });
+		).toEqual({
+			path: 'src/lib/daphne/voice.ts',
+			relevance: 'unmeasured',
+			note: 'no upstream path, but fork ownership is not proven',
+			report: true
+		});
 	});
 
 	it('always reports an edit to a file the fork had never touched', () => {

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { changedRegionLines, classifyVerdict, regionOverlap } from './upstream-relevance';
 
@@ -99,6 +101,15 @@ describe('regionOverlap', () => {
 		expect(
 			regionOverlap([{ removed: ['value = 1;', 'value = 1;', 'value = 1;'], context: [] }], twice)
 		).toBeCloseTo(2 / 3);
+	});
+
+	it('does not clone the complete upstream tally for each hunk', () => {
+		const source = readFileSync(resolve(import.meta.dirname, 'upstream-relevance.ts'), 'utf8');
+		const start = source.indexOf('function hunkOverlap(');
+		const end = source.indexOf('export function classifyVerdict(', start);
+		const implementation = source.slice(start, end);
+		expect(implementation).toContain('const used = new Map<string, number>();');
+		expect(implementation).not.toContain('new Map(upstreamLines)');
 	});
 
 	it('reports "not measured" for an empty region, never zero', () => {

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.test.ts
@@ -254,11 +254,13 @@ describe('integration test routing', () => {
 			scripts: Record<string, string>;
 		};
 		const viteConfig = readFileSync(resolve(root, 'vite.config.ts'), 'utf8');
+		const detectorConfig = readFileSync(resolve(import.meta.dirname, 'vitest.config.ts'), 'utf8');
 		const workflow = readFileSync(resolve(root, '.github/workflows/static-checks.yml'), 'utf8');
 		const integrationPath =
 			'.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts';
 
 		expect(viteConfig).toContain(`'${integrationPath}'`);
+		expect(detectorConfig).toContain('upstream-relevance.test.ts');
 		expect(packageJson.scripts['test:upstream-report']).toContain(
 			'.agents/skills/upstream-report/scripts/vitest.config.ts'
 		);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -197,6 +197,7 @@ function transportConfigEnv(): NodeJS.ProcessEnv {
 //   advice.graftFileDeprecated=false  the empty null-device override otherwise warns
 //                         once per Git process and drowns out the report.
 const PINNED_CONFIG = [
+	...(process.platform === 'win32' ? [] : ['-c', 'core.fileMode=true']),
 	'-c',
 	'core.quotePath=false',
 	'-c',
@@ -302,6 +303,9 @@ function appendTransportConfig(configPath: string, key: string, value: string): 
 }
 
 function proxyCarriesUserinfo(value: string): boolean {
+	if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) {
+		return /^[^/\\\s]*@/.test(value);
+	}
 	try {
 		const parsed = new URL(value);
 		return parsed.username !== '' || parsed.password !== '';
@@ -320,17 +324,17 @@ function safeWindowsTransportValue(key: string, value: string): boolean {
 	return true;
 }
 
+const TRANSPORT_CONFIG_PATTERN =
+	'^(credential\\.|http\\.(pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslverify|schannelusesslcainfo|sslbackend|sslcainfo|sslcapath|sslverify)$|http\\..*\\.(extraheader|pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslcert|proxysslcertpasswordprotected|proxysslkey|proxysslverify|schannelusesslcainfo|sslcainfo|sslcapath|sslcert|sslcertpasswordprotected|sslkey|sslverify)$|protocol(\\.[^.]*)?\\.allow$|remote\\..*\\.(url|proxy|proxyauthmethod)$)';
+
+function readTransportConfiguration(): Buffer {
+	return gitBytes(['config', '--null', '--get-regexp', TRANSPORT_CONFIG_PATTERN], true);
+}
+
 function copyTransportConfiguration(configPath: string): void {
 	const remoteProxyByName = new Map<string, RemoteProxySettings>();
-	const output = gitBytes(
-		[
-			'config',
-			'--null',
-			'--get-regexp',
-			'^(credential\\.|http\\.(pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslverify|sslbackend|sslcainfo|sslcapath|sslverify)$|http\\..*\\.(extraheader|pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslcert|proxysslcertpasswordprotected|proxysslkey|proxysslverify|sslcainfo|sslcapath|sslcert|sslcertpasswordprotected|sslkey|sslverify)$|protocol(\\.[^.]*)?\\.allow$|remote\\..*\\.(proxy|proxyauthmethod)$)'
-		],
-		true
-	);
+	const output = readTransportConfiguration();
+	transportConfigurationAtCopy = output;
 	for (const record of decodeZRecords(output)) {
 		const newline = record.indexOf('\n');
 		if (newline === -1) continue;
@@ -345,10 +349,16 @@ function copyTransportConfiguration(configPath: string): void {
 			transportProtocolPolicies.set(protocol, value.toLowerCase());
 			continue;
 		}
-		const remoteSetting = /^remote\.(.*)\.(proxy|proxyauthmethod)$/i.exec(key);
+		const remoteSetting = /^remote\.(.*)\.(url|proxy|proxyauthmethod)$/i.exec(key);
 		if (remoteSetting) {
 			const settings = remoteProxyByName.get(remoteSetting[1]!) ?? {};
-			if (remoteSetting[2]!.toLowerCase() === 'proxy') settings.proxy = value;
+			const setting = remoteSetting[2]!.toLowerCase();
+			if (setting === 'url') {
+				if (settings.url !== undefined) {
+					fail(`The \`${terminalSafe(remoteSetting[1]!)}\` remote has multiple fetch URLs.`);
+				}
+				settings.url = value;
+			} else if (setting === 'proxy') settings.proxy = value;
 			else settings.proxyAuthMethod = value;
 			remoteProxyByName.set(remoteSetting[1]!, settings);
 			continue;
@@ -380,9 +390,17 @@ function copyTransportConfiguration(configPath: string): void {
 		appendTransportConfig(configPath, `protocol.${protocol}.allow`, policy);
 	}
 	for (const remote of ['origin', 'upstream']) {
-		const url = configuredRemoteUrl(remote);
 		const settings = remoteProxyByName.get(remote);
-		if (url && settings) transportProxyByUrl.set(url, settings);
+		if (settings?.url) transportProxyByUrl.set(settings.url, settings);
+	}
+}
+
+function verifyTransportConfiguration(): void {
+	if (
+		transportConfigurationAtCopy === null ||
+		!readTransportConfiguration().equals(transportConfigurationAtCopy)
+	) {
+		fail('Git transport configuration changed during this report. Run it again on settled config.');
 	}
 }
 
@@ -420,6 +438,9 @@ function transportRemote(url: string): string {
 function rejectUnauthenticatedTransport(url: string): void {
 	if (/^[a-z][a-z0-9+.-]*::/i.test(url)) {
 		fail('Forced Git remote-helper syntax is not accepted for upstream evidence.');
+	}
+	if (/^file:(?!\/\/)/i.test(url)) {
+		fail('Local upstream file URLs must use the canonical file:///absolute/path form.');
 	}
 	if (/^(?:https|ssh|file):/i.test(url)) return;
 	if (isAbsolute(url)) return;
@@ -465,8 +486,8 @@ function rejectSecretBearingRemoteUrl(url: string): void {
 			unsafe = true;
 		}
 	} else {
-		const scpUser = /^([^/@:\s]+)@[^/:\s]+:/.exec(url)?.[1];
-		unsafe = scpUser !== undefined && scpUser !== 'git';
+		const scp = /^([^/@:\s]+)@[^/:\s]+:(.*)$/.exec(url);
+		unsafe = scp !== null && (scp[1] !== 'git' || scp[2]!.includes('?') || scp[2]!.includes('#'));
 	}
 	if (!unsafe) return;
 	fail(
@@ -545,6 +566,12 @@ let diffOperationsRemaining =
 	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_DIFF_OPERATION_LIMIT ?? '')
 		? Number(process.env.UPSTREAM_REPORT_TEST_DIFF_OPERATION_LIMIT)
 		: DEFAULT_DIFF_OPERATION_LIMIT;
+const DEFAULT_HISTORY_RECORD_LIMIT = 500_000;
+const HISTORY_RECORD_LIMIT =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_HISTORY_RECORD_LIMIT ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_HISTORY_RECORD_LIMIT)
+		: DEFAULT_HISTORY_RECORD_LIMIT;
 const DEFAULT_HISTORY_OPERATION_LIMIT = 500;
 let historyOperationsRemaining =
 	process.env.NODE_ENV === 'test' &&
@@ -607,6 +634,26 @@ function gitPartialBytes(
 
 function git(args: string[], allowFail = false, timeout?: number): string {
 	return gitBytes(args, allowFail, {}, timeout).toString('utf8').trim();
+}
+
+function gitPath(args: string[]): string {
+	const value = gitBytes(args).toString('utf8');
+	return value.endsWith('\n') ? value.slice(0, -1) : value;
+}
+
+function gitUnpinned(args: string[], allowFail = false): string {
+	try {
+		return execFileSync('git', args, {
+			env: gitRunEnv(),
+			maxBuffer: MAX_GIT_OUTPUT,
+			stdio: ['pipe', 'pipe', 'pipe']
+		})
+			.toString('utf8')
+			.trim();
+	} catch {
+		if (allowFail) return '';
+		throw new Error('Git could not read unpinned repository configuration.');
+	}
 }
 
 /**
@@ -707,6 +754,7 @@ let transportObjectDir: string | undefined;
 let transportShallow: string | undefined;
 let ownedRepositoryPaths: Set<string> | undefined;
 interface RemoteProxySettings {
+	url?: string;
 	proxy?: string;
 	proxyAuthMethod?: string;
 }
@@ -715,6 +763,7 @@ const transportRemotes = new Map<string, string>();
 const transportProxyByUrl = new Map<string, RemoteProxySettings>();
 const transportProtocolPolicies = new Map<string, string>();
 const transportEnvironmentConfig: Array<[string, string]> = [];
+let transportConfigurationAtCopy: Buffer | null = null;
 const validatedTransportUrls = new Map<string, string>();
 let callerIndexPath: string | undefined;
 let callerShallowPath: string | undefined;
@@ -881,13 +930,7 @@ function useScratchIndex(root: string): void {
 		}
 	}
 	ownedRepositoryPaths = new Set(ownedRoots);
-	const insideOwnedRoot = [...ownedRoots].some((ownedRoot) => {
-		const fromRoot = relative(ownedRoot, tempPath);
-		return (
-			fromRoot === '' ||
-			(!isAbsolute(fromRoot) && fromRoot !== '..' && !fromRoot.startsWith(`..${sep}`))
-		);
-	});
+	const insideOwnedRoot = pathResolvesInsideOwnedRoot(tempPath, ownedRoots);
 	if (insideOwnedRoot) {
 		fail(
 			'The system temporary directory resolves inside this repository or its shared Git storage. Refusing to write or sweep it.'
@@ -955,6 +998,7 @@ function dropScratchIndex(): void {
 	transportProxyByUrl.clear();
 	transportProtocolPolicies.clear();
 	transportEnvironmentConfig.length = 0;
+	transportConfigurationAtCopy = null;
 	validatedTransportUrls.clear();
 	callerIndexPath = undefined;
 	callerShallowPath = undefined;
@@ -1425,13 +1469,7 @@ function rejectOwnedRepositoryRemote(url: string, root: string, remote: string):
 	if (!ownedRepositoryPaths) {
 		fail('The repository checkout inventory is unavailable. Run the report again.');
 	}
-	const owned = [...ownedRepositoryPaths].some((ownedPath) => {
-		const fromOwned = relative(ownedPath, remotePath);
-		return (
-			fromOwned === '' ||
-			(!isAbsolute(fromOwned) && fromOwned !== '..' && !fromOwned.startsWith(`..${sep}`))
-		);
-	});
+	const owned = pathResolvesInsideOwnedRoot(remotePath, ownedRepositoryPaths);
 	if (owned) {
 		fail(
 			`The ${remote} URL resolves inside a checkout or Git directory owned by this repository. ` +
@@ -1443,7 +1481,7 @@ function rejectOwnedRepositoryRemote(url: string, root: string, remote: string):
 
 function rejectUnverifiableFileModes(): void {
 	if (process.platform === 'win32') return;
-	if (git(['config', '--bool', '--get', 'core.fileMode'], true) === 'true') return;
+	if (gitUnpinned(['config', '--bool', '--get', 'core.fileMode'], true) === 'true') return;
 	fail(
 		'Git reports that this filesystem does not preserve executable bits. ' +
 			'The report cannot verify mode-only changes here.'
@@ -1663,6 +1701,8 @@ function cameFromUpstreamMain(entry: RefLogEntry | null, sha: string): boolean {
 }
 
 function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean): UpstreamSnapshot {
+	rejectUnauthenticatedTransport(upstreamUrl);
+	rejectSecretBearingRemoteUrl(upstreamUrl);
 	rejectOwnedRepositoryRemote(upstreamUrl, root, 'marker upstream');
 	const originUrl = configuredRemoteUrl('origin');
 	if (originUrl) {
@@ -1752,6 +1792,7 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 			rejectSecretBearingRemoteUrl(upstreamUrl);
 			try {
 				git(['remote', 'add', 'upstream', upstreamUrl]);
+				transportConfigurationAtCopy = readTransportConfiguration();
 				addedRemote = true;
 			} catch {
 				fail(`Could not add the \`upstream\` remote for ${terminalUrl(upstreamUrl)}.`);
@@ -2105,7 +2146,7 @@ function trustedOriginSnapshot(expectedSha: string): OriginSnapshot {
 		);
 	}
 	rejectUrlRewrite(url);
-	rejectOwnedRepositoryRemote(url, git(['rev-parse', '--show-toplevel']), 'origin');
+	rejectOwnedRepositoryRemote(url, gitPath(['rev-parse', '--show-toplevel']), 'origin');
 	if (!remoteMainRefspecIsCanonical('origin')) {
 		fail(
 			'`origin/main` is not mapped exclusively from `refs/heads/main` by the origin fetch refspec. ' +
@@ -2520,20 +2561,33 @@ function readUpstream(sha: string): Upstream {
 		undefined,
 		HISTORY_COMMAND_TIMEOUT_MS
 	);
-	const rawRecords = history.complete ? decodeZRecords(history.output) : [];
 	const records: Array<{ sha: string; path: string }> = [];
 	let historyParsed = history.complete;
-	for (let i = 0; i < rawRecords.length; i += 2) {
-		const header = rawRecords[i];
-		const path = rawRecords[i + 1];
-		const match = header?.match(/^:\d{6} \d{6} ([0-9a-f]+) ([0-9a-f]+) [AMDTUXB]$/);
-		if (!match || path === undefined) {
-			historyParsed = false;
-			break;
-		}
-		for (const objectSha of [match[1], match[2]]) {
-			if (objectSha && !/^0+$/.test(objectSha)) records.push({ sha: objectSha, path });
-		}
+	let historyRecordsExceeded = false;
+	let pendingHeader: string | undefined;
+	if (history.complete) {
+		visitZRecords(history.output, (record) => {
+			if (!historyParsed || historyRecordsExceeded) return;
+			if (pendingHeader === undefined) {
+				pendingHeader = record;
+				return;
+			}
+			const match = pendingHeader.match(/^:\d{6} \d{6} ([0-9a-f]+) ([0-9a-f]+) [AMDTUXB]$/);
+			pendingHeader = undefined;
+			if (!match) {
+				historyParsed = false;
+				return;
+			}
+			for (const objectSha of [match[1], match[2]]) {
+				if (!objectSha || /^0+$/.test(objectSha)) continue;
+				if (records.length >= HISTORY_RECORD_LIMIT) {
+					historyRecordsExceeded = true;
+					return;
+				}
+				records.push({ sha: objectSha, path: record });
+			}
+		});
+		if (pendingHeader !== undefined) historyParsed = false;
 	}
 	const objectShas = [...new Set(records.map((record) => record.sha))];
 	const objectInfo = gitPartialBytes(
@@ -2589,6 +2643,7 @@ function readUpstream(sha: string): Upstream {
 		historyComplete:
 			history.complete &&
 			historyParsed &&
+			!historyRecordsExceeded &&
 			objectInfo.complete &&
 			objectTypes.size === objectShas.length,
 		uniqueName,
@@ -3100,6 +3155,29 @@ function symlinkParent(path: string): string | null {
 
 function sameFileIdentity(left: Stats, right: Stats): boolean {
 	return left.dev === right.dev && left.ino === right.ino;
+}
+
+function pathResolvesInsideOwnedRoot(candidate: string, ownedRoots: Iterable<string>): boolean {
+	const roots = [...ownedRoots];
+	const rootStats = roots.map((root) => statSync(root));
+	let current = candidate;
+	while (true) {
+		const fromRoot = roots.some((root) => {
+			const relativePath = relative(root, current);
+			return (
+				relativePath === '' ||
+				(!isAbsolute(relativePath) && relativePath !== '..' && !relativePath.startsWith(`..${sep}`))
+			);
+		});
+		if (fromRoot) return true;
+		const currentStats = statSync(current);
+		if (rootStats.some((rootStatsEntry) => sameFileIdentity(rootStatsEntry, currentStats))) {
+			return true;
+		}
+		const parent = resolve(current, '..');
+		if (parent === current) return false;
+		current = parent;
+	}
 }
 
 function statFingerprint(stats: Stats): string {
@@ -3674,7 +3752,7 @@ function main() {
 	const { values, positionals } = commandLineArguments();
 	if (positionals.some((spec) => spec === '')) fail('Path arguments must not be empty.');
 
-	const root = git(['rev-parse', '--show-toplevel']);
+	const root = gitPath(['rev-parse', '--show-toplevel']);
 	// Where the caller typed the command, kept because every path argument was
 	// written relative to it. Resolving them after the chdir silently
 	// reinterprets `../AGENTS.md` against the repository root, where it names
@@ -3900,6 +3978,7 @@ function main() {
 	// The tree stays pinned while it is read, but a sync that moves the shared
 	// ref before output would make an absent-path verdict obsolete. Abort instead.
 	if (baseResolution.origin) verifyOriginSnapshot(baseResolution.origin);
+	verifyTransportConfiguration();
 	verifyScratchIndexEntries();
 	verifyLocalSnapshot(root, local);
 	// Keep the shared upstream ref as the last fence before output. Origin

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -1792,6 +1792,15 @@ function inspectLocalRemote(
 		const gitDir = realpathSync(gitDirValue);
 		const commonDir = realpathSync(commonDirValue);
 		const objectDir = realpathSync(objectDirValue);
+		const refStorage =
+			localGitPath(remotePath, ['config', '--local', '--get', 'extensions.refStorage'], true) ||
+			'files';
+		if (refStorage !== 'files') {
+			fail(
+				`Local upstream repositories using ${terminalSafe(refStorage)} ref storage are not supported. ` +
+					'Use a files-format mirror for this report.'
+			);
+		}
 		effectivePaths.add(gitDir);
 		effectivePaths.add(commonDir);
 		effectivePaths.add(objectDir);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -1557,6 +1557,35 @@ function localGitPath(remotePath: string, args: string[], allowFail = false): st
 	}
 }
 
+const MAX_ALTERNATE_DEPTH = 5;
+
+function addAlternateObjectStores(
+	objectDir: string,
+	effectivePaths: Set<string>,
+	seen: Set<string>,
+	depth: number
+): void {
+	const canonical = realpathSync(objectDir);
+	if (seen.has(canonical)) return;
+	seen.add(canonical);
+	effectivePaths.add(canonical);
+	const alternatesPath = join(canonical, 'info', 'alternates');
+	if (!existsSync(alternatesPath)) return;
+	const alternates = readFileSync(alternatesPath, 'utf8')
+		.split('\n')
+		.map((alternate) => alternate.replace(/\r$/, ''))
+		.filter(Boolean);
+	if (alternates.length === 0 || depth + 1 > MAX_ALTERNATE_DEPTH) return;
+	for (const alternate of alternates) {
+		addAlternateObjectStores(
+			isAbsolute(alternate) ? alternate : resolve(canonical, alternate),
+			effectivePaths,
+			seen,
+			depth + 1
+		);
+	}
+}
+
 function inspectLocalRemote(
 	url: string,
 	root: string,
@@ -1603,12 +1632,17 @@ function inspectLocalRemote(
 			true
 		);
 		if (worktreeValue) effectivePaths.add(realpathSync(worktreeValue));
+		const alternateStores = new Set([objectDir]);
 		const alternatesPath = join(objectDir, 'info', 'alternates');
 		if (existsSync(alternatesPath)) {
 			for (const alternate of readFileSync(alternatesPath, 'utf8').split('\n')) {
-				if (!alternate) continue;
-				effectivePaths.add(
-					realpathSync(isAbsolute(alternate) ? alternate : resolve(objectDir, alternate))
+				const path = alternate.replace(/\r$/, '');
+				if (!path) continue;
+				addAlternateObjectStores(
+					isAbsolute(path) ? path : resolve(objectDir, path),
+					effectivePaths,
+					alternateStores,
+					0
 				);
 			}
 		}

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -118,6 +118,7 @@ const SCRUBBED = [
 	'GIT_SSH_COMMAND',
 	'GIT_SSH_VARIANT',
 	'GIT_PROXY_COMMAND',
+	'GIT_SSL_NO_VERIFY',
 	'GIT_LITERAL_PATHSPECS',
 	'GIT_NOGLOB_PATHSPECS',
 	'GIT_GLOB_PATHSPECS',
@@ -150,8 +151,7 @@ function gitBooleanIsFalse(value: string | undefined): boolean {
 }
 
 function protocolAllowsAlways(protocol: string): boolean {
-	const policy = git(['config', '--get', `protocol.${protocol}.allow`], true);
-	return policy === '' || policy.toLowerCase() === 'always';
+	return transportProtocolPolicies.get(protocol) === 'always';
 }
 
 function transportProtocolEnv(): NodeJS.ProcessEnv {
@@ -330,12 +330,13 @@ function safeWindowsTransportValue(key: string, value: string): boolean {
 }
 
 function copyTransportConfiguration(configPath: string): void {
+	const remoteProxyByName = new Map<string, RemoteProxySettings>();
 	const output = gitBytes(
 		[
 			'config',
 			'--null',
 			'--get-regexp',
-			'^(credential\\.|http\\.(pinnedpubkey|proxy|proxyauthmethod|sslcainfo|sslbackend|sslverify)$|http\\..*\\.(extraheader|pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslcert|proxysslcertpasswordprotected|proxysslkey|proxysslverify|sslcainfo|sslcert|sslcertpasswordprotected|sslkey|sslverify)$|protocol\\..*\\.allow$)'
+			'^(credential\\.|http\\.(pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslverify|sslbackend|sslcainfo|sslcapath|sslverify)$|http\\..*\\.(extraheader|pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslcert|proxysslcertpasswordprotected|proxysslkey|proxysslverify|sslcainfo|sslcapath|sslcert|sslcertpasswordprotected|sslkey|sslverify)$|protocol\\..*\\.allow$|remote\\..*\\.(proxy|proxyauthmethod)$)'
 		],
 		true
 	);
@@ -344,7 +345,19 @@ function copyTransportConfiguration(configPath: string): void {
 		if (newline === -1) continue;
 		const key = record.slice(0, newline);
 		const value = record.slice(newline + 1);
-		if (key.startsWith('protocol.')) continue;
+		const protocol = /^protocol\.([^.]+)\.allow$/i.exec(key)?.[1];
+		if (protocol) {
+			transportProtocolPolicies.set(protocol, value.toLowerCase());
+			continue;
+		}
+		const remoteSetting = /^remote\.(.*)\.(proxy|proxyauthmethod)$/i.exec(key);
+		if (remoteSetting) {
+			const settings = remoteProxyByName.get(remoteSetting[1]!) ?? {};
+			if (remoteSetting[2]!.toLowerCase() === 'proxy') settings.proxy = value;
+			else settings.proxyAuthMethod = value;
+			remoteProxyByName.set(remoteSetting[1]!, settings);
+			continue;
+		}
 		if (!safeWindowsTransportValue(key, value)) {
 			transportEnvironmentConfig.push([key, value]);
 			continue;
@@ -357,16 +370,18 @@ function copyTransportConfiguration(configPath: string): void {
 		['https', 'always'],
 		['ssh', 'always']
 	] as const) {
-		const configured = git(['config', '--get', `protocol.${protocol}.allow`], true).toLowerCase();
+		const configured = transportProtocolPolicies.get(protocol) ?? '';
 		if (configured !== '' && !/^(?:always|never|user)$/.test(configured)) {
 			fail(`Git protocol.${protocol}.allow has an invalid policy.`);
 		}
-		appendTransportConfig(configPath, `protocol.${protocol}.allow`, configured || fallback);
+		const policy = configured || fallback;
+		transportProtocolPolicies.set(protocol, policy);
+		appendTransportConfig(configPath, `protocol.${protocol}.allow`, policy);
 	}
-	for (const remote of git(['remote'], true).split('\n').filter(Boolean)) {
+	for (const remote of ['origin', 'upstream']) {
 		const url = configuredRemoteUrl(remote);
-		const proxy = git(['config', '--get', `remote.${remote}.proxy`], true);
-		if (url && proxy) transportProxyByUrl.set(url, proxy);
+		const settings = remoteProxyByName.get(remote);
+		if (url && settings) transportProxyByUrl.set(url, settings);
 	}
 }
 
@@ -384,11 +399,18 @@ function transportRemote(url: string): string {
 	const name = `upstream-report-${createHash('sha256').update(url).digest('hex').slice(0, 16)}`;
 	appendTransportConfig(transportConfigPath, `remote.${name}.url`, transportUrl);
 	const proxy = transportProxyByUrl.get(url);
-	if (proxy) {
+	if (proxy?.proxy !== undefined) {
 		const key = `remote.${name}.proxy`;
-		if (safeWindowsTransportValue(key, proxy))
-			appendTransportConfig(transportConfigPath, key, proxy);
-		else transportEnvironmentConfig.push([key, proxy]);
+		if (safeWindowsTransportValue(key, proxy.proxy))
+			appendTransportConfig(transportConfigPath, key, proxy.proxy);
+		else transportEnvironmentConfig.push([key, proxy.proxy]);
+	}
+	if (proxy?.proxyAuthMethod !== undefined) {
+		appendTransportConfig(
+			transportConfigPath,
+			`remote.${name}.proxyAuthMethod`,
+			proxy.proxyAuthMethod
+		);
 	}
 	transportRemotes.set(url, name);
 	return name;
@@ -408,7 +430,13 @@ function rejectUnauthenticatedTransport(url: string): void {
 function rejectDisabledTlsVerification(url: string): void {
 	if (!/^https:/i.test(url)) return;
 	for (const key of ['http.sslVerify', 'http.proxySSLVerify']) {
-		const value = git(['config', '--type=bool', '--get-urlmatch', key, url], true);
+		const value = gitBytes(
+			['config', '--type=bool', '--get-urlmatch', key, url],
+			true,
+			trustedTransportEnv()
+		)
+			.toString('utf8')
+			.trim();
 		if (value === 'false') {
 			fail('Upstream evidence requires TLS and proxy TLS verification.');
 		}
@@ -604,8 +632,8 @@ function gitZ(args: string[], allowFail = false, timeout?: number): string[] {
 	return decodeZRecords(gitBytes(args, allowFail, {}, timeout));
 }
 
-function gitZEach(args: string[], visit: (record: string) => void): void {
-	visitZRecords(gitBytes(args), visit);
+function gitZEach(args: string[], visit: (record: string) => void, timeout?: number): void {
+	visitZRecords(gitBytes(args, false, {}, timeout), visit);
 }
 
 function historyGitBytes(args: string[]): Buffer {
@@ -668,8 +696,14 @@ let transportConfigPath: string | undefined;
 let transportObjectDir: string | undefined;
 let transportShallow: string | undefined;
 let ownedRepositoryPaths: Set<string> | undefined;
+interface RemoteProxySettings {
+	proxy?: string;
+	proxyAuthMethod?: string;
+}
+
 const transportRemotes = new Map<string, string>();
-const transportProxyByUrl = new Map<string, string>();
+const transportProxyByUrl = new Map<string, RemoteProxySettings>();
+const transportProtocolPolicies = new Map<string, string>();
 const transportEnvironmentConfig: Array<[string, string]> = [];
 const validatedTransportUrls = new Map<string, string>();
 let callerIndexPath: string | undefined;
@@ -909,6 +943,7 @@ function dropScratchIndex(): void {
 	ownedRepositoryPaths = undefined;
 	transportRemotes.clear();
 	transportProxyByUrl.clear();
+	transportProtocolPolicies.clear();
 	transportEnvironmentConfig.length = 0;
 	validatedTransportUrls.clear();
 	callerIndexPath = undefined;
@@ -1260,8 +1295,18 @@ function readUpstreamMarker(root: string): MarkerSnapshot {
 
 function requireCleanUpstreamMarker(marker: MarkerSnapshot): void {
 	rejectHiddenIndexEntries([MARKER]);
-	const tracked = gitZ(['ls-files', '-z', '--', `:(literal)${MARKER}`]).includes(MARKER);
-	if (marker.bytes !== null && !tracked) {
+	const literalMarker = `:(literal)${MARKER}`;
+	const tracked = gitZ(['ls-files', '-z', '--', literalMarker]).includes(MARKER);
+	const ignored = gitZ([
+		'ls-files',
+		'--others',
+		'--ignored',
+		'--exclude-standard',
+		'-z',
+		'--',
+		literalMarker
+	]).includes(MARKER);
+	if (ignored || (marker.bytes !== null && !tracked)) {
 		fail(
 			`${MARKER} exists but is not tracked. Commit it before upstream relevance selects a parent.`
 		);
@@ -1548,6 +1593,28 @@ function remoteMainRefspecIsCanonical(remote: string): boolean {
 	return sources.length > 0 && sources.every((source) => source === 'refs/heads/main');
 }
 
+function removeDetectorAddedUpstreamRemote(url: string): boolean {
+	const actual = decodeZRecords(
+		gitBytes(['config', '--null', '--get-regexp', '^remote\\.upstream\\.'], true)
+	).sort();
+	const expected = [
+		`remote.upstream.fetch\n+refs/heads/*:refs/remotes/upstream/*`,
+		`remote.upstream.url\n${url}`
+	].sort();
+	if (
+		actual.length !== expected.length ||
+		actual.some((record, index) => record !== expected[index])
+	) {
+		return false;
+	}
+	try {
+		git(['config', '--remove-section', 'remote.upstream']);
+		return configuredRemoteUrl('upstream') === '';
+	} catch {
+		return false;
+	}
+}
+
 function cameFromUpstreamMain(entry: RefLogEntry | null, sha: string): boolean {
 	if (!entry || entry.sha !== sha) return false;
 	const separator = entry.subject.lastIndexOf(': ');
@@ -1620,6 +1687,7 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 		const objectFormat = git(['rev-parse', '--show-object-format'], true);
 		const zeroOid = '0'.repeat(objectFormat === 'sha256' ? 64 : 40);
 		const refBeforeFetch = haveRef() ? git(['rev-parse', UPSTREAM_REF]) : zeroOid;
+		let addedRemote = false;
 		const transport = transportRemote(upstreamUrl);
 		console.error(`Fetching upstream (${terminalUrl(upstreamUrl)}) ...`);
 		const expected = advertisedMainAt(upstreamUrl);
@@ -1657,6 +1725,7 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 			rejectSecretBearingRemoteUrl(upstreamUrl);
 			try {
 				git(['remote', 'add', 'upstream', upstreamUrl]);
+				addedRemote = true;
 			} catch {
 				fail(`Could not add the \`upstream\` remote for ${terminalUrl(upstreamUrl)}.`);
 			}
@@ -1679,9 +1748,16 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 				refBeforeFetch
 			]);
 		} catch {
+			if (addedRemote && !removeDetectorAddedUpstreamRemote(upstreamUrl)) {
+				fail(
+					'The shared upstream tracking ref changed while this report fetched objects, and the newly added remote changed before it could be rolled back.'
+				);
+			}
 			fail(
 				'The shared upstream tracking ref changed while this report fetched objects. ' +
-					'Run it again after the other fetch finishes.'
+					(addedRemote
+						? 'The newly added remote was rolled back; run it again after the other fetch finishes.'
+						: 'Run it again after the other fetch finishes.')
 			);
 		}
 		if (normalizeRemote(configuredRemoteUrl('upstream')) !== normalizeRemote(remoteUrl)) {
@@ -1714,8 +1790,30 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 				`${expected} ${Math.floor(Date.now() / 1000)} ${remoteFingerprint(upstreamUrl)}`
 			]);
 		} catch {
+			let refRolledBack = false;
+			try {
+				git([
+					'update-ref',
+					'--no-deref',
+					'-m',
+					'roll back upstream relevance fetch after config failure',
+					UPSTREAM_REF,
+					refBeforeFetch,
+					expected
+				]);
+				refRolledBack = true;
+			} catch {
+				// The diagnostic below names the state that could not be restored.
+			}
+			const remoteRolledBack = !addedRemote || removeDetectorAddedUpstreamRemote(upstreamUrl);
+			if (!refRolledBack || !remoteRolledBack) {
+				fail(
+					'The upstream fetch time could not be recorded, and shared Git state changed before the ref or new remote could be rolled back.'
+				);
+			}
 			fail(
-				'The upstream fetch succeeded, but its fetch time could not be recorded in local Git config.'
+				'The upstream fetch time could not be recorded. The tracking ref was rolled back' +
+					(addedRemote ? ', along with the newly added remote.' : '.')
 			);
 		}
 		fetchedSha = expected;
@@ -2267,26 +2365,12 @@ function rejectHiddenIndexEntries(paths?: string[]): void {
  */
 function changedPaths(base: string, head: string): string[] {
 	rejectHiddenIndexEntries();
-	const fromStatus = (fields: string[]): string[] => {
-		const paths: string[] = [];
-		for (let i = 0; i < fields.length; i++) {
-			const status = fields[i];
-			if (status === undefined) break;
-			// Rename and copy statuses carry a similarity score and two paths;
-			// every other status carries one.
-			if (/^[RC]\d*$/.test(status)) {
-				const source = fields[i + 1];
-				const destination = fields[i + 2];
-				if (source !== undefined) paths.push(source);
-				if (destination !== undefined) paths.push(destination);
-				i += 2;
-			} else if (/^[A-Z]\d*$/.test(status)) {
-				const path = fields[i + 1];
-				if (path !== undefined) paths.push(path);
-				i += 1;
-			}
+	const paths = new Set<string>();
+	const add = (path: string): void => {
+		paths.add(path);
+		if (paths.size > PATH_LIMIT) {
+			fail(`Automatic discovery found more than ${PATH_LIMIT} changed paths. Narrow the request.`);
 		}
-		return paths;
 	};
 
 	// Every collector reads the same HEAD. The index is snapshotted once, so a
@@ -2299,9 +2383,9 @@ function changedPaths(base: string, head: string): string[] {
 	// indistinguishable from an empty result from a clean tree, and the second
 	// one exits zero saying there is nothing to report. A broken diff.renames
 	// value in inherited config was enough to produce exactly that.
-	const collect = (fn: () => string[], what: string): string[] => {
+	const collect = (fn: () => void, what: string): void => {
 		try {
-			return fn();
+			fn();
 		} catch (err) {
 			fail(
 				`Could not enumerate ${what}: ${terminalSafe(err instanceof Error ? err.message : String(err))}\n` +
@@ -2309,44 +2393,45 @@ function changedPaths(base: string, head: string): string[] {
 			);
 		}
 	};
+	const collectStatus = (args: string[], what: string): void => {
+		collect(() => {
+			let pathsRemaining = 0;
+			gitZEach(
+				args,
+				(record) => {
+					if (pathsRemaining > 0) {
+						add(record);
+						pathsRemaining--;
+						return;
+					}
+					// Rename and copy statuses carry two paths; every other
+					// changed status carries one.
+					if (/^[RC]\d*$/.test(record)) pathsRemaining = 2;
+					else if (/^[A-Z]\d*$/.test(record)) pathsRemaining = 1;
+				},
+				DIFF_COMMAND_TIMEOUT_MS
+			);
+			if (pathsRemaining !== 0) throw new Error('Git returned an incomplete name-status record.');
+		}, what);
+	};
 
-	const all = [
-		...collect(
-			() =>
-				fromStatus(
-					gitZ(
-						['diff', '--ignore-submodules=none', '--name-status', '-M', '-z', `${base}...${head}`],
-						false,
-						DIFF_COMMAND_TIMEOUT_MS
-					)
-				),
-			'committed changes'
-		),
-		...collect(
-			() =>
-				fromStatus(
-					gitZ(
-						['diff', '--ignore-submodules=none', '--name-status', '-M', '-z', head],
-						false,
-						DIFF_COMMAND_TIMEOUT_MS
-					)
-				),
-			'unstaged changes'
-		),
-		...collect(
-			() =>
-				fromStatus(
-					gitZ(
-						['diff', '--ignore-submodules=none', '--name-status', '-M', '-z', '--cached', head],
-						false,
-						DIFF_COMMAND_TIMEOUT_MS
-					)
-				),
-			'staged changes'
-		),
-		...collect(() => gitZ(['ls-files', '--others', '--exclude-standard', '-z']), 'untracked files')
-	];
-	return [...new Set(all)].sort();
+	collectStatus(
+		['diff', '--ignore-submodules=none', '--name-status', '-M', '-z', `${base}...${head}`],
+		'committed changes'
+	);
+	collectStatus(
+		['diff', '--ignore-submodules=none', '--name-status', '-M', '-z', head],
+		'unstaged changes'
+	);
+	collectStatus(
+		['diff', '--ignore-submodules=none', '--name-status', '-M', '-z', '--cached', head],
+		'staged changes'
+	);
+	collect(
+		() => gitZEach(['ls-files', '--others', '--exclude-standard', '-z'], add),
+		'untracked files'
+	);
+	return [...paths].sort();
 }
 
 type CachedBag =
@@ -3635,10 +3720,16 @@ function main() {
 		}
 		paths = [...resolved].sort();
 	} else {
-		paths = [...new Set([...changedPaths(base, head), ...statusPaths.map((entry) => entry.path)])];
-		if (paths.length > PATH_LIMIT) {
-			fail(`Automatic discovery found more than ${PATH_LIMIT} changed paths. Narrow the request.`);
+		const discovered = new Set(changedPaths(base, head));
+		for (const { path } of statusPaths) {
+			discovered.add(path);
+			if (discovered.size > PATH_LIMIT) {
+				fail(
+					`Automatic discovery found more than ${PATH_LIMIT} changed paths. Narrow the request.`
+				);
+			}
 		}
+		paths = [...discovered];
 	}
 	if (positionals.length > 0) rejectHiddenIndexEntries(paths);
 	const captured = capturePaths(paths);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -405,6 +405,7 @@ function verifyTransportConfiguration(): void {
 }
 
 function transportRemote(url: string): string {
+	verifyLocalRemoteSnapshot(url);
 	const existing = transportRemotes.get(url);
 	if (existing) return existing;
 	if (!transportConfigPath) {
@@ -486,8 +487,12 @@ function rejectSecretBearingRemoteUrl(url: string): void {
 			unsafe = true;
 		}
 	} else {
-		const scp = /^([^/@:\s]+)@[^/:\s]+:(.*)$/.exec(url);
-		unsafe = scp !== null && (scp[1] !== 'git' || scp[2]!.includes('?') || scp[2]!.includes('#'));
+		const scp = /^(?:([^/@:\s]+)@)?[^/:\s]+:(.*)$/.exec(url);
+		unsafe =
+			scp !== null &&
+			((scp[1] !== undefined && scp[1] !== 'git') ||
+				scp[2]!.includes('?') ||
+				scp[2]!.includes('#'));
 	}
 	if (!unsafe) return;
 	fail(
@@ -743,11 +748,28 @@ const terminalUrl = (value: string) => terminalSafe(redactUrl(value));
 // A prefix of its own, so a leftover copy is distinguishable from the temp
 // repositories the integration tests build under the same directory.
 const SCRATCH_PREFIX = 'upstream-relevance-index-';
+const SCRATCH_MANIFEST = '.upstream-relevance-scratch.json';
+const SCRATCH_MAGIC = 'upstream-relevance-scratch';
+const SCRATCH_VERSION = 1;
+
+interface PathIdentity {
+	path: string;
+	dev: number;
+	ino: number;
+}
+
+interface LocalRemoteSnapshot {
+	root: string;
+	endpointPath: string;
+	transportPath: string;
+	identities: PathIdentity[];
+}
 
 // Set once the real index has been copied aside; see the GIT_INDEX_FILE note.
 let scratchIndex: string | undefined;
 let scratchShallow: string | undefined;
 let scratchDir: string | undefined;
+let scratchIdentity: PathIdentity | undefined;
 let transportGitDir: string | undefined;
 let transportConfigPath: string | undefined;
 let transportObjectDir: string | undefined;
@@ -760,6 +782,7 @@ interface RemoteProxySettings {
 }
 
 const transportRemotes = new Map<string, string>();
+const localRemoteSnapshots = new Map<string, LocalRemoteSnapshot>();
 const transportProxyByUrl = new Map<string, RemoteProxySettings>();
 const transportProtocolPolicies = new Map<string, string>();
 const transportEnvironmentConfig: Array<[string, string]> = [];
@@ -775,6 +798,32 @@ let scratchIndexEntriesAtCopy: Buffer | null = null;
 /** An hour is far longer than a run and far shorter than a working day. */
 const LEFTOVER_AFTER_MS = 60 * 60 * 1000;
 
+function scratchOwner(dir: string): number | null {
+	try {
+		const directory = lstatSync(dir);
+		if (!directory.isDirectory()) return null;
+		if (process.platform !== 'win32' && (directory.mode & 0o077) !== 0) return null;
+		const manifest = JSON.parse(readFileSync(join(dir, SCRATCH_MANIFEST), 'utf8')) as {
+			magic?: unknown;
+			version?: unknown;
+			owner?: unknown;
+		};
+		const legacyOwner = Number(readFileSync(join(dir, 'owner'), 'utf8'));
+		if (
+			manifest.magic !== SCRATCH_MAGIC ||
+			manifest.version !== SCRATCH_VERSION ||
+			!Number.isInteger(manifest.owner) ||
+			manifest.owner !== legacyOwner ||
+			legacyOwner <= 0
+		) {
+			return null;
+		}
+		return legacyOwner;
+	} catch {
+		return null;
+	}
+}
+
 function sweepLeftovers(tempRoot: string): void {
 	// Whatever ended the last run, its copy is still here. Anything younger than
 	// an hour may belong to a run happening right now.
@@ -788,9 +837,15 @@ function sweepLeftovers(tempRoot: string): void {
 		if (!name.startsWith(SCRATCH_PREFIX)) continue;
 		try {
 			const dir = join(tempRoot, name);
+			if (
+				ownedRepositoryPaths &&
+				pathResolvesInsideOwnedRoot(realpathSync(dir), ownedRepositoryPaths)
+			) {
+				continue;
+			}
 			if (Date.now() - statSync(dir).mtimeMs < LEFTOVER_AFTER_MS) continue;
-			const owner = Number(readFileSync(join(dir, 'owner'), 'utf8'));
-			if (!Number.isInteger(owner) || owner <= 0) continue;
+			const owner = scratchOwner(dir);
+			if (owner === null) continue;
 			try {
 				process.kill(owner, 0);
 				continue;
@@ -958,7 +1013,14 @@ function useScratchIndex(root: string): void {
 		);
 	}
 	scratchDir = mkdtempSync(join(tempPath, SCRATCH_PREFIX));
-	writeFileSync(join(scratchDir, 'owner'), String(process.pid));
+	chmodSync(scratchDir, 0o700);
+	scratchIdentity = pathIdentity(scratchDir);
+	writeFileSync(join(scratchDir, 'owner'), String(process.pid), { mode: 0o600 });
+	writeFileSync(
+		join(scratchDir, SCRATCH_MANIFEST),
+		JSON.stringify({ magic: SCRATCH_MAGIC, version: SCRATCH_VERSION, owner: process.pid }),
+		{ mode: 0o600 }
+	);
 	transportGitDir = join(scratchDir, 'transport.git');
 	transportObjectDir = objectPath;
 	transportShallow = join(scratchDir, 'transport-shallow');
@@ -985,8 +1047,20 @@ function useScratchIndex(root: string): void {
 }
 
 function dropScratchIndex(): void {
-	if (scratchDir) rmSync(scratchDir, { recursive: true, force: true });
+	try {
+		if (
+			scratchDir &&
+			scratchIdentity &&
+			samePathIdentity(scratchIdentity, pathIdentity(scratchDir)) &&
+			scratchOwner(scratchDir) === process.pid
+		) {
+			rmSync(scratchDir, { recursive: true, force: true });
+		}
+	} catch {
+		// A path that no longer names our directory is left untouched.
+	}
 	scratchDir = undefined;
+	scratchIdentity = undefined;
 	scratchIndex = undefined;
 	scratchShallow = undefined;
 	transportGitDir = undefined;
@@ -995,6 +1069,7 @@ function dropScratchIndex(): void {
 	transportShallow = undefined;
 	ownedRepositoryPaths = undefined;
 	transportRemotes.clear();
+	localRemoteSnapshots.clear();
 	transportProxyByUrl.clear();
 	transportProtocolPolicies.clear();
 	transportEnvironmentConfig.length = 0;
@@ -1460,23 +1535,136 @@ function localRemotePath(url: string, root: string): string | null {
 	}
 }
 
-function rejectOwnedRepositoryRemote(url: string, root: string, remote: string): void {
-	const remotePath = localRemotePath(url, root);
-	if (!remotePath) {
-		validatedTransportUrls.set(url, url);
-		return;
+function localGitPath(remotePath: string, args: string[], allowFail = false): string | null {
+	try {
+		const env = gitEnv();
+		env.GIT_CONFIG_NOSYSTEM = '1';
+		env.GIT_CONFIG_GLOBAL = NO_GRAFTS;
+		env.GIT_CONFIG_SYSTEM = NO_GRAFTS;
+		env.GIT_GRAFT_FILE = NO_GRAFTS;
+		env.GIT_NO_REPLACE_OBJECTS = '1';
+		const value = execFileSync('git', [...PINNED_CONFIG, ...args], {
+			cwd: remotePath,
+			env,
+			maxBuffer: MAX_GIT_OUTPUT,
+			stdio: ['pipe', 'pipe', 'pipe'],
+			timeout: WORKTREE_TIMEOUT_MS
+		}).toString('utf8');
+		return value.endsWith('\n') ? value.slice(0, -1) : value;
+	} catch {
+		if (allowFail) return null;
+		fail('A local upstream path does not resolve to stable Git storage.');
 	}
+}
+
+function inspectLocalRemote(
+	url: string,
+	root: string,
+	remote: string,
+	validatedEndpoint?: string
+): LocalRemoteSnapshot | null {
+	const remotePath = validatedEndpoint ?? localRemotePath(url, root);
+	if (!remotePath) return null;
 	if (!ownedRepositoryPaths) {
 		fail('The repository checkout inventory is unavailable. Run the report again.');
 	}
-	const owned = pathResolvesInsideOwnedRoot(remotePath, ownedRepositoryPaths);
-	if (owned) {
+	const endpoint = statSync(remotePath);
+	let transportPath = remotePath;
+	const effectivePaths = new Set([remotePath]);
+	if (endpoint.isDirectory()) {
+		const gitDirValue = localGitPath(remotePath, [
+			'rev-parse',
+			'--path-format=absolute',
+			'--git-dir'
+		]);
+		const commonDirValue = localGitPath(remotePath, [
+			'rev-parse',
+			'--path-format=absolute',
+			'--git-common-dir'
+		]);
+		const objectDirValue = localGitPath(remotePath, [
+			'rev-parse',
+			'--path-format=absolute',
+			'--git-path',
+			'objects'
+		]);
+		if (!gitDirValue || !commonDirValue || !objectDirValue) {
+			fail('A local upstream path does not identify complete Git storage.');
+		}
+		const gitDir = realpathSync(gitDirValue);
+		const commonDir = realpathSync(commonDirValue);
+		const objectDir = realpathSync(objectDirValue);
+		effectivePaths.add(gitDir);
+		effectivePaths.add(commonDir);
+		effectivePaths.add(objectDir);
+		const worktreeValue = localGitPath(
+			remotePath,
+			['rev-parse', '--path-format=absolute', '--show-toplevel'],
+			true
+		);
+		if (worktreeValue) effectivePaths.add(realpathSync(worktreeValue));
+		const alternatesPath = join(objectDir, 'info', 'alternates');
+		if (existsSync(alternatesPath)) {
+			for (const alternate of readFileSync(alternatesPath, 'utf8').split('\n')) {
+				if (!alternate) continue;
+				effectivePaths.add(
+					realpathSync(isAbsolute(alternate) ? alternate : resolve(objectDir, alternate))
+				);
+			}
+		}
+		// The common directory names refs directly. Keeping the wrapper worktree out
+		// of the transport removes its mutable .git indirection from later Git calls.
+		transportPath = commonDir;
+	} else if (!endpoint.isFile()) {
+		fail('A local upstream path must name a Git directory or bundle file.');
+	}
+	for (const path of effectivePaths) {
+		if (!pathResolvesInsideOwnedRoot(path, ownedRepositoryPaths)) continue;
 		fail(
 			`The ${remote} URL resolves inside a checkout or Git directory owned by this repository. ` +
 				'A repository-owned remote can follow branch-controlled refs and hide every committed change.'
 		);
 	}
-	validatedTransportUrls.set(url, remotePath);
+	return {
+		root,
+		endpointPath: remotePath,
+		transportPath,
+		identities: identityChains(effectivePaths)
+	};
+}
+
+function verifyLocalRemoteSnapshot(url: string): void {
+	const expected = localRemoteSnapshots.get(url);
+	if (!expected) return;
+	let current: LocalRemoteSnapshot | null;
+	try {
+		current = inspectLocalRemote(url, expected.root, 'local remote', expected.endpointPath);
+	} catch {
+		fail('A local upstream path or one of its ancestors changed during this report. Run it again.');
+	}
+	if (
+		!current ||
+		current.transportPath !== expected.transportPath ||
+		!sameIdentityChains(current.identities, expected.identities)
+	) {
+		fail('A local upstream path or one of its ancestors changed during this report. Run it again.');
+	}
+}
+
+function rejectOwnedRepositoryRemote(url: string, root: string, remote: string): void {
+	let snapshot: LocalRemoteSnapshot | null;
+	try {
+		snapshot = inspectLocalRemote(url, root, remote);
+	} catch {
+		fail(`Cannot trust the ${remote} URL because its local Git storage cannot be resolved.`);
+	}
+	if (!snapshot) {
+		localRemoteSnapshots.delete(url);
+		validatedTransportUrls.set(url, url);
+		return;
+	}
+	localRemoteSnapshots.set(url, snapshot);
+	validatedTransportUrls.set(url, snapshot.transportPath);
 }
 
 function rejectUnverifiableFileModes(): void {
@@ -1760,6 +1948,7 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 		const expected = advertisedMainAt(transportUrl);
 		try {
 			rejectTransportCommandOverrides();
+			verifyLocalRemoteSnapshot(transportUrl);
 			gitBytes(
 				[
 					'fetch',
@@ -1775,6 +1964,7 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 				trustedTransportEnv(),
 				NETWORK_TIMEOUT_MS
 			);
+			verifyLocalRemoteSnapshot(transportUrl);
 		} catch {
 			fail(
 				`Could not fetch refs/heads/main from ${terminalUrl(upstreamUrl)}. ` +
@@ -2124,7 +2314,7 @@ function advertisedMainAt(url: string): string {
 	// This name exists only in the private config. It keeps the URL out of process
 	// arguments without inheriting remote.<name>.uploadpack from the repository.
 	const remote = transportRemote(url);
-	return gitBytes(
+	const advertised = gitBytes(
 		['ls-remote', '--exit-code', '--refs', remote, 'refs/heads/main'],
 		true,
 		trustedTransportEnv(),
@@ -2133,6 +2323,8 @@ function advertisedMainAt(url: string): string {
 		.toString('utf8')
 		.trim()
 		.split('\t')[0]!;
+	verifyLocalRemoteSnapshot(url);
+	return advertised;
 }
 
 function trustedOriginSnapshot(expectedSha: string): OriginSnapshot {
@@ -3157,6 +3349,36 @@ function sameFileIdentity(left: Stats, right: Stats): boolean {
 	return left.dev === right.dev && left.ino === right.ino;
 }
 
+function pathIdentity(path: string): PathIdentity {
+	const stats = statSync(path);
+	return { path, dev: stats.dev, ino: stats.ino };
+}
+
+function samePathIdentity(left: PathIdentity, right: PathIdentity): boolean {
+	return left.path === right.path && left.dev === right.dev && left.ino === right.ino;
+}
+
+function identityChains(paths: Iterable<string>): PathIdentity[] {
+	const identities = new Map<string, PathIdentity>();
+	for (const path of paths) {
+		let current = path;
+		while (true) {
+			if (!identities.has(current)) identities.set(current, pathIdentity(current));
+			const parent = resolve(current, '..');
+			if (parent === current) break;
+			current = parent;
+		}
+	}
+	return [...identities.values()].sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function sameIdentityChains(left: PathIdentity[], right: PathIdentity[]): boolean {
+	return (
+		left.length === right.length &&
+		left.every((identity, index) => samePathIdentity(identity, right[index]!))
+	);
+}
+
 function pathResolvesInsideOwnedRoot(candidate: string, ownedRoots: Iterable<string>): boolean {
 	const roots = [...ownedRoots];
 	const rootStats = roots.map((root) => statSync(root));
@@ -3819,52 +4041,58 @@ function main() {
 			if (specs) specs.push(spec);
 			else requested.set(pathspec, [spec]);
 		}
-		const resolved = new Set<string>();
-		const addMatch = (match: string): void => {
-			if (resolved.has(match)) return;
-			if (resolved.size >= PATH_LIMIT) {
-				fail(`Explicit paths matched more than ${PATH_LIMIT} files. Narrow the request.`);
-			}
-			resolved.add(match);
-		};
-		for (const [pathspec, specs] of requested) {
-			const literalPathspec = `:(literal)${pathspec}`;
-			let matched = false;
-			const collect = (record: string) => {
-				matched = true;
-				addMatch(record);
+		const enumerate = (): { resolved: Set<string>; unmatched: string[] } => {
+			const resolved = new Set<string>();
+			const missing: string[] = [];
+			const addMatch = (match: string): void => {
+				if (resolved.has(match)) return;
+				if (resolved.size >= PATH_LIMIT) {
+					fail(`Explicit paths matched more than ${PATH_LIMIT} files. Narrow the request.`);
+				}
+				resolved.add(match);
 			};
-			try {
-				gitZEach(
-					[
-						'ls-files',
-						'-z',
-						'--full-name',
-						'--cached',
-						'--others',
-						'--exclude-standard',
-						'--',
-						literalPathspec
-					],
-					collect
-				);
-				// A path deleted in this change matches nothing in the working tree but
-				// still exists at the base, and deleting template code is exactly the
-				// sort of change worth reporting.
-				gitZEach(
-					['ls-tree', '-z', '--full-name', '--name-only', '-r', base, '--', literalPathspec],
-					collect
-				);
-				gitZEach(
-					['ls-tree', '-z', '--full-name', '--name-only', '-r', head, '--', literalPathspec],
-					collect
-				);
-			} catch {
-				fail(`Could not enumerate the requested path "${terminalSafe(specs[0]!)}".`);
+			for (const [pathspec, specs] of requested) {
+				const literalPathspec = `:(literal)${pathspec}`;
+				let matched = false;
+				const collect = (record: string) => {
+					matched = true;
+					addMatch(record);
+				};
+				try {
+					gitZEach(
+						[
+							'ls-files',
+							'-z',
+							'--full-name',
+							'--cached',
+							'--others',
+							'--exclude-standard',
+							'--',
+							literalPathspec
+						],
+						collect
+					);
+					// A path deleted in this change matches nothing in the working tree but
+					// still exists at the base, and deleting template code is exactly the
+					// sort of change worth reporting.
+					gitZEach(
+						['ls-tree', '-z', '--full-name', '--name-only', '-r', base, '--', literalPathspec],
+						collect
+					);
+					gitZEach(
+						['ls-tree', '-z', '--full-name', '--name-only', '-r', head, '--', literalPathspec],
+						collect
+					);
+				} catch {
+					fail(`Could not enumerate the requested path "${terminalSafe(specs[0]!)}".`);
+				}
+				if (!matched) missing.push(...specs);
 			}
-			if (!matched) for (const spec of specs) unmatched.push(spec);
-		}
+			return { resolved, unmatched: missing };
+		};
 
+		const first = enumerate();
+		unmatched.push(...first.unmatched);
 		if (unmatched.length > 0) {
 			fail(
 				`These paths matched nothing: ${unmatched.map(terminalSafe).join(', ')}\n` +
@@ -3872,7 +4100,17 @@ function main() {
 					'reads as "nothing to send upstream".'
 			);
 		}
-		paths = [...resolved].sort();
+		const resolved = [...first.resolved].sort();
+		const confirmed = enumerate();
+		const confirmedPaths = [...confirmed.resolved].sort();
+		if (
+			confirmed.unmatched.length > 0 ||
+			resolved.length !== confirmedPaths.length ||
+			resolved.some((path, index) => path !== confirmedPaths[index])
+		) {
+			fail('Explicit path expansion changed during this report. Run it again on the settled tree.');
+		}
+		paths = resolved;
 	} else {
 		const discovered = new Set(changedPaths(base, head));
 		for (const { path } of statusPaths) {

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -9,10 +9,8 @@
  * privately and every other fork keeps them, or fork-only work gets offered
  * upstream where it makes no sense.
  *
- * Four outcomes, every one of them measured:
+ * Three outcomes, every one of them measured:
  *
- *   fork-only  every available path, blob, name and text comparison ruled out
- *              a tie to upstream. Nothing to report.
  *   pristine   the path exists upstream and, BEFORE this change, was identical
  *              to it. Editing untouched template code is the strongest signal
  *              there is: whatever was wrong there is wrong upstream too.
@@ -37,7 +35,7 @@
  *     --base <ref>   compare from the merge base with this ref instead of origin/main
  *     --fetch        allow creating the upstream remote and fetching it (writes git state)
  *     --json         machine-readable output
- *     --all          list fork-only files too (default: only what could matter)
+ *     --all          accepted for compatibility; every classified path is already listed
  */
 import { execFileSync } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
@@ -73,6 +71,9 @@ const UPSTREAM_FETCH_CONFIG = 'upstreamReport.lastFetch';
 const MAX_MARKER_BYTES = 1024 * 1024;
 const TEMP_ROOT = tmpdir();
 const NO_GRAFTS = process.platform === 'win32' ? 'NUL' : '/dev/null';
+const WINDOWS_SAFETY_MODE =
+	process.platform === 'win32' ||
+	(process.env.NODE_ENV === 'test' && process.env.UPSTREAM_REPORT_TEST_WINDOWS_SAFETY === '1');
 
 // Two days of upstream commits added seven paths that an old copy could not
 // compare. One full day is the first age the summary calls stale; the warning,
@@ -136,6 +137,28 @@ function gitEnv(): NodeJS.ProcessEnv {
 		}
 	}
 	return env;
+}
+
+function inheritedEnvironment(name: string): string | undefined {
+	const key = Object.keys(process.env).find((candidate) => candidate.toUpperCase() === name);
+	return key === undefined ? undefined : process.env[key];
+}
+
+const PRIVATE_TRANSPORT_PROTOCOLS = new Set(['file', 'git', 'http', 'https', 'ssh']);
+function transportProtocolEnv(): NodeJS.ProcessEnv {
+	const inherited = inheritedEnvironment('GIT_ALLOW_PROTOCOL');
+	const fromUser = inheritedEnvironment('GIT_PROTOCOL_FROM_USER');
+	return {
+		...(inherited === undefined
+			? {}
+			: {
+					GIT_ALLOW_PROTOCOL: inherited
+						.split(':')
+						.filter((protocol) => PRIVATE_TRANSPORT_PROTOCOLS.has(protocol))
+						.join(':')
+				}),
+		...(fromUser === '0' ? { GIT_PROTOCOL_FROM_USER: '0' } : {})
+	};
 }
 
 // Config pinned on every invocation, because each of these changes the answer
@@ -224,6 +247,7 @@ function trustedTransportEnv(): NodeJS.ProcessEnv {
 		fail('The private transport repository is unavailable. Run the report again.');
 	}
 	return {
+		...transportProtocolEnv(),
 		GIT_DIR: transportGitDir,
 		GIT_OBJECT_DIRECTORY: transportObjectDir,
 		GIT_SHALLOW_FILE: transportShallow,
@@ -252,16 +276,35 @@ function appendTransportConfig(configPath: string, key: string, value: string): 
 	const first = key.indexOf('.');
 	const last = key.lastIndexOf('.');
 	if (first <= 0 || last === key.length - 1) {
-		fail('Git returned an transport config key that cannot be copied safely.');
+		fail('Git returned a transport config key that cannot be copied safely.');
 	}
 	const section = key.slice(0, first);
 	const name = key.slice(last + 1);
 	if (!/^[a-z][a-z0-9-]*$/i.test(section) || !/^[a-z][a-z0-9-]*$/i.test(name)) {
-		fail('Git returned an transport config key that cannot be copied safely.');
+		fail('Git returned a transport config key that cannot be copied safely.');
 	}
 	const header =
 		first === last ? `[${section}]` : `[${section} ${quotedGitConfig(key.slice(first + 1, last))}]`;
 	writeFileSync(configPath, `${header}\n\t${name} = ${quotedGitConfig(value)}\n`, { flag: 'a' });
+}
+
+function proxyCarriesUserinfo(value: string): boolean {
+	try {
+		const parsed = new URL(value);
+		return parsed.username !== '' || parsed.password !== '';
+	} catch {
+		return true;
+	}
+}
+
+function safeWindowsTransportValue(key: string, value: string): boolean {
+	if (!WINDOWS_SAFETY_MODE) return true;
+	const lower = key.toLowerCase();
+	if (lower.startsWith('credential.') || lower.endsWith('.extraheader')) return false;
+	if ((lower === 'http.proxy' || lower.endsWith('.proxy')) && proxyCarriesUserinfo(value)) {
+		return false;
+	}
+	return true;
 }
 
 function copyTransportConfiguration(configPath: string): void {
@@ -270,14 +313,25 @@ function copyTransportConfiguration(configPath: string): void {
 			'config',
 			'--null',
 			'--get-regexp',
-			'^(credential\\.|http\\..*\\.(extraheader|pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslcert|proxysslcertpasswordprotected|proxysslkey|proxysslverify|sslcainfo|sslcert|sslcertpasswordprotected|sslkey|sslverify)$)'
+			'^(credential\\.|http\\.(pinnedpubkey|proxy|proxyauthmethod|sslcainfo|sslbackend|sslverify)$|http\\..*\\.(extraheader|pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslcert|proxysslcertpasswordprotected|proxysslkey|proxysslverify|sslcainfo|sslcert|sslcertpasswordprotected|sslkey|sslverify)$|protocol\\..*\\.allow$)'
 		],
 		true
 	);
 	for (const record of decodeZRecords(output)) {
 		const newline = record.indexOf('\n');
 		if (newline === -1) continue;
-		appendTransportConfig(configPath, record.slice(0, newline), record.slice(newline + 1));
+		const key = record.slice(0, newline);
+		const value = record.slice(newline + 1);
+		if (key.startsWith('protocol.') && value.toLowerCase() === 'always') continue;
+		if (!safeWindowsTransportValue(key, value)) continue;
+		appendTransportConfig(configPath, key, value);
+	}
+	for (const remote of git(['remote'], true).split('\n').filter(Boolean)) {
+		const url = configuredRemoteUrl(remote);
+		const proxy = git(['config', '--get', `remote.${remote}.proxy`], true);
+		if (url && proxy && safeWindowsTransportValue(`remote.${remote}.proxy`, proxy)) {
+			transportProxyByUrl.set(url, proxy);
+		}
 	}
 }
 
@@ -287,13 +341,16 @@ function transportRemote(url: string): string {
 	if (!transportConfigPath) {
 		fail('The private transport configuration is unavailable. Run the report again.');
 	}
+	if (WINDOWS_SAFETY_MODE) rejectSecretBearingRemoteUrl(url);
 	const name = `upstream-report-${createHash('sha256').update(url).digest('hex').slice(0, 16)}`;
 	appendTransportConfig(transportConfigPath, `remote.${name}.url`, url);
+	const proxy = transportProxyByUrl.get(url);
+	if (proxy) appendTransportConfig(transportConfigPath, `remote.${name}.proxy`, proxy);
 	transportRemotes.set(url, name);
 	return name;
 }
 
-function rejectSecretBearingRemoteCreation(url: string): void {
+function rejectSecretBearingRemoteUrl(url: string): void {
 	let unsafe: boolean;
 	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
 		try {
@@ -316,9 +373,8 @@ function rejectSecretBearingRemoteCreation(url: string): void {
 	}
 	if (!unsafe) return;
 	fail(
-		`Cannot create the shared \`upstream\` remote from ${terminalUrl(url)} because its URL carries ` +
-			'userinfo, a query, or a fragment. Add a credential-free remote yourself and keep authentication ' +
-			'in a credential helper or URL-scoped HTTP config.'
+		`Cannot use ${terminalUrl(url)} because its URL carries userinfo, a query, or a fragment. ` +
+			'Use a credential-free remote and keep authentication in a credential helper or URL-scoped HTTP config.'
 	);
 }
 
@@ -456,14 +512,13 @@ function git(args: string[], allowFail = false, timeout?: number): string {
  * with U+FFFD and can collapse two distinct paths into one map key.
  */
 const PATH_UTF8 = new TextDecoder('utf-8', { fatal: true });
-function decodeZRecords(output: Buffer): string[] {
-	const records: string[] = [];
+function visitZRecords(output: Buffer, visit: (record: string) => void): void {
 	let start = 0;
 	for (let end = 0; end <= output.length; end++) {
 		if (end < output.length && output[end] !== 0) continue;
 		if (end > start) {
 			try {
-				records.push(PATH_UTF8.decode(output.subarray(start, end)));
+				visit(PATH_UTF8.decode(output.subarray(start, end)));
 			} catch {
 				fail(
 					'Git returned a pathname that is not valid UTF-8. Rename it before running this report.'
@@ -472,11 +527,20 @@ function decodeZRecords(output: Buffer): string[] {
 		}
 		start = end + 1;
 	}
+}
+
+function decodeZRecords(output: Buffer): string[] {
+	const records: string[] = [];
+	visitZRecords(output, (record) => records.push(record));
 	return records;
 }
 
 function gitZ(args: string[], allowFail = false, timeout?: number): string[] {
 	return decodeZRecords(gitBytes(args, allowFail, {}, timeout));
+}
+
+function gitZEach(args: string[], visit: (record: string) => void): void {
+	visitZRecords(gitBytes(args), visit);
 }
 
 function historyGitBytes(args: string[]): Buffer {
@@ -540,6 +604,7 @@ let transportObjectDir: string | undefined;
 let transportShallow: string | undefined;
 let ownedRepositoryPaths: Set<string> | undefined;
 const transportRemotes = new Map<string, string>();
+const transportProxyByUrl = new Map<string, string>();
 let callerIndexPath: string | undefined;
 let callerShallowPath: string | undefined;
 let callerIndexAtCopy: Buffer | null = null;
@@ -776,6 +841,7 @@ function dropScratchIndex(): void {
 	transportShallow = undefined;
 	ownedRepositoryPaths = undefined;
 	transportRemotes.clear();
+	transportProxyByUrl.clear();
 	callerIndexPath = undefined;
 	callerShallowPath = undefined;
 	callerIndexAtCopy = null;
@@ -789,7 +855,7 @@ function fail(message: string): never {
 	process.exit(3);
 }
 
-export type Relevance = 'fork-only' | 'pristine' | 'diverged' | 'unmeasured';
+export type Relevance = 'pristine' | 'diverged' | 'unmeasured';
 
 export interface FileVerdict {
 	path: string;
@@ -960,7 +1026,14 @@ export function classifyVerdict(args: {
 	overlap?: number | null;
 	unmeasuredNote?: string;
 }): FileVerdict {
-	if (!args.existsUpstream) return { path: args.path, relevance: 'fork-only', report: false };
+	if (!args.existsUpstream) {
+		return {
+			path: args.path,
+			relevance: 'unmeasured',
+			note: args.unmeasuredNote ?? 'no upstream path, but fork ownership is not proven',
+			report: true
+		};
+	}
 	if (args.baseMatchesUpstream) return { path: args.path, relevance: 'pristine', report: true };
 	if (args.overlap === null || args.overlap === undefined) {
 		return {
@@ -979,7 +1052,74 @@ interface MarkerSnapshot {
 	provenance: string[];
 }
 
+function markerSnapshotFromBytes(bytes: Buffer): MarkerSnapshot {
+	let raw: string;
+	try {
+		raw = PATH_UTF8.decode(bytes);
+	} catch {
+		fail(`${MARKER} is not valid UTF-8.`);
+	}
+	try {
+		const marker: unknown = JSON.parse(raw);
+		if (!marker || Array.isArray(marker) || typeof marker !== 'object') {
+			fail(`${MARKER} must contain a JSON object.`);
+		}
+		const fields = marker as {
+			upstreamUrl?: unknown;
+			forkPoint?: unknown;
+			lastSynced?: unknown;
+		};
+		const upstreamUrl = fields.upstreamUrl;
+		if (upstreamUrl !== undefined && (typeof upstreamUrl !== 'string' || !upstreamUrl.trim())) {
+			fail(`${MARKER}.upstreamUrl must be a non-empty string when present.`);
+		}
+		const provenanceFields = [fields.forkPoint, fields.lastSynced];
+		if (
+			provenanceFields.some(
+				(value) =>
+					value !== undefined &&
+					(typeof value !== 'string' || !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(value))
+			)
+		) {
+			fail(`${MARKER}.forkPoint and .lastSynced must be full commit SHAs when present.`);
+		}
+		const provenance = provenanceFields.filter(
+			(value): value is string => typeof value === 'string'
+		);
+		return { url: upstreamUrl ?? DEFAULT_UPSTREAM, bytes, provenance };
+	} catch (err) {
+		if (err instanceof SyntaxError) {
+			fail(
+				`${MARKER} is not valid JSON: ${terminalSafe(err.message)}\n` +
+					'Refusing to fall back to the default template. That would classify this fork ' +
+					'against the wrong repository and every verdict would look normal.'
+			);
+		}
+		throw err;
+	}
+}
+
+function indexMarkerBytes(): Buffer | null {
+	const staged = git(['ls-files', '--stage', '--', `:(literal)${MARKER}`], true);
+	if (!staged) return null;
+	const mode = /^(\d{6}) [0-9a-f]+ 0\t/.exec(staged)?.[1];
+	if (mode !== '100644' && mode !== '100755') {
+		fail(`${MARKER} must be a regular file. Symlinks cannot bind a repository to its parent.`);
+	}
+	const size = Number(git(['cat-file', '-s', `:${MARKER}`], false, HISTORY_COMMAND_TIMEOUT_MS));
+	if (!Number.isFinite(size) || size > MAX_MARKER_BYTES) {
+		fail(`${MARKER} exceeds the ${MAX_MARKER_BYTES}-byte input limit.`);
+	}
+	return gitBytes(['show', `:${MARKER}`], false, {}, HISTORY_COMMAND_TIMEOUT_MS);
+}
+
 function readUpstreamMarker(root: string): MarkerSnapshot {
+	if (WINDOWS_SAFETY_MODE) {
+		const bytes = indexMarkerBytes();
+		return bytes === null
+			? { url: DEFAULT_UPSTREAM, bytes: null, provenance: [] }
+			: markerSnapshotFromBytes(bytes);
+	}
 	const p = join(root, MARKER);
 	// Open first and bind inspection plus reading to one descriptor. An atomic
 	// replacement between lstat and read used to select a different parent, then
@@ -988,7 +1128,9 @@ function readUpstreamMarker(root: string): MarkerSnapshot {
 	try {
 		fd = openSync(
 			p,
-			fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0) | (fsConstants.O_NONBLOCK ?? 0)
+			fsConstants.O_RDONLY |
+				(WINDOWS_SAFETY_MODE ? 0 : (fsConstants.O_NOFOLLOW ?? 0)) |
+				(fsConstants.O_NONBLOCK ?? 0)
 		);
 	} catch (err) {
 		const code = (err as NodeJS.ErrnoException).code;
@@ -1044,50 +1186,7 @@ function readUpstreamMarker(root: string): MarkerSnapshot {
 	} finally {
 		closeSync(fd);
 	}
-	let raw: string;
-	try {
-		raw = PATH_UTF8.decode(bytes);
-	} catch {
-		fail(`${MARKER} is not valid UTF-8.`);
-	}
-	try {
-		const marker: unknown = JSON.parse(raw);
-		if (!marker || Array.isArray(marker) || typeof marker !== 'object') {
-			fail(`${MARKER} must contain a JSON object.`);
-		}
-		const fields = marker as {
-			upstreamUrl?: unknown;
-			forkPoint?: unknown;
-			lastSynced?: unknown;
-		};
-		const upstreamUrl = fields.upstreamUrl;
-		if (upstreamUrl !== undefined && (typeof upstreamUrl !== 'string' || !upstreamUrl.trim())) {
-			fail(`${MARKER}.upstreamUrl must be a non-empty string when present.`);
-		}
-		const provenanceFields = [fields.forkPoint, fields.lastSynced];
-		if (
-			provenanceFields.some(
-				(value) =>
-					value !== undefined &&
-					(typeof value !== 'string' || !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(value))
-			)
-		) {
-			fail(`${MARKER}.forkPoint and .lastSynced must be full commit SHAs when present.`);
-		}
-		const provenance = provenanceFields.filter(
-			(value): value is string => typeof value === 'string'
-		);
-		return { url: upstreamUrl ?? DEFAULT_UPSTREAM, bytes, provenance };
-	} catch (err) {
-		if (err instanceof SyntaxError) {
-			fail(
-				`${MARKER} is not valid JSON: ${terminalSafe(err.message)}\n` +
-					'Refusing to fall back to the default template. That would classify this fork ' +
-					'against the wrong repository and every verdict would look normal.'
-			);
-		}
-		throw err;
-	}
+	return markerSnapshotFromBytes(bytes);
 }
 
 function requireCleanUpstreamMarker(marker: MarkerSnapshot): void {
@@ -1482,7 +1581,7 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 			fail('Upstream main changed or its fetched commit is unavailable. Run the report again.');
 		}
 		if (!remoteUrl) {
-			rejectSecretBearingRemoteCreation(upstreamUrl);
+			rejectSecretBearingRemoteUrl(upstreamUrl);
 			try {
 				git(['remote', 'add', 'upstream', upstreamUrl]);
 			} catch {
@@ -1751,7 +1850,7 @@ function sameOptionalBuffer(left: Buffer | null, right: Buffer | null): boolean 
 }
 
 function verifyLocalSnapshot(root: string, snapshot: LocalSnapshot): void {
-	const current = localSnapshot(git(['rev-parse', 'HEAD']), optionalFile(join(root, MARKER)));
+	const current = localSnapshot(git(['rev-parse', 'HEAD']), readUpstreamMarker(root).bytes);
 	current.index = optionalFile(callerIndexPath);
 	current.worktree = fingerprintPaths([...snapshot.worktree.keys()]);
 	const worktreeMatches = [...snapshot.worktree].every(
@@ -1877,7 +1976,7 @@ function resolveBase(head: string, explicit?: string): BaseResolution {
  *
  * `-z` matters as much as it does for the collectors: without it git quotes a
  * path holding a tab, a newline or a backslash, and a quoted spelling misses
- * the exact lookup that decides `fork-only`.
+ * the exact lookup that decides whether the path exists upstream.
  */
 type TreeEntry = { mode: string; type: string; sha: string };
 interface HistoricalEntries {
@@ -3011,7 +3110,7 @@ function verdictFor(
 		// macOS and Windows compare filenames case-insensitively while git does
 		// not, so a fork file differing from a template file only in case is one
 		// file to the filesystem and two to the exact lookup. Calling that
-		// fork-only is a silent negative on what may be the same file; say it is
+		// Hiding it would be a silent negative on what may be the same file; say it is
 		// ambiguous instead.
 		const folded = upstream.byFold.get(path.toLowerCase());
 		if (folded !== undefined) {
@@ -3153,7 +3252,14 @@ function verdictFor(
 					'path entered local history after repository creation; negative resemblance cannot prove fork ownership'
 			});
 		}
-		return classifyVerdict({ path, existsUpstream: false, baseMatchesUpstream: false });
+		return classifyVerdict({
+			path,
+			existsUpstream: true,
+			baseMatchesUpstream: false,
+			overlap: null,
+			unmeasuredNote:
+				'path existed in the bootstrap root, but bootstrap-time relocation or customization cannot be ruled out'
+		});
 	}
 
 	if (upstreamEntry.type !== 'blob') {
@@ -3402,69 +3508,55 @@ function main() {
 			else requested.set(pathspec, [spec]);
 		}
 		const resolved = new Set<string>();
-		const addMatches = (matches: string[]): void => {
-			for (const match of matches) {
-				if (resolved.has(match)) continue;
-				if (resolved.size >= PATH_LIMIT) {
-					fail(`Explicit paths matched more than ${PATH_LIMIT} files. Narrow the request.`);
-				}
-				resolved.add(match);
+		const addMatch = (match: string): void => {
+			if (resolved.has(match)) return;
+			if (resolved.size >= PATH_LIMIT) {
+				fail(`Explicit paths matched more than ${PATH_LIMIT} files. Narrow the request.`);
 			}
+			resolved.add(match);
 		};
 		for (const [pathspec, specs] of requested) {
 			const literalPathspec = `:(literal)${pathspec}`;
-			let listed: string[];
-			let atBase: string[];
-			let atHead: string[];
+			let matched = false;
+			const collect = (record: string) => {
+				matched = true;
+				addMatch(record);
+			};
 			try {
-				listed = gitZ([
-					'ls-files',
-					'-z',
-					'--full-name',
-					'--cached',
-					'--others',
-					'--exclude-standard',
-					'--',
-					literalPathspec
-				]);
+				gitZEach(
+					[
+						'ls-files',
+						'-z',
+						'--full-name',
+						'--cached',
+						'--others',
+						'--exclude-standard',
+						'--',
+						literalPathspec
+					],
+					collect
+				);
 				// A path deleted in this change matches nothing in the working tree but
 				// still exists at the base, and deleting template code is exactly the
 				// sort of change worth reporting.
-				atBase = gitZ([
-					'ls-tree',
-					'-z',
-					'--full-name',
-					'--name-only',
-					'-r',
-					base,
-					'--',
-					literalPathspec
-				]);
-				atHead = gitZ([
-					'ls-tree',
-					'-z',
-					'--full-name',
-					'--name-only',
-					'-r',
-					head,
-					'--',
-					literalPathspec
-				]);
+				gitZEach(
+					['ls-tree', '-z', '--full-name', '--name-only', '-r', base, '--', literalPathspec],
+					collect
+				);
+				gitZEach(
+					['ls-tree', '-z', '--full-name', '--name-only', '-r', head, '--', literalPathspec],
+					collect
+				);
 			} catch {
 				fail(`Could not enumerate the requested path "${terminalSafe(specs[0]!)}".`);
 			}
-			if (listed.length === 0 && atBase.length === 0 && atHead.length === 0) {
-				for (const spec of specs) unmatched.push(spec);
-			} else {
-				addMatches(listed);
-				addMatches(atBase);
-				addMatches(atHead);
-			}
+			if (!matched) for (const spec of specs) unmatched.push(spec);
 		}
+
 		if (unmatched.length > 0) {
 			fail(
 				`These paths matched nothing: ${unmatched.map(terminalSafe).join(', ')}\n` +
-					'Refusing to report on the run. An unmatched path classifies as fork-only and ' +
+					'Refusing to report on the run. An unmatched path was never inspected and ' +
 					'reads as "nothing to send upstream".'
 			);
 		}
@@ -3581,7 +3673,7 @@ function main() {
 				upstreamRef: upstreamTree.sha,
 				upstreamUrl: redactUrl(upstreamUrl),
 				// A machine caller gets the staleness the text renderer prints, or
-				// it consumes fork-only verdicts from an old path set unwarned.
+				// it consumes comparisons from an old upstream tree unwarned.
 				upstreamAgeDays: upstream.ageDays,
 				upstreamAgeFrom: upstream.ageFrom,
 				upstreamStale: upstream.ageDays !== null && upstream.ageDays >= STALE_AFTER_DAYS,
@@ -3601,10 +3693,9 @@ function main() {
 	const RANK: Record<Relevance, number> = {
 		pristine: 0,
 		unmeasured: 1,
-		diverged: 2,
-		'fork-only': 3
+		diverged: 2
 	};
-	const shown = (values.all ? verdicts : verdicts.filter((v) => v.relevance !== 'fork-only'))
+	const shown = verdicts
 		.slice()
 		.sort(
 			(a, b) =>
@@ -3627,7 +3718,7 @@ function main() {
 	}
 	console.log('');
 	if (shown.length === 0) {
-		console.log(`No template-derived file changed (${verdicts.length} checked, all fork-only).`);
+		console.log('No changed file was found.');
 	} else {
 		for (const v of shown) {
 			const mark = v.report ? '>>' : '  ';

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -418,6 +418,9 @@ function transportRemote(url: string): string {
 }
 
 function rejectUnauthenticatedTransport(url: string): void {
+	if (/^[a-z][a-z0-9+.-]*::/i.test(url)) {
+		fail('Forced Git remote-helper syntax is not accepted for upstream evidence.');
+	}
 	if (/^(?:https|ssh|file):/i.test(url)) return;
 	if (isAbsolute(url)) return;
 	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
@@ -536,6 +539,12 @@ const DIFF_COMMAND_TIMEOUT_MS =
 	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_DIFF_TIMEOUT_MS ?? '')
 		? Number(process.env.UPSTREAM_REPORT_TEST_DIFF_TIMEOUT_MS)
 		: DEFAULT_DIFF_COMMAND_TIMEOUT_MS;
+const DEFAULT_DIFF_OPERATION_LIMIT = 2_000;
+let diffOperationsRemaining =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_DIFF_OPERATION_LIMIT ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_DIFF_OPERATION_LIMIT)
+		: DEFAULT_DIFF_OPERATION_LIMIT;
 const DEFAULT_HISTORY_OPERATION_LIMIT = 500;
 let historyOperationsRemaining =
 	process.env.NODE_ENV === 'test' &&
@@ -1369,9 +1378,23 @@ function sameRepository(left: string, right: string): boolean {
 
 function localRemotePath(url: string, root: string): string | null {
 	let candidate: string;
+	if (/^[\\/]{2}[^\\/]/.test(url)) {
+		fail('UNC paths are network transports and are not accepted as local upstream evidence.');
+	}
+	if (WINDOWS_SAFETY_MODE && /^[a-z]:(?![\\/])/i.test(url)) {
+		fail(
+			'Windows drive-relative paths are not accepted as upstream evidence. Use an absolute path.'
+		);
+	}
 	if (/^file:/i.test(url)) {
 		try {
-			candidate = fileURLToPath(url);
+			const parsed = new URL(url);
+			if (parsed.hostname !== '') {
+				fail(
+					'Hosted file URLs are network transports and are not accepted as local upstream evidence.'
+				);
+			}
+			candidate = fileURLToPath(parsed);
 		} catch {
 			fail(
 				`Cannot trust ${terminalUrl(url)} because its file URL cannot be resolved to one canonical local path.`
@@ -2776,9 +2799,22 @@ function textOf(bytes: Buffer): string | null {
 	}
 }
 
-function cacheBags(keys: string[], upstream: Upstream): void {
-	const unread = keys.filter((key) => !upstream.bags.has(key));
-	if (unread.length === 0) return;
+function takeSimilarityOperations(upstream: Upstream, count: number): boolean {
+	if (count > upstream.similarityOperationsRemaining) {
+		upstream.similarityOperationsRemaining = 0;
+		return false;
+	}
+	upstream.similarityOperationsRemaining -= count;
+	return true;
+}
+
+function cacheBags(keys: string[], upstream: Upstream): boolean {
+	const unread: string[] = [];
+	for (const key of keys) {
+		if (!takeSimilarityOperations(upstream, 1)) return false;
+		if (!upstream.bags.has(key)) unread.push(key);
+	}
+	if (unread.length === 0) return true;
 	const blobs = readBlobs(
 		[...new Set(unread.map((key) => upstream.candidates.get(key)!.sha))],
 		Math.max(0, BLOB_BATCH_BYTES - upstream.bagSourceBytes)
@@ -2821,6 +2857,7 @@ function cacheBags(keys: string[], upstream: Upstream): void {
 		}
 		upstream.bags.set(key, cached);
 	}
+	return true;
 }
 
 const POTENTIAL_TEXT_EXTENSIONS = new Set([
@@ -2882,7 +2919,13 @@ function searchSimilar(
 	upstream: Upstream,
 	unreadableIsUnknown = false
 ): SimilarityResult {
-	cacheBags(candidates, upstream);
+	if (!cacheBags(candidates, upstream)) {
+		return {
+			path: null,
+			measured: false,
+			note: 'similarity comparison exceeded the bounded operation count'
+		};
+	}
 	let best = SIMILAR_ENOUGH;
 	let bestPath: string | null = null;
 	let missing = false;
@@ -2891,6 +2934,10 @@ function searchSimilar(
 	let unreadable = false;
 	let operationsExhausted = false;
 	for (const key of candidates) {
+		if (!takeSimilarityOperations(upstream, 1)) {
+			operationsExhausted = true;
+			break;
+		}
 		const cached = upstream.bags.get(key)!;
 		if (cached.kind === 'missing') {
 			missing = true;
@@ -2917,11 +2964,10 @@ function searchSimilar(
 		const operations =
 			mine.lines.size +
 			(mine.grams && cached.bag.grams ? mine.grams.length + cached.bag.grams.length : 0);
-		if (operations > upstream.similarityOperationsRemaining) {
+		if (!takeSimilarityOperations(upstream, operations)) {
 			operationsExhausted = true;
 			break;
 		}
-		upstream.similarityOperationsRemaining -= operations;
 		const score = blobSimilarity(mine, cached.bag);
 		if (score >= best) {
 			best = score;
@@ -3015,7 +3061,17 @@ function similarTo(content: Buffer, path: string, upstream: Upstream): Similarit
 	if (first.path !== null) return first;
 
 	const same = new Set(sameExtension);
-	const rest = upstream.blobKeys.filter((candidate) => !same.has(candidate));
+	const rest: string[] = [];
+	for (const candidate of upstream.blobKeys) {
+		if (!takeSimilarityOperations(upstream, 1)) {
+			return {
+				path: null,
+				measured: false,
+				note: 'similarity comparison exceeded the bounded operation count'
+			};
+		}
+		if (!same.has(candidate)) rest.push(candidate);
+	}
 	const widened = searchSimilar(source.bag, rest, upstream);
 	if (widened.path !== null) return widened;
 	return {
@@ -3029,6 +3085,7 @@ interface ContentSet {
 	values: Buffer[];
 	incompleteNote?: string;
 	missing?: boolean;
+	fingerprintHint?: string;
 }
 
 function symlinkParent(path: string): string | null {
@@ -3043,6 +3100,10 @@ function symlinkParent(path: string): string | null {
 
 function sameFileIdentity(left: Stats, right: Stats): boolean {
 	return left.dev === right.dev && left.ino === right.ino;
+}
+
+function statFingerprint(stats: Stats): string {
+	return [stats.dev, stats.ino, stats.mode, stats.size, stats.mtimeMs, stats.ctimeMs].join(':');
 }
 
 function workingTreeContent(path: string, maxBytes = CAPTURE_LIMIT): ContentSet {
@@ -3060,7 +3121,8 @@ function workingTreeContent(path: string, maxBytes = CAPTURE_LIMIT): ContentSet 
 			if (target.length > maxBytes) {
 				return {
 					values: [],
-					incompleteNote: 'working-tree content exceeds the bounded capture size'
+					incompleteNote: 'working-tree content exceeds the bounded capture size',
+					fingerprintHint: statFingerprint(initial)
 				};
 			}
 			const changedParent = symlinkParent(path);
@@ -3095,7 +3157,8 @@ function workingTreeContent(path: string, maxBytes = CAPTURE_LIMIT): ContentSet 
 			if (opened.size > maxBytes) {
 				return {
 					values: [],
-					incompleteNote: 'working-tree content exceeds the bounded capture size'
+					incompleteNote: 'working-tree content exceeds the bounded capture size',
+					fingerprintHint: statFingerprint(opened)
 				};
 			}
 
@@ -3132,6 +3195,8 @@ function fingerprintContent(content: ContentSet): string {
 	const hash = createHash('sha256');
 	hash.update(content.missing ? 'missing\0' : 'present\0');
 	hash.update(content.incompleteNote ?? '');
+	hash.update('\0');
+	hash.update(content.fingerprintHint ?? '');
 	for (const value of content.values) {
 		hash.update(String(value.length));
 		hash.update('\0');
@@ -3164,6 +3229,13 @@ function capturedDiff(
 	before: Buffer,
 	after: Buffer
 ): { output: Buffer | null; incompleteNote?: string } {
+	if (diffOperationsRemaining <= 0) {
+		return {
+			output: null,
+			incompleteNote: 'shared-path comparison exceeded the bounded diff command count'
+		};
+	}
+	diffOperationsRemaining--;
 	if (!scratchDir) fail('The scratch directory disappeared before captured content was compared.');
 	const id = randomUUID();
 	const beforePath = join(scratchDir, `${id}-before`);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -559,6 +559,12 @@ const PATH_LIMIT =
 	process.env.NODE_ENV === 'test' && /^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_PATH_LIMIT ?? '')
 		? Number(process.env.UPSTREAM_REPORT_TEST_PATH_LIMIT)
 		: DEFAULT_PATH_LIMIT;
+const DEFAULT_CHANGED_REGION_LIMIT = 8 * 1024 * 1024;
+const CHANGED_REGION_LIMIT =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_CHANGED_REGION_LIMIT ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_CHANGED_REGION_LIMIT)
+		: DEFAULT_CHANGED_REGION_LIMIT;
 const DEFAULT_DIFF_COMMAND_TIMEOUT_MS = 30_000;
 const DIFF_COMMAND_TIMEOUT_MS =
 	process.env.NODE_ENV === 'test' &&
@@ -1126,20 +1132,39 @@ interface Region {
  * `---content`, and skipping it discards the only evidence a one-line change
  * has.
  */
-export function changedRegionLines(unifiedDiff: string): Region[] {
+function changedRegionLinesWithin(unifiedDiff: string, maxRepresentation: number): Region[] | null {
 	const regions: Region[] = [];
 	let current: Region | null = null;
-	for (const line of unifiedDiff.split('\n')) {
-		if (line.startsWith('@@')) {
+	let representation = 0;
+	let start = 0;
+	while (start <= unifiedDiff.length) {
+		const newline = unifiedDiff.indexOf('\n', start);
+		const end = newline === -1 ? unifiedDiff.length : newline;
+		const lineLength = end - start;
+		representation += 32 + lineLength * 2;
+		if (representation > maxRepresentation) return null;
+		if (
+			lineLength >= 2 &&
+			unifiedDiff.charCodeAt(start) === 0x40 &&
+			unifiedDiff.charCodeAt(start + 1) === 0x40
+		) {
+			representation += 64;
+			if (representation > maxRepresentation) return null;
 			current = { removed: [], context: [] };
 			regions.push(current);
-			continue;
+		} else if (current && lineLength > 0) {
+			const prefix = unifiedDiff.charCodeAt(start);
+			if (prefix === 0x2d) current.removed.push(unifiedDiff.slice(start + 1, end));
+			else if (prefix === 0x20) current.context.push(unifiedDiff.slice(start + 1, end));
 		}
-		if (!current) continue;
-		if (line.startsWith('-')) current.removed.push(line.slice(1));
-		else if (line.startsWith(' ')) current.context.push(line.slice(1));
+		if (newline === -1) break;
+		start = end + 1;
 	}
 	return regions;
+}
+
+export function changedRegionLines(unifiedDiff: string): Region[] {
+	return changedRegionLinesWithin(unifiedDiff, Number.MAX_SAFE_INTEGER) ?? [];
 }
 
 /**
@@ -4029,12 +4054,21 @@ function verdictFor(
 	for (const after of afterValues) {
 		const captured = capturedDiff(baseBlob, after);
 		if (captured.incompleteNote) incompleteNote ??= captured.incompleteNote;
+		if (captured.output && captured.output.length > CHANGED_REGION_LIMIT) {
+			incompleteNote ??= 'one shared-path diff exceeds the bounded changed-region representation';
+			continue;
+		}
 		const diff = captured.output ? textOf(captured.output) : null;
 		if (diff === null) {
 			incompleteNote ??= 'one shared-path diff is not valid UTF-8 text';
 			continue;
 		}
-		const score = regionOverlapWithLines(changedRegionLines(diff), upstreamLines);
+		const regions = changedRegionLinesWithin(diff, CHANGED_REGION_LIMIT);
+		if (regions === null) {
+			incompleteNote ??= 'one shared-path diff exceeds the bounded changed-region representation';
+			continue;
+		}
+		const score = regionOverlapWithLines(regions, upstreamLines);
 		if (score !== null) overlap = overlap === null ? score : Math.max(overlap, score);
 		sawBinary ||= /^Binary files/m.test(diff);
 	}

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -1496,6 +1496,27 @@ function requireMarkerAtHead(head: string, marker: MarkerSnapshot): void {
 	}
 }
 
+function markerAtCommit(commit: string): MarkerSnapshot {
+	const record = gitZ(
+		['ls-tree', '-z', commit, '--', `:(literal)${MARKER}`],
+		false,
+		HISTORY_COMMAND_TIMEOUT_MS
+	)[0];
+	if (!record) return { url: DEFAULT_UPSTREAM, bytes: null, provenance: [] };
+	const tab = record.indexOf('\t');
+	const [mode, type, sha] = tab === -1 ? [] : record.slice(0, tab).split(' ');
+	if ((mode !== '100644' && mode !== '100755') || type !== 'blob' || !sha) {
+		fail(`${MARKER} at the selected base must be a regular file.`);
+	}
+	const size = Number(git(['cat-file', '-s', sha], false, HISTORY_COMMAND_TIMEOUT_MS));
+	if (!Number.isFinite(size) || size > MAX_MARKER_BYTES) {
+		fail(`${MARKER} at the selected base exceeds the ${MAX_MARKER_BYTES}-byte input limit.`);
+	}
+	return markerSnapshotFromBytes(
+		gitBytes(['cat-file', 'blob', sha], false, {}, HISTORY_COMMAND_TIMEOUT_MS)
+	);
+}
+
 // Compare the server address Git will actually use. Credentials do not identify
 // an HTTPS repository; transport syntax, path roots, trailing suffixes and SSH
 // users do. Servers are free to map each of those to different repositories.
@@ -2034,11 +2055,6 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 		rejectUrlRewrite(originUrl);
 		rejectOwnedRepositoryRemote(originUrl, root, 'origin');
 	}
-	if (originUrl && sameRepository(originUrl, upstreamUrl)) {
-		console.error('This repository IS the upstream template. Nothing to report upstream.');
-		process.exit(2);
-	}
-
 	let remoteUrl = configuredRemoteUrl('upstream');
 	const haveRef = () => git(['rev-parse', '--verify', '--quiet', UPSTREAM_REF], true) !== '';
 	const remoteMatches = (url: string) => url !== '' && sameRepository(url, upstreamUrl);
@@ -2509,7 +2525,11 @@ function verifyOriginSnapshot(snapshot: OriginSnapshot): void {
  * classifies against another; a sibling branch passed here reported an empty
  * list and exited zero.
  */
-function resolveBase(head: string, explicit?: string): BaseResolution {
+function resolveBase(
+	head: string,
+	explicit?: string,
+	beforeOriginValidation?: (base: string) => void
+): BaseResolution {
 	const ref = explicit ?? 'origin/main';
 	const resolved = git(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], true);
 	if (!resolved) {
@@ -2520,7 +2540,6 @@ function resolveBase(head: string, explicit?: string): BaseResolution {
 				'would report an empty diff for a branch full of changes.'
 		);
 	}
-	const origin = explicit ? null : trustedOriginSnapshot(resolved);
 	const mergeBases = git(['merge-base', '--all', head, resolved], true).split('\n').filter(Boolean);
 	if (mergeBases.length === 0) {
 		fail(
@@ -2535,7 +2554,10 @@ function resolveBase(head: string, explicit?: string): BaseResolution {
 				'Refusing to choose one arbitrarily and omit changes from the report.'
 		);
 	}
-	return { base: mergeBases[0]!, origin };
+	const base = mergeBases[0]!;
+	beforeOriginValidation?.(base);
+	const origin = explicit ? null : trustedOriginSnapshot(resolved);
+	return { base, origin };
 }
 
 /**
@@ -4140,11 +4162,23 @@ function main() {
 	const upstreamUrl = marker.url;
 	const originUrlAtStart = configuredRemoteUrl('origin');
 	if (originUrlAtStart) rejectUrlRewrite(originUrlAtStart);
-	if (originUrlAtStart && sameRepository(originUrlAtStart, upstreamUrl)) {
-		console.error('This repository IS the upstream template. Nothing to report upstream.');
-		process.exit(2);
-	}
-	const baseResolution = resolveBase(head, values.base as string | undefined);
+	const baseResolution = resolveBase(head, values.base as string | undefined, (base) => {
+		if (!originUrlAtStart) return;
+		const baseMarker = markerAtCommit(base);
+		if (
+			sameRepository(originUrlAtStart, DEFAULT_UPSTREAM) ||
+			sameRepository(originUrlAtStart, baseMarker.url)
+		) {
+			console.error('This repository IS the upstream template. Nothing to report upstream.');
+			process.exit(2);
+		}
+		if (sameRepository(originUrlAtStart, upstreamUrl)) {
+			fail(
+				`${MARKER}.upstreamUrl names this fork's origin, but the selected base did not. ` +
+					'Refusing branch-controlled template self-detection.'
+			);
+		}
+	});
 	const base = baseResolution.base;
 	if (
 		positionals.length > 0 &&

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -1559,6 +1559,94 @@ function localGitPath(remotePath: string, args: string[], allowFail = false): st
 
 const MAX_ALTERNATE_DEPTH = 5;
 
+function decodeAlternatePath(bytes: Buffer): string {
+	if (bytes.includes(0)) fail('A local upstream alternates entry contains a NUL byte.');
+	try {
+		return PATH_UTF8.decode(bytes);
+	} catch {
+		fail('A local upstream alternates entry is not valid UTF-8.');
+	}
+}
+
+const C_ESCAPE_BYTES = new Map([
+	[0x61, 0x07],
+	[0x62, 0x08],
+	[0x66, 0x0c],
+	[0x6e, 0x0a],
+	[0x72, 0x0d],
+	[0x74, 0x09],
+	[0x76, 0x0b],
+	[0x5c, 0x5c],
+	[0x22, 0x22]
+]);
+
+function unquoteAlternatePath(line: Buffer): { path: string; consumed: number } | null {
+	if (line[0] !== 0x22) return null;
+	const output: number[] = [];
+	for (let index = 1; index < line.length; index++) {
+		const byte = line[index]!;
+		if (byte === 0x22) {
+			return { path: decodeAlternatePath(Buffer.from(output)), consumed: index + 1 };
+		}
+		if (byte !== 0x5c) {
+			output.push(byte);
+			continue;
+		}
+		const escaped = line[++index];
+		if (escaped === undefined) return null;
+		const decoded = C_ESCAPE_BYTES.get(escaped);
+		if (decoded !== undefined) {
+			output.push(decoded);
+			continue;
+		}
+		const second = line[index + 1];
+		const third = line[index + 2];
+		if (
+			escaped < 0x30 ||
+			escaped > 0x33 ||
+			second === undefined ||
+			second < 0x30 ||
+			second > 0x37 ||
+			third === undefined ||
+			third < 0x30 ||
+			third > 0x37
+		) {
+			return null;
+		}
+		output.push((escaped - 0x30) * 64 + (second - 0x30) * 8 + (third - 0x30));
+		index += 2;
+	}
+	return null;
+}
+
+function alternatePaths(objectDir: string): string[] {
+	const alternatesPath = join(objectDir, 'info', 'alternates');
+	if (!existsSync(alternatesPath)) return [];
+	const paths: string[] = [];
+	const file = readFileSync(alternatesPath);
+	let start = 0;
+	for (let end = 0; end <= file.length; end++) {
+		if (end < file.length && file[end] !== 0x0a) continue;
+		const line = file.subarray(start, end);
+		start = end + 1;
+		if (line.length === 0 || line[0] === 0x23) continue;
+		if (line[0] !== 0x22) {
+			paths.push(decodeAlternatePath(line));
+			continue;
+		}
+		const quoted = unquoteAlternatePath(line);
+		if (!quoted) {
+			fail('A local upstream alternates entry has malformed C-style quoting.');
+		}
+		const trailing = line.subarray(quoted.consumed);
+		if (trailing.length > 1 || (trailing.length === 1 && trailing[0] !== 0x0d)) {
+			fail('A local upstream alternates entry has bytes after its closing quote.');
+		}
+		paths.push(quoted.path);
+	}
+	return paths;
+}
+
 function addAlternateObjectStores(
 	objectDir: string,
 	effectivePaths: Set<string>,
@@ -1569,12 +1657,7 @@ function addAlternateObjectStores(
 	if (seen.has(canonical)) return;
 	seen.add(canonical);
 	effectivePaths.add(canonical);
-	const alternatesPath = join(canonical, 'info', 'alternates');
-	if (!existsSync(alternatesPath)) return;
-	const alternates = readFileSync(alternatesPath, 'utf8')
-		.split('\n')
-		.map((alternate) => alternate.replace(/\r$/, ''))
-		.filter(Boolean);
+	const alternates = alternatePaths(canonical);
 	if (alternates.length === 0 || depth + 1 > MAX_ALTERNATE_DEPTH) return;
 	for (const alternate of alternates) {
 		addAlternateObjectStores(
@@ -1633,18 +1716,13 @@ function inspectLocalRemote(
 		);
 		if (worktreeValue) effectivePaths.add(realpathSync(worktreeValue));
 		const alternateStores = new Set([objectDir]);
-		const alternatesPath = join(objectDir, 'info', 'alternates');
-		if (existsSync(alternatesPath)) {
-			for (const alternate of readFileSync(alternatesPath, 'utf8').split('\n')) {
-				const path = alternate.replace(/\r$/, '');
-				if (!path) continue;
-				addAlternateObjectStores(
-					isAbsolute(path) ? path : resolve(objectDir, path),
-					effectivePaths,
-					alternateStores,
-					0
-				);
-			}
+		for (const path of alternatePaths(objectDir)) {
+			addAlternateObjectStores(
+				isAbsolute(path) ? path : resolve(objectDir, path),
+				effectivePaths,
+				alternateStores,
+				0
+			);
 		}
 		// The common directory names refs directly. Keeping the wrapper worktree out
 		// of the transport removes its mutable .git indirection from later Git calls.

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -267,7 +267,10 @@ function trustedTransportEnv(): NodeJS.ProcessEnv {
 		GIT_SHALLOW_FILE: transportShallow,
 		GIT_CONFIG_NOSYSTEM: '1',
 		GIT_CONFIG_GLOBAL: NO_GRAFTS,
-		GIT_CONFIG_SYSTEM: NO_GRAFTS
+		GIT_CONFIG_SYSTEM: NO_GRAFTS,
+		// OpenSSH otherwise reads user and system host aliases, proxy commands, and
+		// host-key policy after Git's own configuration has been isolated.
+		GIT_SSH_COMMAND: 'ssh -F none'
 	};
 }
 
@@ -769,6 +772,7 @@ interface LocalRemoteSnapshot {
 	endpointPath: string;
 	transportPath: string;
 	identities: PathIdentity[];
+	fileFingerprints: Map<string, string>;
 }
 
 // Set once the real index has been copied aside; see the GIT_INDEX_FILE note.
@@ -1715,6 +1719,41 @@ function addAlternateObjectStores(
 	}
 }
 
+function addLocalRefBacking(
+	commonDir: string,
+	effectivePaths: Set<string>,
+	backingFiles: Set<string>
+): void {
+	for (const [kind, path] of [
+		['loose main ref', join(commonDir, 'refs', 'heads', 'main')],
+		['packed refs', join(commonDir, 'packed-refs')]
+	] as const) {
+		let stats: Stats;
+		try {
+			stats = lstatSync(path);
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+			throw err;
+		}
+		if (stats.isSymbolicLink()) {
+			fail(`A local upstream ${kind} is a filesystem symlink. Refusing indirect ref storage.`);
+		}
+		if (!stats.isFile()) {
+			fail(`A local upstream ${kind} is not a regular file.`);
+		}
+		const canonical = realpathSync(path);
+		effectivePaths.add(canonical);
+		backingFiles.add(canonical);
+		if (kind === 'loose main ref') {
+			if (stats.size > 1024) fail('A local upstream loose main ref is unexpectedly large.');
+			const value = readFileSync(canonical, 'utf8');
+			if (value.startsWith('ref:')) {
+				fail('A local upstream loose main ref is symbolic. Refusing indirect ref storage.');
+			}
+		}
+	}
+}
+
 function inspectLocalRemote(
 	url: string,
 	root: string,
@@ -1729,6 +1768,7 @@ function inspectLocalRemote(
 	const endpoint = statSync(remotePath);
 	let transportPath = remotePath;
 	const effectivePaths = new Set([remotePath]);
+	const backingFiles = new Set<string>();
 	if (endpoint.isDirectory()) {
 		const gitDirValue = localGitPath(remotePath, [
 			'rev-parse',
@@ -1755,6 +1795,7 @@ function inspectLocalRemote(
 		effectivePaths.add(gitDir);
 		effectivePaths.add(commonDir);
 		effectivePaths.add(objectDir);
+		addLocalRefBacking(commonDir, effectivePaths, backingFiles);
 		const worktreeValue = localGitPath(
 			remotePath,
 			['rev-parse', '--path-format=absolute', '--show-toplevel'],
@@ -1787,7 +1828,8 @@ function inspectLocalRemote(
 		root,
 		endpointPath: remotePath,
 		transportPath,
-		identities: identityChains(effectivePaths)
+		identities: identityChains(effectivePaths),
+		fileFingerprints: fileFingerprints(backingFiles)
 	};
 }
 
@@ -1803,7 +1845,8 @@ function verifyLocalRemoteSnapshot(url: string): void {
 	if (
 		!current ||
 		current.transportPath !== expected.transportPath ||
-		!sameIdentityChains(current.identities, expected.identities)
+		!sameIdentityChains(current.identities, expected.identities) ||
+		!sameStringMaps(current.fileFingerprints, expected.fileFingerprints)
 	) {
 		fail('A local upstream path or one of its ancestors changed during this report. Run it again.');
 	}
@@ -3538,6 +3581,14 @@ function sameIdentityChains(left: PathIdentity[], right: PathIdentity[]): boolea
 	);
 }
 
+function fileFingerprints(paths: Iterable<string>): Map<string, string> {
+	return new Map([...paths].map((path) => [path, statFingerprint(statSync(path))]));
+}
+
+function sameStringMaps(left: Map<string, string>, right: Map<string, string>): boolean {
+	return left.size === right.size && [...left].every(([key, value]) => right.get(key) === value);
+}
+
 function pathResolvesInsideOwnedRoot(candidate: string, ownedRoots: Iterable<string>): boolean {
 	const roots = [...ownedRoots];
 	const rootStats = roots.map((root) => statSync(root));
@@ -4162,6 +4213,7 @@ function main() {
 	const upstreamUrl = marker.url;
 	const originUrlAtStart = configuredRemoteUrl('origin');
 	if (originUrlAtStart) rejectUrlRewrite(originUrlAtStart);
+	rejectTransportCommandOverrides();
 	const baseResolution = resolveBase(head, values.base as string | undefined, (base) => {
 		if (!originUrlAtStart) return;
 		const baseMarker = markerAtCommit(base);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -237,7 +237,7 @@ function quotedGitConfig(value: string): string {
 	for (const character of value) {
 		const code = character.charCodeAt(0);
 		if (code <= 7 || (code >= 11 && code <= 31) || code === 127) {
-			fail('Git authentication config contains a control character that cannot be copied safely.');
+			fail('Git transport config contains a control character that cannot be copied safely.');
 		}
 	}
 	return `"${value
@@ -252,25 +252,25 @@ function appendTransportConfig(configPath: string, key: string, value: string): 
 	const first = key.indexOf('.');
 	const last = key.lastIndexOf('.');
 	if (first <= 0 || last === key.length - 1) {
-		fail('Git returned an authentication config key that cannot be copied safely.');
+		fail('Git returned an transport config key that cannot be copied safely.');
 	}
 	const section = key.slice(0, first);
 	const name = key.slice(last + 1);
 	if (!/^[a-z][a-z0-9-]*$/i.test(section) || !/^[a-z][a-z0-9-]*$/i.test(name)) {
-		fail('Git returned an authentication config key that cannot be copied safely.');
+		fail('Git returned an transport config key that cannot be copied safely.');
 	}
 	const header =
 		first === last ? `[${section}]` : `[${section} ${quotedGitConfig(key.slice(first + 1, last))}]`;
 	writeFileSync(configPath, `${header}\n\t${name} = ${quotedGitConfig(value)}\n`, { flag: 'a' });
 }
 
-function copyTransportAuthentication(configPath: string): void {
+function copyTransportConfiguration(configPath: string): void {
 	const output = gitBytes(
 		[
 			'config',
 			'--null',
 			'--get-regexp',
-			'^(credential\\.|http\\..*\\.(extraheader|sslcert|sslkey|sslcertpasswordprotected)$)'
+			'^(credential\\.|http\\..*\\.(extraheader|pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslcert|proxysslcertpasswordprotected|proxysslkey|proxysslverify|sslcainfo|sslcert|sslcertpasswordprotected|sslkey|sslverify)$)'
 		],
 		true
 	);
@@ -754,7 +754,7 @@ function useScratchIndex(root: string): void {
 			: '[core]\nrepositoryformatversion = 0\nbare = true\n'
 	);
 	chmodSync(transportConfigPath, 0o600);
-	copyTransportAuthentication(transportConfigPath);
+	copyTransportConfiguration(transportConfigPath);
 	writeFileSync(transportShallow, Buffer.alloc(0));
 	const copy = join(scratchDir, 'index');
 	writeFileSync(copy, indexAtCopy);
@@ -2337,7 +2337,8 @@ function readBlobs(shas: string[], maxSourceBytes = Number.POSITIVE_INFINITY): M
 	if (unique.length === 0) return out;
 	const sizeResult = gitPartialBytes(
 		['cat-file', '--batch-check=%(objectname) %(objecttype) %(objectsize)'],
-		unique.join('\n') + '\n'
+		unique.join('\n') + '\n',
+		HISTORY_COMMAND_TIMEOUT_MS
 	);
 	if (!sizeResult.complete) return out;
 	const sizes = new Map<string, number>();
@@ -2355,7 +2356,8 @@ function readBlobs(shas: string[], maxSourceBytes = Number.POSITIVE_INFINITY): M
 				input: batch.join('\n') + '\n',
 				maxBuffer: BLOB_OUTPUT_LIMIT,
 				env: gitRunEnv(),
-				stdio: ['pipe', 'pipe', 'pipe']
+				stdio: ['pipe', 'pipe', 'pipe'],
+				timeout: HISTORY_COMMAND_TIMEOUT_MS
 			});
 		} catch {
 			return;

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -60,6 +60,7 @@ import {
 	statSync,
 	writeFileSync
 } from 'node:fs';
+import type { Stats } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -883,7 +884,9 @@ function lineRepresentationCost(content: string): number {
 		const newline = content.indexOf('\n', start);
 		const end = newline === -1 ? content.length : newline;
 		const line = content.slice(start, end).trim();
-		if (meaningful(line)) cost += 32 + line.length;
+		// countLines materializes one split entry per line, including entries that
+		// are too short to compare. Charge each slot before allocating the array.
+		cost += 32 + line.length;
 		if (newline === -1) break;
 		start = newline + 1;
 	}
@@ -2096,14 +2099,18 @@ function changedPaths(base: string, head: string): string[] {
 		const paths: string[] = [];
 		for (let i = 0; i < fields.length; i++) {
 			const status = fields[i];
+			if (status === undefined) break;
 			// Rename and copy statuses carry a similarity score and two paths;
 			// every other status carries one.
 			if (/^[RC]\d*$/.test(status)) {
-				if (fields[i + 1]) paths.push(fields[i + 1]);
-				if (fields[i + 2]) paths.push(fields[i + 2]);
+				const source = fields[i + 1];
+				const destination = fields[i + 2];
+				if (source !== undefined) paths.push(source);
+				if (destination !== undefined) paths.push(destination);
 				i += 2;
 			} else if (/^[A-Z]\d*$/.test(status)) {
-				if (fields[i + 1]) paths.push(fields[i + 1]);
+				const path = fields[i + 1];
+				if (path !== undefined) paths.push(path);
 				i += 1;
 			}
 		}
@@ -2771,10 +2778,7 @@ function symlinkParent(path: string): string | null {
 	return null;
 }
 
-function sameFileIdentity(
-	left: ReturnType<typeof lstatSync>,
-	right: ReturnType<typeof lstatSync>
-): boolean {
+function sameFileIdentity(left: Stats, right: Stats): boolean {
 	return left.dev === right.dev && left.ino === right.ino;
 }
 
@@ -3303,7 +3307,7 @@ function callerPathspec(root: string, calledFrom: string, spec: string): string 
 function commandLineArguments() {
 	try {
 		return parseArgs({
-			args: Bun.argv.slice(2),
+			args: process.argv.slice(2),
 			options: {
 				base: { type: 'string' },
 				fetch: { type: 'boolean', default: false },
@@ -3326,6 +3330,7 @@ function commandLineArguments() {
 
 function main() {
 	const { values, positionals } = commandLineArguments();
+	if (positionals.some((spec) => spec === '')) fail('Path arguments must not be empty.');
 
 	const root = git(['rev-parse', '--show-toplevel']);
 	// Where the caller typed the command, kept because every path argument was

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -150,22 +150,13 @@ function gitBooleanIsFalse(value: string | undefined): boolean {
 	return value !== undefined && /^(?:|0|false|no|off)$/i.test(value);
 }
 
-function protocolAllowsAlways(protocol: string): boolean {
-	return transportProtocolPolicies.get(protocol) === 'always';
-}
-
 function transportProtocolEnv(): NodeJS.ProcessEnv {
 	const inherited = inheritedEnvironment('GIT_ALLOW_PROTOCOL');
 	const fromUser = inheritedEnvironment('GIT_PROTOCOL_FROM_USER');
 	const userProtocolsDisabled = gitBooleanIsFalse(fromUser);
 	const permitted = inherited
 		?.split(':')
-		.filter(
-			(protocol) =>
-				PRIVATE_TRANSPORT_PROTOCOLS.has(protocol) &&
-				!(userProtocolsDisabled && protocol === 'file') &&
-				protocolAllowsAlways(protocol)
-		)
+		.filter((protocol) => PRIVATE_TRANSPORT_PROTOCOLS.has(protocol))
 		.join(':');
 	return {
 		...(permitted === undefined ? {} : { GIT_ALLOW_PROTOCOL: permitted }),
@@ -336,7 +327,7 @@ function copyTransportConfiguration(configPath: string): void {
 			'config',
 			'--null',
 			'--get-regexp',
-			'^(credential\\.|http\\.(pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslverify|sslbackend|sslcainfo|sslcapath|sslverify)$|http\\..*\\.(extraheader|pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslcert|proxysslcertpasswordprotected|proxysslkey|proxysslverify|sslcainfo|sslcapath|sslcert|sslcertpasswordprotected|sslkey|sslverify)$|protocol\\..*\\.allow$|remote\\..*\\.(proxy|proxyauthmethod)$)'
+			'^(credential\\.|http\\.(pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslverify|sslbackend|sslcainfo|sslcapath|sslverify)$|http\\..*\\.(extraheader|pinnedpubkey|proxy|proxyauthmethod|proxysslcainfo|proxysslcert|proxysslcertpasswordprotected|proxysslkey|proxysslverify|sslcainfo|sslcapath|sslcert|sslcertpasswordprotected|sslkey|sslverify)$|protocol(\\.[^.]*)?\\.allow$|remote\\..*\\.(proxy|proxyauthmethod)$)'
 		],
 		true
 	);
@@ -345,6 +336,10 @@ function copyTransportConfiguration(configPath: string): void {
 		if (newline === -1) continue;
 		const key = record.slice(0, newline);
 		const value = record.slice(newline + 1);
+		if (key.toLowerCase() === 'protocol.allow') {
+			transportProtocolPolicies.set('*', value.toLowerCase());
+			continue;
+		}
 		const protocol = /^protocol\.([^.]+)\.allow$/i.exec(key)?.[1];
 		if (protocol) {
 			transportProtocolPolicies.set(protocol, value.toLowerCase());
@@ -364,6 +359,10 @@ function copyTransportConfiguration(configPath: string): void {
 		}
 		appendTransportConfig(configPath, key, value);
 	}
+	const globalProtocolPolicy = transportProtocolPolicies.get('*') ?? '';
+	if (globalProtocolPolicy !== '' && !/^(?:always|never|user)$/.test(globalProtocolPolicy)) {
+		fail('Git protocol.allow has an invalid policy.');
+	}
 	appendTransportConfig(configPath, 'protocol.allow', 'never');
 	for (const [protocol, fallback] of [
 		['file', 'user'],
@@ -374,7 +373,9 @@ function copyTransportConfiguration(configPath: string): void {
 		if (configured !== '' && !/^(?:always|never|user)$/.test(configured)) {
 			fail(`Git protocol.${protocol}.allow has an invalid policy.`);
 		}
-		const policy = configured || fallback;
+		const policy =
+			configured ||
+			(/^(?:never|user)$/.test(globalProtocolPolicy) ? globalProtocolPolicy : fallback);
 		transportProtocolPolicies.set(protocol, policy);
 		appendTransportConfig(configPath, `protocol.${protocol}.allow`, policy);
 	}
@@ -1108,17 +1109,14 @@ function hunkOverlap(region: Region, upstreamLines: Map<string, number>): number
 	const lines = removed.length > 0 ? removed : context;
 	if (lines.length === 0) return null;
 
-	// A private tally per hunk. Sharing one would let an earlier hunk consume the
-	// upstream lines a later hunk needs, so a file's score would depend on hunk
-	// order.
-	const available = new Map(upstreamLines);
+	// Count only lines this hunk uses. Cloning the complete upstream tally for
+	// every hunk turns a sparse diff into a hunk-by-file cross-product.
+	const used = new Map<string, number>();
 	let hits = 0;
 	for (const line of lines) {
-		const left = available.get(line) ?? 0;
-		if (left > 0) {
-			hits++;
-			available.set(line, left - 1);
-		}
+		const count = (used.get(line) ?? 0) + 1;
+		used.set(line, count);
+		if (count <= (upstreamLines.get(line) ?? 0)) hits++;
 	}
 	return hits / lines.length;
 }
@@ -1375,7 +1373,9 @@ function localRemotePath(url: string, root: string): string | null {
 		try {
 			candidate = fileURLToPath(url);
 		} catch {
-			return null;
+			fail(
+				`Cannot trust ${terminalUrl(url)} because its file URL cannot be resolved to one canonical local path.`
+			);
 		}
 	} else if (isAbsolute(url)) {
 		candidate = url;
@@ -1387,7 +1387,9 @@ function localRemotePath(url: string, root: string): string | null {
 	try {
 		return realpathSync(candidate);
 	} catch {
-		return null;
+		fail(
+			`Cannot trust ${terminalUrl(url)} because its local path cannot be resolved to one canonical location.`
+		);
 	}
 }
 
@@ -1662,6 +1664,8 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 				"`git remote set-url` on its own leaves the previous remote's tracking ref behind."
 		);
 	}
+	const transportUrl = remoteUrl || upstreamUrl;
+	if (remoteUrl) rejectOwnedRepositoryRemote(remoteUrl, root, 'configured upstream');
 
 	// A tracking ref with no remote behind it proves nothing about which
 	// repository it came from. An orphan left by a former parent fork makes paths
@@ -1688,9 +1692,9 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 		const zeroOid = '0'.repeat(objectFormat === 'sha256' ? 64 : 40);
 		const refBeforeFetch = haveRef() ? git(['rev-parse', UPSTREAM_REF]) : zeroOid;
 		let addedRemote = false;
-		const transport = transportRemote(upstreamUrl);
+		const transport = transportRemote(transportUrl);
 		console.error(`Fetching upstream (${terminalUrl(upstreamUrl)}) ...`);
-		const expected = advertisedMainAt(upstreamUrl);
+		const expected = advertisedMainAt(transportUrl);
 		try {
 			rejectTransportCommandOverrides();
 			gitBytes(
@@ -1716,7 +1720,7 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 		}
 		if (
 			!expected ||
-			advertisedMainAt(upstreamUrl) !== expected ||
+			advertisedMainAt(transportUrl) !== expected ||
 			git(['cat-file', '-t', expected], true) !== 'commit'
 		) {
 			fail('Upstream main changed or its fetched commit is unavailable. Run the report again.');
@@ -1872,7 +1876,7 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 	}
 	const liveAdvertisementMatches = Number.isFinite(recordedFetch)
 		? false
-		: advertisedMainAt(upstreamUrl) === sha;
+		: advertisedMainAt(finalUrl) === sha;
 	const committed = Number(git(['log', '-1', '--format=%ct', sha], true));
 	const measured = Number.isFinite(fetched) && fetched > 0 ? fetched : committed;
 	const ageDays = Number.isFinite(measured)
@@ -1903,7 +1907,7 @@ function verifyUpstreamSnapshot(upstreamUrl: string, snapshot: UpstreamSnapshot)
 				'Run it again after the sync or fetch finishes.'
 		);
 	}
-	if (snapshot.verifyAdvertisedMain && advertisedMainAt(upstreamUrl) !== snapshot.sha) {
+	if (snapshot.verifyAdvertisedMain && advertisedMainAt(snapshot.remoteUrl) !== snapshot.sha) {
 		fail('Upstream main changed during this report. Run it again on the settled remote.');
 	}
 }

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -1,0 +1,3667 @@
+#!/usr/bin/env bun
+/**
+ * upstream-relevance.ts: decide, per changed file, whether a change could
+ * belong in the upstream template.
+ *
+ * This exists so the question stops being a judgement call. A fork accumulates
+ * its own code next to copied template code, and after a few months nobody can
+ * tell them apart by looking. Guessing goes both ways: template bugs get fixed
+ * privately and every other fork keeps them, or fork-only work gets offered
+ * upstream where it makes no sense.
+ *
+ * Four outcomes, every one of them measured:
+ *
+ *   fork-only  every available path, blob, name and text comparison ruled out
+ *              a tie to upstream. Nothing to report.
+ *   pristine   the path exists upstream and, BEFORE this change, was identical
+ *              to it. Editing untouched template code is the strongest signal
+ *              there is: whatever was wrong there is wrong upstream too.
+ *   diverged   the path exists upstream but the fork had already rewritten it.
+ *              Only here does the line-level check earn its cost.
+ *   unmeasured a comparison was unavailable or found a possible tie: binary
+ *              content, a missing partial-clone blob, a submodule, a renamed or
+ *              copied file. Reported, because missing evidence proves nothing.
+ *
+ * Every failure mode here is asymmetric, and the code leans one way throughout.
+ * A false "look at this" costs one glance. A false "nothing to report" loses a
+ * fix for every other fork, permanently and silently. So anything the detector
+ * cannot establish is surfaced or made fatal, never quietly resolved as a
+ * negative.
+ *
+ * Read-only inside the repository unless --fetch is explicit. Default base
+ * validation reads origin with ls-remote; fetch mode may add the upstream remote,
+ * update its tracking ref, and record the fetch time in local Git config.
+ *
+ * Usage:
+ *   bun .agents/skills/upstream-report/scripts/upstream-relevance.ts [paths...]
+ *     --base <ref>   compare from the merge base with this ref instead of origin/main
+ *     --fetch        allow creating the upstream remote and fetching it (writes git state)
+ *     --json         machine-readable output
+ *     --all          list fork-only files too (default: only what could matter)
+ */
+import { execFileSync } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import {
+	chmodSync,
+	closeSync,
+	constants as fsConstants,
+	existsSync,
+	fstatSync,
+	lstatSync,
+	mkdtempSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	readlinkSync,
+	readSync,
+	readdirSync,
+	realpathSync,
+	rmSync,
+	statSync,
+	writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+const DEFAULT_UPSTREAM = 'https://github.com/stickerdaniel/saas-starter.git';
+const MARKER = '.upstream-sync.json';
+const UPSTREAM_REF = 'refs/remotes/upstream/main';
+const UPSTREAM_FETCH_CONFIG = 'upstreamReport.lastFetch';
+const MAX_MARKER_BYTES = 1024 * 1024;
+const TEMP_ROOT = tmpdir();
+const NO_GRAFTS = process.platform === 'win32' ? 'NUL' : '/dev/null';
+
+// Two days of upstream commits added seven paths that an old copy could not
+// compare. One full day is the first age the summary calls stale; the warning,
+// JSON flag and summary all use this threshold.
+const STALE_AFTER_DAYS = 1;
+
+// Overlap ranks a shared file's changes; it does NOT gate them. Three review
+// rounds each found a new input where a threshold silently dropped a real
+// finding, because the underlying question is undecidable from line matching:
+// a removed line absent upstream is either fork-only code or a template line
+// this fork had renamed, and nothing in the diff distinguishes them. The last
+// measurement settled it: on the branch that carried this repository's one
+// genuine upstream bug, a 20% gate suppressed exactly that file at 15%.
+//
+// So every shared file that changed is reported, ordered by how much of what it
+// replaced still exists upstream. That costs about five extra glances on a
+// forty-file branch and removes the whole class of silent false negatives.
+
+// Every repository-local variable git documents. Leaving GIT_COMMON_DIR in
+// place lets an inherited value point the whole run at another repository's
+// refs and config, which reads as a completely normal set of wrong verdicts.
+const SCRUBBED = [
+	'GIT_DIR',
+	'GIT_WORK_TREE',
+	'GIT_IMPLICIT_WORK_TREE',
+	'GIT_INDEX_FILE',
+	'GIT_OBJECT_DIRECTORY',
+	'GIT_COMMON_DIR',
+	'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+	'GIT_CEILING_DIRECTORIES',
+	'GIT_CONFIG',
+	'GIT_CONFIG_PARAMETERS',
+	'GIT_GRAFT_FILE',
+	'GIT_NO_REPLACE_OBJECTS',
+	'GIT_REPLACE_REF_BASE',
+	'GIT_PREFIX',
+	'GIT_SHALLOW_FILE',
+	'GIT_NAMESPACE',
+	'GIT_ALLOW_PROTOCOL',
+	'GIT_PROTOCOL_FROM_USER',
+	'GIT_SSH',
+	'GIT_SSH_COMMAND',
+	'GIT_SSH_VARIANT',
+	'GIT_PROXY_COMMAND',
+	'GIT_LITERAL_PATHSPECS',
+	'GIT_NOGLOB_PATHSPECS',
+	'GIT_GLOB_PATHSPECS',
+	'GIT_ICASE_PATHSPECS'
+];
+function gitEnv(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	const scrubbed = new Set(SCRUBBED.map((key) => key.toUpperCase()));
+	for (const key of Object.keys(env)) {
+		const normalized = key.toUpperCase();
+		if (
+			scrubbed.has(normalized) ||
+			/^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/.test(normalized) ||
+			normalized.startsWith('GIT_TRACE')
+		) {
+			delete env[key];
+		}
+	}
+	return env;
+}
+
+// Config pinned on every invocation, because each of these changes the answer
+// instead of failing:
+//   core.quotePath=false  the default returns a non-ASCII path as an escaped,
+//                         quoted string ("enc\303\266ded") that then fails when
+//                         handed straight back to rev-parse or diff.
+//   diff.ignoreSubmodules inherited as `all` it drops every submodule change
+//                         from all three diff collectors. Each diff also passes
+//                         --ignore-submodules=none, which overrides the stronger
+//                         per-submodule ignore setting.
+//   diff.renameLimit=0    keeps inexact rename detection exhaustive. A skipped
+//                         source loses the local blob that proves provenance.
+//   core.fsmonitor=       an fsmonitor hook is another program a read-only run
+//                         would execute, and it keeps a cache of its own.
+//   core.splitIndex=false prevents a copied ordinary index from creating shared
+//                         backing state in the repository during refresh.
+//   core.trustctime=true
+//   core.checkStat=default
+//   core.ignoreStat=false  keep same-size edits visible when repository config
+//                         weakens Git's stat-cache checks.
+//   color.ui=false        `always` prefixes diff markers with ANSI bytes, so the
+//                         hunk parser sees no `@@`, removal or context lines.
+//   advice.graftFileDeprecated=false  the empty null-device override otherwise warns
+//                         once per Git process and drowns out the report.
+const PINNED_CONFIG = [
+	'-c',
+	'core.quotePath=false',
+	'-c',
+	'diff.ignoreSubmodules=none',
+	'-c',
+	'diff.renameLimit=0',
+	'-c',
+	'core.fsmonitor=',
+	'-c',
+	'core.splitIndex=false',
+	'-c',
+	'core.trustctime=true',
+	'-c',
+	'core.checkStat=default',
+	'-c',
+	'core.ignoreStat=false',
+	'-c',
+	'color.ui=false',
+	'-c',
+	'advice.graftFileDeprecated=false'
+];
+
+/**
+ * The environment every git call in this file runs under. One function, because
+ * a read that skipped any of these would be a read this file promises it does
+ * not make.
+ */
+function gitRunEnv(): NodeJS.ProcessEnv {
+	ensureScratchIndexExists();
+	return {
+		...gitEnv(),
+		GIT_EXTERNAL_DIFF: '',
+		GIT_TERMINAL_PROMPT: '0',
+		// Every worktree read happens against a private copy of the index, so the
+		// refresh a stat-only mismatch triggers writes there. Without it a run
+		// takes index.lock in the caller's repository and can fail a concurrent
+		// `git add`. GIT_OPTIONAL_LOCKS is not the answer: on git 2.55 it
+		// suppresses the rewrite for `git status` and not for `git diff`, which is
+		// the command this file actually uses.
+		...(scratchIndex ? { GIT_INDEX_FILE: scratchIndex } : {}),
+		// Freeze the commit graph alongside the index. A shared shallow boundary can
+		// otherwise appear and disappear between matching endpoint snapshots.
+		...(scratchShallow ? { GIT_SHALLOW_FILE: scratchShallow } : {}),
+		GIT_OPTIONAL_LOCKS: '0',
+		// In a partial clone an ordinary read fetches missing objects from the
+		// promisor remote and writes a pack into the shared object store. That is
+		// network and disk from a command that promises neither.
+		GIT_NO_LAZY_FETCH: '1',
+		// Replacement refs make object readers see a different commit while
+		// rev-parse still prints the original SHA. Ignore them for every snapshot.
+		GIT_NO_REPLACE_OBJECTS: '1',
+		// Deleting GIT_GRAFT_FILE re-enables .git/info/grafts. The null device
+		// cannot be planted with graft records by another process.
+		GIT_GRAFT_FILE: NO_GRAFTS
+	};
+}
+
+function trustedTransportEnv(): NodeJS.ProcessEnv {
+	if (!transportGitDir || !transportObjectDir || !transportShallow) {
+		fail('The private transport repository is unavailable. Run the report again.');
+	}
+	return {
+		GIT_DIR: transportGitDir,
+		GIT_OBJECT_DIRECTORY: transportObjectDir,
+		GIT_SHALLOW_FILE: transportShallow,
+		GIT_CONFIG_NOSYSTEM: '1',
+		GIT_CONFIG_GLOBAL: NO_GRAFTS,
+		GIT_CONFIG_SYSTEM: NO_GRAFTS
+	};
+}
+
+function quotedGitConfig(value: string): string {
+	for (const character of value) {
+		const code = character.charCodeAt(0);
+		if (code <= 7 || (code >= 11 && code <= 31) || code === 127) {
+			fail('Git authentication config contains a control character that cannot be copied safely.');
+		}
+	}
+	return `"${value
+		.replace(/\\/g, '\\\\')
+		.replace(/"/g, '\\"')
+		.replaceAll(String.fromCharCode(8), '\\b')
+		.replace(/\t/g, '\\t')
+		.replace(/\n/g, '\\n')}"`;
+}
+
+function appendTransportConfig(configPath: string, key: string, value: string): void {
+	const first = key.indexOf('.');
+	const last = key.lastIndexOf('.');
+	if (first <= 0 || last === key.length - 1) {
+		fail('Git returned an authentication config key that cannot be copied safely.');
+	}
+	const section = key.slice(0, first);
+	const name = key.slice(last + 1);
+	if (!/^[a-z][a-z0-9-]*$/i.test(section) || !/^[a-z][a-z0-9-]*$/i.test(name)) {
+		fail('Git returned an authentication config key that cannot be copied safely.');
+	}
+	const header =
+		first === last ? `[${section}]` : `[${section} ${quotedGitConfig(key.slice(first + 1, last))}]`;
+	writeFileSync(configPath, `${header}\n\t${name} = ${quotedGitConfig(value)}\n`, { flag: 'a' });
+}
+
+function copyTransportAuthentication(configPath: string): void {
+	const output = gitBytes(
+		[
+			'config',
+			'--null',
+			'--get-regexp',
+			'^(credential\\.|http\\..*\\.(extraheader|sslcert|sslkey|sslcertpasswordprotected)$)'
+		],
+		true
+	);
+	for (const record of decodeZRecords(output)) {
+		const newline = record.indexOf('\n');
+		if (newline === -1) continue;
+		appendTransportConfig(configPath, record.slice(0, newline), record.slice(newline + 1));
+	}
+}
+
+function transportRemote(url: string): string {
+	const existing = transportRemotes.get(url);
+	if (existing) return existing;
+	if (!transportConfigPath) {
+		fail('The private transport configuration is unavailable. Run the report again.');
+	}
+	const name = `upstream-report-${createHash('sha256').update(url).digest('hex').slice(0, 16)}`;
+	appendTransportConfig(transportConfigPath, `remote.${name}.url`, url);
+	transportRemotes.set(url, name);
+	return name;
+}
+
+function rejectSecretBearingRemoteCreation(url: string): void {
+	let unsafe: boolean;
+	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
+		try {
+			const parsed = new URL(url);
+			const standardSshUser =
+				(parsed.protocol === 'ssh:' || parsed.protocol === 'git+ssh:') &&
+				parsed.username === 'git' &&
+				parsed.password === '';
+			unsafe =
+				parsed.search !== '' ||
+				parsed.hash !== '' ||
+				parsed.password !== '' ||
+				(parsed.username !== '' && !standardSshUser);
+		} catch {
+			unsafe = true;
+		}
+	} else {
+		const scpUser = /^([^/@:\s]+)@[^/:\s]+:/.exec(url)?.[1];
+		unsafe = scpUser !== undefined && scpUser !== 'git';
+	}
+	if (!unsafe) return;
+	fail(
+		`Cannot create the shared \`upstream\` remote from ${terminalUrl(url)} because its URL carries ` +
+			'userinfo, a query, or a fragment. Add a credential-free remote yourself and keep authentication ' +
+			'in a credential helper or URL-scoped HTTP config.'
+	);
+}
+
+// Enough for a whole repository's text read in one batch. An overrun is an
+// ENOBUFS throw, so this number is the difference between reading upstream and
+// failing the run.
+const MAX_GIT_OUTPUT = 256 * 1024 * 1024;
+const DEFAULT_BLOB_OUTPUT_LIMIT = 256 * 1024 * 1024;
+const BLOB_OUTPUT_LIMIT =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_BLOB_OUTPUT_LIMIT ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_BLOB_OUTPUT_LIMIT)
+		: DEFAULT_BLOB_OUTPUT_LIMIT;
+const BLOB_BATCH_BYTES = Math.max(1, Math.floor(BLOB_OUTPUT_LIMIT / 4));
+const BLOB_BATCH_ITEMS = 4096;
+const DEFAULT_CAPTURE_LIMIT = 256 * 1024 * 1024;
+const CAPTURE_LIMIT =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_CAPTURE_LIMIT ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_CAPTURE_LIMIT)
+		: DEFAULT_CAPTURE_LIMIT;
+// Character grams retain four bytes per input character before string and map
+// overhead. Large generated files stay visible without expanding into gigabytes.
+const DEFAULT_SIMILARITY_SOURCE_LIMIT = 8 * 1024 * 1024;
+const SIMILARITY_SOURCE_LIMIT =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_SIMILARITY_LIMIT ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_SIMILARITY_LIMIT)
+		: DEFAULT_SIMILARITY_SOURCE_LIMIT;
+// Character grams cost four bytes each; distinct-line map entries cost much more.
+// Weighted units bound both before either representation is retained.
+const DEFAULT_SIMILARITY_REPRESENTATION_LIMIT = 4 * 1024 * 1024;
+const SIMILARITY_REPRESENTATION_LIMIT =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_SIMILARITY_REPRESENTATION_LIMIT ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_SIMILARITY_REPRESENTATION_LIMIT)
+		: DEFAULT_SIMILARITY_REPRESENTATION_LIMIT;
+// Bound the cross-product of changed content and historical upstream candidates.
+// Representation limits cap memory; they do not cap repeated comparisons.
+const DEFAULT_SIMILARITY_OPERATION_LIMIT = 10_000_000;
+const SIMILARITY_OPERATION_LIMIT =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_SIMILARITY_OPERATION_LIMIT ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_SIMILARITY_OPERATION_LIMIT)
+		: DEFAULT_SIMILARITY_OPERATION_LIMIT;
+const DEFAULT_NETWORK_TIMEOUT_MS = 30_000;
+const NETWORK_TIMEOUT_MS =
+	process.env.NODE_ENV === 'test' && /^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_TIMEOUT_MS ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_TIMEOUT_MS)
+		: DEFAULT_NETWORK_TIMEOUT_MS;
+const DEFAULT_WORKTREE_TIMEOUT_MS = 30_000;
+const WORKTREE_TIMEOUT_MS =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_WORKTREE_TIMEOUT_MS ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_WORKTREE_TIMEOUT_MS)
+		: DEFAULT_WORKTREE_TIMEOUT_MS;
+const DEFAULT_PATH_LIMIT = 500_000;
+const PATH_LIMIT =
+	process.env.NODE_ENV === 'test' && /^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_PATH_LIMIT ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_PATH_LIMIT)
+		: DEFAULT_PATH_LIMIT;
+const DEFAULT_DIFF_COMMAND_TIMEOUT_MS = 30_000;
+const DIFF_COMMAND_TIMEOUT_MS =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_DIFF_TIMEOUT_MS ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_DIFF_TIMEOUT_MS)
+		: DEFAULT_DIFF_COMMAND_TIMEOUT_MS;
+const DEFAULT_HISTORY_OPERATION_LIMIT = 500;
+let historyOperationsRemaining =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_HISTORY_OPERATION_LIMIT ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_HISTORY_OPERATION_LIMIT)
+		: DEFAULT_HISTORY_OPERATION_LIMIT;
+const DEFAULT_HISTORY_COMMAND_TIMEOUT_MS = 5_000;
+const HISTORY_COMMAND_TIMEOUT_MS =
+	process.env.NODE_ENV === 'test' &&
+	/^\d+$/.test(process.env.UPSTREAM_REPORT_TEST_HISTORY_TIMEOUT_MS ?? '')
+		? Number(process.env.UPSTREAM_REPORT_TEST_HISTORY_TIMEOUT_MS)
+		: DEFAULT_HISTORY_COMMAND_TIMEOUT_MS;
+
+function gitBytes(
+	args: string[],
+	allowFail = false,
+	extraEnv: NodeJS.ProcessEnv = {},
+	timeout?: number
+): Buffer {
+	try {
+		const output = execFileSync('git', [...PINNED_CONFIG, ...args], {
+			env: { ...gitRunEnv(), ...extraEnv },
+			maxBuffer: MAX_GIT_OUTPUT,
+			stdio: ['pipe', 'pipe', 'pipe'],
+			timeout
+		});
+		ensureScratchIndexExists();
+		return output;
+	} catch (err) {
+		ensureScratchIndexExists();
+		if ((err as NodeJS.ErrnoException).code === 'ETIMEDOUT') {
+			fail(`Git operation timed out after ${Math.ceil((timeout ?? 0) / 1000)} seconds.`);
+		}
+		if (allowFail) return Buffer.alloc(0);
+		throw err;
+	}
+}
+
+function gitPartialBytes(
+	args: string[],
+	input?: string | Buffer,
+	timeout?: number
+): { output: Buffer; complete: boolean } {
+	try {
+		return {
+			output: execFileSync('git', [...PINNED_CONFIG, ...args], {
+				env: gitRunEnv(),
+				maxBuffer: MAX_GIT_OUTPUT,
+				input,
+				stdio: ['pipe', 'pipe', 'pipe'],
+				timeout
+			}),
+			complete: true
+		};
+	} catch (err) {
+		const output = (err as { stdout?: unknown }).stdout;
+		return { output: Buffer.isBuffer(output) ? output : Buffer.alloc(0), complete: false };
+	}
+}
+
+function git(args: string[], allowFail = false, timeout?: number): string {
+	return gitBytes(args, allowFail, {}, timeout).toString('utf8').trim();
+}
+
+/**
+ * A NUL-delimited path read. Decode each record strictly: Git permits arbitrary
+ * non-NUL bytes in a pathname, while JavaScript strings replace malformed UTF-8
+ * with U+FFFD and can collapse two distinct paths into one map key.
+ */
+const PATH_UTF8 = new TextDecoder('utf-8', { fatal: true });
+function decodeZRecords(output: Buffer): string[] {
+	const records: string[] = [];
+	let start = 0;
+	for (let end = 0; end <= output.length; end++) {
+		if (end < output.length && output[end] !== 0) continue;
+		if (end > start) {
+			try {
+				records.push(PATH_UTF8.decode(output.subarray(start, end)));
+			} catch {
+				fail(
+					'Git returned a pathname that is not valid UTF-8. Rename it before running this report.'
+				);
+			}
+		}
+		start = end + 1;
+	}
+	return records;
+}
+
+function gitZ(args: string[], allowFail = false, timeout?: number): string[] {
+	return decodeZRecords(gitBytes(args, allowFail, {}, timeout));
+}
+
+function historyGitBytes(args: string[]): Buffer {
+	if (historyOperationsRemaining <= 0) throw new Error('local history operation limit reached');
+	historyOperationsRemaining--;
+	try {
+		const output = execFileSync('git', [...PINNED_CONFIG, ...args], {
+			env: gitRunEnv(),
+			maxBuffer: MAX_GIT_OUTPUT,
+			stdio: ['pipe', 'pipe', 'pipe'],
+			timeout: HISTORY_COMMAND_TIMEOUT_MS
+		});
+		ensureScratchIndexExists();
+		return output;
+	} catch (err) {
+		ensureScratchIndexExists();
+		throw err;
+	}
+}
+
+function historyGit(args: string[]): string {
+	return historyGitBytes(args).toString('utf8').trim();
+}
+
+function historyGitZ(args: string[]): string[] {
+	return decodeZRecords(historyGitBytes(args));
+}
+
+/**
+ * A remote URL can carry a token (https://<PAT>@github.com/owner/repo.git).
+ * Every URL here exists to be compared or printed, so it is redacted before it
+ * reaches a terminal, an agent transcript or a CI log.
+ */
+const redactUrl = (u: string) =>
+	u
+		.replace(/(^[a-z][a-z0-9+.-]*:\/\/)[^/?#]*@/i, '$1***@')
+		.replace(/^[^/@:]+@([^:]+:)/, '***@$1')
+		.replace(/\?[\s\S]*$/, '?***')
+		.replace(/#[\s\S]*$/, '#***');
+
+const OUTPUT_CONTROL = /[\u007f-\u009f\u061c\u200e\u200f\u2028-\u202e\u2066-\u2069]/g;
+const escapeOutputControls = (value: string) =>
+	value.replace(
+		OUTPUT_CONTROL,
+		(control) => `\\u${control.charCodeAt(0).toString(16).padStart(4, '0')}`
+	);
+const terminalSafe = (value: string) => escapeOutputControls(JSON.stringify(value).slice(1, -1));
+const terminalUrl = (value: string) => terminalSafe(redactUrl(value));
+
+// A prefix of its own, so a leftover copy is distinguishable from the temp
+// repositories the integration tests build under the same directory.
+const SCRATCH_PREFIX = 'upstream-relevance-index-';
+
+// Set once the real index has been copied aside; see the GIT_INDEX_FILE note.
+let scratchIndex: string | undefined;
+let scratchShallow: string | undefined;
+let scratchDir: string | undefined;
+let transportGitDir: string | undefined;
+let transportConfigPath: string | undefined;
+let transportObjectDir: string | undefined;
+let transportShallow: string | undefined;
+let ownedRepositoryPaths: Set<string> | undefined;
+const transportRemotes = new Map<string, string>();
+let callerIndexPath: string | undefined;
+let callerShallowPath: string | undefined;
+let callerIndexAtCopy: Buffer | null = null;
+let callerShallowAtCopy: Buffer | null = null;
+let scratchShallowAtCopy: Buffer | null = null;
+let scratchIndexEntriesAtCopy: Buffer | null = null;
+
+/** An hour is far longer than a run and far shorter than a working day. */
+const LEFTOVER_AFTER_MS = 60 * 60 * 1000;
+
+function sweepLeftovers(tempRoot: string): void {
+	// Whatever ended the last run, its copy is still here. Anything younger than
+	// an hour may belong to a run happening right now.
+	let names: string[];
+	try {
+		names = readdirSync(tempRoot);
+	} catch {
+		return;
+	}
+	for (const name of names) {
+		if (!name.startsWith(SCRATCH_PREFIX)) continue;
+		try {
+			const dir = join(tempRoot, name);
+			if (Date.now() - statSync(dir).mtimeMs < LEFTOVER_AFTER_MS) continue;
+			const owner = Number(readFileSync(join(dir, 'owner'), 'utf8'));
+			if (!Number.isInteger(owner) || owner <= 0) continue;
+			try {
+				process.kill(owner, 0);
+				continue;
+			} catch {
+				// The owning process is gone; this directory is abandoned.
+			}
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// Another report may remove its directory between listing and inspection.
+		}
+	}
+}
+
+function ensureScratchIndexExists(): void {
+	if (!scratchIndex) return;
+	if (!existsSync(scratchIndex)) {
+		fail('The private scratch index disappeared during this report. Run it again.');
+	}
+	if (scratchShallow && !existsSync(scratchShallow)) {
+		fail('The private shallow snapshot disappeared during this report. Run it again.');
+	}
+	if (
+		scratchShallow &&
+		scratchShallowAtCopy &&
+		!readFileSync(scratchShallow).equals(scratchShallowAtCopy)
+	) {
+		fail('The private shallow snapshot changed during this report. Run it again.');
+	}
+}
+
+function verifyScratchIndexEntries(): void {
+	if (!scratchIndexEntriesAtCopy) return;
+	ensureScratchIndexExists();
+	const current = gitBytes(['ls-files', '--stage', '-z']);
+	if (!current.equals(scratchIndexEntriesAtCopy)) {
+		fail('The private scratch index entries changed during this report. Run it again.');
+	}
+}
+
+function indexHasSplitLink(index: Buffer, hashLength: number): boolean {
+	if (index.length < 12 + hashLength || index.subarray(0, 4).toString('ascii') !== 'DIRC') {
+		fail('The Git index has an unreadable header.');
+	}
+	const version = index.readUInt32BE(4);
+	if (version < 2 || version > 4) fail(`Git index version ${version} is not supported.`);
+	const entries = index.readUInt32BE(8);
+	let offset = 12;
+	for (let i = 0; i < entries; i++) {
+		const start = offset;
+		const fixed = 40 + hashLength;
+		if (offset + fixed + 2 > index.length - hashLength)
+			fail('The Git index entry table is truncated.');
+		offset += fixed;
+		const flags = index.readUInt16BE(offset);
+		offset += 2;
+		if ((flags & 0x4000) !== 0) offset += 2;
+		if (version === 4) {
+			while (offset < index.length && (index[offset++]! & 0x80) !== 0) {
+				// Skip the pathname-prefix varint. Only its end matters here.
+			}
+		}
+		const nul = index.indexOf(0, offset);
+		if (nul < 0 || nul >= index.length - hashLength)
+			fail('The Git index pathname table is truncated.');
+		offset = nul + 1;
+		if (version < 4) while ((offset - start) % 8 !== 0) offset++;
+	}
+	const checksum = index.length - hashLength;
+	while (offset + 8 <= checksum) {
+		const signature = index.subarray(offset, offset + 4).toString('ascii');
+		const size = index.readUInt32BE(offset + 4);
+		offset += 8;
+		if (offset + size > checksum) fail('The Git index extension table is truncated.');
+		if (signature === 'link') return true;
+		offset += size;
+	}
+	return false;
+}
+
+function useScratchIndex(root: string): void {
+	if (!isAbsolute(TEMP_ROOT)) {
+		fail(
+			'The system temporary directory must be an absolute path. Refusing to write inside the repository.'
+		);
+	}
+	let rootPath: string;
+	let tempPath: string;
+	let commonPath: string;
+	let gitPath: string;
+	let objectPath: string;
+	try {
+		rootPath = realpathSync(root);
+		tempPath = realpathSync(TEMP_ROOT);
+		commonPath = realpathSync(git(['rev-parse', '--path-format=absolute', '--git-common-dir']));
+		gitPath = realpathSync(git(['rev-parse', '--path-format=absolute', '--git-dir']));
+		objectPath = realpathSync(
+			git(['rev-parse', '--path-format=absolute', '--git-path', 'objects'])
+		);
+	} catch {
+		fail('The system temporary directory or Git storage is not readable.');
+	}
+	const ownedRoots = new Set([rootPath, commonPath, gitPath]);
+	const worktreeFields = decodeZRecords(gitBytes(['worktree', 'list', '--porcelain', '-z'])).filter(
+		(field) => field.startsWith('worktree ')
+	);
+	if (worktreeFields.length === 0) {
+		fail('Git did not identify any checkout for this repository.');
+	}
+	for (const field of worktreeFields) {
+		let worktreePath: string;
+		try {
+			worktreePath = realpathSync(field.slice('worktree '.length));
+		} catch {
+			fail(
+				'Git listed a checkout whose path is not readable. Prune stale worktrees, then try again.'
+			);
+		}
+		if (worktreePath === commonPath) {
+			const configured = git(['config', '--get', 'core.worktree'], true);
+			if (!configured) {
+				fail(
+					'Git cannot identify the primary checkout for this separate Git directory. ' +
+						'Configure core.worktree before running the report from a linked worktree.'
+				);
+			}
+			worktreePath = realpathSync(
+				isAbsolute(configured) ? configured : resolve(commonPath, configured)
+			);
+		}
+		ownedRoots.add(worktreePath);
+		try {
+			ownedRoots.add(
+				realpathSync(git(['-C', worktreePath, 'rev-parse', '--path-format=absolute', '--git-dir']))
+			);
+		} catch {
+			fail("Git could not identify the storage for one of this repository's checkouts.");
+		}
+	}
+	ownedRepositoryPaths = new Set(ownedRoots);
+	const insideOwnedRoot = [...ownedRoots].some((ownedRoot) => {
+		const fromRoot = relative(ownedRoot, tempPath);
+		return (
+			fromRoot === '' ||
+			(!isAbsolute(fromRoot) && fromRoot !== '..' && !fromRoot.startsWith(`..${sep}`))
+		);
+	});
+	if (insideOwnedRoot) {
+		fail(
+			'The system temporary directory resolves inside this repository or its shared Git storage. Refusing to write or sweep it.'
+		);
+	}
+	sweepLeftovers(tempPath);
+	const realIndex = git(['rev-parse', '--git-path', 'index'], true);
+	if (!realIndex || !existsSync(realIndex)) {
+		fail(
+			'Upstream relevance requires an existing Git index to snapshot. Restore the index, then run the report again.'
+		);
+	}
+	callerIndexPath = realIndex;
+	const indexAtCopy = readFileSync(realIndex);
+	callerIndexAtCopy = indexAtCopy;
+	callerShallowPath = git(['rev-parse', '--git-path', 'shallow'], true) || undefined;
+	const shallowAtCopy = optionalFile(callerShallowPath);
+	callerShallowAtCopy = shallowAtCopy;
+	const objectFormat = git(['rev-parse', '--show-object-format'], true);
+	const hashLength = objectFormat === 'sha256' ? 32 : 20;
+	if (indexHasSplitLink(indexAtCopy, hashLength)) {
+		fail(
+			'Upstream relevance cannot read a split index without touching its shared backing file. ' +
+				'Disable core.splitIndex, then run the report again.'
+		);
+	}
+	scratchDir = mkdtempSync(join(tempPath, SCRATCH_PREFIX));
+	writeFileSync(join(scratchDir, 'owner'), String(process.pid));
+	transportGitDir = join(scratchDir, 'transport.git');
+	transportObjectDir = objectPath;
+	transportShallow = join(scratchDir, 'transport-shallow');
+	mkdirSync(join(transportGitDir, 'objects'), { recursive: true });
+	mkdirSync(join(transportGitDir, 'refs'));
+	writeFileSync(join(transportGitDir, 'HEAD'), 'ref: refs/heads/transport\n');
+	transportConfigPath = join(transportGitDir, 'config');
+	writeFileSync(
+		transportConfigPath,
+		objectFormat === 'sha256'
+			? '[core]\nrepositoryformatversion = 1\nbare = true\n[extensions]\nobjectFormat = sha256\n'
+			: '[core]\nrepositoryformatversion = 0\nbare = true\n'
+	);
+	chmodSync(transportConfigPath, 0o600);
+	copyTransportAuthentication(transportConfigPath);
+	writeFileSync(transportShallow, Buffer.alloc(0));
+	const copy = join(scratchDir, 'index');
+	writeFileSync(copy, indexAtCopy);
+	scratchIndex = copy;
+	scratchShallow = join(scratchDir, 'shallow');
+	scratchShallowAtCopy = shallowAtCopy ?? Buffer.alloc(0);
+	writeFileSync(scratchShallow, scratchShallowAtCopy);
+	scratchIndexEntriesAtCopy = gitBytes(['ls-files', '--stage', '-z']);
+}
+
+function dropScratchIndex(): void {
+	if (scratchDir) rmSync(scratchDir, { recursive: true, force: true });
+	scratchDir = undefined;
+	scratchIndex = undefined;
+	scratchShallow = undefined;
+	transportGitDir = undefined;
+	transportConfigPath = undefined;
+	transportObjectDir = undefined;
+	transportShallow = undefined;
+	ownedRepositoryPaths = undefined;
+	transportRemotes.clear();
+	callerIndexPath = undefined;
+	callerShallowPath = undefined;
+	callerIndexAtCopy = null;
+	callerShallowAtCopy = null;
+	scratchShallowAtCopy = null;
+	scratchIndexEntriesAtCopy = null;
+}
+
+function fail(message: string): never {
+	console.error(message);
+	process.exit(3);
+}
+
+export type Relevance = 'fork-only' | 'pristine' | 'diverged' | 'unmeasured';
+
+export interface FileVerdict {
+	path: string;
+	relevance: Relevance;
+	/** Fraction of the changed region that exists in the upstream copy. */
+	overlap?: number;
+	/** Why nothing could be measured, when relevance is `unmeasured`. */
+	note?: string;
+	/** Whether this file is worth a human or agent look. */
+	report: boolean;
+}
+
+/** One hunk's worth of evidence about where a change landed. */
+interface Region {
+	removed: string[];
+	context: string[];
+}
+
+/**
+ * One region per hunk, describing WHERE that hunk landed: everything it
+ * removed, plus the context git kept around it.
+ *
+ * Per hunk and not per file, because the two kinds of hunk are scored by
+ * different evidence (see regionOverlap) and pooling them lets one erase the
+ * other: a file that removes a fork-only call in one place and inserts a guard
+ * beside template code in another scored purely on the fork-only removal, which
+ * sorted the most upstream-shaped file in the branch to the bottom.
+ * Added lines are excluded on purpose. They are by
+ * definition absent upstream, so counting them would drive every overlap toward
+ * zero and hide exactly the pristine-file edits this is meant to catch.
+ *
+ * Only lines inside a hunk are read, so the `---`/`+++` file headers are
+ * already excluded by position. They are deliberately NOT filtered by prefix: a
+ * removed line whose own content starts with `--` reaches the parser as
+ * `---content`, and skipping it discards the only evidence a one-line change
+ * has.
+ */
+export function changedRegionLines(unifiedDiff: string): Region[] {
+	const regions: Region[] = [];
+	let current: Region | null = null;
+	for (const line of unifiedDiff.split('\n')) {
+		if (line.startsWith('@@')) {
+			current = { removed: [], context: [] };
+			regions.push(current);
+			continue;
+		}
+		if (!current) continue;
+		if (line.startsWith('-')) current.removed.push(line.slice(1));
+		else if (line.startsWith(' ')) current.context.push(line.slice(1));
+	}
+	return regions;
+}
+
+/**
+ * How much of a changed region still exists in the upstream copy of the file.
+ *
+ * Compared as a multiset of trimmed lines, so reindentation and moved code do
+ * not read as divergence. Blank lines and single-character lines (a lone brace)
+ * are dropped: they match everywhere and would inflate every score toward 1.
+ *
+ * Returns null when nothing comparable remains, which the caller must treat as
+ * "not measured" and never as an overlap of zero.
+ */
+export function regionOverlap(regions: Region[], upstreamContent: string): number | null {
+	return regionOverlapWithLines(regions, countLines(upstreamContent));
+}
+
+function regionOverlapWithLines(regions: Region[], available: Map<string, number>): number | null {
+	let best: number | null = null;
+	for (const region of regions) {
+		const score = hunkOverlap(region, available);
+		if (score !== null && (best === null || score > best)) best = score;
+	}
+	return best;
+}
+
+/** Trimmed, meaningful lines of a file with their multiplicities. */
+function countLines(content: string): Map<string, number> {
+	const available = new Map<string, number>();
+	for (const line of content.split('\n')) {
+		const t = line.trim();
+		if (!meaningful(t)) continue;
+		available.set(t, (available.get(t) ?? 0) + 1);
+	}
+	return available;
+}
+
+function lineRepresentationCost(content: string): number {
+	let cost = 0;
+	let start = 0;
+	while (start <= content.length) {
+		const newline = content.indexOf('\n', start);
+		const end = newline === -1 ? content.length : newline;
+		const line = content.slice(start, end).trim();
+		if (meaningful(line)) cost += 32 + line.length;
+		if (newline === -1) break;
+		start = newline + 1;
+	}
+	return cost;
+}
+
+function bagRepresentationCost(content: string): number {
+	let lines = 0;
+	let joinedLength = 0;
+	let start = 0;
+	while (start <= content.length) {
+		const newline = content.indexOf('\n', start);
+		const end = newline === -1 ? content.length : newline;
+		const line = content.slice(start, end).trim();
+		if (meaningful(line)) {
+			if (lines > 0) joinedLength++;
+			lines++;
+			joinedLength += line.length;
+		}
+		if (newline === -1) break;
+		start = newline + 1;
+	}
+	const grams = Math.max(0, joinedLength - GRAM_WIDTH + 1);
+	return lines * 32 + grams * Uint32Array.BYTES_PER_ELEMENT;
+}
+
+function bagOf(content: string): Bag {
+	const lines = countLines(content);
+	let total = 0;
+	for (const count of lines.values()) total += count;
+	const kept = content
+		.split('\n')
+		.map((line) => line.trim())
+		.filter(meaningful);
+	return { lines, total, ...(kept.length > 0 ? { grams: characterGrams(kept.join('\n')) } : {}) };
+}
+
+const meaningful = (s: string) => s.trim().length > 1;
+
+function hunkOverlap(region: Region, upstreamLines: Map<string, number>): number | null {
+	const removed = region.removed.map((l) => l.trim()).filter(meaningful);
+	const context = region.context.map((l) => l.trim()).filter(meaningful);
+	// Removed lines say what this change actually replaced, so they decide the
+	// verdict on their own whenever there are any. Mixing context in dilutes
+	// them: a one-line fix to template code carries six lines of surrounding
+	// fork-only context, and averaging the seven buries the one line that is
+	// the entire finding. Context is used only for a pure insertion, where
+	// there is nothing else to go on.
+	const lines = removed.length > 0 ? removed : context;
+	if (lines.length === 0) return null;
+
+	// A private tally per hunk. Sharing one would let an earlier hunk consume the
+	// upstream lines a later hunk needs, so a file's score would depend on hunk
+	// order.
+	const available = new Map(upstreamLines);
+	let hits = 0;
+	for (const line of lines) {
+		const left = available.get(line) ?? 0;
+		if (left > 0) {
+			hits++;
+			available.set(line, left - 1);
+		}
+	}
+	return hits / lines.length;
+}
+
+export function classifyVerdict(args: {
+	path: string;
+	existsUpstream: boolean;
+	baseMatchesUpstream: boolean;
+	overlap?: number | null;
+	unmeasuredNote?: string;
+}): FileVerdict {
+	if (!args.existsUpstream) return { path: args.path, relevance: 'fork-only', report: false };
+	if (args.baseMatchesUpstream) return { path: args.path, relevance: 'pristine', report: true };
+	if (args.overlap === null || args.overlap === undefined) {
+		return {
+			path: args.path,
+			relevance: 'unmeasured',
+			note: args.unmeasuredNote ?? 'no comparable text in the change',
+			report: true
+		};
+	}
+	return { path: args.path, relevance: 'diverged', overlap: args.overlap, report: true };
+}
+
+interface MarkerSnapshot {
+	url: string;
+	bytes: Buffer | null;
+	provenance: string[];
+}
+
+function readUpstreamMarker(root: string): MarkerSnapshot {
+	const p = join(root, MARKER);
+	// Open first and bind inspection plus reading to one descriptor. An atomic
+	// replacement between lstat and read used to select a different parent, then
+	// leave its remote and tracking ref behind when the final snapshot aborted.
+	let fd: number;
+	try {
+		fd = openSync(
+			p,
+			fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0) | (fsConstants.O_NONBLOCK ?? 0)
+		);
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException).code;
+		if (code === 'ENOENT') {
+			return { url: DEFAULT_UPSTREAM, bytes: null, provenance: [] };
+		}
+		if (code === 'ELOOP') {
+			fail(`${MARKER} must be a regular file. Symlinks cannot bind a repository to its parent.`);
+		}
+		fail(
+			`${MARKER} could not be opened: ${terminalSafe(
+				err instanceof Error ? err.message : String(err)
+			)}`
+		);
+	}
+	let bytes: Buffer;
+	try {
+		const opened = fstatSync(fd);
+		const atPath = lstatSync(p);
+		if (!opened.isFile() || !atPath.isFile() || !sameFileIdentity(opened, atPath)) {
+			fail(
+				`${MARKER} must be one stable regular file. Symlinks cannot bind a repository to its parent.`
+			);
+		}
+		if (opened.size > MAX_MARKER_BYTES) {
+			fail(`${MARKER} exceeds the ${MAX_MARKER_BYTES}-byte input limit.`);
+		}
+		bytes = Buffer.allocUnsafe(opened.size);
+		let total = 0;
+		while (total < bytes.length) {
+			const read = readSync(fd, bytes, total, bytes.length - total, total);
+			if (read === 0) break;
+			total += read;
+		}
+		const afterRead = fstatSync(fd);
+		const afterPath = lstatSync(p);
+		if (
+			total !== opened.size ||
+			afterRead.size !== opened.size ||
+			afterRead.mtimeMs !== opened.mtimeMs ||
+			afterRead.ctimeMs !== opened.ctimeMs ||
+			!afterPath.isFile() ||
+			!sameFileIdentity(opened, afterPath)
+		) {
+			fail(`${MARKER} changed while it was read. Run the report again on the settled file.`);
+		}
+	} catch (err) {
+		fail(
+			`${MARKER} exists but could not be read: ${terminalSafe(
+				err instanceof Error ? err.message : String(err)
+			)}`
+		);
+	} finally {
+		closeSync(fd);
+	}
+	let raw: string;
+	try {
+		raw = PATH_UTF8.decode(bytes);
+	} catch {
+		fail(`${MARKER} is not valid UTF-8.`);
+	}
+	try {
+		const marker: unknown = JSON.parse(raw);
+		if (!marker || Array.isArray(marker) || typeof marker !== 'object') {
+			fail(`${MARKER} must contain a JSON object.`);
+		}
+		const fields = marker as {
+			upstreamUrl?: unknown;
+			forkPoint?: unknown;
+			lastSynced?: unknown;
+		};
+		const upstreamUrl = fields.upstreamUrl;
+		if (upstreamUrl !== undefined && (typeof upstreamUrl !== 'string' || !upstreamUrl.trim())) {
+			fail(`${MARKER}.upstreamUrl must be a non-empty string when present.`);
+		}
+		const provenanceFields = [fields.forkPoint, fields.lastSynced];
+		if (
+			provenanceFields.some(
+				(value) =>
+					value !== undefined &&
+					(typeof value !== 'string' || !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(value))
+			)
+		) {
+			fail(`${MARKER}.forkPoint and .lastSynced must be full commit SHAs when present.`);
+		}
+		const provenance = provenanceFields.filter(
+			(value): value is string => typeof value === 'string'
+		);
+		return { url: upstreamUrl ?? DEFAULT_UPSTREAM, bytes, provenance };
+	} catch (err) {
+		if (err instanceof SyntaxError) {
+			fail(
+				`${MARKER} is not valid JSON: ${terminalSafe(err.message)}\n` +
+					'Refusing to fall back to the default template. That would classify this fork ' +
+					'against the wrong repository and every verdict would look normal.'
+			);
+		}
+		throw err;
+	}
+}
+
+function requireCleanUpstreamMarker(marker: MarkerSnapshot): void {
+	rejectHiddenIndexEntries([MARKER]);
+	const tracked = gitZ(['ls-files', '-z', '--', `:(literal)${MARKER}`]).includes(MARKER);
+	if (marker.bytes !== null && !tracked) {
+		fail(
+			`${MARKER} exists but is not tracked. Commit it before upstream relevance selects a parent.`
+		);
+	}
+	const status = gitBytes(
+		['status', '--porcelain=v2', '-z', '--untracked-files=all', '--', `:(literal)${MARKER}`],
+		false,
+		{},
+		WORKTREE_TIMEOUT_MS
+	);
+	if (status.length === 0) return;
+	fail(
+		`${MARKER} must be committed and clean before upstream relevance can select a parent. ` +
+			'Commit or restore it, then run the report again.'
+	);
+}
+
+function requireMarkerAtHead(head: string, marker: MarkerSnapshot): void {
+	const type = git(['cat-file', '-t', `${head}:${MARKER}`], true);
+	if (marker.bytes === null) {
+		if (!type) return;
+		fail(`${MARKER} appeared or disappeared while the report selected its parent.`);
+	}
+	if (type !== 'blob') {
+		fail(`${MARKER} does not match the committed file at HEAD.`);
+	}
+	const size = Number(git(['cat-file', '-s', `${head}:${MARKER}`]));
+	if (!Number.isFinite(size) || size > MAX_MARKER_BYTES) {
+		fail(`${MARKER} exceeds the ${MAX_MARKER_BYTES}-byte input limit at HEAD.`);
+	}
+	const committed = gitBytes(['show', `${head}:${MARKER}`]);
+	if (!committed.equals(marker.bytes)) {
+		fail(
+			`${MARKER} changed while the report selected its parent. Run it again on the settled file.`
+		);
+	}
+}
+
+// Compare the server address Git will actually use. Credentials do not identify
+// an HTTPS repository; transport syntax, path roots, trailing suffixes and SSH
+// users do. Servers are free to map each of those to different repositories.
+function normalizeRemote(u: string): string {
+	return u.replace(/^(https?:\/\/)[^/?#]*@/i, '$1');
+}
+
+function githubRepository(u: string): string | null {
+	const url = normalizeRemote(u);
+	const match =
+		/^https:\/\/github\.com\/([^/?#]+)\/([^/?#]+)\/?$/i.exec(url) ??
+		/^git@github\.com:([^/?#]+)\/([^/?#]+)\/?$/i.exec(url) ??
+		/^ssh:\/\/git@github\.com\/([^/?#]+)\/([^/?#]+)\/?$/i.exec(url);
+	if (!match) return null;
+	const repository = match[2]!.replace(/\.git$/i, '');
+	return repository ? `${match[1]!.toLowerCase()}/${repository.toLowerCase()}` : null;
+}
+
+function sameRepository(left: string, right: string): boolean {
+	if (normalizeRemote(left) === normalizeRemote(right)) return true;
+	const leftGithub = githubRepository(left);
+	return leftGithub !== null && leftGithub === githubRepository(right);
+}
+
+function localRemotePath(url: string, root: string): string | null {
+	let candidate: string;
+	if (/^file:/i.test(url)) {
+		try {
+			candidate = fileURLToPath(url);
+		} catch {
+			return null;
+		}
+	} else if (isAbsolute(url)) {
+		candidate = url;
+	} else if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url) || /^(?:[^/\\]+@)?[^/\\:]+:.+/.test(url)) {
+		return null;
+	} else {
+		candidate = resolve(root, url);
+	}
+	try {
+		return realpathSync(candidate);
+	} catch {
+		return null;
+	}
+}
+
+function rejectOwnedRepositoryRemote(url: string, root: string, remote: string): void {
+	const remotePath = localRemotePath(url, root);
+	if (!remotePath) return;
+	if (!ownedRepositoryPaths) {
+		fail('The repository checkout inventory is unavailable. Run the report again.');
+	}
+	const owned = [...ownedRepositoryPaths].some((ownedPath) => {
+		const fromOwned = relative(ownedPath, remotePath);
+		return (
+			fromOwned === '' ||
+			(!isAbsolute(fromOwned) && fromOwned !== '..' && !fromOwned.startsWith(`..${sep}`))
+		);
+	});
+	if (owned) {
+		fail(
+			`The ${remote} URL resolves inside a checkout or Git directory owned by this repository. ` +
+				'A repository-owned remote can follow branch-controlled refs and hide every committed change.'
+		);
+	}
+}
+
+function rejectUnverifiableFileModes(): void {
+	if (process.platform === 'win32') return;
+	if (git(['config', '--bool', '--get', 'core.fileMode'], true) === 'true') return;
+	fail(
+		'Git reports that this filesystem does not preserve executable bits. ' +
+			'The report cannot verify mode-only changes here.'
+	);
+}
+
+function rejectUnsafePartialClone(): void {
+	const promisor = git(['config', '--bool', '--get-regexp', '^remote\\..*\\.promisor$'], true)
+		.split('\n')
+		.some((line) => /\s+true$/i.test(line));
+	const partialClone = git(['config', '--get', 'extensions.partialClone'], true);
+	if (!promisor && !partialClone) return;
+	const match = /^git version (\d+)\.(\d+)/.exec(git(['version']));
+	const supportsNoLazyFetch =
+		match !== null && (Number(match[1]) > 2 || (Number(match[1]) === 2 && Number(match[2]) >= 45));
+	if (!supportsNoLazyFetch) {
+		fail(
+			'Git 2.45 or newer is required for a partial-clone report. Older Git can lazily fetch missing objects during a no-fetch run.'
+		);
+	}
+}
+
+function configuredRemoteUrl(remote: string): string {
+	const urls = decodeZRecords(
+		gitBytes(['config', '--null', '--get-all', `remote.${remote}.url`], true)
+	);
+	if (urls.length > 1) {
+		fail(
+			`The \`${remote}\` remote has multiple fetch URLs. Keep one URL before running this report.`
+		);
+	}
+	return urls[0] ?? '';
+}
+
+function rejectTransportCommandOverrides(): void {
+	const output = gitBytes(
+		['config', '--null', '--get-regexp', '^(core\\.sshcommand|core\\.gitproxy)$'],
+		true
+	);
+	for (const record of decodeZRecords(output)) {
+		const newline = record.indexOf('\n');
+		if (newline === -1) continue;
+		const key = record.slice(0, newline);
+		const value = record.slice(newline + 1).trim();
+		if (!value || (key.toLowerCase() === 'core.gitproxy' && /^none(?:\\s|$)/i.test(value))) {
+			continue;
+		}
+		const displayKey =
+			key.toLowerCase() === 'core.sshcommand' ? 'core.sshCommand' : 'core.gitProxy';
+		fail(
+			`Git transport command override ${displayKey} is active. ` +
+				'Remove it before trusting remote evidence.'
+		);
+	}
+}
+
+function rejectUrlRewrite(url: string): void {
+	const output = gitBytes(['config', '--null', '--get-regexp', '^url\\..*\\.insteadof$'], true);
+	for (const record of decodeZRecords(output)) {
+		const newline = record.indexOf('\n');
+		if (newline === -1) continue;
+		const replacementKey = record.slice(0, newline);
+		const prefix = record.slice(newline + 1);
+		if (!prefix || !url.startsWith(prefix)) continue;
+		const replacement = replacementKey.slice('url.'.length, -'.insteadof'.length);
+		fail(
+			`Git rewrites ${terminalUrl(url)} to ${terminalUrl(replacement)} through url.*.insteadOf. ` +
+				'Remove that rewrite before trusting remote evidence.'
+		);
+	}
+}
+
+/**
+ * Make `upstream/main` readable without writing anything, unless told to.
+ *
+ * Three things go wrong here if you let them, and all three end in confident
+ * wrong answers instead of errors:
+ *
+ * 1. `git remote add` and `git fetch` write config and refs that every linked
+ *    worktree shares, and the URL comes from a file the branch controls. So
+ *    they happen only under --fetch, never as a side effect of asking a
+ *    question.
+ * 2. An existing `upstream` ref may track a different repository. The name is
+ *    conventional, and a parent fork is the usual squatter. Its URL is checked
+ *    against the marker before the ref is trusted, because classifying against
+ *    the wrong tree produces a complete and plausible set of wrong verdicts.
+ * 3. A blobless fetch would set `promisor` and `partialclonefilter` on the
+ *    shared remote, so every later upstream blob read needs the network,
+ *    including `upstream-sync`'s. Not worth the saved bytes.
+ */
+interface UpstreamSnapshot {
+	sha: string;
+	ageDays: number | null;
+	ageFrom: string;
+	remoteUrl: string;
+	/** The tracking tree came from the configured upstream remote or this detector's fetch. */
+	identityTrusted: boolean;
+	/** Recheck a live advertisement used to bind this snapshot before output. */
+	verifyAdvertisedMain: boolean;
+	/** Only this run's explicit fetch can support a negative path verdict. */
+	absenceTrusted: boolean;
+}
+
+interface RefLogEntry {
+	sha: string;
+	timestamp: number;
+	subject: string;
+}
+
+function latestRefLogEntry(ref: string): RefLogEntry | null {
+	const line = git(['reflog', 'show', '-1', '--date=unix', '--format=%H%x09%gd%x09%gs', ref], true);
+	if (!line) return null;
+	const [sha = '', selector = '', subject = ''] = line.split('\t');
+	const timestamp = Number(/@\{(\d+)\}$/.exec(selector)?.[1] ?? NaN);
+	return sha && Number.isFinite(timestamp) ? { sha, timestamp, subject } : null;
+}
+
+function remoteFingerprint(url: string): string {
+	return createHash('sha256').update(normalizeRemote(url)).digest('hex');
+}
+
+function recordedFetchTimestamp(sha: string, url: string): number {
+	const value = git(['config', '--get', UPSTREAM_FETCH_CONFIG], true);
+	const match = /^([0-9a-f]+) (\d+) ([0-9a-f]{64})$/.exec(value);
+	if (!match || match[1] !== sha || match[3] !== remoteFingerprint(url)) return NaN;
+	const timestamp = Number(match[2]);
+	return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : NaN;
+}
+
+function refspecSourceForTarget(refspec: string, target: string): string | null {
+	const normalized = refspec.replace(/^\+/, '');
+	if (normalized.startsWith('^')) return null;
+	const colon = normalized.indexOf(':');
+	if (colon === -1) return null;
+	const source = normalized.slice(0, colon);
+	const destination = normalized.slice(colon + 1);
+	const star = destination.indexOf('*');
+	if (star === -1) return destination === target ? source : null;
+	if (destination.indexOf('*', star + 1) !== -1 || source.split('*').length !== 2) return null;
+	const prefix = destination.slice(0, star);
+	const suffix = destination.slice(star + 1);
+	if (!target.startsWith(prefix) || !target.endsWith(suffix)) return null;
+	const middle = target.slice(prefix.length, target.length - suffix.length);
+	return source.replace('*', middle);
+}
+
+function refPatternMatches(pattern: string, ref: string): boolean {
+	const star = pattern.indexOf('*');
+	if (star === -1) return pattern === ref;
+	if (pattern.indexOf('*', star + 1) !== -1) return false;
+	return ref.startsWith(pattern.slice(0, star)) && ref.endsWith(pattern.slice(star + 1));
+}
+
+function remoteMainRefspecIsCanonical(remote: string): boolean {
+	const refspecs = git(['config', '--get-all', `remote.${remote}.fetch`], true)
+		.split('\n')
+		.filter(Boolean);
+	if (
+		refspecs.some((refspec) => {
+			const normalized = refspec.replace(/^\+/, '');
+			return (
+				normalized.startsWith('^') && refPatternMatches(normalized.slice(1), 'refs/heads/main')
+			);
+		})
+	) {
+		return false;
+	}
+	const target = `refs/remotes/${remote}/main`;
+	const sources = refspecs
+		.map((refspec) => refspecSourceForTarget(refspec, target))
+		.filter((source): source is string => source !== null);
+	return sources.length > 0 && sources.every((source) => source === 'refs/heads/main');
+}
+
+function cameFromUpstreamMain(entry: RefLogEntry | null, sha: string): boolean {
+	if (!entry || entry.sha !== sha) return false;
+	const separator = entry.subject.lastIndexOf(': ');
+	if (separator === -1) return false;
+	const command = entry.subject.slice(0, separator).trim().split(/\s+/);
+	if (command[0] !== 'fetch' && command[0] !== 'pull') return false;
+	const configuredRemotes = new Set(git(['remote'], true).split('\n').filter(Boolean));
+	const namedRemotes = command.slice(1).filter((token) => configuredRemotes.has(token));
+	if (namedRemotes.length !== 1 || namedRemotes[0] !== 'upstream') return false;
+	const remoteIndex = command.lastIndexOf('upstream');
+	const refArguments = command.slice(remoteIndex + 1).filter((token) => !token.startsWith('-'));
+	const target = 'refs/remotes/upstream/main';
+	const mappedSources = refArguments
+		.map((refspec) => refspecSourceForTarget(refspec, target))
+		.filter((source): source is string => source !== null);
+	if (mappedSources.length > 0) {
+		return mappedSources.every((source) => source === 'refs/heads/main');
+	}
+	if (refArguments.some((ref) => ref === 'main' || ref === 'refs/heads/main')) return true;
+	return remoteMainRefspecIsCanonical('upstream');
+}
+
+function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean): UpstreamSnapshot {
+	rejectOwnedRepositoryRemote(upstreamUrl, root, 'marker upstream');
+	const originUrl = configuredRemoteUrl('origin');
+	if (originUrl) {
+		rejectUrlRewrite(originUrl);
+		rejectOwnedRepositoryRemote(originUrl, root, 'origin');
+	}
+	if (originUrl && sameRepository(originUrl, upstreamUrl)) {
+		console.error('This repository IS the upstream template. Nothing to report upstream.');
+		process.exit(2);
+	}
+
+	let remoteUrl = configuredRemoteUrl('upstream');
+	const haveRef = () => git(['rev-parse', '--verify', '--quiet', UPSTREAM_REF], true) !== '';
+	const remoteMatches = (url: string) => url !== '' && sameRepository(url, upstreamUrl);
+
+	if (remoteUrl && !remoteMatches(remoteUrl)) {
+		fail(
+			`The \`upstream\` remote points at ${terminalUrl(remoteUrl)}, but ${MARKER} names ` +
+				`${terminalUrl(upstreamUrl)}.\n` +
+				'Refusing to classify against a different repository. Every verdict would be wrong ' +
+				'and none would look it. Repoint the remote and fetch it, or correct the marker.\n' +
+				"`git remote set-url` on its own leaves the previous remote's tracking ref behind."
+		);
+	}
+
+	// A tracking ref with no remote behind it proves nothing about which
+	// repository it came from. An orphan left by a former parent fork makes paths
+	// from the real template look fork-only.
+	if (!remoteUrl && haveRef() && !allowFetch) {
+		fail(
+			`${UPSTREAM_REF} exists but no \`upstream\` remote is configured, so nothing ties it to ` +
+				`${terminalUrl(upstreamUrl)}.\nRun \`git remote add upstream <url> && git fetch upstream\`, ` +
+				'or re-run with --fetch.'
+		);
+	}
+
+	let fetchedSha: string | null = null;
+	if (allowFetch) {
+		rejectUrlRewrite(upstreamUrl);
+		const symbolicTarget = git(['symbolic-ref', '-q', UPSTREAM_REF], true);
+		if (symbolicTarget) {
+			fail(
+				`${UPSTREAM_REF} is a symbolic ref to ${terminalSafe(symbolicTarget)}. ` +
+					'Replace it with an ordinary remote-tracking ref before fetching.'
+			);
+		}
+		const objectFormat = git(['rev-parse', '--show-object-format'], true);
+		const zeroOid = '0'.repeat(objectFormat === 'sha256' ? 64 : 40);
+		const refBeforeFetch = haveRef() ? git(['rev-parse', UPSTREAM_REF]) : zeroOid;
+		const transport = transportRemote(upstreamUrl);
+		console.error(`Fetching upstream (${terminalUrl(upstreamUrl)}) ...`);
+		const expected = advertisedMainAt(upstreamUrl);
+		try {
+			rejectTransportCommandOverrides();
+			gitBytes(
+				[
+					'fetch',
+					'--quiet',
+					'--no-auto-maintenance',
+					'--refmap=',
+					'--no-tags',
+					'--no-write-fetch-head',
+					transport,
+					'refs/heads/main'
+				],
+				false,
+				trustedTransportEnv(),
+				NETWORK_TIMEOUT_MS
+			);
+		} catch {
+			fail(
+				`Could not fetch refs/heads/main from ${terminalUrl(upstreamUrl)}. ` +
+					'Refusing to reuse an older tracking ref.'
+			);
+		}
+		if (
+			!expected ||
+			advertisedMainAt(upstreamUrl) !== expected ||
+			git(['cat-file', '-t', expected], true) !== 'commit'
+		) {
+			fail('Upstream main changed or its fetched commit is unavailable. Run the report again.');
+		}
+		if (!remoteUrl) {
+			rejectSecretBearingRemoteCreation(upstreamUrl);
+			try {
+				git(['remote', 'add', 'upstream', upstreamUrl]);
+			} catch {
+				fail(`Could not add the \`upstream\` remote for ${terminalUrl(upstreamUrl)}.`);
+			}
+			remoteUrl = upstreamUrl;
+		}
+		if (normalizeRemote(configuredRemoteUrl('upstream')) !== normalizeRemote(remoteUrl)) {
+			fail(
+				'The shared upstream URL changed while this report fetched objects. ' +
+					'No tracking ref was written; run the report again.'
+			);
+		}
+		try {
+			git([
+				'update-ref',
+				'--no-deref',
+				'-m',
+				'fetch upstream main: upstream relevance',
+				UPSTREAM_REF,
+				expected,
+				refBeforeFetch
+			]);
+		} catch {
+			fail(
+				'The shared upstream tracking ref changed while this report fetched objects. ' +
+					'Run it again after the other fetch finishes.'
+			);
+		}
+		if (normalizeRemote(configuredRemoteUrl('upstream')) !== normalizeRemote(remoteUrl)) {
+			try {
+				git([
+					'update-ref',
+					'--no-deref',
+					'-m',
+					'roll back upstream relevance fetch after URL change',
+					UPSTREAM_REF,
+					refBeforeFetch,
+					expected
+				]);
+			} catch {
+				fail(
+					'The shared upstream URL changed after the tracking ref update, and the ref also moved before it could be rolled back.'
+				);
+			}
+			fail(
+				'The shared upstream URL changed after the tracking ref update. The ref was rolled back; run the report again.'
+			);
+		}
+		try {
+			// A no-op update-ref writes no reflog entry. Keep the fetched SHA, time,
+			// and URL identity together so a later no-fetch run can bind this copy.
+			git([
+				'config',
+				'--local',
+				UPSTREAM_FETCH_CONFIG,
+				`${expected} ${Math.floor(Date.now() / 1000)} ${remoteFingerprint(upstreamUrl)}`
+			]);
+		} catch {
+			fail(
+				'The upstream fetch succeeded, but its fetch time could not be recorded in local Git config.'
+			);
+		}
+		fetchedSha = expected;
+	}
+
+	if (!haveRef()) {
+		fail(
+			`No local copy of upstream (${UPSTREAM_REF} is missing).\n` +
+				`Upstream relevance is UNKNOWN for this run. Say so; "nothing to report" is a different answer.\n` +
+				'Run `git fetch upstream main:refs/remotes/upstream/main` (add the remote first if needed), ' +
+				'or re-run with --fetch.'
+		);
+	}
+
+	// Pin the tree between two checks of the shared remote. A final check after
+	// classification also catches a sync that lands while the pinned tree is read.
+	const sha = fetchedSha ?? git(['rev-parse', UPSTREAM_REF]);
+	const checkedUrl = configuredRemoteUrl('upstream');
+	const checkedSha = git(['rev-parse', UPSTREAM_REF]);
+	if (!remoteMatches(checkedUrl) || checkedSha !== sha) {
+		fail(
+			'The shared `upstream` remote or its main tracking ref changed while this report started. ' +
+				'Run it again after the sync or fetch finishes.'
+		);
+	}
+	remoteUrl = checkedUrl;
+
+	if (fetchedSha !== null) {
+		return {
+			sha,
+			ageDays: 0,
+			ageFrom: 'fetch',
+			remoteUrl,
+			identityTrusted: true,
+			verifyAdvertisedMain: true,
+			absenceTrusted: true
+		};
+	}
+
+	// Only the newest ref movement can describe the pinned tree. An older fetch
+	// cannot lend its timestamp to a ref that another command later restored.
+	const entry = latestRefLogEntry(UPSTREAM_REF);
+	const reflogFetch = cameFromUpstreamMain(entry, sha) ? entry!.timestamp : NaN;
+	const recordedFetch = recordedFetchTimestamp(sha, upstreamUrl);
+	const fetched = Math.max(
+		Number.isFinite(reflogFetch) ? reflogFetch : 0,
+		Number.isFinite(recordedFetch) ? recordedFetch : 0
+	);
+	const finalUrl = configuredRemoteUrl('upstream');
+	const finalSha = git(['rev-parse', UPSTREAM_REF]);
+	if (!remoteMatches(finalUrl) || finalSha !== sha) {
+		fail(
+			'The shared `upstream` remote or its main tracking ref changed while this report started. ' +
+				'Run it again after the sync or fetch finishes.'
+		);
+	}
+	const liveAdvertisementMatches = Number.isFinite(recordedFetch)
+		? false
+		: advertisedMainAt(upstreamUrl) === sha;
+	const committed = Number(git(['log', '-1', '--format=%ct', sha], true));
+	const measured = Number.isFinite(fetched) && fetched > 0 ? fetched : committed;
+	const ageDays = Number.isFinite(measured)
+		? Math.floor((Date.now() / 1000 - measured) / 86400)
+		: null;
+	const ageFrom = Number.isFinite(fetched) && fetched > 0 ? 'fetch' : 'tip commit';
+	return {
+		sha,
+		ageDays,
+		ageFrom,
+		remoteUrl: finalUrl,
+		identityTrusted: Number.isFinite(recordedFetch) || liveAdvertisementMatches,
+		verifyAdvertisedMain: !Number.isFinite(recordedFetch) && liveAdvertisementMatches,
+		absenceTrusted: false
+	};
+}
+
+function verifyUpstreamSnapshot(upstreamUrl: string, snapshot: UpstreamSnapshot): void {
+	const url = configuredRemoteUrl('upstream');
+	const sha = git(['rev-parse', '--verify', '--quiet', UPSTREAM_REF], true);
+	if (
+		normalizeRemote(url) !== normalizeRemote(snapshot.remoteUrl) ||
+		!sameRepository(url, upstreamUrl) ||
+		sha !== snapshot.sha
+	) {
+		fail(
+			'The shared `upstream` remote or its main tracking ref changed during this report. ' +
+				'Run it again after the sync or fetch finishes.'
+		);
+	}
+	if (snapshot.verifyAdvertisedMain && advertisedMainAt(upstreamUrl) !== snapshot.sha) {
+		fail('Upstream main changed during this report. Run it again on the settled remote.');
+	}
+}
+
+function absenceUnmeasuredNote(
+	marker: MarkerSnapshot,
+	upstream: UpstreamSnapshot
+): string | undefined {
+	if (!upstream.absenceTrusted) {
+		return 'this run did not fetch upstream, so an absent local path cannot prove fork ownership';
+	}
+	if (marker.provenance.length === 0) {
+		return `${MARKER} has no forkPoint or lastSynced commit to bind negative evidence to this fork`;
+	}
+	if (
+		marker.provenance.some((commit) => git(['merge-base', commit, upstream.sha], true) !== commit)
+	) {
+		return `${MARKER} provenance is not reachable from the fetched upstream tip; rewritten upstream history cannot prove fork ownership`;
+	}
+	return undefined;
+}
+
+interface LocalSnapshot {
+	head: string;
+	marker: Buffer | null;
+	index: Buffer | null;
+	shallow: Buffer | null;
+	status: Buffer;
+	worktree: Map<string, string>;
+}
+
+function optionalFile(path: string | undefined): Buffer | null {
+	if (!path) return null;
+	try {
+		lstatSync(path);
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+		fail(
+			`Could not inspect snapshot file: ${terminalSafe(err instanceof Error ? err.message : String(err))}`
+		);
+	}
+	try {
+		return readFileSync(path);
+	} catch (err) {
+		fail(
+			`Snapshot file exists but could not be read: ${terminalSafe(err instanceof Error ? err.message : String(err))}`
+		);
+	}
+}
+
+function localSnapshot(
+	head: string,
+	marker: Buffer | null,
+	shallow = optionalFile(callerShallowPath)
+): LocalSnapshot {
+	return {
+		head,
+		marker,
+		index: callerIndexAtCopy,
+		shallow,
+		worktree: new Map(),
+		status: gitBytes(
+			['status', '--porcelain=v2', '-z', '--untracked-files=all', '--ignore-submodules=none'],
+			false,
+			{},
+			WORKTREE_TIMEOUT_MS
+		)
+	};
+}
+
+function statusPathAfter(record: string, fields: number): string | null {
+	let at = -1;
+	for (let i = 0; i < fields; i++) {
+		at = record.indexOf(' ', at + 1);
+		if (at === -1) return null;
+	}
+	return record.slice(at + 1);
+}
+
+interface StatusPath {
+	path: string;
+	unstaged: boolean;
+}
+
+function changedStatusPaths(status: Buffer): StatusPath[] {
+	const records = decodeZRecords(status);
+	const paths: StatusPath[] = [];
+	for (let i = 0; i < records.length; i++) {
+		const record = records[i]!;
+		let path: string | null = null;
+		let unstaged = false;
+		if (record.startsWith('1 ')) {
+			path = statusPathAfter(record, 8);
+			unstaged = record[3] !== '.';
+		} else if (record.startsWith('2 ')) {
+			path = statusPathAfter(record, 9);
+			unstaged = record[3] !== '.';
+			i++;
+		} else if (record.startsWith('u ')) {
+			path = statusPathAfter(record, 10);
+			unstaged = true;
+		} else if (record.startsWith('? ')) {
+			path = record.slice(2);
+			unstaged = true;
+		} else if (record.startsWith('! ')) continue;
+		else fail('Git returned an unrecognized porcelain-v2 status record.');
+		if (!path) fail('Git returned a malformed porcelain-v2 status record.');
+		paths.push({ path, unstaged });
+	}
+	return paths;
+}
+
+function sameOptionalBuffer(left: Buffer | null, right: Buffer | null): boolean {
+	return left === null ? right === null : right !== null && left.equals(right);
+}
+
+function verifyLocalSnapshot(root: string, snapshot: LocalSnapshot): void {
+	const current = localSnapshot(git(['rev-parse', 'HEAD']), optionalFile(join(root, MARKER)));
+	current.index = optionalFile(callerIndexPath);
+	current.worktree = fingerprintPaths([...snapshot.worktree.keys()]);
+	const worktreeMatches = [...snapshot.worktree].every(
+		([path, fingerprint]) => current.worktree.get(path) === fingerprint
+	);
+	if (
+		current.head !== snapshot.head ||
+		!sameOptionalBuffer(current.marker, snapshot.marker) ||
+		!sameOptionalBuffer(current.index, snapshot.index) ||
+		!sameOptionalBuffer(current.shallow, snapshot.shallow) ||
+		!current.status.equals(snapshot.status) ||
+		!worktreeMatches
+	) {
+		fail(
+			'HEAD, the upstream marker, the index, the shallow boundary, or the working tree changed during this report. Run it again on the settled state.'
+		);
+	}
+}
+
+interface OriginSnapshot {
+	url: string;
+	sha: string;
+}
+
+interface BaseResolution {
+	base: string;
+	origin: OriginSnapshot | null;
+}
+
+function advertisedMainAt(url: string): string {
+	rejectTransportCommandOverrides();
+	// This name exists only in the private config. It keeps the URL out of process
+	// arguments without inheriting remote.<name>.uploadpack from the repository.
+	const remote = transportRemote(url);
+	return gitBytes(
+		['ls-remote', '--exit-code', '--refs', remote, 'refs/heads/main'],
+		true,
+		trustedTransportEnv(),
+		NETWORK_TIMEOUT_MS
+	)
+		.toString('utf8')
+		.trim()
+		.split('\t')[0]!;
+}
+
+function trustedOriginSnapshot(expectedSha: string): OriginSnapshot {
+	const originMain = 'refs/remotes/origin/main';
+	const url = configuredRemoteUrl('origin');
+	const sha = git(['rev-parse', '--verify', '--quiet', originMain], true);
+	if (!url || sha !== expectedSha) {
+		fail(
+			'`origin/main` or its URL changed during base validation. ' +
+				'Fetch `origin main`, then run the report again.'
+		);
+	}
+	rejectUrlRewrite(url);
+	rejectOwnedRepositoryRemote(url, git(['rev-parse', '--show-toplevel']), 'origin');
+	if (!remoteMainRefspecIsCanonical('origin')) {
+		fail(
+			'`origin/main` is not mapped exclusively from `refs/heads/main` by the origin fetch refspec. ' +
+				'Pass --base <ref> after verifying which commit this change starts from.'
+		);
+	}
+	if (advertisedMainAt(url) !== sha) {
+		fail(
+			'`origin/main` does not match `refs/heads/main` at the currently configured origin URL. ' +
+				'Fetch `origin main`, or pass --base <ref> after verifying the repository and commit.'
+		);
+	}
+	return { url, sha };
+}
+
+function verifyOriginSnapshot(snapshot: OriginSnapshot): void {
+	const current = trustedOriginSnapshot(snapshot.sha);
+	if (normalizeRemote(current.url) !== normalizeRemote(snapshot.url)) {
+		fail('The origin URL changed during this report. Run it again on the settled repository.');
+	}
+}
+
+/**
+ * The commit this change starts from. Never guesses: a base that cannot be
+ * resolved makes the run fail, because falling back to HEAD turns a fully
+ * committed branch into an empty diff and a cheerful "nothing to report".
+ *
+ * Always the merge base, including for an explicit --base. The file list comes
+ * from `base...head` while every verdict compares against `base` directly, so a
+ * base that is not an ancestor of HEAD enumerates against one commit and
+ * classifies against another; a sibling branch passed here reported an empty
+ * list and exited zero.
+ */
+function resolveBase(head: string, explicit?: string): BaseResolution {
+	const ref = explicit ?? 'origin/main';
+	const resolved = git(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], true);
+	if (!resolved) {
+		if (explicit) fail(`--base ${terminalSafe(explicit)} does not resolve to a commit.`);
+		fail(
+			'Could not resolve `origin/main`.\n' +
+				'Fetch it, or pass --base <ref> explicitly. Refusing to fall back to HEAD, which ' +
+				'would report an empty diff for a branch full of changes.'
+		);
+	}
+	const origin = explicit ? null : trustedOriginSnapshot(resolved);
+	const mergeBases = git(['merge-base', '--all', head, resolved], true).split('\n').filter(Boolean);
+	if (mergeBases.length === 0) {
+		fail(
+			`No merge base between HEAD and ${terminalSafe(ref)}.\n` +
+				'Refusing to compare unrelated histories, which enumerates nothing and reads as ' +
+				'"nothing to report".'
+		);
+	}
+	if (mergeBases.length > 1) {
+		fail(
+			`HEAD and ${terminalSafe(ref)} have multiple best merge bases. ` +
+				'Refusing to choose one arbitrarily and omit changes from the report.'
+		);
+	}
+	return { base: mergeBases[0]!, origin };
+}
+
+/**
+ * One tree, read once. Resolving a path with `rev-parse <ref>:<path>` costs a
+ * process per file, and the two trees are read for every file anyway.
+ *
+ * `-z` matters as much as it does for the collectors: without it git quotes a
+ * path holding a tab, a newline or a backslash, and a quoted spelling misses
+ * the exact lookup that decides `fork-only`.
+ */
+type TreeEntry = { mode: string; type: string; sha: string };
+interface HistoricalEntries {
+	entries: TreeEntry[];
+	complete: boolean;
+}
+
+function parseTreeRecord(record: string): { path: string; entry: TreeEntry } | null {
+	const tab = record.indexOf('\t');
+	if (tab === -1) return null;
+	const [mode, type, sha] = record.slice(0, tab).split(' ');
+	return mode && type && sha ? { path: record.slice(tab + 1), entry: { mode, type, sha } } : null;
+}
+
+function readTree(ref: string): Map<string, TreeEntry> {
+	const tree = new Map<string, TreeEntry>();
+	for (const record of gitZ(['ls-tree', '-r', '-z', ref], false, HISTORY_COMMAND_TIMEOUT_MS)) {
+		const parsed = parseTreeRecord(record);
+		if (parsed) tree.set(parsed.path, parsed.entry);
+	}
+	return tree;
+}
+
+function commitParents(commit: string): string[] {
+	return historyGit(['rev-list', '--parents', '-n', '1', commit])
+		.split(' ')
+		.slice(1)
+		.filter(Boolean);
+}
+
+function treeEntryAt(commit: string, path: string): TreeEntry | null {
+	const record = historyGitZ(['ls-tree', '-z', commit, '--', `:(literal)${path}`])[0];
+	return record ? (parseTreeRecord(record)?.entry ?? null) : null;
+}
+
+function renamedSourceBetween(parent: string, commit: string, path: string): string | null {
+	const fields = historyGitZ([
+		'diff-tree',
+		'--no-commit-id',
+		'-r',
+		'--find-renames=1%',
+		'--find-copies=1%',
+		'--find-copies-harder',
+		'-l0',
+		'--name-status',
+		'-z',
+		parent,
+		commit
+	]);
+	for (let i = 0; i < fields.length; i++) {
+		const status = fields[i] ?? '';
+		if (/^[RC]\d+$/.test(status)) {
+			const source = fields[i + 1];
+			const destination = fields[i + 2];
+			if (source && destination === path) return source;
+			i += 2;
+		} else {
+			i += 1;
+		}
+	}
+	return null;
+}
+
+function readHistoricalEntries(head: string, path: string): HistoricalEntries {
+	// `git log --follow` stops when a merge creates the destination. Treat each
+	// merge parent as another follow segment, mapping copies and renames against
+	// that parent before continuing.
+	const entries: TreeEntry[] = [];
+	const segments: Array<{ tip: string; path: string }> = [{ tip: head, path }];
+	const visited = new Set<string>();
+	let complete = true;
+	while (segments.length > 0) {
+		const segment = segments.pop()!;
+		const segmentKey = `${segment.tip}\0${segment.path}`;
+		if (visited.has(segmentKey)) continue;
+		visited.add(segmentKey);
+		let commits: string[];
+		try {
+			commits = historyGit([
+				'log',
+				'--format=%H',
+				'--follow',
+				'--find-renames=1%',
+				'--find-copies=1%',
+				'--find-copies-harder',
+				'-l0',
+				segment.tip,
+				'--',
+				`:(literal)${segment.path}`
+			])
+				.split('\n')
+				.filter(Boolean);
+		} catch {
+			complete = false;
+			continue;
+		}
+		try {
+			if (commits[0] !== segment.tip && treeEntryAt(segment.tip, segment.path)) {
+				commits.unshift(segment.tip);
+			}
+		} catch {
+			complete = false;
+			continue;
+		}
+		let historicalPath = segment.path;
+		let oldestCommit: string | null = null;
+		let endedAtMerge = false;
+		for (const commit of commits) {
+			oldestCommit = commit;
+			try {
+				const entry = treeEntryAt(commit, historicalPath);
+				if (
+					entry &&
+					!entries.some((existing) => existing.mode === entry.mode && existing.sha === entry.sha)
+				) {
+					entries.push(entry);
+				}
+				const parents = commitParents(commit);
+				if (parents.length > 1) {
+					endedAtMerge = true;
+					for (const parent of parents) {
+						const source = renamedSourceBetween(parent, commit, historicalPath);
+						const parentPath =
+							source ?? (treeEntryAt(parent, historicalPath) ? historicalPath : null);
+						if (parentPath) segments.push({ tip: parent, path: parentPath });
+					}
+					break;
+				}
+				if (parents.length === 1) {
+					historicalPath =
+						renamedSourceBetween(parents[0]!, commit, historicalPath) ?? historicalPath;
+				}
+			} catch {
+				complete = false;
+				break;
+			}
+		}
+		if (!endedAtMerge && oldestCommit) {
+			try {
+				for (const parent of commitParents(oldestCommit)) {
+					if (treeEntryAt(parent, historicalPath)) {
+						segments.push({ tip: parent, path: historicalPath });
+					}
+				}
+			} catch {
+				complete = false;
+			}
+		}
+	}
+	return { entries, complete };
+}
+
+/** The snapshotted index, including content staged over HEAD. */
+function readIndexTree(): Map<string, TreeEntry> {
+	const tree = new Map<string, TreeEntry>();
+	const unmerged = new Set<string>();
+	for (const record of gitZ(['ls-files', '--stage', '-z'])) {
+		const tab = record.indexOf('\t');
+		if (tab === -1) continue;
+		const [mode, sha, stage] = record.slice(0, tab).split(' ');
+		const path = record.slice(tab + 1);
+		if (stage !== '0') {
+			unmerged.add(path);
+			continue;
+		}
+		if (mode && sha) {
+			tree.set(path, {
+				mode,
+				type: mode === '160000' ? 'commit' : 'blob',
+				sha
+			});
+		}
+	}
+	if (unmerged.size > 0) {
+		fail(
+			'Upstream relevance cannot classify an index with unresolved merge stages:\n' +
+				[...unmerged]
+					.sort()
+					.map((path) => `  ${terminalSafe(path)}`)
+					.join('\n') +
+				'\nResolve the conflicts, then run the report again.'
+		);
+	}
+	return tree;
+}
+
+const basename = (p: string) => p.slice(p.lastIndexOf('/') + 1);
+
+function rejectHiddenIndexEntries(paths?: string[]): void {
+	const requested = paths ? new Set(paths) : null;
+	const hidden: string[] = [];
+	for (const record of gitZ(['ls-files', '-v', '-z'])) {
+		const marker = record[0] ?? '';
+		const path = record.slice(2);
+		if ((marker === 'S' || /^[a-z]$/.test(marker)) && (requested === null || requested.has(path))) {
+			hidden.push(path);
+		}
+	}
+	if (hidden.length === 0) return;
+	fail(
+		'Upstream relevance cannot trust index entries marked assume-unchanged or skip-worktree:\n' +
+			hidden.map((path) => `  ${terminalSafe(path)}`).join('\n') +
+			'\nClear those flags, then run the report again.'
+	);
+}
+
+/**
+ * Every path this change touches, including the ones the obvious command drops.
+ *
+ * `--name-only` prints a rename's destination and not its source, so moving a
+ * pristine template file to a fork-only path would be classified on the
+ * destination alone and disappear. `--name-status -M` keeps both. Untracked
+ * files are absent from every diff, so they are collected separately; a brand
+ * new file at a path upstream also has is exactly the case worth seeing.
+ */
+function changedPaths(base: string, head: string): string[] {
+	rejectHiddenIndexEntries();
+	const fromStatus = (fields: string[]): string[] => {
+		const paths: string[] = [];
+		for (let i = 0; i < fields.length; i++) {
+			const status = fields[i];
+			// Rename and copy statuses carry a similarity score and two paths;
+			// every other status carries one.
+			if (/^[RC]\d*$/.test(status)) {
+				if (fields[i + 1]) paths.push(fields[i + 1]);
+				if (fields[i + 2]) paths.push(fields[i + 2]);
+				i += 2;
+			} else if (/^[A-Z]\d*$/.test(status)) {
+				if (fields[i + 1]) paths.push(fields[i + 1]);
+				i += 1;
+			}
+		}
+		return paths;
+	};
+
+	// Every collector reads the same HEAD. The index is snapshotted once, so a
+	// commit landing mid-run would otherwise let the committed collector see the
+	// old HEAD while the later two compare the new one against a copy that
+	// already holds the change: the path drops out of all three lists and the
+	// run exits zero on a state the repository was never in.
+	//
+	// Deliberately NOT allowFail. An empty result from a failed git call is
+	// indistinguishable from an empty result from a clean tree, and the second
+	// one exits zero saying there is nothing to report. A broken diff.renames
+	// value in inherited config was enough to produce exactly that.
+	const collect = (fn: () => string[], what: string): string[] => {
+		try {
+			return fn();
+		} catch (err) {
+			fail(
+				`Could not enumerate ${what}: ${terminalSafe(err instanceof Error ? err.message : String(err))}\n` +
+					'Refusing to continue. An incomplete file list reports as "nothing to send upstream".'
+			);
+		}
+	};
+
+	const all = [
+		...collect(
+			() =>
+				fromStatus(
+					gitZ(
+						['diff', '--ignore-submodules=none', '--name-status', '-M', '-z', `${base}...${head}`],
+						false,
+						DIFF_COMMAND_TIMEOUT_MS
+					)
+				),
+			'committed changes'
+		),
+		...collect(
+			() =>
+				fromStatus(
+					gitZ(
+						['diff', '--ignore-submodules=none', '--name-status', '-M', '-z', head],
+						false,
+						DIFF_COMMAND_TIMEOUT_MS
+					)
+				),
+			'unstaged changes'
+		),
+		...collect(
+			() =>
+				fromStatus(
+					gitZ(
+						['diff', '--ignore-submodules=none', '--name-status', '-M', '-z', '--cached', head],
+						false,
+						DIFF_COMMAND_TIMEOUT_MS
+					)
+				),
+			'staged changes'
+		),
+		...collect(() => gitZ(['ls-files', '--others', '--exclude-standard', '-z']), 'untracked files')
+	];
+	return [...new Set(all)].sort();
+}
+
+type CachedBag =
+	| { kind: 'text'; bag: Bag }
+	| { kind: 'binary' }
+	| { kind: 'invalid-text' }
+	| { kind: 'missing' }
+	| { kind: 'oversized' }
+	| { kind: 'representation' };
+
+interface UpstreamBlobCandidate {
+	path: string;
+	sha: string;
+}
+
+interface Upstream {
+	/** Resolved once, so a fetch landing mid-run cannot mix two trees. */
+	sha: string;
+	tree: Map<string, TreeEntry>;
+	byFold: Map<string, string>;
+	/** Objects reachable from upstream history; local blob SHAs cannot collide across object types. */
+	blobs: Set<string>;
+	historyComplete: boolean;
+	/** Only names the current template carries exactly once; see uniqueName. */
+	uniqueName: Map<string, string>;
+	/** Historical blob versions keyed by SHA and the path that named them. */
+	candidates: Map<string, UpstreamBlobCandidate>;
+	/** Lower-cased extension groups are searched first. */
+	byExt: Map<string, string[]>;
+	/** Every candidate key, used when a port changed language or extension. */
+	blobKeys: string[];
+	/** Text tallies and unreadable states, filled in batches on first use. */
+	bags: Map<string, CachedBag>;
+	bagsBySha: Map<string, CachedBag>;
+	bagSourceBytes: number;
+	bagRepresentationUnits: number;
+	similarityOperationsRemaining: number;
+}
+
+function readUpstream(sha: string): Upstream {
+	const tree = readTree(sha);
+	const byFold = new Map<string, string>();
+	// `rev-list --objects -z` arrived in Git 2.50. Raw log records have used NUL
+	// path framing for much longer, and --no-renames gives every record one path.
+	// Root and merge-parent diffs expose both historical sides of every blob.
+	const history = gitPartialBytes(
+		[
+			'log',
+			'--format=',
+			'--raw',
+			'-z',
+			'--no-abbrev',
+			'--full-index',
+			'-m',
+			'--root',
+			'--no-renames',
+			sha
+		],
+		undefined,
+		HISTORY_COMMAND_TIMEOUT_MS
+	);
+	const rawRecords = history.complete ? decodeZRecords(history.output) : [];
+	const records: Array<{ sha: string; path: string }> = [];
+	let historyParsed = history.complete;
+	for (let i = 0; i < rawRecords.length; i += 2) {
+		const header = rawRecords[i];
+		const path = rawRecords[i + 1];
+		const match = header?.match(/^:\d{6} \d{6} ([0-9a-f]+) ([0-9a-f]+) [AMDTUXB]$/);
+		if (!match || path === undefined) {
+			historyParsed = false;
+			break;
+		}
+		for (const objectSha of [match[1], match[2]]) {
+			if (objectSha && !/^0+$/.test(objectSha)) records.push({ sha: objectSha, path });
+		}
+	}
+	const objectShas = [...new Set(records.map((record) => record.sha))];
+	const objectInfo = gitPartialBytes(
+		['cat-file', '--batch-check=%(objectname) %(objecttype)'],
+		objectShas.join('\n') + (objectShas.length > 0 ? '\n' : ''),
+		HISTORY_COMMAND_TIMEOUT_MS
+	);
+	const objectTypes = new Map<string, string>();
+	for (const line of objectInfo.output.toString('utf8').trim().split('\n')) {
+		const [objectSha, type] = line.split(' ');
+		if (objectSha && type && type !== 'missing') objectTypes.set(objectSha, type);
+	}
+	const blobs = new Set(
+		[...objectTypes].filter(([, type]) => type === 'blob').map(([objectSha]) => objectSha)
+	);
+	const seen = new Map<string, string | null>();
+	for (const [path] of tree) {
+		if (!byFold.has(path.toLowerCase())) byFold.set(path.toLowerCase(), path);
+		const name = basename(path).toLowerCase();
+		seen.set(name, seen.has(name) ? null : path);
+	}
+	// A name the template uses more than once says nothing: `types.ts` and
+	// `index.ts` sit in a dozen places and would flag every fork file that
+	// happens to share one. Measured against this fork's 1293 fork-only paths,
+	// keeping only the names upstream carries once flags 21 of them, most of
+	// them real relocations (src/lib/convex/usage/* was aiUsage/* upstream,
+	// src/lib/auth/clock-skew* was hooks/clock-skew*). The looser form flags 61.
+	const uniqueName = new Map<string, string>();
+	for (const [name, path] of seen) if (path !== null) uniqueName.set(name, path);
+	const candidates = new Map<string, UpstreamBlobCandidate>();
+	for (const record of records) {
+		if (objectTypes.get(record.sha) !== 'blob') continue;
+		candidates.set(`${record.sha}\0${record.path}`, { path: record.path, sha: record.sha });
+	}
+	for (const [path, entry] of tree) {
+		if (entry.type === 'blob') {
+			candidates.set(`${entry.sha}\0${path}`, { path, sha: entry.sha });
+		}
+	}
+	const byExt = new Map<string, string[]>();
+	const blobKeys = [...candidates.keys()];
+	for (const [key, candidate] of candidates) {
+		const e = extension(candidate.path);
+		const group = byExt.get(e);
+		if (group) group.push(key);
+		else byExt.set(e, [key]);
+	}
+	return {
+		sha,
+		tree,
+		byFold,
+		blobs,
+		historyComplete:
+			history.complete &&
+			historyParsed &&
+			objectInfo.complete &&
+			objectTypes.size === objectShas.length,
+		uniqueName,
+		candidates,
+		byExt,
+		blobKeys,
+		bags: new Map(),
+		bagsBySha: new Map(),
+		bagSourceBytes: 0,
+		bagRepresentationUnits: 0,
+		similarityOperationsRemaining: SIMILARITY_OPERATION_LIMIT
+	};
+}
+
+function extension(path: string): string {
+	const name = basename(path);
+	const dot = name.lastIndexOf('.');
+	return (dot <= 0 ? '' : name.slice(dot)).toLowerCase();
+}
+
+/**
+ * Blob contents by SHA, in bounded batches.
+ *
+ * A missing or oversized blob stays absent. Callers turn that unknown into
+ * `unmeasured`; one large history cannot overflow the process output buffer.
+ */
+function readBlobs(shas: string[], maxSourceBytes = Number.POSITIVE_INFINITY): Map<string, Buffer> {
+	const out = new Map<string, Buffer>();
+	const unique = [...new Set(shas)];
+	if (unique.length === 0) return out;
+	const sizeResult = gitPartialBytes(
+		['cat-file', '--batch-check=%(objectname) %(objecttype) %(objectsize)'],
+		unique.join('\n') + '\n'
+	);
+	if (!sizeResult.complete) return out;
+	const sizes = new Map<string, number>();
+	for (const line of sizeResult.output.toString('utf8').trim().split('\n')) {
+		const [sha, type, rawSize] = line.split(' ');
+		const size = Number(rawSize);
+		if (sha && type === 'blob' && Number.isFinite(size)) sizes.set(sha, size);
+	}
+
+	const readBatch = (batch: string[]) => {
+		if (batch.length === 0) return;
+		let res: Buffer;
+		try {
+			res = execFileSync('git', [...PINNED_CONFIG, 'cat-file', '--batch'], {
+				input: batch.join('\n') + '\n',
+				maxBuffer: BLOB_OUTPUT_LIMIT,
+				env: gitRunEnv(),
+				stdio: ['pipe', 'pipe', 'pipe']
+			});
+		} catch {
+			return;
+		}
+		let at = 0;
+		while (at < res.length) {
+			const newline = res.indexOf(0x0a, at);
+			if (newline < 0) break;
+			const header = res.slice(at, newline).toString('utf8').split(' ');
+			if (header.length < 3) {
+				at = newline + 1;
+				continue;
+			}
+			const size = Number(header[2]);
+			if (!Number.isFinite(size)) break;
+			out.set(header[0]!, res.subarray(newline + 1, newline + 1 + size));
+			at = newline + 1 + size + 1;
+		}
+	};
+
+	let batch: string[] = [];
+	let bytes = 0;
+	let sourceBytes = 0;
+	for (const sha of unique) {
+		const size = sizes.get(sha);
+		if (size === undefined || sourceBytes + size > maxSourceBytes) continue;
+		const estimated = size + 128;
+		if (estimated > BLOB_BATCH_BYTES) continue;
+		if (batch.length >= BLOB_BATCH_ITEMS || bytes + estimated > BLOB_BATCH_BYTES) {
+			readBatch(batch);
+			batch = [];
+			bytes = 0;
+		}
+		batch.push(sha);
+		bytes += estimated;
+		sourceBytes += size;
+	}
+	readBatch(batch);
+	return out;
+}
+
+/** A line tally with its total kept alongside, so a bound can skip reading it. */
+interface Bag {
+	lines: Map<string, number>;
+	total: number;
+	grams?: Uint32Array;
+}
+
+const GRAM_WIDTH = 8;
+
+function characterGrams(line: string): Uint32Array {
+	if (line.length < GRAM_WIDTH) return new Uint32Array();
+	const grams = new Uint32Array(line.length - GRAM_WIDTH + 1);
+	for (let i = 0; i < grams.length; i++) {
+		let hash = 0x811c9dc5;
+		for (let j = 0; j < GRAM_WIDTH; j++) {
+			hash ^= line.charCodeAt(i + j);
+			hash = Math.imul(hash, 0x01000193);
+		}
+		grams[i] = hash >>> 0;
+	}
+	return grams.sort();
+}
+
+function gramSimilarity(mine: Uint32Array, theirs: Uint32Array): number {
+	const denominator = Math.min(mine.length, theirs.length);
+	if (denominator === 0) return 0;
+	let left = 0;
+	let right = 0;
+	let shared = 0;
+	while (left < mine.length && right < theirs.length) {
+		if (mine[left] === theirs[right]) {
+			shared++;
+			left++;
+			right++;
+		} else if (mine[left]! < theirs[right]!) left++;
+		else right++;
+	}
+	return shared / denominator;
+}
+
+/**
+ * How much of one blob the other still carries. Multiline text uses shared
+ * lines over the larger file; overlapping character spans catch systematic
+ * edits that change every line and small changes to minified one-line text.
+ */
+function blobSimilarity(mine: Bag, theirs: Bag): number {
+	const denominator = Math.max(mine.total, theirs.total);
+	if (denominator === 0) return 0;
+	let shared = 0;
+	for (const [line, count] of mine.lines) shared += Math.min(count, theirs.lines.get(line) ?? 0);
+	const lineScore = shared / denominator;
+	return mine.grams && theirs.grams
+		? Math.max(lineScore, gramSimilarity(mine.grams, theirs.grams))
+		: lineScore;
+}
+
+/**
+ * Git's default rename similarity. Measured against this fork's 1267 remaining
+ * fork-only paths: 14 are flagged at 50%, 24 at 40% and 10 at 60%. Sixty loses
+ * the case this rung exists for (an email template copied from the template's
+ * own and then rewritten scores 59), and forty starts flagging shadcn barrel
+ * files that merely share a shape.
+ */
+const SIMILAR_ENOUGH = 0.5;
+
+interface SimilarityResult {
+	path: string | null;
+	measured: boolean;
+	note?: string;
+}
+
+const UTF8 = new TextDecoder('utf-8', { fatal: true });
+const UTF16_LE = new TextDecoder('utf-16le', { fatal: true });
+const UTF16_BE = new TextDecoder('utf-16be', { fatal: true });
+const hasUtf16Bom = (bytes: Buffer) =>
+	(bytes[0] === 0xff && bytes[1] === 0xfe) || (bytes[0] === 0xfe && bytes[1] === 0xff);
+
+function utf16TextOf(bytes: Buffer): { detected: boolean; text?: string } {
+	let decoder: TextDecoder | undefined;
+	let content = bytes;
+	if (bytes[0] === 0xff && bytes[1] === 0xfe) {
+		decoder = UTF16_LE;
+		content = bytes.subarray(2);
+	} else if (bytes[0] === 0xfe && bytes[1] === 0xff) {
+		decoder = UTF16_BE;
+		content = bytes.subarray(2);
+	} else {
+		const pairs = Math.floor(bytes.length / 2);
+		if (pairs === 0) return { detected: false };
+		let evenNuls = 0;
+		let oddNuls = 0;
+		for (let index = 0; index < pairs * 2; index += 2) {
+			if (bytes[index] === 0) evenNuls++;
+			if (bytes[index + 1] === 0) oddNuls++;
+		}
+		if (oddNuls / pairs >= 0.3 && evenNuls / pairs <= 0.1) decoder = UTF16_LE;
+		else if (evenNuls / pairs >= 0.3 && oddNuls / pairs <= 0.1) decoder = UTF16_BE;
+		else return { detected: false };
+	}
+	try {
+		const text = decoder.decode(content);
+		return text.includes('\0') ? { detected: true } : { detected: true, text };
+	} catch {
+		return { detected: true };
+	}
+}
+
+function textOf(bytes: Buffer): string | null {
+	if (hasUtf16Bom(bytes) || bytes.includes(0)) return utf16TextOf(bytes).text ?? null;
+	try {
+		return UTF8.decode(bytes);
+	} catch {
+		return null;
+	}
+}
+
+function cacheBags(keys: string[], upstream: Upstream): void {
+	const unread = keys.filter((key) => !upstream.bags.has(key));
+	if (unread.length === 0) return;
+	const blobs = readBlobs(
+		[...new Set(unread.map((key) => upstream.candidates.get(key)!.sha))],
+		Math.max(0, BLOB_BATCH_BYTES - upstream.bagSourceBytes)
+	);
+	for (const key of unread) {
+		const sha = upstream.candidates.get(key)!.sha;
+		let cached = upstream.bagsBySha.get(sha);
+		if (!cached) {
+			const blob = blobs.get(sha);
+			if (blob === undefined || upstream.bagSourceBytes + blob.length > BLOB_BATCH_BYTES) {
+				cached = { kind: 'missing' };
+			} else if (blob.length > SIMILARITY_SOURCE_LIMIT) {
+				cached = { kind: 'oversized' };
+			} else {
+				upstream.bagSourceBytes += blob.length;
+				const utf16 = hasUtf16Bom(blob) || blob.includes(0) ? utf16TextOf(blob) : undefined;
+				if (utf16 && !utf16.detected) cached = { kind: 'binary' };
+				else {
+					try {
+						const text = utf16 ? utf16.text : UTF8.decode(blob);
+						if (text === undefined) cached = { kind: 'invalid-text' };
+						else {
+							const cost = bagRepresentationCost(text);
+							if (
+								cost > SIMILARITY_REPRESENTATION_LIMIT ||
+								upstream.bagRepresentationUnits + cost > SIMILARITY_REPRESENTATION_LIMIT
+							) {
+								cached = { kind: 'representation' };
+							} else {
+								upstream.bagRepresentationUnits += cost;
+								cached = { kind: 'text', bag: bagOf(text) };
+							}
+						}
+					} catch {
+						cached = { kind: 'invalid-text' };
+					}
+				}
+			}
+			upstream.bagsBySha.set(sha, cached);
+		}
+		upstream.bags.set(key, cached);
+	}
+}
+
+const POTENTIAL_TEXT_EXTENSIONS = new Set([
+	'',
+	'.c',
+	'.cc',
+	'.cpp',
+	'.conf',
+	'.cs',
+	'.css',
+	'.csv',
+	'.cts',
+	'.go',
+	'.gql',
+	'.graphql',
+	'.h',
+	'.hpp',
+	'.html',
+	'.ini',
+	'.java',
+	'.js',
+	'.json',
+	'.jsonc',
+	'.jsx',
+	'.less',
+	'.lua',
+	'.m',
+	'.md',
+	'.mdx',
+	'.mjs',
+	'.mts',
+	'.php',
+	'.properties',
+	'.proto',
+	'.ps1',
+	'.py',
+	'.rb',
+	'.rs',
+	'.sass',
+	'.scss',
+	'.sh',
+	'.sql',
+	'.svg',
+	'.svelte',
+	'.swift',
+	'.toml',
+	'.ts',
+	'.tsx',
+	'.txt',
+	'.vue',
+	'.xml',
+	'.yaml',
+	'.yml'
+]);
+
+function searchSimilar(
+	mine: Bag,
+	candidates: string[],
+	upstream: Upstream,
+	unreadableIsUnknown = false
+): SimilarityResult {
+	cacheBags(candidates, upstream);
+	let best = SIMILAR_ENOUGH;
+	let bestPath: string | null = null;
+	let missing = false;
+	let oversized = false;
+	let representation = false;
+	let unreadable = false;
+	let operationsExhausted = false;
+	for (const key of candidates) {
+		const cached = upstream.bags.get(key)!;
+		if (cached.kind === 'missing') {
+			missing = true;
+			continue;
+		}
+		if (cached.kind === 'oversized') {
+			oversized = true;
+			continue;
+		}
+		if (cached.kind === 'representation') {
+			representation = true;
+			continue;
+		}
+		if (cached.kind === 'binary') {
+			const candidate = upstream.candidates.get(key)!;
+			unreadable ||=
+				unreadableIsUnknown || POTENTIAL_TEXT_EXTENSIONS.has(extension(candidate.path));
+			continue;
+		}
+		if (cached.kind === 'invalid-text') {
+			unreadable = true;
+			continue;
+		}
+		const operations =
+			mine.lines.size +
+			(mine.grams && cached.bag.grams ? mine.grams.length + cached.bag.grams.length : 0);
+		if (operations > upstream.similarityOperationsRemaining) {
+			operationsExhausted = true;
+			break;
+		}
+		upstream.similarityOperationsRemaining -= operations;
+		const score = blobSimilarity(mine, cached.bag);
+		if (score >= best) {
+			best = score;
+			bestPath = upstream.candidates.get(key)!.path;
+		}
+	}
+	return bestPath === null
+		? {
+				path: null,
+				measured: !operationsExhausted && !missing && !oversized && !representation && !unreadable,
+				note: operationsExhausted
+					? 'similarity comparison exceeded the bounded operation count'
+					: missing
+						? 'one or more upstream blobs are absent from this partial clone'
+						: oversized
+							? 'an upstream blob exceeds the bounded similarity size'
+							: representation
+								? 'upstream text exceeds the bounded similarity representation'
+								: unreadable
+									? 'an upstream blob has no safe UTF-8 text comparison'
+									: undefined
+			}
+		: { path: bestPath, measured: true };
+}
+
+type SourceBag = { kind: 'bag'; bag: Bag } | { kind: 'unmeasured'; note: string };
+const sourceBags = new WeakMap<Buffer, SourceBag>();
+
+function sourceBag(content: Buffer, upstream: Upstream): SourceBag {
+	const cached = sourceBags.get(content);
+	if (cached) return cached;
+	let result: SourceBag;
+	if (content.length > SIMILARITY_SOURCE_LIMIT) {
+		result = { kind: 'unmeasured', note: 'content exceeds the bounded similarity size' };
+	} else if (content.length > upstream.similarityOperationsRemaining) {
+		result = {
+			kind: 'unmeasured',
+			note: 'similarity comparison exceeded the bounded operation count'
+		};
+	} else {
+		upstream.similarityOperationsRemaining -= content.length;
+		const text = textOf(content);
+		if (text === null) {
+			result = {
+				kind: 'unmeasured',
+				note: 'binary content has no safe line-level resemblance score'
+			};
+		} else {
+			const representation = bagRepresentationCost(text);
+			if (representation > SIMILARITY_REPRESENTATION_LIMIT) {
+				result = {
+					kind: 'unmeasured',
+					note: 'content exceeds the bounded similarity representation'
+				};
+			} else if (representation > upstream.similarityOperationsRemaining) {
+				result = {
+					kind: 'unmeasured',
+					note: 'similarity comparison exceeded the bounded operation count'
+				};
+			} else {
+				upstream.similarityOperationsRemaining -= representation;
+				const bag = bagOf(text);
+				result =
+					bag.total === 0 || (bag.total === 1 && (bag.grams?.length ?? 0) === 0)
+						? {
+								kind: 'unmeasured',
+								note: 'text is too compact to retain a safe line or character-span comparison'
+							}
+						: { kind: 'bag', bag };
+			}
+		}
+	}
+	sourceBags.set(content, result);
+	return result;
+}
+
+/**
+ * The upstream file this content most resembles.
+ *
+ * Same-extension files go first because they usually find the answer without
+ * loading the rest of the tree. A miss widens to every blob. Ports between JS
+ * and TS are ordinary, and an extension gate turns them into silent negatives.
+ */
+function similarTo(content: Buffer, path: string, upstream: Upstream): SimilarityResult {
+	const source = sourceBag(content, upstream);
+	if (source.kind === 'unmeasured') {
+		return { path: null, measured: false, note: source.note };
+	}
+	const sameExtension = upstream.byExt.get(extension(path)) ?? [];
+	const first = searchSimilar(source.bag, sameExtension, upstream, true);
+	if (first.path !== null) return first;
+
+	const same = new Set(sameExtension);
+	const rest = upstream.blobKeys.filter((candidate) => !same.has(candidate));
+	const widened = searchSimilar(source.bag, rest, upstream);
+	if (widened.path !== null) return widened;
+	return {
+		path: null,
+		measured: first.measured && widened.measured,
+		note: first.note ?? widened.note
+	};
+}
+
+interface ContentSet {
+	values: Buffer[];
+	incompleteNote?: string;
+	missing?: boolean;
+}
+
+function symlinkParent(path: string): string | null {
+	const parts = path.split('/');
+	let parent = '';
+	for (const part of parts.slice(0, -1)) {
+		parent = parent ? join(parent, part) : part;
+		if (lstatSync(parent).isSymbolicLink()) return parent;
+	}
+	return null;
+}
+
+function sameFileIdentity(
+	left: ReturnType<typeof lstatSync>,
+	right: ReturnType<typeof lstatSync>
+): boolean {
+	return left.dev === right.dev && left.ino === right.ino;
+}
+
+function workingTreeContent(path: string, maxBytes = CAPTURE_LIMIT): ContentSet {
+	try {
+		const unsafeParent = symlinkParent(path);
+		if (unsafeParent) {
+			return {
+				values: [],
+				incompleteNote: `working-tree parent "${unsafeParent}" is a symlink`
+			};
+		}
+		const initial = lstatSync(path);
+		if (initial.isSymbolicLink()) {
+			const target = readlinkSync(path, { encoding: 'buffer' });
+			if (target.length > maxBytes) {
+				return {
+					values: [],
+					incompleteNote: 'working-tree content exceeds the bounded capture size'
+				};
+			}
+			const changedParent = symlinkParent(path);
+			const after = lstatSync(path);
+			if (changedParent || !after.isSymbolicLink() || !sameFileIdentity(initial, after)) {
+				return { values: [], incompleteNote: 'working-tree path changed during capture' };
+			}
+			return { values: [target] };
+		}
+		if (!initial.isFile()) {
+			return { values: [], incompleteNote: 'working-tree path is not a regular file' };
+		}
+
+		let fd: number | null = null;
+		try {
+			fd = openSync(
+				path,
+				fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0) | (fsConstants.O_NONBLOCK ?? 0)
+			);
+			const opened = fstatSync(fd);
+			const changedParent = symlinkParent(path);
+			const afterOpen = lstatSync(path);
+			if (
+				changedParent ||
+				!opened.isFile() ||
+				!afterOpen.isFile() ||
+				!sameFileIdentity(initial, opened) ||
+				!sameFileIdentity(opened, afterOpen)
+			) {
+				return { values: [], incompleteNote: 'working-tree path changed during capture' };
+			}
+			if (opened.size > maxBytes) {
+				return {
+					values: [],
+					incompleteNote: 'working-tree content exceeds the bounded capture size'
+				};
+			}
+
+			const bytes = Buffer.allocUnsafe(opened.size);
+			let total = 0;
+			while (total < bytes.length) {
+				const read = readSync(fd, bytes, total, bytes.length - total, total);
+				if (read === 0) break;
+				total += read;
+			}
+			const afterRead = fstatSync(fd);
+			if (
+				total !== opened.size ||
+				afterRead.size !== opened.size ||
+				afterRead.mtimeMs !== opened.mtimeMs ||
+				afterRead.ctimeMs !== opened.ctimeMs
+			) {
+				return { values: [], incompleteNote: 'working-tree content changed during capture' };
+			}
+			return { values: [bytes] };
+		} finally {
+			if (fd !== null) closeSync(fd);
+		}
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { values: [], missing: true };
+		return {
+			values: [],
+			incompleteNote: `working-tree content could not be read: ${err instanceof Error ? err.message : String(err)}`
+		};
+	}
+}
+
+function fingerprintContent(content: ContentSet): string {
+	const hash = createHash('sha256');
+	hash.update(content.missing ? 'missing\0' : 'present\0');
+	hash.update(content.incompleteNote ?? '');
+	for (const value of content.values) {
+		hash.update(String(value.length));
+		hash.update('\0');
+		hash.update(value);
+	}
+	return hash.digest('hex');
+}
+
+function capturePaths(paths: string[]): {
+	fingerprints: Map<string, string>;
+	contents: Map<string, ContentSet>;
+} {
+	const fingerprints = new Map<string, string>();
+	const contents = new Map<string, ContentSet>();
+	let remaining = CAPTURE_LIMIT;
+	for (const path of paths) {
+		const content = workingTreeContent(path, remaining);
+		contents.set(path, content);
+		fingerprints.set(path, fingerprintContent(content));
+		remaining -= content.values.reduce((total, value) => total + value.length, 0);
+	}
+	return { fingerprints, contents };
+}
+
+function fingerprintPaths(paths: string[]): Map<string, string> {
+	return capturePaths(paths).fingerprints;
+}
+
+function capturedDiff(
+	before: Buffer,
+	after: Buffer
+): { output: Buffer | null; incompleteNote?: string } {
+	if (!scratchDir) fail('The scratch directory disappeared before captured content was compared.');
+	const id = randomUUID();
+	const beforePath = join(scratchDir, `${id}-before`);
+	const afterPath = join(scratchDir, `${id}-after`);
+	writeFileSync(beforePath, before);
+	writeFileSync(afterPath, after);
+	try {
+		return {
+			output: execFileSync(
+				'git',
+				[
+					...PINNED_CONFIG,
+					'diff',
+					'--no-index',
+					'--unified=3',
+					'--no-ext-diff',
+					'--no-textconv',
+					'--',
+					beforePath,
+					afterPath
+				],
+				{
+					env: gitRunEnv(),
+					maxBuffer: MAX_GIT_OUTPUT,
+					stdio: ['pipe', 'pipe', 'pipe'],
+					timeout: DIFF_COMMAND_TIMEOUT_MS
+				}
+			)
+		};
+	} catch (err) {
+		const failed = err as { status?: unknown; stdout?: unknown };
+		// `git diff --no-index` uses status 1 for an ordinary difference. Any
+		// other failure may expose only a prefix of stdout, which is not a diff.
+		if (failed.status === 1 && Buffer.isBuffer(failed.stdout)) return { output: failed.stdout };
+		return {
+			output: null,
+			incompleteNote: 'one shared-path diff command failed before completing'
+		};
+	} finally {
+		rmSync(beforePath, { force: true });
+		rmSync(afterPath, { force: true });
+	}
+}
+
+/** Every observable version of a path, before and after each change layer. */
+function contentsOf(
+	working: ContentSet,
+	entries: Array<TreeEntry | undefined>,
+	localBlobs: Map<string, Buffer>
+): ContentSet {
+	const values = [...working.values];
+	let incompleteNote = working.incompleteNote;
+	if (working.missing && !entries.some(Boolean)) {
+		incompleteNote = 'working-tree path disappeared after it was enumerated';
+	}
+	for (const entry of entries) {
+		if (!entry) continue;
+		if (entry.type !== 'blob') {
+			incompleteNote ??= 'one repository state is a gitlink rather than a blob';
+			continue;
+		}
+		const blob = localBlobs.get(entry.sha);
+		if (blob === undefined) {
+			incompleteNote ??=
+				'one repository-state blob is unavailable or outside the bounded local-history capture';
+			continue;
+		}
+		if (!values.some((value) => value.equals(blob))) values.push(blob);
+	}
+	return { values, incompleteNote };
+}
+
+function verdictFor(
+	path: string,
+	upstream: Upstream,
+	baseTree: Map<string, TreeEntry>,
+	headTree: Map<string, TreeEntry>,
+	indexTree: Map<string, TreeEntry>,
+	localBlobs: Map<string, Buffer>,
+	upstreamBlobs: Map<string, Buffer>,
+	historyEntries: TreeEntry[],
+	rootPaths: Set<string>,
+	provenancePaths: Set<string>,
+	provenancePathsByFold: Set<string>,
+	rootOwnershipNote: string | undefined,
+	working: ContentSet,
+	unstaged: boolean,
+	historyIncompleteNote: string | undefined,
+	absenceNote: string | undefined,
+	identityNote: string | undefined
+): FileVerdict {
+	const upstreamEntry = upstream.tree.get(path);
+	const baseEntry = baseTree.get(path);
+
+	if (identityNote) {
+		return classifyVerdict({
+			path,
+			existsUpstream: true,
+			baseMatchesUpstream: false,
+			overlap: null,
+			unmeasuredNote: identityNote
+		});
+	}
+
+	if (upstreamEntry === undefined) {
+		// macOS and Windows compare filenames case-insensitively while git does
+		// not, so a fork file differing from a template file only in case is one
+		// file to the filesystem and two to the exact lookup. Calling that
+		// fork-only is a silent negative on what may be the same file; say it is
+		// ambiguous instead.
+		const folded = upstream.byFold.get(path.toLowerCase());
+		if (folded !== undefined) {
+			return classifyVerdict({
+				path,
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap: null,
+				unmeasuredNote: `differs from upstream's "${folded}" only by case`
+			});
+		}
+		if (provenancePaths.has(path) || provenancePathsByFold.has(path.toLowerCase())) {
+			return classifyVerdict({
+				path,
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap: null,
+				unmeasuredNote: `path existed in ${MARKER} provenance before upstream removed it`
+			});
+		}
+		// An absent path is not proof of fork ownership. Upstream renames a file
+		// this fork still carries under the old name, or the fork copies an
+		// inherited file to a product-specific path and fixes an inherited bug in
+		// the copy. Check every repository state so a staged edit or a later
+		// worktree rewrite cannot erase the copied blob from the evidence.
+		const entries = [baseEntry, ...historyEntries, headTree.get(path), indexTree.get(path)];
+		if (entries.some((entry) => entry && upstream.blobs.has(entry.sha))) {
+			return classifyVerdict({
+				path,
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap: null,
+				unmeasuredNote:
+					'no upstream path, but this content is upstream elsewhere (renamed or copied)'
+			});
+		}
+		// Blob identity only recognises a copy this fork never edited. Once the
+		// fork has customised its copy, nothing in either tree relates the two,
+		// and a file upstream renamed away is the one most likely to still carry
+		// a template bug. A name the template uses exactly once is the cheap half
+		// of that: it costs a glance and finds a real relocation.
+		const sameName = upstream.uniqueName.get(basename(path).toLowerCase());
+		if (sameName !== undefined) {
+			return classifyVerdict({
+				path,
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap: null,
+				unmeasuredNote: `no upstream path, but upstream has one file named this: "${sameName}"`
+			});
+		}
+		// Blob identity recognises a copy nobody edited, and the name rung a
+		// relocation that kept its name. Neither sees the ordinary case: a
+		// template file copied to a product-specific path and customised in the
+		// same commit. Measured on this fork, src/lib/emails/templates/
+		// SessionHandoffEmail.svelte is a 59% copy of the template's own
+		// NewTicketAdminNotificationEmail.svelte, shares no blob and no name, and
+		// was silently hidden. An accessibility fix made in it would never have
+		// been offered upstream, which is precisely the loss this tool exists to
+		// prevent.
+		const contents = contentsOf(working, entries, localBlobs);
+		let incompleteNote = contents.incompleteNote;
+		for (const content of contents.values) {
+			const similar = similarTo(content, path, upstream);
+			if (similar.path !== null) {
+				return classifyVerdict({
+					path,
+					existsUpstream: true,
+					baseMatchesUpstream: false,
+					overlap: null,
+					unmeasuredNote: `no upstream path, but this mostly matches upstream's "${similar.path}"`
+				});
+			}
+			if (!similar.measured) incompleteNote ??= similar.note;
+		}
+		if (incompleteNote) {
+			return classifyVerdict({
+				path,
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap: null,
+				unmeasuredNote: incompleteNote
+			});
+		}
+		if (!baseEntry) {
+			return classifyVerdict({
+				path,
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap: null,
+				unmeasuredNote:
+					'new file with no measurable upstream counterpart; relevance needs a design judgment'
+			});
+		}
+		if (absenceNote) {
+			return classifyVerdict({
+				path,
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap: null,
+				unmeasuredNote: absenceNote
+			});
+		}
+		if (historyIncompleteNote) {
+			return classifyVerdict({
+				path,
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap: null,
+				unmeasuredNote: historyIncompleteNote
+			});
+		}
+		if (unstaged) {
+			return classifyVerdict({
+				path,
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap: null,
+				unmeasuredNote:
+					'unstaged bytes were compared without executing Git clean filters; they cannot prove fork ownership'
+			});
+		}
+		if (rootOwnershipNote) {
+			return classifyVerdict({
+				path,
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap: null,
+				unmeasuredNote: rootOwnershipNote
+			});
+		}
+		if (!rootPaths.has(path)) {
+			return classifyVerdict({
+				path,
+				existsUpstream: true,
+				baseMatchesUpstream: false,
+				overlap: null,
+				unmeasuredNote:
+					'path entered local history after repository creation; negative resemblance cannot prove fork ownership'
+			});
+		}
+		return classifyVerdict({ path, existsUpstream: false, baseMatchesUpstream: false });
+	}
+
+	if (upstreamEntry.type !== 'blob') {
+		return classifyVerdict({
+			path,
+			existsUpstream: true,
+			baseMatchesUpstream: false,
+			overlap: null,
+			unmeasuredNote: working.incompleteNote ?? 'upstream copy is a gitlink rather than a blob'
+		});
+	}
+
+	if (baseEntry && baseEntry.sha === upstreamEntry.sha) {
+		// Same bytes is not the same file. One blob is shared by a regular file
+		// and a symlink pointing at that text, and by an executable and a
+		// non-executable copy; only the mode tells them apart. Calling that
+		// pristine claims the fork never touched a file whose semantics it did
+		// in fact change.
+		if (baseEntry.mode === upstreamEntry.mode)
+			return classifyVerdict({ path, existsUpstream: true, baseMatchesUpstream: true });
+		return classifyVerdict({
+			path,
+			existsUpstream: true,
+			baseMatchesUpstream: false,
+			overlap: null,
+			unmeasuredNote: `upstream's bytes under a different mode (${baseEntry.mode} here, ${upstreamEntry.mode} upstream)`
+		});
+	}
+
+	// Nothing at the base: the path is new here and upstream happens to have it
+	// too. There is no "before" to compare, so this is unmeasured, and it is a
+	// case worth seeing.
+	if (!baseEntry)
+		return classifyVerdict({
+			path,
+			existsUpstream: true,
+			baseMatchesUpstream: false,
+			unmeasuredNote: 'added here at a path upstream also has'
+		});
+
+	if (baseEntry.type !== 'blob') {
+		return classifyVerdict({
+			path,
+			existsUpstream: true,
+			baseMatchesUpstream: false,
+			overlap: null,
+			unmeasuredNote: 'the base copy is a gitlink rather than a blob'
+		});
+	}
+	const baseBlob = localBlobs.get(baseEntry.sha);
+	if (!baseBlob) {
+		return classifyVerdict({
+			path,
+			existsUpstream: true,
+			baseMatchesUpstream: false,
+			overlap: null,
+			unmeasuredNote: 'the base blob is absent from this partial clone'
+		});
+	}
+	const upstreamBlob = upstreamBlobs.get(upstreamEntry.sha);
+	const upstreamContent = upstreamBlob ? textOf(upstreamBlob) : null;
+	if (upstreamContent === null) {
+		return classifyVerdict({
+			path,
+			existsUpstream: true,
+			baseMatchesUpstream: false,
+			overlap: null,
+			unmeasuredNote: upstreamBlob
+				? 'upstream copy is not valid UTF-8 text'
+				: 'upstream blob is absent from this partial clone'
+		});
+	}
+
+	const overlapRepresentation = lineRepresentationCost(upstreamContent);
+	if (overlapRepresentation > SIMILARITY_REPRESENTATION_LIMIT) {
+		return classifyVerdict({
+			path,
+			existsUpstream: true,
+			baseMatchesUpstream: false,
+			overlap: null,
+			unmeasuredNote: 'upstream text exceeds the bounded similarity representation'
+		});
+	}
+	if (overlapRepresentation > upstream.similarityOperationsRemaining) {
+		return classifyVerdict({
+			path,
+			existsUpstream: true,
+			baseMatchesUpstream: false,
+			overlap: null,
+			unmeasuredNote: 'similarity comparison exceeded the bounded operation count'
+		});
+	}
+	upstream.similarityOperationsRemaining -= overlapRepresentation;
+	const upstreamLines = countLines(upstreamContent);
+
+	const afterValues: Buffer[] = [];
+	let incompleteNote = working.incompleteNote;
+	const addAfterValue = (value: Buffer) => {
+		if (!afterValues.some((existing) => existing.equals(value))) afterValues.push(value);
+	};
+	const addRepositoryState = (entry: TreeEntry | undefined) => {
+		if (!entry) {
+			addAfterValue(Buffer.alloc(0));
+			return;
+		}
+		if (entry.type !== 'blob') {
+			incompleteNote ??= 'one after-state is a gitlink rather than a blob';
+			return;
+		}
+		const blob = localBlobs.get(entry.sha);
+		if (blob) addAfterValue(blob);
+		else incompleteNote ??= 'one after-state blob is unavailable from the bounded capture';
+	};
+	addRepositoryState(headTree.get(path));
+	addRepositoryState(indexTree.get(path));
+	if (working.missing) addAfterValue(Buffer.alloc(0));
+	else for (const value of working.values) addAfterValue(value);
+
+	let overlap: number | null = null;
+	let sawBinary = false;
+	for (const after of afterValues) {
+		const captured = capturedDiff(baseBlob, after);
+		if (captured.incompleteNote) incompleteNote ??= captured.incompleteNote;
+		const diff = captured.output ? textOf(captured.output) : null;
+		if (diff === null) {
+			incompleteNote ??= 'one shared-path diff is not valid UTF-8 text';
+			continue;
+		}
+		const score = regionOverlapWithLines(changedRegionLines(diff), upstreamLines);
+		if (score !== null) overlap = overlap === null ? score : Math.max(overlap, score);
+		sawBinary ||= /^Binary files/m.test(diff);
+	}
+	return classifyVerdict({
+		path,
+		existsUpstream: true,
+		baseMatchesUpstream: false,
+		overlap,
+		unmeasuredNote:
+			incompleteNote ??
+			(sawBinary
+				? 'binary file, no text to compare'
+				: 'no comparable text in the change (mode-only or empty)')
+	});
+}
+
+function callerPathspec(root: string, calledFrom: string, spec: string): string | null {
+	const absolute = resolve(calledFrom, spec);
+	const fromRoot = relative(root, absolute);
+	if (isAbsolute(fromRoot) || fromRoot === '..' || fromRoot.startsWith(`..${sep}`)) return null;
+	return (fromRoot || '.').split(sep).join('/');
+}
+
+function commandLineArguments() {
+	try {
+		return parseArgs({
+			args: Bun.argv.slice(2),
+			options: {
+				base: { type: 'string' },
+				fetch: { type: 'boolean', default: false },
+				json: { type: 'boolean', default: false },
+				all: { type: 'boolean', default: false }
+			},
+			allowPositionals: true,
+			// Strict on purpose. With strict:false a mistyped `--bsae origin/main`
+			// became a boolean flag plus a positional, and a positional replaces the
+			// whole automatic file list, so the run checked one nonexistent path and
+			// exited zero saying there was nothing to send upstream.
+			strict: true
+		});
+	} catch (err) {
+		fail(
+			`Invalid upstream-report arguments: ${terminalSafe(err instanceof Error ? err.message : String(err))}`
+		);
+	}
+}
+
+function main() {
+	const { values, positionals } = commandLineArguments();
+
+	const root = git(['rev-parse', '--show-toplevel']);
+	// Where the caller typed the command, kept because every path argument was
+	// written relative to it. Resolving them after the chdir silently
+	// reinterprets `../AGENTS.md` against the repository root, where it names
+	// nothing, and an argument that matches nothing is fatal by design.
+	const calledFrom = process.cwd();
+	process.chdir(root);
+	useScratchIndex(root);
+	rejectUnverifiableFileModes();
+	rejectUnsafePartialClone();
+
+	const marker = readUpstreamMarker(root);
+	requireCleanUpstreamMarker(marker);
+	const head = git(['rev-parse', 'HEAD']);
+	requireMarkerAtHead(head, marker);
+	const local = localSnapshot(head, marker.bytes, callerShallowAtCopy);
+	verifyScratchIndexEntries();
+	const upstreamUrl = marker.url;
+	const originUrlAtStart = configuredRemoteUrl('origin');
+	if (originUrlAtStart) rejectUrlRewrite(originUrlAtStart);
+	if (originUrlAtStart && sameRepository(originUrlAtStart, upstreamUrl)) {
+		console.error('This repository IS the upstream template. Nothing to report upstream.');
+		process.exit(2);
+	}
+	const baseResolution = resolveBase(head, values.base as string | undefined);
+	const base = baseResolution.base;
+	if (
+		positionals.length > 0 &&
+		git(['rev-parse', '--verify', '--quiet', `${base}:${MARKER}`], true) !==
+			git(['rev-parse', '--verify', '--quiet', `${head}:${MARKER}`], true)
+	) {
+		fail(
+			`${MARKER} changed in the selected commit range. Run without explicit paths so the parent change stays visible.`
+		);
+	}
+	const upstream = ensureUpstream(root, upstreamUrl, values.fetch === true);
+	const absenceNote = absenceUnmeasuredNote(marker, upstream);
+	const identityNote = upstream.identityTrusted
+		? undefined
+		: 'the local upstream tree has no provenance from the configured upstream remote';
+	const statusPaths = changedStatusPaths(local.status);
+	const unstagedPaths = new Set(
+		statusPaths.filter((entry) => entry.unstaged).map((entry) => entry.path)
+	);
+	const historyComplete = local.shallow === null;
+	let paths: string[];
+	if (positionals.length > 0) {
+		// Each argument is resolved on its own, and one that matches nothing is
+		// fatal even when its neighbours matched. Checking only the combined
+		// result lets a valid path mask a typo beside it: git drops the unmatched
+		// argument without a word, the list is still non-empty, and the run exits
+		// zero having never looked at the file the caller meant.
+		const requested = new Map<string, string[]>();
+		const unmatched: string[] = [];
+		for (const spec of positionals) {
+			// Hand one canonical, repository-relative spelling to both readers. The
+			// base lookup used to receive the raw argument after chdir, so a deleted
+			// `config.ts` typed from `product/` looked for `/config.ts` instead.
+			const pathspec = callerPathspec(root, calledFrom, spec);
+			if (pathspec === null) {
+				unmatched.push(spec);
+				continue;
+			}
+			const specs = requested.get(pathspec);
+			if (specs) specs.push(spec);
+			else requested.set(pathspec, [spec]);
+		}
+		const resolved = new Set<string>();
+		const addMatches = (matches: string[]): void => {
+			for (const match of matches) {
+				if (resolved.has(match)) continue;
+				if (resolved.size >= PATH_LIMIT) {
+					fail(`Explicit paths matched more than ${PATH_LIMIT} files. Narrow the request.`);
+				}
+				resolved.add(match);
+			}
+		};
+		for (const [pathspec, specs] of requested) {
+			const literalPathspec = `:(literal)${pathspec}`;
+			let listed: string[];
+			let atBase: string[];
+			let atHead: string[];
+			try {
+				listed = gitZ([
+					'ls-files',
+					'-z',
+					'--full-name',
+					'--cached',
+					'--others',
+					'--exclude-standard',
+					'--',
+					literalPathspec
+				]);
+				// A path deleted in this change matches nothing in the working tree but
+				// still exists at the base, and deleting template code is exactly the
+				// sort of change worth reporting.
+				atBase = gitZ([
+					'ls-tree',
+					'-z',
+					'--full-name',
+					'--name-only',
+					'-r',
+					base,
+					'--',
+					literalPathspec
+				]);
+				atHead = gitZ([
+					'ls-tree',
+					'-z',
+					'--full-name',
+					'--name-only',
+					'-r',
+					head,
+					'--',
+					literalPathspec
+				]);
+			} catch {
+				fail(`Could not enumerate the requested path "${terminalSafe(specs[0]!)}".`);
+			}
+			if (listed.length === 0 && atBase.length === 0 && atHead.length === 0) {
+				for (const spec of specs) unmatched.push(spec);
+			} else {
+				addMatches(listed);
+				addMatches(atBase);
+				addMatches(atHead);
+			}
+		}
+		if (unmatched.length > 0) {
+			fail(
+				`These paths matched nothing: ${unmatched.map(terminalSafe).join(', ')}\n` +
+					'Refusing to report on the run. An unmatched path classifies as fork-only and ' +
+					'reads as "nothing to send upstream".'
+			);
+		}
+		paths = [...resolved].sort();
+	} else {
+		paths = [...new Set([...changedPaths(base, head), ...statusPaths.map((entry) => entry.path)])];
+		if (paths.length > PATH_LIMIT) {
+			fail(`Automatic discovery found more than ${PATH_LIMIT} changed paths. Narrow the request.`);
+		}
+	}
+	if (positionals.length > 0) rejectHiddenIndexEntries(paths);
+	const captured = capturePaths(paths);
+	local.worktree = captured.fingerprints;
+	const upstreamTree = readUpstream(upstream.sha);
+	const historyIncompleteNote = !historyComplete
+		? 'repository history is shallow, so earlier upstream ancestry is unknown'
+		: !upstreamTree.historyComplete
+			? 'upstream history did not complete, so earlier ancestry is unknown'
+			: undefined;
+	const baseTree = readTree(base);
+	const headTree = readTree(head);
+	const rootRead = gitPartialBytes(
+		['rev-list', '--max-parents=0', head],
+		undefined,
+		HISTORY_COMMAND_TIMEOUT_MS
+	);
+	const rootCommits = rootRead.output.toString('utf8').trim().split('\n').filter(Boolean);
+	const rootOwnershipNote = !rootRead.complete
+		? 'repository root history did not complete within the bounded time'
+		: rootCommits.length !== 1
+			? 'repository history has multiple root commits, so creation-time path ownership is ambiguous'
+			: undefined;
+	const rootPaths = new Set<string>();
+	if (!rootOwnershipNote) {
+		for (const path of readTree(rootCommits[0]!).keys()) rootPaths.add(path);
+	}
+	const provenancePaths = new Set<string>();
+	const provenancePathsByFold = new Set<string>();
+	if (!absenceNote) {
+		for (const commit of new Set(marker.provenance)) {
+			for (const path of readTree(commit).keys()) {
+				provenancePaths.add(path);
+				provenancePathsByFold.add(path.toLowerCase());
+			}
+		}
+	}
+	const indexTree = readIndexTree();
+	const history = new Map(
+		paths.map((path) => [
+			path,
+			upstreamTree.tree.has(path)
+				? { entries: [], complete: true }
+				: readHistoricalEntries(head, path)
+		])
+	);
+	const localEntries = paths.flatMap((path) => [
+		baseTree.get(path),
+		headTree.get(path),
+		indexTree.get(path),
+		...(history.get(path)?.entries ?? [])
+	]);
+	const localBlobs = readBlobs(
+		[...new Set(localEntries.filter((entry) => entry?.type === 'blob').map((entry) => entry!.sha))],
+		BLOB_BATCH_BYTES
+	);
+	const upstreamBlobs = readBlobs(
+		[
+			...new Set(
+				paths
+					.map((path) => upstreamTree.tree.get(path))
+					.filter((entry) => entry?.type === 'blob')
+					.map((entry) => entry!.sha)
+			)
+		],
+		BLOB_BATCH_BYTES
+	);
+	const verdicts = paths.map((path) =>
+		verdictFor(
+			path,
+			upstreamTree,
+			baseTree,
+			headTree,
+			indexTree,
+			localBlobs,
+			upstreamBlobs,
+			history.get(path)?.entries ?? [],
+			rootPaths,
+			provenancePaths,
+			provenancePathsByFold,
+			rootOwnershipNote,
+			captured.contents.get(path) ?? { values: [], missing: true },
+			unstagedPaths.has(path),
+			historyIncompleteNote ??
+				(history.get(path)?.complete === false
+					? 'local history is incomplete, so earlier ancestry is unknown'
+					: undefined),
+			absenceNote,
+			identityNote
+		)
+	);
+	// The tree stays pinned while it is read, but a sync that moves the shared
+	// ref before output would make an absent-path verdict obsolete. Abort instead.
+	if (baseResolution.origin) verifyOriginSnapshot(baseResolution.origin);
+	verifyScratchIndexEntries();
+	verifyLocalSnapshot(root, local);
+	// Keep the shared upstream ref as the last fence before output. Origin
+	// validation can wait on the network while another worktree fetches upstream.
+	verifyUpstreamSnapshot(upstreamUrl, upstream);
+
+	if (values.json) {
+		const output = JSON.stringify(
+			{
+				base,
+				upstreamRef: upstreamTree.sha,
+				upstreamUrl: redactUrl(upstreamUrl),
+				// A machine caller gets the staleness the text renderer prints, or
+				// it consumes fork-only verdicts from an old path set unwarned.
+				upstreamAgeDays: upstream.ageDays,
+				upstreamAgeFrom: upstream.ageFrom,
+				upstreamStale: upstream.ageDays !== null && upstream.ageDays >= STALE_AFTER_DAYS,
+				verdicts
+			},
+			null,
+			2
+		);
+		console.log(escapeOutputControls(output));
+		return;
+	}
+
+	const reportable = verdicts.filter((v) => v.report);
+	// Reading order, and the only place the overlap is allowed to matter. The
+	// paths arrive alphabetised, which would put a 0% file above a 100% one
+	// while the skill tells the reader to start at the top.
+	const RANK: Record<Relevance, number> = {
+		pristine: 0,
+		unmeasured: 1,
+		diverged: 2,
+		'fork-only': 3
+	};
+	const shown = (values.all ? verdicts : verdicts.filter((v) => v.relevance !== 'fork-only'))
+		.slice()
+		.sort(
+			(a, b) =>
+				RANK[a.relevance] - RANK[b.relevance] ||
+				(b.overlap ?? 0) - (a.overlap ?? 0) ||
+				a.path.localeCompare(b.path)
+		);
+
+	console.log('');
+	console.log(`Base: ${base.slice(0, 12)}   Upstream: ${upstreamTree.sha.slice(0, 12)}`);
+	// Printed on every run. The age explains why absent paths remain unmeasured
+	// and tells the reader when a fetch is worth the shared-state write.
+	if (upstream.ageDays !== null) {
+		console.log(
+			`Local upstream copy: ${upstream.ageDays} day(s) old (by ${upstream.ageFrom}).` +
+				(upstream.ageDays >= 1
+					? ' This copy may miss ties; absent paths stay unmeasured until a run with `--fetch`.'
+					: '')
+		);
+	}
+	console.log('');
+	if (shown.length === 0) {
+		console.log(`No template-derived file changed (${verdicts.length} checked, all fork-only).`);
+	} else {
+		for (const v of shown) {
+			const mark = v.report ? '>>' : '  ';
+			const displayPath = terminalSafe(v.path);
+			const detail =
+				v.relevance === 'diverged'
+					? ` (${Math.round((v.overlap ?? 0) * 100)}% of what it replaced is upstream)`
+					: v.relevance === 'unmeasured'
+						? ` (${terminalSafe(v.note ?? '')})`
+						: '';
+			console.log(`${mark} ${v.relevance.padEnd(10)} ${displayPath}${detail}`);
+		}
+	}
+	console.log('');
+	const guesses = reportable.filter((v) => v.relevance === 'unmeasured').length;
+	// An empty report and an unusable one read identically, and the warning
+	// above does not survive the summary line: an agent that acts on the last
+	// sentence stops. Only the empty case is rephrased, because a report with
+	// something in it already sends the reader to the files.
+	const stale = upstream.ageDays !== null && upstream.ageDays >= STALE_AFTER_DAYS;
+	console.log(
+		`${reportable.length} of ${verdicts.length} changed files need a look` +
+			(guesses > 0 ? `, ${guesses} of them because the tie to upstream is unproven` : '') +
+			'. ' +
+			(reportable.length > 0
+				? 'Read the change in each and decide whether the fix is upstream-shaped.'
+				: stale
+					? 'Nothing to report against a copy this old, which is not the same answer. ' +
+						'Run `bun run upstream:report -- --fetch`.'
+					: 'Nothing to report upstream.')
+	);
+}
+
+// Measured on Bun 1.3.14: SIGINT reaches the exit listener and SIGTERM and
+// SIGHUP do not, so those two leave the copy behind. A handler for them is the
+// wrong answer and was measured to be worse: this file spends almost all of its
+// time inside execFileSync, a JS handler cannot run until the event loop turns,
+// and installing one only replaces the default disposition. The run then
+// ignores SIGTERM entirely and needs SIGKILL. Sweeping on the way in cleans up
+// after whatever killed the last run, which no handler can promise anyway.
+if (import.meta.main) {
+	process.on('exit', dropScratchIndex);
+	main();
+}

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -144,21 +144,42 @@ function inheritedEnvironment(name: string): string | undefined {
 	return key === undefined ? undefined : process.env[key];
 }
 
-const PRIVATE_TRANSPORT_PROTOCOLS = new Set(['file', 'git', 'http', 'https', 'ssh']);
+const PRIVATE_TRANSPORT_PROTOCOLS = new Set(['file', 'https', 'ssh']);
+function gitBooleanIsFalse(value: string | undefined): boolean {
+	return value !== undefined && /^(?:|0|false|no|off)$/i.test(value);
+}
+
+function protocolAllowsAlways(protocol: string): boolean {
+	const policy = git(['config', '--get', `protocol.${protocol}.allow`], true);
+	return policy === '' || policy.toLowerCase() === 'always';
+}
+
 function transportProtocolEnv(): NodeJS.ProcessEnv {
 	const inherited = inheritedEnvironment('GIT_ALLOW_PROTOCOL');
 	const fromUser = inheritedEnvironment('GIT_PROTOCOL_FROM_USER');
+	const userProtocolsDisabled = gitBooleanIsFalse(fromUser);
+	const permitted = inherited
+		?.split(':')
+		.filter(
+			(protocol) =>
+				PRIVATE_TRANSPORT_PROTOCOLS.has(protocol) &&
+				!(userProtocolsDisabled && protocol === 'file') &&
+				protocolAllowsAlways(protocol)
+		)
+		.join(':');
 	return {
-		...(inherited === undefined
-			? {}
-			: {
-					GIT_ALLOW_PROTOCOL: inherited
-						.split(':')
-						.filter((protocol) => PRIVATE_TRANSPORT_PROTOCOLS.has(protocol))
-						.join(':')
-				}),
-		...(fromUser === '0' ? { GIT_PROTOCOL_FROM_USER: '0' } : {})
+		...(permitted === undefined ? {} : { GIT_ALLOW_PROTOCOL: permitted }),
+		...(userProtocolsDisabled ? { GIT_PROTOCOL_FROM_USER: '0' } : {})
 	};
+}
+
+function transportConfigEnv(): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { GIT_CONFIG_COUNT: String(transportEnvironmentConfig.length) };
+	for (const [index, [key, value]] of transportEnvironmentConfig.entries()) {
+		env[`GIT_CONFIG_KEY_${index}`] = key;
+		env[`GIT_CONFIG_VALUE_${index}`] = value;
+	}
+	return env;
 }
 
 // Config pinned on every invocation, because each of these changes the answer
@@ -248,6 +269,7 @@ function trustedTransportEnv(): NodeJS.ProcessEnv {
 	}
 	return {
 		...transportProtocolEnv(),
+		...transportConfigEnv(),
 		GIT_DIR: transportGitDir,
 		GIT_OBJECT_DIRECTORY: transportObjectDir,
 		GIT_SHALLOW_FILE: transportShallow,
@@ -322,16 +344,29 @@ function copyTransportConfiguration(configPath: string): void {
 		if (newline === -1) continue;
 		const key = record.slice(0, newline);
 		const value = record.slice(newline + 1);
-		if (key.startsWith('protocol.') && value.toLowerCase() === 'always') continue;
-		if (!safeWindowsTransportValue(key, value)) continue;
+		if (key.startsWith('protocol.')) continue;
+		if (!safeWindowsTransportValue(key, value)) {
+			transportEnvironmentConfig.push([key, value]);
+			continue;
+		}
 		appendTransportConfig(configPath, key, value);
+	}
+	appendTransportConfig(configPath, 'protocol.allow', 'never');
+	for (const [protocol, fallback] of [
+		['file', 'user'],
+		['https', 'always'],
+		['ssh', 'always']
+	] as const) {
+		const configured = git(['config', '--get', `protocol.${protocol}.allow`], true).toLowerCase();
+		if (configured !== '' && !/^(?:always|never|user)$/.test(configured)) {
+			fail(`Git protocol.${protocol}.allow has an invalid policy.`);
+		}
+		appendTransportConfig(configPath, `protocol.${protocol}.allow`, configured || fallback);
 	}
 	for (const remote of git(['remote'], true).split('\n').filter(Boolean)) {
 		const url = configuredRemoteUrl(remote);
 		const proxy = git(['config', '--get', `remote.${remote}.proxy`], true);
-		if (url && proxy && safeWindowsTransportValue(`remote.${remote}.proxy`, proxy)) {
-			transportProxyByUrl.set(url, proxy);
-		}
+		if (url && proxy) transportProxyByUrl.set(url, proxy);
 	}
 }
 
@@ -341,13 +376,43 @@ function transportRemote(url: string): string {
 	if (!transportConfigPath) {
 		fail('The private transport configuration is unavailable. Run the report again.');
 	}
-	if (WINDOWS_SAFETY_MODE) rejectSecretBearingRemoteUrl(url);
+	rejectUnauthenticatedTransport(url);
+	rejectSecretBearingRemoteUrl(url);
+	rejectDisabledTlsVerification(url);
+	const transportUrl = validatedTransportUrls.get(url);
+	if (!transportUrl) fail('The remote URL reached transport before location validation.');
 	const name = `upstream-report-${createHash('sha256').update(url).digest('hex').slice(0, 16)}`;
-	appendTransportConfig(transportConfigPath, `remote.${name}.url`, url);
+	appendTransportConfig(transportConfigPath, `remote.${name}.url`, transportUrl);
 	const proxy = transportProxyByUrl.get(url);
-	if (proxy) appendTransportConfig(transportConfigPath, `remote.${name}.proxy`, proxy);
+	if (proxy) {
+		const key = `remote.${name}.proxy`;
+		if (safeWindowsTransportValue(key, proxy))
+			appendTransportConfig(transportConfigPath, key, proxy);
+		else transportEnvironmentConfig.push([key, proxy]);
+	}
 	transportRemotes.set(url, name);
 	return name;
+}
+
+function rejectUnauthenticatedTransport(url: string): void {
+	if (/^(?:https|ssh|file):/i.test(url)) return;
+	if (isAbsolute(url)) return;
+	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
+		fail(
+			`Cannot trust ${terminalUrl(url)} because upstream evidence requires HTTPS, SSH, or a local file transport.`
+		);
+	}
+	if (/^(?:[^/\\]+@)?[^/\\:]+:.+/.test(url)) return;
+}
+
+function rejectDisabledTlsVerification(url: string): void {
+	if (!/^https:/i.test(url)) return;
+	for (const key of ['http.sslVerify', 'http.proxySSLVerify']) {
+		const value = git(['config', '--type=bool', '--get-urlmatch', key, url], true);
+		if (value === 'false') {
+			fail('Upstream evidence requires TLS and proxy TLS verification.');
+		}
+	}
 }
 
 function rejectSecretBearingRemoteUrl(url: string): void {
@@ -605,6 +670,8 @@ let transportShallow: string | undefined;
 let ownedRepositoryPaths: Set<string> | undefined;
 const transportRemotes = new Map<string, string>();
 const transportProxyByUrl = new Map<string, string>();
+const transportEnvironmentConfig: Array<[string, string]> = [];
+const validatedTransportUrls = new Map<string, string>();
 let callerIndexPath: string | undefined;
 let callerShallowPath: string | undefined;
 let callerIndexAtCopy: Buffer | null = null;
@@ -842,6 +909,8 @@ function dropScratchIndex(): void {
 	ownedRepositoryPaths = undefined;
 	transportRemotes.clear();
 	transportProxyByUrl.clear();
+	transportEnvironmentConfig.length = 0;
+	validatedTransportUrls.clear();
 	callerIndexPath = undefined;
 	callerShallowPath = undefined;
 	callerIndexAtCopy = null;
@@ -1279,7 +1348,10 @@ function localRemotePath(url: string, root: string): string | null {
 
 function rejectOwnedRepositoryRemote(url: string, root: string, remote: string): void {
 	const remotePath = localRemotePath(url, root);
-	if (!remotePath) return;
+	if (!remotePath) {
+		validatedTransportUrls.set(url, url);
+		return;
+	}
 	if (!ownedRepositoryPaths) {
 		fail('The repository checkout inventory is unavailable. Run the report again.');
 	}
@@ -1296,6 +1368,7 @@ function rejectOwnedRepositoryRemote(url: string, root: string, remote: string):
 				'A repository-owned remote can follow branch-controlled refs and hide every committed change.'
 		);
 	}
+	validatedTransportUrls.set(url, remotePath);
 }
 
 function rejectUnverifiableFileModes(): void {

--- a/.agents/skills/upstream-report/scripts/vitest.config.ts
+++ b/.agents/skills/upstream-report/scripts/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		include: ['.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts'],
+		environment: 'node',
+		passWithNoTests: false
+	}
+});

--- a/.agents/skills/upstream-report/scripts/vitest.config.ts
+++ b/.agents/skills/upstream-report/scripts/vitest.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts'],
+		include: [
+			'.agents/skills/upstream-report/scripts/upstream-relevance.test.ts',
+			'.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts'
+		],
 		environment: 'node',
 		passWithNoTests: false
 	}

--- a/.agents/skills/upstream-report/tsconfig.json
+++ b/.agents/skills/upstream-report/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"declaration": false,
+		"declarationMap": false,
+		"noEmit": true,
+		"types": ["node", "vitest/globals"]
+	},
+	"include": ["scripts/**/*.ts"]
+}

--- a/.agents/skills/upstream-sync/SKILL.md
+++ b/.agents/skills/upstream-sync/SKILL.md
@@ -136,6 +136,6 @@ in dependency order. Keep the invariant: one branch, one writer, one consolidate
 
 ## Template-bug linkage (do not strip on rebrand)
 
-Keep the AGENTS.md "SaaS Starter Template Bugs" section intact through rebrands; file
+Keep the AGENTS.md "Reporting template bugs from a fork" section intact through rebrands; file
 template-originated bugs upstream using its issue template. Fixes flow down (this skill);
 bug reports flow up.

--- a/.agents/skills/upstream-sync/SKILL.md
+++ b/.agents/skills/upstream-sync/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: upstream-sync
-description: Review and integrate upstream saas-starter template changes into a fork. Detects the fork point (forks are content-copies that share no git ancestor), lists every upstream commit since the last sync, and guides reviewing each one to integrate, skip as already-present, or exclude with a reason, adapting to this fork's divergences (branding, theme, env/deploy, i18n, fork-owned features), then ships one consolidated PR. Use when asked to sync or update from upstream, pull template changes, review what the template added, or apply an upstream fix.
+description: "Started by a human and by nothing else. Reviews and integrates upstream saas-starter template changes into a fork: detects the fork point (forks are content-copies that share no git ancestor), lists every upstream commit since the last sync, guides reviewing each one to integrate, skip, or exclude with a reason, adapting to this fork's divergences (branding, theme, env/deploy, i18n, fork-owned features), then ships one consolidated PR. Use when a human asks to sync from upstream or pull template changes, and at no other time. Sending a fix the other way is upstream-report."
 argument-hint: '[--type fix|feat|...] [--tag security]'
 allowed-tools: Bash, Read, Edit, Grep, Glob
 ---
 
 # Upstream Template Sync
 
-Pull later template changes into this fork. Review **every** upstream commit and
-integrate what fits: bug fixes, features, refactors, chores, and security fixes alike.
-Security fixes apply first and are never optional, and every other commit still gets
-the same review.
+Pull later template changes into this fork. The goal is to review **every** upstream
+enhancement, understand it, and integrate what fits: bug fixes, features, refactors,
+chores, and security fixes alike. Security fixes are never optional and apply first,
+but this is a comprehensive review, not a security-only pass.
 
 This fork was created by **content-copy** (GitHub "Use this template"), so it shares
 **NO git ancestor** with upstream: `git merge`, `git rebase`, and `gh repo sync` do
@@ -19,21 +19,32 @@ manually-adapted port.
 
 ## When to use
 
-- "sync from upstream", "pull template changes", "what did saas-starter add", "apply the upstream fix".
+Only when a human asks, in those words or close to them: "sync from upstream", "pull
+template changes", "what did saas-starter add", "apply the upstream fix".
+
+Never start this yourself. A sync rewrites files across the whole repository against a
+range of foreign commits, and deciding to take that on is the human's call, not an
+inference from having noticed the template moved. Sending a fix in the other direction
+is `upstream-report`, and that one is yours to run.
 
 ## When to STOP and ask the human
 
-- A candidate commit touches a file this fork has heavily rewritten (auth, schema, deploy config). Show the diff, do not auto-apply.
+- A candidate commit touches a file this fork has heavily rewritten (auth, schema, deploy config). Show the diff; do not auto-apply.
 - Fork-point detection returns a `closest-tree GUESS` (the bootstrap commit was edited). Confirm before proceeding.
 - A ported commit needs an env var that does not exist as a preview deployment default.
 - Before opening the PR, and before any merge. Never auto-merge.
 
-## Step 1: Discover (read-only)
+## Discover the upstream range
 
 ```bash
-bun .agents/skills/upstream-sync/scripts/find-fork-point.ts        # fork point via tree-SHA match
+bun run upstream:sync                                              # fork point via tree-SHA match
 bun .agents/skills/upstream-sync/scripts/list-upstream-changes.ts  # every commit since last sync, oldest-first
 ```
+
+Discovery leaves this fork's files alone, and it is not read-only: the fork-point script
+adds or repoints the `upstream` remote and fetches it. Both are shared by every linked
+worktree. A concurrent `upstream-report` aborts if this mutation lands before its report finishes.
+Re-run the report after discovery finishes.
 
 The list scopes from `.upstream-sync.json`'s `lastSynced` (falls back to the fork
 point on the first sync). Each row shows a priority tag, the divergence categories
@@ -43,7 +54,7 @@ the default). The upstream defaults to the template this skill shipped from; if 
 fork was forked from another fork, pass `--upstream <url>` (or set `upstreamUrl` in the
 marker) to point at the right template.
 
-## Step 2: Isolated worktree off main
+## Create an isolated worktree
 
 Never work in the shared checkout (a parallel process can sweep up staged files).
 
@@ -51,30 +62,30 @@ Never work in the shared checkout (a parallel process can sweep up staged files)
 bun run worktree chore/upstream-sync --base main
 ```
 
-## Step 3: Detect THIS fork's divergences
+## Detect this fork's divergences
 
 Do not assume; detect from the diff against the fork point. Categories: branding/legal
 config, theme/design tokens, env/deploy config, i18n content, fork-owned features. See
 [reference/divergence-categories.md](reference/divergence-categories.md). A commit
 touching a diverged file needs extra care: re-apply the upstream _intent_ onto the
-fork's values. A commit that touches no diverged area still gets the full Step 4
-verdict. Divergence categories change how much adaptation a commit needs, never whether
-you review it.
+fork's values. A commit that touches no diverged area is **not** a free pass. It still
+gets the full per-commit verdict. Divergence categories change how much adaptation a commit
+needs, never whether you review it.
 
-## Step 4: Review and classify every commit
+## Review and classify every commit
 
-The priority tag and divergence categories from Step 1 are **hints only**: they set
-ordering and how much adaptation a commit needs. They are never a gate or a substitute
-for review. Read **every** commit's actual diff and give it an explicit verdict; never
-integrate, skip, or exclude a commit from its label alone, and never blind-apply an
-untagged or unlabeled commit. "Security first" is about apply order; you still read
-every commit.
+The priority tag and divergence categories from discovery are **hints only**. Use them for
+ordering and for how much adaptation a commit needs. They are never a gate or a
+substitute for review. Read **every** commit's actual diff and give it an explicit
+verdict; never integrate, skip, or exclude a commit from its label alone, and never
+blind-apply an untagged or unlabeled commit. "Security first" is about apply order, not
+about which commits to look at. Review all of them.
 
 Process oldest-first (dependency order). Apply security and bug fixes first, then
 features/refactors/chores. For each commit, from its diff, decide:
 
 - **Integrate.** Applies to this fork, possibly adapted.
-- **Already present.** The fork already has equivalent code (grep / `git log` the fork). Skip.
+- **Already present.** The fork already has equivalent code. Grep or `git log` the fork, then skip.
 - **Exclude.** Conflicts with a deliberate fork divergence, or re-introduces something
   the fork removed. Record `{sha, reason}` in `.upstream-sync.json` so it is not
   re-triaged next sync.
@@ -85,15 +96,15 @@ rename). Port prerequisites first or together; never batch-apply the whole range
 The review unit is the squashed first-parent commit; for an oversized commit, triage
 within it by file/hunk. See [reference/triage.md](reference/triage.md).
 
-## Step 5: Apply, dependency-aware
+## Apply in dependency order
 
 Cherry-pick or hand-port in order.
 
-- **Branding/theme/config.** Re-apply the upstream _intent_ on the fork's values; never clobber fork branding or tokens.
-- **i18n JSON conflicts.** Use a JSON-aware 3-way deep merge, NEVER a line-based resolver (it corrupts nested objects). See [reference/i18n-merge.md](reference/i18n-merge.md), then run the locale-parity test.
+- **Branding/theme/config**: re-apply the upstream _intent_ on the fork's values; never clobber fork branding or tokens.
+- **i18n JSON conflicts**: use a JSON-aware 3-way deep merge, NEVER a line-based resolver (it corrupts nested objects). See [reference/i18n-merge.md](reference/i18n-merge.md), then run the locale-parity test.
 - Skip any commit that purely reverts a fork choice (rebrand, font, removed feature).
 
-## Step 6: Validate against WHOLE-PROJECT CI
+## Validate against whole-project CI
 
 `scripts/static-checks.ts` is file-scoped and misses project-wide gates. Run the
 project-wide lint, type check, unit tests, and a build before the PR. A newly ported
@@ -102,7 +113,7 @@ var, ensure it exists as a preview deployment default (CI's `convex deploy` fail
 missing required var; a green local build does not cover the deploy step). See
 [reference/ci-gotchas.md](reference/ci-gotchas.md).
 
-## Step 7: Ship ONE consolidated PR
+## Ship one consolidated PR
 
 One branch off current `main` with all integrated commits, grouped thematically for
 readable history but applied in dependency order. Do NOT stack PRs (deleting a stack
@@ -116,12 +127,12 @@ commit `.upstream-sync.json`.
 
 ## Large syncs (many commits): fan out per-commit, not per-category
 
-Run the two discovery scripts once, then parallelize the _triage_ one agent per commit,
-plus an adversarial recheck of every dismissal. The commit is the unit of intent and the
-only level where cross-commit dependencies are visible. A single **lead** owns the one
-worktree branch and is the only writer (serialized commits); subagents return patches +
-verdicts + dependency notes as text, the lead applies them in dependency order. Keep the
-invariant: one branch, one writer, one consolidated PR.
+Run the two discovery scripts once, then parallelize the _triage_ one agent per commit
+(plus an adversarial recheck of every dismissal). The commit is the atomic unit of
+intent and the only granularity where cross-commit dependencies are visible. A single
+**lead** owns the one worktree branch and is the only writer (serialized commits);
+subagents return patches + verdicts + dependency notes as text, the lead applies them
+in dependency order. Keep the invariant: one branch, one writer, one consolidated PR.
 
 ## Template-bug linkage (do not strip on rebrand)
 

--- a/.claude/skills/upstream-report
+++ b/.claude/skills/upstream-report
@@ -1,0 +1,1 @@
+../../.agents/skills/upstream-report

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -84,3 +84,12 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install
       - run: bun run test:unit
+
+  upstream-report-tests:
+    name: Upstream Report Tests
+    runs-on: ubicloud-standard-2
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - run: bun install
+      - run: bun run test:upstream-report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Template code and fork-owned code share one tree. Measure whether a change came 
 bun run upstream:report
 ```
 
-The report keeps every uncertain file visible as `unmeasured`; bootstrap presence and negative text resemblance do not prove fork ownership. An incomplete run exits non-zero. Load `.agents/skills/upstream-report/SKILL.md` to interpret each file, search existing saas-starter issues, and use the repository's issue template. Ask the human before filing.
+The report keeps every uncertain file visible as `unmeasured`; bootstrap presence and negative text resemblance do not prove fork ownership. An incomplete run exits non-zero. Load `.agents/skills/upstream-report/SKILL.md` to interpret each file, search existing saas-starter issues, and match recent issue style. Ask the human before filing.
 
 ### Pulling upstream changes into a fork
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Template code and fork-owned code share one tree. Measure whether a change came 
 bun run upstream:report
 ```
 
-The report keeps uncertain files visible as `unmeasured` and reserves `fork-only` for evidence that rules out an upstream tie. An incomplete run exits non-zero. Load `.agents/skills/upstream-report/SKILL.md` to interpret each file, search existing saas-starter issues, and use the repository's issue template. Ask the human before filing.
+The report keeps every uncertain file visible as `unmeasured`; bootstrap presence and negative text resemblance do not prove fork ownership. An incomplete run exits non-zero. Load `.agents/skills/upstream-report/SKILL.md` to interpret each file, search existing saas-starter issues, and use the repository's issue template. Ask the human before filing.
 
 ### Pulling upstream changes into a fork
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,21 +21,23 @@ Skills hold dependency and workflow tutorials. Use the applicable skill instead 
 
 ## Template and fork workflow
 
-### SaaS Starter template bugs
+### Reporting template bugs from a fork
 
 <!-- DO NOT rename or remove this section when rebranding a fork. These links point to the upstream template repo. -->
 
-If a fork discovers a bug or unexpected behavior that originates in the template:
+Template code and fork-owned code share one tree. Measure whether a change came from the template instead of judging it by eye:
 
-1. Search [saas-starter issues](https://github.com/stickerdaniel/saas-starter/issues).
-2. If none exists, fetch the relevant upstream issue template with `gh api repos/stickerdaniel/saas-starter/contents/.github/ISSUE_TEMPLATE`.
-3. File the issue using that template.
+```bash
+bun run upstream:report
+```
+
+The report keeps uncertain files visible as `unmeasured` and reserves `fork-only` for evidence that rules out an upstream tie. An incomplete run exits non-zero. Load `.agents/skills/upstream-report/SKILL.md` to interpret each file, search existing saas-starter issues, and use the repository's issue template. Ask the human before filing.
 
 ### Pulling upstream changes into a fork
 
 <!-- DO NOT rename or remove this section when rebranding a fork. -->
 
-Use the `upstream-sync` skill (`.agents/skills/upstream-sync/SKILL.md`) and start with `bun run upstream:fork-point` and `bun run upstream:changes`. Forks are content copies without a shared Git ancestor, so ordinary merge/rebase/sync workflows do not apply.
+A human starts the `upstream-sync` skill (`.agents/skills/upstream-sync/SKILL.md`) with `bun run upstream:sync`, then reviews `bun run upstream:changes`. Forks are content copies without a shared Git ancestor, so ordinary merge, rebase, and repository-sync workflows do not apply.
 
 ## Global rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,8 @@ A finished mechanical guard fails on the buggy revision for the same causal reas
 - `bun run dev:cloud` — Vite + cloud Convex backend
 - `bun scripts/static-checks.ts <changed files...>` — required after implementation
 - `bun scripts/static-checks.ts --scope types` — required once before final handoff or PR for changes to JS, TS, Svelte, Convex, email templates, or Autumn config; pre-commit intentionally runs staged lint only
-- `bun run test:unit` — Vitest suite
+- `bun run test:unit` — Vitest unit suite
+- `bun run test:upstream-report` — repository-backed detector suite; required after upstream-report code or test changes
 - `bun run test:e2e` — Playwright suite; required after E2E changes
 - `bun run test` — complete test suite
 - `bun run check:convex` — required after Convex or Convex-imported shared-code changes

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"test:e2e:headed": "VARLOCK_ENV=test playwright test --headed",
 		"test": "bun run test:e2e && bun run test:unit",
 		"test:unit": "bun run generate:content && vitest --run --reporter=verbose --passWithNoTests",
+		"test:upstream-report": "vitest --config .agents/skills/upstream-report/scripts/vitest.config.ts --run --reporter=verbose",
 		"model:eval": "bun scripts/model-eval.ts",
 		"i18n:pull": "varlock run -- bun run _tolgee:pull && prettier --write src/i18n/*.json",
 		"i18n:push": "varlock run -- bun run _tolgee:push",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
 		"worktree:setup": "bun scripts/create-worktree.ts --setup-only",
 		"worktree:prune": "bun scripts/prune-worktrees.ts",
 		"setup": "bun scripts/template-setup.ts",
+		"upstream:report": "bun .agents/skills/upstream-report/scripts/upstream-relevance.ts",
+		"upstream:sync": "bun .agents/skills/upstream-sync/scripts/find-fork-point.ts",
 		"upstream:fork-point": "bun .agents/skills/upstream-sync/scripts/find-fork-point.ts",
 		"upstream:changes": "bun .agents/skills/upstream-sync/scripts/list-upstream-changes.ts"
 	},

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"worktree:setup": "bun scripts/create-worktree.ts --setup-only",
 		"worktree:prune": "bun scripts/prune-worktrees.ts",
 		"setup": "bun scripts/template-setup.ts",
+		"check:upstream-report": "tsc -p .agents/skills/upstream-report/tsconfig.json",
 		"upstream:report": "bun .agents/skills/upstream-report/scripts/upstream-relevance.ts",
 		"upstream:sync": "bun .agents/skills/upstream-sync/scripts/find-fork-point.ts",
 		"upstream:fork-point": "bun .agents/skills/upstream-sync/scripts/find-fork-point.ts",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"check:precommit": "bun run static-checks:staged && bunx varlock scan --staged",
 		"test:e2e": "VARLOCK_ENV=test playwright test",
 		"test:e2e:headed": "VARLOCK_ENV=test playwright test --headed",
-		"test": "bun run test:e2e && bun run test:unit",
+		"test": "bun run test:e2e && bun run test:unit && bun run test:upstream-report",
 		"test:unit": "bun run generate:content && vitest --run --reporter=verbose --passWithNoTests",
 		"test:upstream-report": "vitest --config .agents/skills/upstream-report/scripts/vitest.config.ts --run --reporter=verbose",
 		"model:eval": "bun scripts/model-eval.ts",

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -208,6 +208,13 @@ describe('route predicates', () => {
 		]);
 	});
 
+	it('routes upstream-report TypeScript through its dedicated project', () => {
+		expect(
+			ROUTES['skill-types']('.agents/skills/upstream-report/scripts/upstream-relevance.ts')
+		).toBe(true);
+		expect(ROUTES['skill-types']('.agents/skills/upstream-report/SKILL.md')).toBe(false);
+	});
+
 	it('are blind to an absolute path, which is why normalization is load-bearing', () => {
 		const absolute = path.join(ROOT, 'src/lib/utils/auth-messages.ts');
 		const absoluteConvex = path.join(ROOT, 'src/lib/convex/schema.ts');

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -212,6 +212,8 @@ describe('route predicates', () => {
 		expect(
 			ROUTES['skill-types']('.agents/skills/upstream-report/scripts/upstream-relevance.ts')
 		).toBe(true);
+		expect(ROUTES['skill-types']('.agents/skills/upstream-report/tsconfig.json')).toBe(true);
+		expect(ROUTES['skill-types']('.agents/skills/upstream-report/helper.ts')).toBe(false);
 		expect(ROUTES['skill-types']('.agents/skills/upstream-report/SKILL.md')).toBe(false);
 	});
 

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -356,6 +356,26 @@ describe('resolveInputs', () => {
 			rmSync(directory, { recursive: true, force: true });
 		}
 	});
+
+	it.skipIf(process.platform === 'win32')(
+		'accepts a directory whose files were already named',
+		() => {
+			const directory = path.join(ROOT, `.static-checks-overlap-target-${process.pid}`);
+			const link = path.join(ROOT, `.static-checks-overlap-link-${process.pid}`);
+			const file = path.join(directory, 'only.ts');
+			mkdirSync(directory);
+			writeFileSync(file, 'export {};\n');
+			symlinkSync(directory, link);
+			try {
+				expect(resolveInputs([file, link], 'test')).toEqual([
+					path.relative(ROOT, file).split(path.sep).join('/')
+				]);
+			} finally {
+				rmSync(link, { force: true });
+				rmSync(directory, { recursive: true, force: true });
+			}
+		}
+	);
 });
 
 describe('bad input dies at the boundary', () => {

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -331,6 +331,8 @@ export const ROUTES = {
 	// The old gate was `jsTsSvelteFiles.length === 0 && svelteFiles.length === 0`;
 	// svelteFiles is a subset of jsTsSvelteFiles, so the second clause was dead.
 	'svelte-check': (f: string) => /\.(js|ts|svelte)$/.test(f),
+	'skill-types': (f: string) =>
+		f.startsWith('.agents/skills/upstream-report/') && /\.(ts|json)$/.test(f),
 	convex: (f: string) => f.startsWith('src/lib/convex/')
 } as const;
 
@@ -393,7 +395,7 @@ const LINT_CHECKS: CheckId[] = [
 	'prettier',
 	'eslint'
 ];
-const TYPE_CHECKS: CheckId[] = ['svelte-check', 'convex'];
+const TYPE_CHECKS: CheckId[] = ['svelte-check', 'skill-types', 'convex'];
 
 type Mode = 'files' | 'staged' | 'full';
 
@@ -1042,6 +1044,20 @@ async function main(): Promise<void> {
 				// svelte-check is tsconfig-driven: the routed files decide WHETHER it runs,
 				// then it type-checks the whole project regardless.
 				ledger.ran('svelte-check', 'project');
+			}
+		}
+		console.log('\n');
+
+		// Agent skill type checking
+		printHeader(step++, 'Agent skill type checking');
+		{
+			const files = ledger.filesFor('skill-types');
+			if (!scopedMode || files.length > 0) {
+				await runCommand('bun', ['run', 'check:upstream-report']);
+				ledger.ran('skill-types', 'project');
+			} else {
+				console.log('No upstream-report TypeScript files to check');
+				ledger.ran('skill-types', 0);
 			}
 		}
 		console.log('\n');

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -270,14 +270,15 @@ export function resolveInputs(raw: string[], origin: string): string[] {
 		}
 
 		if (statSync(real).isDirectory()) {
-			const before = out.size;
+			let matched = false;
 			const prefix = `${relative}/`;
 			for (const file of repositoryPaths()) {
 				if (!file.startsWith(prefix) || !existsSync(path.join(REPO_ROOT, file))) continue;
 				if (NEVER_WALK.some((skip) => file.includes(skip))) continue;
+				matched = true;
 				out.add(file);
 			}
-			if (out.size === before)
+			if (!matched)
 				fail(`Directory contains no files to check (${origin}): ${formatPathForDiagnostic(arg)}`);
 			continue;
 		}

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -332,7 +332,8 @@ export const ROUTES = {
 	// svelteFiles is a subset of jsTsSvelteFiles, so the second clause was dead.
 	'svelte-check': (f: string) => /\.(js|ts|svelte)$/.test(f),
 	'skill-types': (f: string) =>
-		f.startsWith('.agents/skills/upstream-report/') && /\.(ts|json)$/.test(f),
+		f === '.agents/skills/upstream-report/tsconfig.json' ||
+		(f.startsWith('.agents/skills/upstream-report/scripts/') && f.endsWith('.ts')),
 	convex: (f: string) => f.startsWith('src/lib/convex/')
 } as const;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -380,7 +380,9 @@ export default defineConfig(async ({ mode }) => {
 				'references/**',
 				// Skills live in .agents/skills/ and are symlinked into .claude/skills/;
 				// exclude the symlinked path so tests are not discovered and run twice.
-				'.claude/skills/**'
+				'.claude/skills/**',
+				// Repository-spawning detector tests run in their own CI job.
+				'.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts'
 			],
 			passWithNoTests: true,
 			environment: 'jsdom'


### PR DESCRIPTION
Regression guard: added detector integration, transport-policy, path-bound, and static-check routing tests

Content-copy forks have no shared Git ancestry, so a path alone cannot show whether a local fix belongs in the template. Template defects can stay stranded in one fork, while product-only changes get sent upstream.

This adds `upstream:report`, which classifies changed paths as `pristine`, `diverged`, or `unmeasured`. Absent and bootstrap-root paths stay visible because negative resemblance cannot prove ownership. The detector binds remote identity, snapshots Git state, permits only local file, HTTPS, and SSH transport, requires TLS verification, keeps Windows authentication out of temporary files, canonicalizes local remotes, and bounds path, blob, history, and text work. The copied skill also makes upstream sync human-started and adds its TypeScript project to required static checks.

Verified with changed-file and full type checks, 2,026 passing tests, a production build, red mutation probes for the trust guards, and independent review rounds.
