### PR TITLE
fix(lint): Preserve formatter input paths

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "./node_modules/oxlint/configuration_schema.json",
 	"jsPlugins": ["oxlint-plugin-convex"],
-	"ignorePatterns": ["**/node_modules/**", "**/_generated/**", "**/references/**"],
+	"ignorePatterns": ["scratch/**", "**/node_modules/**", "**/_generated/**", "**/references/**"],
 	"rules": {
 		"convex/no-unused-functions": [
 			"warn",

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,7 +12,7 @@ docs/references/
 /scratch/
 
 # Cross-platform symlink pointer
-CLAUDE.md
+/CLAUDE.md
 
 # Generated files
 **/_generated/

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,12 @@ bun.lockb
 # Git submodules
 docs/references/
 
+# Local session artifacts
+/scratch/
+
+# Cross-platform symlink pointer
+CLAUDE.md
+
 # Generated files
 **/_generated/
 src/env.d.ts

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,7 +74,7 @@ export default defineConfig(
 	// exposed to a character nobody typed, so the later file block disables its inline
 	// directive and exempts only the generated style rules it then trips.
 	{
-		ignores: ['**/_generated/**', 'src/lib/convex/convex-env.d.ts']
+		ignores: ['scratch/**', '**/_generated/**', 'src/lib/convex/convex-env.d.ts']
 	},
 	js.configs.recommended,
 	...ts.configs.recommended,

--- a/knowledge-policy.config.ts
+++ b/knowledge-policy.config.ts
@@ -24,6 +24,7 @@ const policyRuntime = anyOf(
 );
 const ignored = anyOf(
 	underPath('references'),
+	underPath('scratch'),
 	underPath('node_modules'),
 	underPath('.git'),
 	underPath('.svelte-kit'),

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -532,6 +532,36 @@ describe('format-only static checks', () => {
 		}
 	);
 
+	it.each(['.git', '.sl', '.svn', '.hg', '.jj'])(
+		"counts Prettier's hard-coded %s exclusion as zero formatter work",
+		(vcsDirectory) => {
+			const parent = path.join(ROOT, 'scripts', `.format-vcs-${process.pid}`);
+			const directory = path.join(parent, vcsDirectory);
+			const relative = `scripts/.format-vcs-${process.pid}/${vcsDirectory}/probe.ts`;
+			mkdirSync(directory, { recursive: true });
+			writeFileSync(path.join(ROOT, relative), 'export const skipped   =1\n');
+			try {
+				// Prettier's CLI drops these path segments before expansion. `getFileInfo` does not,
+				// so the classifier carries the same closed list instead of claiming this file was
+				// checked when a formatted peer gives the CLI a successful match.
+				const direct = spawnSync(
+					testExecutable('bun'),
+					['prettier', '--check', '--', relative, 'README.md'],
+					{ cwd: ROOT, env: { ...sanitizedGitEnv(), NO_COLOR: '1' }, encoding: 'utf8' }
+				);
+				expect(direct.status, `${direct.stdout}${direct.stderr}`).toBe(0);
+				expect(`${direct.stdout}${direct.stderr}`).not.toContain(relative);
+
+				const result = formatCheckFilesFrom(`${relative}\0README.md\0`);
+				expect(result.status, result.output).toBe(0);
+				expect(result.output).toContain('prettier         1 file(s)');
+				expect(result.output).not.toContain(relative);
+			} finally {
+				rmSync(parent, { recursive: true, force: true });
+			}
+		}
+	);
+
 	it.skipIf(process.platform === 'win32')(
 		'accepts an absolute path through a symlinked checkout alias',
 		() => {

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -13,7 +13,9 @@ import { tmpdir } from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
+import knowledgePolicy from '../knowledge-policy.config';
 import { sanitizedGitEnv } from './git-context';
+import { runKnowledgePolicy } from './knowledge-policy/repository';
 import {
 	isNeverWalked,
 	prettierArguments,
@@ -485,8 +487,10 @@ describe('format-only static checks', () => {
 			const aliasRelative = `.format-symlink-alias-${process.pid}`;
 			const alias = path.join(ROOT, aliasRelative);
 			const named = `${aliasRelative}/probe.ts`;
-			mkdirSync(target, { recursive: true });
+			const namedDirectory = `${aliasRelative}/subdir`;
+			mkdirSync(path.join(target, 'subdir'), { recursive: true });
 			writeFileSync(path.join(target, 'probe.ts'), 'export const value   =1\n');
+			writeFileSync(path.join(target, 'subdir', 'nested.ts'), 'export const nested   =1\n');
 			symlinkSync(target, alias, 'dir');
 			try {
 				// The target is ignored as root scratch, while the caller-visible alias is not.
@@ -504,9 +508,55 @@ describe('format-only static checks', () => {
 				expect(result.status, result.output).toBe(1);
 				expect(result.output).toContain(named);
 				expect(result.output).not.toContain('No formatter work');
+
+				// Directory traversal reads the resolved target, then maps every child back below
+				// the alias before ignore classification and launch.
+				expect(
+					resolveInputs(
+						[namedDirectory],
+						'arguments',
+						ROOT,
+						(directory) => prettierTraversalPaths(directory, false, ROOT),
+						false
+					)
+				).toEqual([`${namedDirectory}/nested.ts`]);
+				const directory = formatCheck(namedDirectory);
+				expect(directory.status, directory.output).toBe(1);
+				expect(directory.output).toContain(`${namedDirectory}/nested.ts`);
+				expect(directory.output).not.toContain('No formatter work');
 			} finally {
 				rmSync(alias, { force: true });
 				rmSync(target, { recursive: true, force: true });
+			}
+		}
+	);
+
+	it.skipIf(process.platform === 'win32')(
+		'accepts an absolute path through a symlinked checkout alias',
+		() => {
+			const directory = mkdtempSync(path.join(tmpdir(), 'format-checkout-alias-'));
+			const alias = path.join(directory, 'repository');
+			symlinkSync(ROOT, alias, 'dir');
+			const named = path.join(alias, 'README.md');
+			try {
+				const direct = spawnSync(testExecutable('bun'), ['prettier', '--check', '--', named], {
+					cwd: alias,
+					env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
+					encoding: 'utf8'
+				});
+				expect(direct.status, `${direct.stdout}${direct.stderr}`).toBe(0);
+
+				const result = spawnSync(testExecutable('bun'), [SCRIPT, '--scope', 'format', named], {
+					cwd: alias,
+					env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
+					encoding: 'utf8'
+				});
+				const output = `${result.stdout}${result.stderr}`;
+				expect(result.status, output).toBe(0);
+				expect(output).toContain('prettier         1 file(s)');
+				expect(output).not.toContain('outside the repository');
+			} finally {
+				rmSync(directory, { recursive: true, force: true });
 			}
 		}
 	);
@@ -764,6 +814,7 @@ describe('scope routing', () => {
 	it('keeps scratch out of project-wide checks', () => {
 		const directory = path.join(ROOT, 'scratch', `exclusion-${process.pid}`);
 		const relative = `scratch/exclusion-${process.pid}/abandoned.test.ts`;
+		const markdown = `scratch/exclusion-${process.pid}/review.md`;
 		mkdirSync(directory, { recursive: true });
 		const run = (args: string[]) =>
 			spawnSync(testExecutable('bun'), args, {
@@ -778,6 +829,15 @@ describe('scope routing', () => {
 				path.join(directory, 'abandoned.test.ts'),
 				'const unused = ;\nexport function broken(: never {}\n'
 			);
+			writeFileSync(path.join(ROOT, markdown), '[missing](missing.md)\n');
+
+			const policy = runKnowledgePolicy({
+				root: ROOT,
+				policy: knowledgePolicy,
+				scope: { kind: 'files', files: [markdown] }
+			});
+			expect(policy.filesEvaluated).toBe(0);
+			expect(policy.findings).toEqual([]);
 
 			const oxlint = run(['oxlint']);
 			expect(`${oxlint.stdout}${oxlint.stderr}`).not.toContain('abandoned.test.ts');

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -289,6 +289,28 @@ describe('format-only static checks', () => {
 		}
 	);
 
+	// Git lists a directory symlink as one entry and knows nothing below it, so an expansion
+	// that keeps the link's name routes eleven directories by their own extension, which is
+	// none. Measured before this: `.claude/skills` expanded to eleven names and zero
+	// TypeScript files, and `--scope types` over the parent reported success having checked
+	// nothing. The child links resolve now, so the same expansion reaches their targets.
+	it.skipIf(!lstatSync(path.join(ROOT, '.claude/skills/upstream-sync')).isSymbolicLink())(
+		'resolves a symlinked child of an expanded directory',
+		() => {
+			const expanded = resolveInputs(['.claude/skills'], 'arguments', ROOT);
+			expect(expanded.filter((file) => file.endsWith('.ts')).length).toBeGreaterThan(0);
+			// Every entry names a real file under the link's target, never the link itself.
+			expect(expanded.some((file) => file.startsWith('.claude/skills/'))).toBe(false);
+
+			// The formatter neither follows nor accepts a link, so the same directory holds
+			// nothing it can format. It says so and exits non-zero rather than reporting a
+			// green run over an empty set.
+			const formatted = formatCheck('.claude/skills');
+			expect(formatted.status, formatted.output).toBe(1);
+			expect(formatted.output).toContain('Directory contains no files to check');
+		}
+	);
+
 	it('refuses two paths that collide under formatter escaping', () => {
 		const directory = path.join(ROOT, 'scripts', `.format-collide-${process.pid}`);
 		const relative = `scripts/.format-collide-${process.pid}`;
@@ -726,7 +748,11 @@ describe('scope routing', () => {
 		const output = `${result.stdout}${result.stderr}`;
 		expect(result.status).toBe(1);
 		expect(output).toContain('--scope format does not support --staged');
-		expect(output).toContain('--files-from');
+		// The diagnostic must not send a staged gate to `--files-from`: that names paths, and
+		// every checker then reads the working tree, so a file staged unformatted and then
+		// formatted only on disk would pass the gate and be committed unformatted.
+		expect(output).toContain('always as the files are on disk');
+		expect(output).not.toContain('use --files-from');
 		expect(output).not.toContain('Code formatting');
 	});
 

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'child_process';
 import {
 	copyFileSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
@@ -212,7 +213,7 @@ describe('format-only static checks', () => {
 		// replaces every backslash with a slash. A backslash-escaped route would arrive there
 		// with its escapes stripped and match nothing, so the escape has to be a character
 		// class, and the pattern has to survive that same rewrite unchanged.
-		expect(pattern).toBe('src/routes/[[][[]lang[]][]]/[(]marketing[)]/+page.svelte');
+		expect(pattern).toBe('src/routes/[[][[]lang[]][]]/[(]marketing[)]/[+]page.svelte');
 		expect(pattern.replaceAll('\\', '/')).toBe(pattern);
 
 		const result = formatCheck(route);
@@ -264,23 +265,65 @@ describe('format-only static checks', () => {
 		expect(`${vanished.stdout}${vanished.stderr}`).toContain('No files matching the pattern');
 	});
 
-	it('expands a symlinked directory for every scope except format', () => {
-		const link = '.claude/skills/upstream-sync';
-		const expanded = resolveInputs([link], 'arguments', ROOT);
-		expect(expanded.length).toBeGreaterThan(1);
-		expect(expanded.some((file) => file.endsWith('.ts'))).toBe(true);
+	// A Windows checkout with core.symlinks=false materializes the tracked link as an
+	// ordinary file holding its target's path, and there is nothing to expand there.
+	it.skipIf(!lstatSync(path.join(ROOT, '.claude/skills/upstream-sync')).isSymbolicLink())(
+		'expands a symlinked directory for every scope except format',
+		() => {
+			const link = '.claude/skills/upstream-sync';
+			const expanded = resolveInputs([link], 'arguments', ROOT);
+			expect(expanded.length).toBeGreaterThan(1);
+			expect(expanded.some((file) => file.endsWith('.ts'))).toBe(true);
 
-		// Prettier refuses an explicitly named symlink, so the formatter passes the link
-		// itself and lets that refusal happen instead of silently checking the target.
-		expect(
-			resolveInputs(
-				[link],
-				'arguments',
-				ROOT,
-				(directory) => prettierTraversalPaths(directory, false, ROOT),
-				false
-			)
-		).toEqual([link]);
+			// Prettier refuses an explicitly named symlink, so the formatter passes the link
+			// itself and lets that refusal happen instead of silently checking the target.
+			expect(
+				resolveInputs(
+					[link],
+					'arguments',
+					ROOT,
+					(directory) => prettierTraversalPaths(directory, false, ROOT),
+					false
+				)
+			).toEqual([link]);
+		}
+	);
+
+	it('refuses two paths that collide under formatter escaping', () => {
+		const directory = path.join(ROOT, 'scripts', `.format-collide-${process.pid}`);
+		const relative = `scripts/.format-collide-${process.pid}`;
+		mkdirSync(directory, { recursive: true });
+		try {
+			writeFileSync(path.join(directory, '[ab].ts'), 'export const a   =1\n');
+			writeFileSync(path.join(directory, '[[]ab[]].ts'), 'export const b = 1;\n');
+
+			const result = formatCheck(`${relative}/[ab].ts`);
+			expect(result.status, result.output).toBe(1);
+			expect(result.output).toContain('collide under formatter escaping');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it('escapes a plus so it cannot quantify the escape before it', () => {
+		expect(prettierLiteralPattern('[+.ts')).toBe('[[][+].ts');
+		expect(prettierLiteralPattern('src/routes/+page.svelte')).toBe('src/routes/[+]page.svelte');
+
+		const directory = path.join(ROOT, 'scripts', `.format-plus-${process.pid}`);
+		const relative = `scripts/.format-plus-${process.pid}`;
+		mkdirSync(directory, { recursive: true });
+		try {
+			// Unescaped, `[[]+.ts` quantifies the class and matches the formatted neighbour
+			// instead, which is a green run over a file that was never looked at.
+			writeFileSync(path.join(directory, '[+.ts'), 'export const a   =1\n');
+			writeFileSync(path.join(directory, '[.ts'), 'export const b = 1;\n');
+
+			const result = formatCheck(`${relative}/[+.ts`);
+			expect(result.status, result.output).toBe(1);
+			expect(result.output).toContain('[+.ts');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 
 	it('anchors the generated trees .gitignore anchors and no others', () => {

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'child_process';
 import {
+	chmodSync,
 	copyFileSync,
 	lstatSync,
 	mkdirSync,
@@ -881,6 +882,47 @@ describe('scope routing', () => {
 			rmSync(checkout.directory, { recursive: true, force: true });
 		}
 	}, 120_000);
+
+	it.skipIf(process.platform === 'win32')(
+		'rejects a full lint run whose formatter matched zero files',
+		() => {
+			const checkout = createCheckerClone();
+			const tools = path.join(checkout.directory, 'tools');
+			mkdirSync(tools);
+			const misspell = path.join(tools, 'misspell');
+			writeFileSync(misspell, '#!/bin/sh\nexit 0\n');
+			chmodSync(misspell, 0o755);
+			// The invariant under test is the ledger's real in-process Prettier classification.
+			// Child commands are irrelevant after that and would turn one assertion into a full
+			// lint suite, so the PATH-local Bun acknowledges them without doing duplicate work.
+			const childBun = path.join(tools, 'bun');
+			writeFileSync(childBun, '#!/bin/sh\nexit 0\n');
+			chmodSync(childBun, 0o755);
+			writeFileSync(path.join(checkout.repository, '.prettierignore'), '**/*\n');
+			try {
+				const env = sanitizedGitEnv();
+				env.NO_COLOR = '1';
+				env.PATH = `${tools}${path.delimiter}${env.PATH ?? ''}`;
+				const result = spawnSync(
+					testExecutable('bun'),
+					[
+						path.join(checkout.repository, 'scripts', 'static-checks.ts'),
+						'--ci',
+						'--scope',
+						'lint'
+					],
+					{ cwd: checkout.repository, env, encoding: 'utf8', timeout: 240_000 }
+				);
+				const output = `${result.stdout}${result.stderr}`;
+				expect(result.status, output).toBe(1);
+				expect(output).toContain('Full-project run: "prettier" matched 0 files');
+				expect(output).not.toContain('prettier         whole project');
+			} finally {
+				rmSync(checkout.directory, { recursive: true, force: true });
+			}
+		},
+		300_000
+	);
 
 	// The staged gate ends by proving the checked bytes are still the staged bytes, and
 	// that argument belongs to the lint-and-types path. A format scope leaves through its

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -453,6 +453,22 @@ describe('format-only static checks', () => {
 		60_000
 	);
 
+	it('rejects an unsafe child expanded from a safe formatter directory', () => {
+		const relative = `scripts/.format-unsafe-child-${process.pid}`;
+		const directory = path.join(ROOT, relative);
+		const child = `bad${String.fromCharCode(0x202e)}.ts`;
+		mkdirSync(directory, { recursive: true });
+		writeFileSync(path.join(directory, child), 'export const value = 1;\n');
+		try {
+			const result = formatCheck(relative);
+			expect(result.status, result.output).toBe(1);
+			expect(result.output).toContain('Unsafe U+202E');
+			expect(result.output).not.toContain('All checks passed');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
 	it('treats an explicitly named repository symlink like the project traversal', () => {
 		const { status, output } = formatCheck(path.join(ROOT, 'CLAUDE.md'));
 		expect(status).toBe(0);
@@ -998,6 +1014,68 @@ describe('scope routing', () => {
 				const output = `${result.stdout}${result.stderr}`;
 				expect(result.status, output).toBe(1);
 				expect(output).toContain('No check in the active scope (lint) is responsible');
+			} finally {
+				rmSync(checkout.directory, { recursive: true, force: true });
+			}
+		},
+		180_000
+	);
+
+	it.skipIf(process.platform === 'win32')(
+		'accepts a deletion-only staged change after validating the final index',
+		() => {
+			const checkout = createCheckerClone();
+			const tools = path.join(checkout.directory, 'deletion-tools');
+			mkdirSync(tools);
+			for (const command of ['bun', 'misspell']) {
+				const executable = path.join(tools, command);
+				writeFileSync(executable, '#!/bin/sh\nexit 0\n');
+				chmodSync(executable, 0o755);
+			}
+			const relative = 'scripts/deletion-probe.md';
+			writeFileSync(path.join(checkout.repository, relative), '# delete me\n');
+			const git = (args: string[]) =>
+				spawnSync('git', args, {
+					cwd: checkout.repository,
+					env: sanitizedGitEnv(),
+					encoding: 'utf8'
+				});
+			expect(git(['add', '--', relative]).status).toBe(0);
+			expect(
+				git([
+					'-c',
+					'user.name=Probe',
+					'-c',
+					'user.email=probe@example.com',
+					'commit',
+					'--quiet',
+					'--no-gpg-sign',
+					'--no-verify',
+					'-m',
+					'Deletion fixture'
+				]).status
+			).toBe(0);
+			expect(git(['rm', '--quiet', '--', relative]).status).toBe(0);
+			try {
+				const env = sanitizedGitEnv();
+				env.NO_COLOR = '1';
+				env.PATH = `${tools}${path.delimiter}${env.PATH ?? ''}`;
+				const result = spawnSync(
+					testExecutable('bun'),
+					[
+						path.join(checkout.repository, 'scripts', 'static-checks.ts'),
+						'--staged',
+						'--scope',
+						'lint'
+					],
+					{ cwd: checkout.repository, env, encoding: 'utf8', timeout: 120_000 }
+				);
+				const output = `${result.stdout}${result.stderr}`;
+				expect(result.status, output).toBe(0);
+				expect(output).toContain(
+					'NO WORK: staged changes only delete paths absent from the final index.'
+				);
+				expect(output).toContain('All checks passed');
 			} finally {
 				rmSync(checkout.directory, { recursive: true, force: true });
 			}

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from 'vitest';
 import { sanitizedGitEnv } from './git-context';
 import {
 	prettierArguments,
+	prettierLiteralPattern,
 	prettierProjectPaths,
 	prettierTraversalPaths,
 	resolveInputs
@@ -202,9 +203,50 @@ describe('format-only static checks', () => {
 		expect(result.output).not.toContain('No such file');
 	});
 
-	it('documents a Git producer that excludes deleted paths', () => {
+	it('escapes a route without a backslash and still checks the named file', () => {
+		const route = 'src/routes/[[lang]]/(marketing)/+page.svelte';
+		const pattern = prettierLiteralPattern(route);
+
+		// Prettier hands an argument it cannot resolve to normalizeToPosix, which on Windows
+		// replaces every backslash with a slash. A backslash-escaped route would arrive there
+		// with its escapes stripped and match nothing, so the escape has to be a character
+		// class, and the pattern has to survive that same rewrite unchanged.
+		expect(pattern).toBe('src/routes/[[][[]lang[]][]]/[(]marketing[)]/+page.svelte');
+		expect(pattern.replaceAll('\\', '/')).toBe(pattern);
+
+		const result = formatCheck(route);
+		expect(result.status, result.output).toBe(0);
+		expect(result.output).toContain('prettier         1 file(s)');
+	});
+
+	it('keeps a literal backslash from matching the neighbour without one', () => {
+		const directory = path.join(ROOT, 'scripts', `.format-backslash-${process.pid}`);
+		const relative = `scripts/.format-backslash-${process.pid}`;
+		mkdirSync(directory, { recursive: true });
+		try {
+			// Only one of the two is malformed. A pattern that drops the backslash checks the
+			// other file and reports a formatted repository while the named one stays broken.
+			writeFileSync(path.join(directory, 'a\\[b].ts'), 'export const a   =1\n');
+			writeFileSync(path.join(directory, 'a[b].ts'), 'export const b = 1;\n');
+
+			const result = formatCheck(`${relative}/a\\[b].ts`);
+			expect(result.status, result.output).toBe(1);
+			expect(result.output).toContain('a\\[b].ts');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it('documents a Git producer that excludes deleted paths and stays root-relative', () => {
 		const source = readFileSync(SCRIPT, 'utf8');
-		expect(source).toContain('git diff --name-only --diff-filter=d -z');
+		// --no-relative decides which records the producer emits at all: measured with git
+		// 2.55.0 and diff.relative=true, running it from scripts/ reports a change to
+		// scripts/AGENTS.md as the record "AGENTS.md" and omits every path above that
+		// directory, so the consumer would check the root file of the same name.
+		for (const documented of source.matchAll(/git diff [^`]*--name-only[^`]*/g)) {
+			expect(documented[0]).toContain('--no-relative');
+		}
+		expect(source).toContain('git diff --no-relative --name-only --diff-filter=d -z');
 	});
 
 	it('rejects the replacement character produced by lossy argv decoding', () => {

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -478,6 +478,59 @@ describe('format-only static checks', () => {
 	);
 
 	it.skipIf(process.platform === 'win32')(
+		'preserves a named path through a symlinked ancestor',
+		() => {
+			const targetRelative = `scratch/format-symlink-target-${process.pid}`;
+			const target = path.join(ROOT, targetRelative);
+			const aliasRelative = `.format-symlink-alias-${process.pid}`;
+			const alias = path.join(ROOT, aliasRelative);
+			const named = `${aliasRelative}/probe.ts`;
+			mkdirSync(target, { recursive: true });
+			writeFileSync(path.join(target, 'probe.ts'), 'export const value   =1\n');
+			symlinkSync(target, alias, 'dir');
+			try {
+				// The target is ignored as root scratch, while the caller-visible alias is not.
+				// Canonicalizing the ancestor classified the alias under the target's ignore rule and
+				// turned this direct Prettier failure into a zero-file pass.
+				const direct = spawnSync(testExecutable('bun'), ['prettier', '--check', '--', named], {
+					cwd: ROOT,
+					env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
+					encoding: 'utf8'
+				});
+				expect(direct.status, `${direct.stdout}${direct.stderr}`).toBe(1);
+
+				expect(resolveInputs([named], 'arguments', ROOT, undefined, false)).toEqual([named]);
+				const result = formatCheck(named);
+				expect(result.status, result.output).toBe(1);
+				expect(result.output).toContain(named);
+				expect(result.output).not.toContain('No formatter work');
+			} finally {
+				rmSync(alias, { force: true });
+				rmSync(target, { recursive: true, force: true });
+			}
+		}
+	);
+
+	it.skipIf(process.platform === 'win32')(
+		'rejects a special file Prettier would drop from a mixed batch',
+		() => {
+			const relative = `scripts/.format-fifo-${process.pid}.ts`;
+			const file = path.join(ROOT, relative);
+			const created = spawnSync('mkfifo', [file], { encoding: 'utf8' });
+			expect(created.status, created.stderr).toBe(0);
+			try {
+				const result = formatCheckFilesFrom(`${relative}\0package.json\0`);
+				expect(result.status, result.output).toBe(1);
+				expect(result.output).toContain('not a regular file');
+				expect(result.output).toContain(relative);
+				expect(result.output).not.toContain('All checks passed');
+			} finally {
+				rmSync(file, { force: true });
+			}
+		}
+	);
+
+	it.skipIf(process.platform === 'win32')(
 		'rejects a repository symlink to an external file',
 		() => {
 			const external = mkdtempSync(path.join(tmpdir(), 'format-external-link-'));

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 import { sanitizedGitEnv } from './git-context';
 import {
+	isNeverWalked,
 	prettierArguments,
 	prettierLiteralPattern,
 	prettierProjectPaths,
@@ -219,22 +220,98 @@ describe('format-only static checks', () => {
 		expect(result.output).toContain('prettier         1 file(s)');
 	});
 
-	it('keeps a literal backslash from matching the neighbour without one', () => {
-		const directory = path.join(ROOT, 'scripts', `.format-backslash-${process.pid}`);
-		const relative = `scripts/.format-backslash-${process.pid}`;
-		mkdirSync(directory, { recursive: true });
-		try {
-			// Only one of the two is malformed. A pattern that drops the backslash checks the
-			// other file and reports a formatted repository while the named one stays broken.
-			writeFileSync(path.join(directory, 'a\\[b].ts'), 'export const a   =1\n');
-			writeFileSync(path.join(directory, 'a[b].ts'), 'export const b = 1;\n');
+	// A backslash is a path separator on Windows and cannot appear in a filename there, so
+	// the fixture itself is unbuildable rather than the assertion being wrong.
+	it.skipIf(process.platform === 'win32')(
+		'keeps a literal backslash from matching the neighbour without one',
+		() => {
+			const directory = path.join(ROOT, 'scripts', `.format-backslash-${process.pid}`);
+			const relative = `scripts/.format-backslash-${process.pid}`;
+			mkdirSync(directory, { recursive: true });
+			try {
+				// Only one of the two is malformed. A pattern that drops the backslash checks the
+				// other file and reports a formatted repository while the named one stays broken.
+				writeFileSync(path.join(directory, 'a\\[b].ts'), 'export const a   =1\n');
+				writeFileSync(path.join(directory, 'a[b].ts'), 'export const b = 1;\n');
 
-			const result = formatCheck(`${relative}/a\\[b].ts`);
-			expect(result.status, result.output).toBe(1);
-			expect(result.output).toContain('a\\[b].ts');
-		} finally {
-			rmSync(directory, { recursive: true, force: true });
+				const result = formatCheck(`${relative}/a\\[b].ts`);
+				expect(result.status, result.output).toBe(1);
+				expect(result.output).toContain('a\\[b].ts');
+			} finally {
+				rmSync(directory, { recursive: true, force: true });
+			}
 		}
+	);
+
+	it('escapes a leading exclamation mark into a pattern Prettier cannot negate', () => {
+		expect(prettierLiteralPattern('!a[b].ts')).toBe('@(!)a[[]b[]].ts');
+
+		withRepositoryFile('!a[b].ts', 'export const a   =1\n', () => {
+			const named = formatCheck('!a[b].ts');
+			expect(named.status, named.output).toBe(1);
+			expect(named.output).toContain('!a[b].ts');
+		});
+
+		// The file is gone again here, which is the case a negation turns into a silent pass:
+		// measured with Prettier 3.9.5, `./!a[[]b[]].ts` matched every other root file and
+		// exited 0 instead of reporting the path it was given.
+		const vanished = spawnSync(
+			testExecutable('bun'),
+			['prettier', '--check', '--ignore-unknown', '--', prettierLiteralPattern('!a[b].ts')],
+			{ cwd: ROOT, env: { ...sanitizedGitEnv(), NO_COLOR: '1' }, encoding: 'utf8' }
+		);
+		expect(vanished.status).toBe(2);
+		expect(`${vanished.stdout}${vanished.stderr}`).toContain('No files matching the pattern');
+	});
+
+	it('expands a symlinked directory for every scope except format', () => {
+		const link = '.claude/skills/upstream-sync';
+		const expanded = resolveInputs([link], 'arguments', ROOT);
+		expect(expanded.length).toBeGreaterThan(1);
+		expect(expanded.some((file) => file.endsWith('.ts'))).toBe(true);
+
+		// Prettier refuses an explicitly named symlink, so the formatter passes the link
+		// itself and lets that refusal happen instead of silently checking the target.
+		expect(
+			resolveInputs(
+				[link],
+				'arguments',
+				ROOT,
+				(directory) => prettierTraversalPaths(directory, false, ROOT),
+				false
+			)
+		).toEqual([link]);
+	});
+
+	it('anchors the generated trees .gitignore anchors and no others', () => {
+		// /build, /dist and /.svelte-kit are root-anchored in .gitignore, so a tracked
+		// src/build/generator.ts is an ordinary source file rather than generated output.
+		expect(isNeverWalked('build/output.js')).toBe(true);
+		expect(isNeverWalked('dist/output.js')).toBe(true);
+		expect(isNeverWalked('.svelte-kit/ambient.d.ts')).toBe(true);
+		expect(isNeverWalked('src/build/generator.ts')).toBe(false);
+		expect(isNeverWalked('src/lib/dist/value.ts')).toBe(false);
+		expect(isNeverWalked('src/redist/value.ts')).toBe(false);
+
+		// node_modules, .git and .convex are ignored at every depth.
+		expect(isNeverWalked('packages/app/node_modules/x.js')).toBe(true);
+		expect(isNeverWalked('src/.convex/generated.ts')).toBe(true);
+	});
+
+	it('accepts the same directory named twice', () => {
+		const once = resolveInputs(['scripts'], 'arguments', ROOT);
+		expect(resolveInputs(['scripts', 'scripts'], 'arguments', ROOT)).toEqual(once);
+	});
+
+	it('ignores only the repository root CLAUDE.md pointer', () => {
+		const ignore = readFileSync(path.join(ROOT, '.prettierignore'), 'utf8');
+		expect(ignore).toContain('/CLAUDE.md');
+
+		withRepositoryFile('scripts/CLAUDE.md', '# Nested\n', () => {
+			const result = formatCheck('scripts/CLAUDE.md');
+			expect(result.status, result.output).toBe(0);
+			expect(result.output).toContain('prettier         1 file(s)');
+		});
 	});
 
 	it('documents a Git producer that excludes deleted paths and stays root-relative', () => {

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -563,30 +563,38 @@ describe('format-only static checks', () => {
 	);
 
 	it.skipIf(process.platform === 'win32')(
-		'accepts an absolute path through a symlinked checkout alias',
+		'rejects an absolute path through an external checkout alias',
 		() => {
 			const directory = mkdtempSync(path.join(tmpdir(), 'format-checkout-alias-'));
 			const alias = path.join(directory, 'repository');
+			const target = path.join(ROOT, 'scratch', `format-alias-${process.pid}`);
+			mkdirSync(target, { recursive: true });
+			writeFileSync(path.join(target, 'probe.ts'), 'export const value   =1\n');
 			symlinkSync(ROOT, alias, 'dir');
-			const named = path.join(alias, 'README.md');
+			const named = path.join(alias, 'scratch', `format-alias-${process.pid}`, 'probe.ts');
 			try {
+				// Direct Prettier classifies the caller-visible alias outside the repository, so the
+				// root-anchored scratch ignore does not match and the unformatted file is checked.
 				const direct = spawnSync(testExecutable('bun'), ['prettier', '--check', '--', named], {
 					cwd: alias,
 					env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
 					encoding: 'utf8'
 				});
-				expect(direct.status, `${direct.stdout}${direct.stderr}`).toBe(0);
+				expect(direct.status, `${direct.stdout}${direct.stderr}`).toBe(1);
 
+				// A repository-relative ledger cannot preserve that external spelling. Canonicalizing
+				// it to root scratch produced a zero-file success, so the boundary fails closed.
 				const result = spawnSync(testExecutable('bun'), [SCRIPT, '--scope', 'format', named], {
 					cwd: alias,
 					env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
 					encoding: 'utf8'
 				});
 				const output = `${result.stdout}${result.stderr}`;
-				expect(result.status, output).toBe(0);
-				expect(output).toContain('prettier         1 file(s)');
-				expect(output).not.toContain('outside the repository');
+				expect(result.status, output).toBe(1);
+				expect(output).toContain('outside the repository');
+				expect(output).not.toContain('All checks passed');
 			} finally {
+				rmSync(target, { recursive: true, force: true });
 				rmSync(directory, { recursive: true, force: true });
 			}
 		}
@@ -952,6 +960,49 @@ describe('scope routing', () => {
 			}
 		},
 		300_000
+	);
+
+	it.skipIf(process.platform === 'win32')(
+		'rejects a staged file that no active lint check consumes',
+		() => {
+			const checkout = createCheckerClone();
+			const tools = path.join(checkout.directory, 'staged-tools');
+			mkdirSync(tools);
+			for (const command of ['bun', 'misspell']) {
+				const executable = path.join(tools, command);
+				writeFileSync(executable, '#!/bin/sh\nexit 0\n');
+				chmodSync(executable, 0o755);
+			}
+			const file = path.join(checkout.repository, 'src', 'i18n', 'repro.bin');
+			writeFileSync(file, String.fromCharCode(1, 2, 3));
+			const staged = spawnSync('git', ['add', '--', 'src/i18n/repro.bin'], {
+				cwd: checkout.repository,
+				env: sanitizedGitEnv(),
+				encoding: 'utf8'
+			});
+			expect(staged.status, staged.stderr).toBe(0);
+			try {
+				const env = sanitizedGitEnv();
+				env.NO_COLOR = '1';
+				env.PATH = `${tools}${path.delimiter}${env.PATH ?? ''}`;
+				const result = spawnSync(
+					testExecutable('bun'),
+					[
+						path.join(checkout.repository, 'scripts', 'static-checks.ts'),
+						'--staged',
+						'--scope',
+						'lint'
+					],
+					{ cwd: checkout.repository, env, encoding: 'utf8', timeout: 120_000 }
+				);
+				const output = `${result.stdout}${result.stderr}`;
+				expect(result.status, output).toBe(1);
+				expect(output).toContain('No check in the active scope (lint) is responsible');
+			} finally {
+				rmSync(checkout.directory, { recursive: true, force: true });
+			}
+		},
+		180_000
 	);
 
 	// The staged gate ends by proving the checked bytes are still the staged bytes, and

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -1083,6 +1083,53 @@ describe('scope routing', () => {
 		180_000
 	);
 
+	it.skipIf(process.platform === 'win32')(
+		'rejects an index-only deletion whose worktree configuration remains active',
+		() => {
+			const checkout = createCheckerClone();
+			const tools = path.join(checkout.directory, 'cached-delete-tools');
+			mkdirSync(tools);
+			for (const command of ['bun', 'misspell']) {
+				const executable = path.join(tools, command);
+				writeFileSync(executable, '#!/bin/sh\nexit 0\n');
+				chmodSync(executable, 0o755);
+			}
+			const git = (args: string[]) =>
+				spawnSync('git', args, {
+					cwd: checkout.repository,
+					env: sanitizedGitEnv(),
+					encoding: 'utf8'
+				});
+			expect(git(['rm', '--cached', '--quiet', '.prettierignore']).status).toBe(0);
+			writeFileSync(path.join(checkout.repository, '.prettierignore'), 'static/repro.json\n');
+			const repro = path.join(checkout.repository, 'static', 'repro.json');
+			writeFileSync(repro, '{"value":1}\n');
+			expect(git(['add', '--', 'static/repro.json']).status).toBe(0);
+			try {
+				const env = sanitizedGitEnv();
+				env.NO_COLOR = '1';
+				env.PATH = `${tools}${path.delimiter}${env.PATH ?? ''}`;
+				const result = spawnSync(
+					testExecutable('bun'),
+					[
+						path.join(checkout.repository, 'scripts', 'static-checks.ts'),
+						'--staged',
+						'--scope',
+						'lint'
+					],
+					{ cwd: checkout.repository, env, encoding: 'utf8', timeout: 120_000 }
+				);
+				const output = `${result.stdout}${result.stderr}`;
+				expect(result.status, output).toBe(1);
+				expect(output).toContain('Staged file contents differ from the worktree');
+				expect(output).not.toContain('All checks passed');
+			} finally {
+				rmSync(checkout.directory, { recursive: true, force: true });
+			}
+		},
+		180_000
+	);
+
 	// The staged gate ends by proving the checked bytes are still the staged bytes, and
 	// that argument belongs to the lint-and-types path. A format scope leaves through its
 	// own early exit, so the combination is refused rather than given a second closing.

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -205,6 +205,31 @@ describe('format-only static checks', () => {
 		expect(result.output).not.toContain('No such file');
 	});
 
+	// Prettier lowercases a basename before comparing plugin extensions. The fallback here
+	// exists because classification deliberately does not load the Svelte plugin, so it has
+	// to make the same comparison: a case-sensitive `.svelte` test classified this file as
+	// unformattable and a mixed computed list exited 0 after checking only its Markdown peer.
+	it('checks a mixed-case Svelte extension the configured plugin formats', () => {
+		const relative = `scripts/.format-component-${process.pid}.SVELTE`;
+		withRepositoryFile(relative, '<script>const value=1</script>\n', () => {
+			const direct = spawnSync(testExecutable('bun'), ['prettier', '--check', '--', relative], {
+				cwd: ROOT,
+				env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
+				encoding: 'utf8'
+			});
+			expect(direct.status, `${direct.stdout}${direct.stderr}`).toBe(1);
+
+			const named = formatCheck(relative);
+			expect(named.status, named.output).toBe(1);
+			expect(named.output).toContain(relative);
+
+			const computed = formatCheckFilesFrom(`${relative}\0README.md\0`);
+			expect(computed.status, computed.output).toBe(1);
+			expect(computed.output).toContain(relative);
+			expect(computed.output).toContain(`README.md ${relative}`);
+		});
+	});
+
 	it('escapes a route without a backslash and still checks the named file', () => {
 		const route = 'src/routes/[[lang]]/(marketing)/+page.svelte';
 		const pattern = prettierLiteralPattern(route);

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -1,9 +1,24 @@
 import { spawnSync } from 'child_process';
-import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import {
+	copyFileSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync
+} from 'fs';
+import { tmpdir } from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 import { sanitizedGitEnv } from './git-context';
+import {
+	prettierArguments,
+	prettierProjectPaths,
+	prettierTraversalPaths,
+	resolveInputs
+} from './static-checks';
 import { testExecutable } from './test-executable';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -17,6 +32,48 @@ function formatCheck(...args: string[]): { status: number; output: string } {
 		encoding: 'utf8'
 	});
 	return { status: result.status ?? -1, output: `${result.stdout}${result.stderr}` };
+}
+
+/** The computed-list channel used by format-only hook consumers. */
+function formatCheckFilesFrom(
+	input: string | Uint8Array,
+	cwd = ROOT
+): { status: number; output: string } {
+	const result = spawnSync(
+		testExecutable('bun'),
+		[SCRIPT, '--ci', '--scope', 'format', '--files-from', '-'],
+		{
+			cwd,
+			env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
+			input,
+			encoding: 'utf8'
+		}
+	);
+	return { status: result.status ?? -1, output: `${result.stdout}${result.stderr}` };
+}
+
+function createCheckerClone(): { directory: string; repository: string } {
+	const directory = path.join(ROOT, 'scratch', `format-ledger-${process.pid}-${Date.now()}`);
+	const repository = path.join(directory, 'repository');
+	mkdirSync(directory, { recursive: true });
+	try {
+		const result = spawnSync(
+			'git',
+			['clone', '--quiet', '--local', '--no-hardlinks', ROOT, repository],
+			{ env: sanitizedGitEnv(), encoding: 'utf8' }
+		);
+		if (result.status !== 0) throw new Error(`Local checker clone failed: ${result.stderr}`);
+		symlinkSync(
+			path.join(ROOT, 'node_modules'),
+			path.join(repository, 'node_modules'),
+			process.platform === 'win32' ? 'junction' : 'dir'
+		);
+		copyFileSync(SCRIPT, path.join(repository, 'scripts', 'static-checks.ts'));
+		return { directory, repository };
+	} catch (error) {
+		rmSync(directory, { recursive: true, force: true });
+		throw error;
+	}
 }
 
 /** Write an unformatted file into the repository for one assertion. */
@@ -66,6 +123,217 @@ describe('format-only static checks', () => {
 			expect(relayed.output).toContain(`[warn] ${relative}`);
 			expect(relayed.output).not.toContain('Bad arguments');
 		});
+	});
+
+	it('keeps a filename whose name begins with a space distinct from its neighbour', () => {
+		const plain = `.format-space-${process.pid}.ts`;
+		const spaced = ` ${plain}`;
+		writeFileSync(path.join(ROOT, spaced), 'export const value    =    1;\n');
+		writeFileSync(path.join(ROOT, plain), 'export const value = 1;\n');
+		try {
+			// Trimming rewrote the spaced path into the formatted neighbour and let the
+			// unformatted file pass unseen.
+			const alone = formatCheckFilesFrom(`${spaced}\0`);
+			expect(alone.status).not.toBe(0);
+			expect(alone.output).toContain(`[warn] ${spaced}`);
+			expect(alone.output).not.toContain(`[warn] ${plain}`);
+
+			const plainRecord = formatCheckFilesFrom(`${plain}\0`);
+			expect(plainRecord.status).toBe(0);
+			expect(plainRecord.output).toContain('prettier         1 file(s)');
+
+			const finalCr = formatCheckFilesFrom(`${plain}\r\0`);
+			expect(finalCr.status).toBe(1);
+			expect(finalCr.output).toContain('Unsafe U+000D');
+		} finally {
+			rmSync(path.join(ROOT, spaced), { force: true });
+			rmSync(path.join(ROOT, plain), { force: true });
+		}
+	}, 60_000);
+
+	it.skipIf(process.platform === 'win32')('accepts a path made entirely of spaces', () => {
+		withRepositoryFile(' ', 'plain text\n', (file) => {
+			const result = formatCheckFilesFrom(' \0');
+			expect(result.status).toBe(0);
+			expect(result.output).toContain('No formatter work');
+			expect(result.output).not.toContain('Empty path');
+			expect(file).toBe(path.join(ROOT, ' '));
+		});
+	});
+
+	it('rejects an ambiguous BOM whether it starts the stream or a later path', () => {
+		const plain = `.format-bom-${process.pid}.ts`;
+		const marked = `${String.fromCharCode(0xfeff)}${plain}`;
+		writeFileSync(path.join(ROOT, plain), 'export const value = 1;\n');
+		try {
+			const first = formatCheckFilesFrom(`${marked}\0${plain}\0`);
+			expect(first.status).toBe(1);
+			expect(first.output).toContain('without a byte-order mark');
+
+			writeFileSync(path.join(ROOT, marked), 'export const value = 1;\n');
+			const later = formatCheckFilesFrom(`${plain}\0${marked}\0`);
+			expect(later.status).toBe(1);
+			expect(later.output).toContain('Unsafe U+FEFF');
+		} finally {
+			rmSync(path.join(ROOT, marked), { force: true });
+			rmSync(path.join(ROOT, plain), { force: true });
+		}
+	});
+
+	it('rejects file lists that are not valid UTF-8', () => {
+		const result = formatCheckFilesFrom(Uint8Array.from([0xc3, 0x28]));
+		expect(result.status).toBe(1);
+		expect(result.output).toContain('bytes that are not valid UTF-8');
+		expect(result.output).not.toContain('SvelteKit sync');
+	});
+
+	it('rejects nonempty computed lists containing an empty path record', () => {
+		for (const input of ['\0', 'README.md\0\0']) {
+			const result = formatCheckFilesFrom(input);
+			expect(result.status).toBe(1);
+			expect(result.output).toContain('empty path record');
+		}
+	});
+
+	it('resolves computed Git records from the repository root', () => {
+		const result = formatCheckFilesFrom('README.md\0', path.join(ROOT, 'scripts'));
+		expect(result.status).toBe(0);
+		expect(result.output).toContain('prettier         1 file(s)');
+		expect(result.output).not.toContain('No such file');
+	});
+
+	it('documents a Git producer that excludes deleted paths', () => {
+		const source = readFileSync(SCRIPT, 'utf8');
+		expect(source).toContain('git diff --name-only --diff-filter=d -z');
+	});
+
+	it('rejects the replacement character produced by lossy argv decoding', () => {
+		const relative = `.format-replacement-${String.fromCharCode(0xfffd)}-${process.pid}.ts`;
+		withRepositoryFile(relative, 'export const value = 1;\n', (file) => {
+			const result = formatCheck(file);
+			expect(result.status).toBe(1);
+			expect(result.output).toContain('Unsafe U+FFFD');
+			expect(result.output).not.toContain('SvelteKit sync');
+		});
+	});
+
+	it.skipIf(process.platform === 'win32')(
+		'rejects unsafe controls even when the computed-list protocol preserves them',
+		() => {
+			const safe = `.format-newline-${process.pid}.ts`;
+			const unsafe = `.format-newline-${process.pid}\n.ts`;
+			writeFileSync(path.join(ROOT, safe), 'export const value = 1;\n');
+			writeFileSync(path.join(ROOT, unsafe), 'export const value = 1;\n');
+			try {
+				const result = formatCheckFilesFrom(`${unsafe}\0`);
+				expect(result.status).toBe(1);
+				expect(result.output).toContain('Unsafe U+000A');
+				expect(result.output).not.toContain('SvelteKit sync');
+			} finally {
+				rmSync(path.join(ROOT, unsafe), { force: true });
+				rmSync(path.join(ROOT, safe), { force: true });
+			}
+		},
+		60_000
+	);
+
+	it('treats an explicitly named repository symlink like the project traversal', () => {
+		const { status, output } = formatCheck(path.join(ROOT, 'CLAUDE.md'));
+		expect(status).toBe(0);
+		expect(output).toContain('No formatter work');
+		expect(output).toContain('symbolic link');
+		expect(output).toContain('prettier         0 file(s)');
+		expect(output).not.toContain('[warn] AGENTS.md');
+	});
+
+	it.skipIf(process.platform === 'win32')(
+		'treats an explicitly named directory symlink like the project traversal',
+		() => {
+			const relative = `.format-directory-link-${process.pid}`;
+			const file = path.join(ROOT, relative);
+			symlinkSync(path.join(ROOT, 'scripts'), file, 'dir');
+			try {
+				const { status, output } = formatCheck(file);
+				expect(status).toBe(0);
+				expect(output).toContain('No formatter work');
+				expect(output).toContain('prettier         0 file(s)');
+				expect(output).not.toContain('scripts/static-checks.ts');
+			} finally {
+				rmSync(file, { force: true });
+			}
+		}
+	);
+
+	it.skipIf(process.platform === 'win32')(
+		'rejects a repository symlink to an external file',
+		() => {
+			const external = mkdtempSync(path.join(tmpdir(), 'format-external-link-'));
+			const target = path.join(external, 'target.ts');
+			const file = path.join(ROOT, `.format-external-link-${process.pid}.ts`);
+			writeFileSync(target, 'export const external = true;\n');
+			symlinkSync(target, file);
+			try {
+				const { status, output } = formatCheck(file);
+				expect(status).toBe(1);
+				expect(output).toContain('outside the repository');
+				expect(output).not.toContain('Code formatting');
+			} finally {
+				rmSync(file, { force: true });
+				rmSync(external, { recursive: true, force: true });
+			}
+		}
+	);
+
+	it.skipIf(process.platform !== 'linux')(
+		'rejects repository paths whose bytes are not valid UTF-8',
+		() => {
+			const relative = Buffer.concat([
+				Buffer.from(`.format-invalid-utf8-${process.pid}-`),
+				Buffer.from([0xff]),
+				Buffer.from('.ts')
+			]);
+			const invalid = Buffer.concat([Buffer.from(`${ROOT}/`), relative]);
+			writeFileSync(invalid, 'export const value = 1;\n');
+			try {
+				const result = formatCheckFilesFrom(Buffer.concat([relative, Buffer.from([0])]));
+				expect(result.status).toBe(1);
+				expect(result.output).toContain('bytes that are not valid UTF-8');
+				expect(result.output).not.toContain('SvelteKit sync');
+			} finally {
+				rmSync(invalid, { force: true });
+			}
+		},
+		60_000
+	);
+
+	it('keeps locally Git-ignored files in an explicit Prettier directory', () => {
+		const directory = `.format-local-ignore-${process.pid}`;
+		const ignored = `${directory}/ignored.ts`;
+		const excludesDirectory = mkdtempSync(path.join(tmpdir(), 'format-local-ignore-'));
+		const excludes = path.join(excludesDirectory, 'excludes');
+		const saved = new Map<string, string | undefined>();
+		for (const key of ['GIT_CONFIG_COUNT', 'GIT_CONFIG_KEY_0', 'GIT_CONFIG_VALUE_0']) {
+			saved.set(key, process.env[key]);
+		}
+		mkdirSync(path.join(ROOT, directory));
+		writeFileSync(path.join(ROOT, directory, 'kept.ts'), 'export const kept = true;\n');
+		writeFileSync(path.join(ROOT, ignored), 'export const ignored    =    true;\n');
+		writeFileSync(excludes, `${ignored}\n`);
+		process.env.GIT_CONFIG_COUNT = '1';
+		process.env.GIT_CONFIG_KEY_0 = 'core.excludesFile';
+		process.env.GIT_CONFIG_VALUE_0 = excludes;
+		try {
+			const result = formatCheck(path.join(ROOT, directory));
+			expect(result.status).not.toBe(0);
+			expect(result.output).toContain(`[warn] ${ignored}`);
+		} finally {
+			for (const [key, value] of saved) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+			rmSync(path.join(ROOT, directory), { recursive: true, force: true });
+			rmSync(excludesDirectory, { recursive: true, force: true });
+		}
 	});
 
 	it('checks a web app manifest with the real formatter', () => {
@@ -148,6 +416,69 @@ describe('format-only static checks', () => {
 		});
 	}, 60_000);
 
+	it('does not reinterpret a disappeared formatter path as a glob', () => {
+		const directory = `scripts/.format-glob-${process.pid}`;
+		const named = `${directory}/[ab].ts`;
+		const neighbour = `${directory}/a.ts`;
+		mkdirSync(path.join(ROOT, directory), { recursive: true });
+		writeFileSync(path.join(ROOT, named), 'export const named = true;\n');
+		writeFileSync(path.join(ROOT, neighbour), 'export const neighbour = true;\n');
+		try {
+			const selected = prettierProjectPaths([named], ROOT, true);
+			rmSync(path.join(ROOT, named));
+
+			const raw = spawnSync(
+				testExecutable('bun'),
+				['prettier', '--check', '--ignore-unknown', '--', named],
+				{ cwd: ROOT, env: { ...sanitizedGitEnv(), NO_COLOR: '1' }, encoding: 'utf8' }
+			);
+			const escaped = spawnSync(testExecutable('bun'), prettierArguments('--check', selected), {
+				cwd: ROOT,
+				env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
+				encoding: 'utf8'
+			});
+
+			expect(raw.status, `${raw.stdout}${raw.stderr}`).toBe(0);
+			expect(escaped.status).not.toBe(0);
+			expect(`${escaped.stdout}${escaped.stderr}`).toContain('No files matching the pattern');
+		} finally {
+			rmSync(path.join(ROOT, directory), { recursive: true, force: true });
+		}
+	});
+
+	it('accepts the repository root as an explicit format directory', () => {
+		const seen: string[] = [];
+		const inputs = resolveInputs(['.'], 'arguments', ROOT, (directory) => {
+			seen.push(directory);
+			return ['README.md', 'scripts/static-checks.ts'];
+		});
+
+		expect(seen).toEqual([ROOT]);
+		expect(inputs).toEqual(['README.md', 'scripts/static-checks.ts']);
+	});
+
+	it('traverses only the explicitly named format directory', () => {
+		const scripts = path.join(ROOT, 'scripts');
+		const files = prettierTraversalPaths(scripts, false, ROOT);
+
+		expect(files.length).toBeGreaterThan(0);
+		expect(files.every((file) => file.startsWith('scripts/'))).toBe(true);
+		expect(files).not.toContain('.svelte-kit/ambient.d.ts');
+	});
+
+	it('fails if a named formatter input disappears before routing', () => {
+		const result = spawnSync(
+			testExecutable('bun'),
+			[
+				'-e',
+				'import { prettierProjectPaths } from "./scripts/static-checks.ts"; prettierProjectPaths([".missing-format-input"], process.cwd(), true);'
+			],
+			{ cwd: ROOT, env: { ...sanitizedGitEnv(), NO_COLOR: '1' }, encoding: 'utf8' }
+		);
+		expect(result.status).toBe(1);
+		expect(`${result.stdout}${result.stderr}`).toContain('disappeared before formatter routing');
+	});
+
 	it('keeps a root file whose name begins with dots inside the repository', () => {
 		const relative = `..format-dots-${process.pid}.ts`;
 		withRepositoryFile(relative, 'export const value    =    1;\n', (file) => {
@@ -160,11 +491,39 @@ describe('format-only static checks', () => {
 });
 
 describe('scope routing', () => {
-	it('records a positive formatter match count for a full-project run', () => {
-		const { status, output } = formatCheck();
-		expect(status).toBe(0);
-		expect(output).toMatch(/prettier\s+[1-9]\d* file\(s\)/);
-		expect(output).not.toContain('prettier         whole project');
+	it('keeps abandoned checker clones out of project-wide checks', () => {
+		const vite = readFileSync(path.join(ROOT, 'vite.config.ts'), 'utf8');
+		const eslint = readFileSync(path.join(ROOT, 'eslint.config.js'), 'utf8');
+		const oxlint = readFileSync(path.join(ROOT, '.oxlintrc.json'), 'utf8');
+		expect(vite).toContain("'scratch/**'");
+		expect(eslint).toContain("'scratch/**'");
+		expect(oxlint).toContain('"scratch/**"');
+	});
+
+	it('records a numeric formatter count in an isolated full-project run', () => {
+		const checkout = createCheckerClone();
+		try {
+			const result = spawnSync(
+				testExecutable('bun'),
+				[
+					path.join(checkout.repository, 'scripts', 'static-checks.ts'),
+					'--ci',
+					'--scope',
+					'format'
+				],
+				{
+					cwd: checkout.repository,
+					env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
+					encoding: 'utf8'
+				}
+			);
+			const output = `${result.stdout}${result.stderr}`;
+			expect(result.status, output).toBe(0);
+			expect(output).toMatch(/prettier\s+[1-9]\d* file\(s\)/);
+			expect(output).not.toContain('prettier         whole project');
+		} finally {
+			rmSync(checkout.directory, { recursive: true, force: true });
+		}
 	}, 120_000);
 
 	// The staged gate ends by proving the checked bytes are still the staged bytes, and

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -213,7 +213,7 @@ describe('format-only static checks', () => {
 		// replaces every backslash with a slash. A backslash-escaped route would arrive there
 		// with its escapes stripped and match nothing, so the escape has to be a character
 		// class, and the pattern has to survive that same rewrite unchanged.
-		expect(pattern).toBe('src/routes/[[][[]lang[]][]]/[(]marketing[)]/[+]page.svelte');
+		expect(pattern).toBe('src/routes/[[][[]lang@(])@(])/[(]marketing[)]/[+]page.svelte');
 		expect(pattern.replaceAll('\\', '/')).toBe(pattern);
 
 		const result = formatCheck(route);
@@ -245,7 +245,7 @@ describe('format-only static checks', () => {
 	);
 
 	it('escapes a leading exclamation mark into a pattern Prettier cannot negate', () => {
-		expect(prettierLiteralPattern('!a[b].ts')).toBe('@(!)a[[]b[]].ts');
+		expect(prettierLiteralPattern('!a[b].ts')).toBe('@(!)a[[]b@(]).ts');
 
 		withRepositoryFile('!a[b].ts', 'export const a   =1\n', () => {
 			const named = formatCheck('!a[b].ts');
@@ -254,7 +254,7 @@ describe('format-only static checks', () => {
 		});
 
 		// The file is gone again here, which is the case a negation turns into a silent pass:
-		// measured with Prettier 3.9.5, `./!a[[]b[]].ts` matched every other root file and
+		// measured with Prettier 3.9.5, `./!a[[]b@(]).ts` matched every other root file and
 		// exited 0 instead of reporting the path it was given.
 		const vanished = spawnSync(
 			testExecutable('bun'),
@@ -295,7 +295,7 @@ describe('format-only static checks', () => {
 		mkdirSync(directory, { recursive: true });
 		try {
 			writeFileSync(path.join(directory, '[ab].ts'), 'export const a   =1\n');
-			writeFileSync(path.join(directory, '[[]ab[]].ts'), 'export const b = 1;\n');
+			writeFileSync(path.join(directory, '[[]ab@(]).ts'), 'export const b = 1;\n');
 
 			const result = formatCheck(`${relative}/[ab].ts`);
 			expect(result.status, result.output).toBe(1);
@@ -304,6 +304,32 @@ describe('format-only static checks', () => {
 			rmSync(directory, { recursive: true, force: true });
 		}
 	});
+
+	// fast-glob runs micromatch.braces() over the whole pattern before picomatch parses it,
+	// and that pass has no notion of character classes: the POSIX form `[]]` next to `[{]` or
+	// `[}]` is read as a brace expression, so the pattern stops naming the file it was built
+	// from. Measured with Prettier 3.9.5, `[]][{][}].ts` reported the neighbouring `{}.ts`
+	// clean while the named file stayed malformed, and the other two matched nothing at all.
+	it.each([']{}.ts', '{]}.ts', '{}].ts'])(
+		'keeps brace escapes from swallowing a literal bracket in %s',
+		(name) => {
+			const directory = path.join(ROOT, 'scripts', `.format-brace-${process.pid}`);
+			const relative = `scripts/.format-brace-${process.pid}`;
+			mkdirSync(directory, { recursive: true });
+			try {
+				// Only the named file is malformed. A pattern that expands into a brace expression
+				// either checks the neighbour and passes, or matches nothing and passes.
+				writeFileSync(path.join(directory, name), 'export const a   =1\n');
+				writeFileSync(path.join(directory, '{}.ts'), 'export const b = 1;\n');
+
+				const result = formatCheck(`${relative}/${name}`);
+				expect(result.status, result.output).toBe(1);
+				expect(result.output).toContain(name);
+			} finally {
+				rmSync(directory, { recursive: true, force: true });
+			}
+		}
+	);
 
 	it('escapes a plus so it cannot quantify the escape before it', () => {
 		expect(prettierLiteralPattern('[+.ts')).toBe('[[][+].ts');

--- a/scripts/static-checks.format.test.ts
+++ b/scripts/static-checks.format.test.ts
@@ -289,28 +289,6 @@ describe('format-only static checks', () => {
 		}
 	);
 
-	// Git lists a directory symlink as one entry and knows nothing below it, so an expansion
-	// that keeps the link's name routes eleven directories by their own extension, which is
-	// none. Measured before this: `.claude/skills` expanded to eleven names and zero
-	// TypeScript files, and `--scope types` over the parent reported success having checked
-	// nothing. The child links resolve now, so the same expansion reaches their targets.
-	it.skipIf(!lstatSync(path.join(ROOT, '.claude/skills/upstream-sync')).isSymbolicLink())(
-		'resolves a symlinked child of an expanded directory',
-		() => {
-			const expanded = resolveInputs(['.claude/skills'], 'arguments', ROOT);
-			expect(expanded.filter((file) => file.endsWith('.ts')).length).toBeGreaterThan(0);
-			// Every entry names a real file under the link's target, never the link itself.
-			expect(expanded.some((file) => file.startsWith('.claude/skills/'))).toBe(false);
-
-			// The formatter neither follows nor accepts a link, so the same directory holds
-			// nothing it can format. It says so and exits non-zero rather than reporting a
-			// green run over an empty set.
-			const formatted = formatCheck('.claude/skills');
-			expect(formatted.status, formatted.output).toBe(1);
-			expect(formatted.output).toContain('Directory contains no files to check');
-		}
-	);
-
 	it('refuses two paths that collide under formatter escaping', () => {
 		const directory = path.join(ROOT, 'scripts', `.format-collide-${process.pid}`);
 		const relative = `scripts/.format-collide-${process.pid}`;
@@ -701,14 +679,44 @@ describe('format-only static checks', () => {
 });
 
 describe('scope routing', () => {
-	it('keeps abandoned checker clones out of project-wide checks', () => {
-		const vite = readFileSync(path.join(ROOT, 'vite.config.ts'), 'utf8');
-		const eslint = readFileSync(path.join(ROOT, 'eslint.config.js'), 'utf8');
-		const oxlint = readFileSync(path.join(ROOT, '.oxlintrc.json'), 'utf8');
-		expect(vite).toContain("'scratch/**'");
-		expect(eslint).toContain("'scratch/**'");
-		expect(oxlint).toContain('"scratch/**"');
-	});
+	// Session artifacts and an interrupted fixture both leave whole trees under `scratch/`,
+	// and every project-wide tool walks the repository itself. Asserting the configuration
+	// files contain the string proves nothing: it stays green when the pattern moves into a
+	// comment or a block that never applies. Each tool is asked instead.
+	it('keeps scratch out of project-wide checks', () => {
+		const directory = path.join(ROOT, 'scratch', `exclusion-${process.pid}`);
+		const relative = `scratch/exclusion-${process.pid}/abandoned.test.ts`;
+		mkdirSync(directory, { recursive: true });
+		const run = (args: string[]) =>
+			spawnSync(testExecutable('bun'), args, {
+				cwd: ROOT,
+				env: { ...sanitizedGitEnv(), NO_COLOR: '1' },
+				encoding: 'utf8'
+			});
+		try {
+			// Invalid TypeScript, an unused binding and a test file name in one: whichever tool
+			// reads it has something to say about it.
+			writeFileSync(
+				path.join(directory, 'abandoned.test.ts'),
+				'const unused = ;\nexport function broken(: never {}\n'
+			);
+
+			const oxlint = run(['oxlint']);
+			expect(`${oxlint.stdout}${oxlint.stderr}`).not.toContain('abandoned.test.ts');
+
+			const vitest = run(['vitest', 'list', '--filesOnly']);
+			expect(`${vitest.stdout}${vitest.stderr}`).not.toContain('abandoned.test.ts');
+
+			// ESLint is asked about the file directly rather than over the project, which takes
+			// minutes: naming an ignored path is how it reports the ignore rule as applied.
+			const eslint = run(['eslint', relative]);
+			const output = `${eslint.stdout}${eslint.stderr}`;
+			expect(output).toContain('File ignored because of a matching ignore pattern');
+			expect(output).not.toContain('Parsing error');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}, 240_000);
 
 	it('records a numeric formatter count in an isolated full-project run', () => {
 		const checkout = createCheckerClone();

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -488,7 +488,6 @@ describe('bad input dies at the boundary', () => {
 
 	it.each([
 		['an empty argument', ['']],
-		['a whitespace argument', ['   ']],
 		['a newline-joined list arriving as one argument', ['src/a.ts\nsrc/b.ts']],
 		['a path that does not exist', ['src/does-not-exist.ts']],
 		['a path outside the repository', ['/etc/hosts']],

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -343,8 +343,16 @@ describe('repository path safety', () => {
 			symlinkSync(path.join(ROOT, 'README.md'), file);
 			try {
 				expect(repositoryPaths()).toContain(relative);
-				expect(resolveInputs([file], 'test')).toEqual([relative]);
+				// The formatter scope keeps the link's own name, because Prettier neither follows
+				// nor accepts one, and the project ledger is what drops it.
+				expect(resolveInputs([file], 'test', process.cwd(), repositoryPaths, false)).toEqual([
+					relative
+				]);
 				expect(prettierProjectPaths([relative])).toEqual([]);
+				// Every other scope routes by extension, so it needs the target instead: under the
+				// link's own `.md` name a TypeScript target reaches no checker and the run passes
+				// having checked nothing.
+				expect(resolveInputs([file], 'test')).toEqual(['README.md']);
 			} finally {
 				rmSync(file, { force: true });
 			}

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -147,9 +147,9 @@ describe('route predicates', () => {
 		// Prettier has no built-in Svelte language, and loading the plugin to find that out
 		// would run it inside the checker. The route asserts the convention instead, which
 		// is only honest while the two declarations above are the ones the formatter reads.
-		expect(await prettierFormattableFiles(['src/routes/+layout.svelte'])).toEqual([
-			'src/routes/+layout.svelte'
-		]);
+		expect(
+			await prettierFormattableFiles(['src/routes/+layout.svelte', 'src/routes/Component.SVELTE'])
+		).toEqual(['src/routes/+layout.svelte', 'src/routes/Component.SVELTE']);
 	});
 
 	it('classifies without executing repository configuration', async () => {

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -144,28 +144,23 @@ describe('route predicates', () => {
 			)
 		).toBe(true);
 
-		// Prettier has no built-in Svelte language, and loading the plugin to find that out
-		// would run it inside the checker. The route asserts the convention instead, which
-		// is only honest while the two declarations above are the ones the formatter reads.
+		// Classification resolves the same config and plugin list as the formatter, so mixed
+		// case follows Prettier's own extension matching rather than a local fallback grammar.
 		expect(
 			await prettierFormattableFiles(['src/routes/+layout.svelte', 'src/routes/Component.SVELTE'])
 		).toEqual(['src/routes/+layout.svelte', 'src/routes/Component.SVELTE']);
 	});
 
-	it('classifies without executing repository configuration', async () => {
-		// Measured: with configuration resolution left on, one malformed .prettierrc makes
-		// getFileInfo throw, so a routing question would take the whole run down before any
-		// check it was classifying for could start. Classification answers from Prettier's
-		// built-in table and the repository convention alone, and never runs a config file
-		// or a plugin inside the checker.
+	it('honours a parser override from repository configuration', async () => {
 		const fixture = mkdtempSync(path.join(tmpdir(), 'static-checks-config-'));
 		try {
-			writeFileSync(path.join(fixture, '.prettierrc'), '{ this is not json\n');
-			writeFileSync(path.join(fixture, 'probe.ts'), 'export const probe = 1;\n');
-			writeFileSync(path.join(fixture, 'probe.svelte'), '<p>probe</p>\n');
-			expect(await prettierFormattableFiles(['probe.ts', 'probe.svelte'], fixture)).toEqual([
-				'probe.ts',
-				'probe.svelte'
+			writeFileSync(
+				path.join(fixture, '.prettierrc'),
+				JSON.stringify({ overrides: [{ files: '*.customfmt', options: { parser: 'typescript' } }] })
+			);
+			writeFileSync(path.join(fixture, 'probe.customfmt'), 'export const probe = 1;\n');
+			expect(await prettierFormattableFiles(['probe.customfmt'], fixture)).toEqual([
+				'probe.customfmt'
 			]);
 		} finally {
 			rmSync(fixture, { recursive: true, force: true });

--- a/scripts/static-checks.test.ts
+++ b/scripts/static-checks.test.ts
@@ -31,6 +31,8 @@ import {
 	literalControlCharacterViolations,
 	prettierArguments,
 	prettierFormattableFiles,
+	prettierProjectPaths,
+	prettierTraversalPaths,
 	repositoryPaths,
 	ROUTES,
 	resolveInputs,
@@ -171,13 +173,18 @@ describe('route predicates', () => {
 	});
 
 	it('applies the ignore rules the formatter CLI applies', async () => {
-		// The CLI's default --ignore-path is exactly [.gitignore, .prettierignore], and
-		// .prettierignore excludes the generated src/env.d.ts. A file the command would
-		// skip is not work this run may claim, so it must not reach the ledger as one.
-		expect(await prettierFormattableFiles(['src/env.d.ts'])).toEqual([]);
-		expect(await prettierFormattableFiles(['src/routes/+layout.svelte', 'src/env.d.ts'])).toEqual([
-			'src/routes/+layout.svelte'
-		]);
+		// The CLI's default --ignore-path is exactly [.gitignore, .prettierignore]. Files
+		// its project traversal skips must stay out of the ledger too.
+		expect(
+			await prettierFormattableFiles(['src/env.d.ts', 'scratch/probe.ts', 'CLAUDE.md'])
+		).toEqual([]);
+		expect(
+			await prettierFormattableFiles([
+				'src/routes/+layout.svelte',
+				'src/lib/scratch/probe.ts',
+				'src/env.d.ts'
+			])
+		).toEqual(['src/routes/+layout.svelte', 'src/lib/scratch/probe.ts']);
 	});
 
 	it('keeps a run honest about which named files it formatted', async () => {
@@ -255,6 +262,15 @@ describe('repository path safety', () => {
 		expect(existingRepositoryPaths(['README.md', 'docs/does-not-exist.md'])).toEqual(['README.md']);
 	});
 
+	it('preflights a positive formatter match count for the whole project', async () => {
+		const traversed = await prettierTraversalPaths();
+		const formattable = await prettierFormattableFiles(prettierProjectPaths(traversed));
+
+		expect(formattable.length).toBeGreaterThan(0);
+		expect(formattable.length).toBeLessThanOrEqual(traversed.length);
+		expect(formattable).not.toContain('src/env.d.ts');
+	});
+
 	it('includes untracked nonignored files in the full-mode preflight', () => {
 		const relative = `src/lib/content/.static-checks-untracked-${process.pid}.md`;
 		const file = path.join(ROOT, relative);
@@ -265,6 +281,75 @@ describe('repository path safety', () => {
 			rmSync(file, { force: true });
 		}
 	});
+
+	it('counts files Prettier visits even when local Git configuration ignores them', async () => {
+		const directory = mkdtempSync(path.join(tmpdir(), 'static-checks-local-ignore-'));
+		const excludes = path.join(directory, 'excludes');
+		const relative = `.static-checks-local-ignore-${process.pid}.json`;
+		const file = path.join(ROOT, relative);
+		const saved = new Map<string, string | undefined>();
+		for (const key of ['GIT_CONFIG_COUNT', 'GIT_CONFIG_KEY_0', 'GIT_CONFIG_VALUE_0']) {
+			saved.set(key, process.env[key]);
+		}
+		writeFileSync(excludes, `${relative}\n`);
+		writeFileSync(file, '{"safe": true}\n');
+		process.env.GIT_CONFIG_COUNT = '1';
+		process.env.GIT_CONFIG_KEY_0 = 'core.excludesFile';
+		process.env.GIT_CONFIG_VALUE_0 = excludes;
+		try {
+			expect(repositoryPaths()).not.toContain(relative);
+			expect(await prettierTraversalPaths()).toContain(relative);
+			expect(await prettierFormattableFiles([relative])).toEqual([relative]);
+		} finally {
+			for (const [key, value] of saved) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+			rmSync(file, { force: true });
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it.skipIf(process.platform === 'win32')(
+		'skips session artifacts and Sapling metadata without guessing file-level ignores',
+		async () => {
+			const fixture = mkdtempSync(path.join(tmpdir(), 'prettier-traversal-'));
+			mkdirSync(path.join(fixture, 'scratch'));
+			mkdirSync(path.join(fixture, '.sl'));
+			mkdirSync(path.join(fixture, 'src', '__fixtures__'), { recursive: true });
+			writeFileSync(path.join(fixture, '.gitignore'), '');
+			writeFileSync(path.join(fixture, '.prettierignore'), '/scratch/\n**/__fixtures__/*.ts\n');
+			writeFileSync(path.join(fixture, 'scratch', 'bad\n.ts'), 'unsafe');
+			writeFileSync(path.join(fixture, '.sl', 'probe.ts'), 'metadata');
+			writeFileSync(path.join(fixture, 'src', 'good.ts'), 'source');
+			writeFileSync(path.join(fixture, 'src', '__fixtures__', 'README.md'), 'markdown');
+			try {
+				const files = await prettierTraversalPaths(fixture, true);
+				expect(files).toContain('src/good.ts');
+				expect(files).toContain('src/__fixtures__/README.md');
+				expect(files).not.toContain('scratch/bad\n.ts');
+				expect(files).not.toContain('.sl/probe.ts');
+			} finally {
+				rmSync(fixture, { recursive: true, force: true });
+			}
+		}
+	);
+
+	it.skipIf(process.platform === 'win32')(
+		'keeps symlinks out of the project formatter ledger',
+		() => {
+			const relative = `.static-checks-prettier-link-${process.pid}.md`;
+			const file = path.join(ROOT, relative);
+			symlinkSync(path.join(ROOT, 'README.md'), file);
+			try {
+				expect(repositoryPaths()).toContain(relative);
+				expect(resolveInputs([file], 'test')).toEqual([relative]);
+				expect(prettierProjectPaths([relative])).toEqual([]);
+			} finally {
+				rmSync(file, { force: true });
+			}
+		}
+	);
 
 	it('encodes unsafe path characters in diagnostics', () => {
 		expect(formatPathForDiagnostic(`bad${String.fromCharCode(0x1b)}.txt`)).toBe(
@@ -321,8 +406,8 @@ describe('repository path safety', () => {
 		10_000
 	);
 
-	it('identifies structural, line-separator, and bidirectional controls in paths', () => {
-		for (const code of [0x09, 0x0a, 0x0d, 0x7f, 0x85, 0x2028, 0x2029, 0x202e]) {
+	it('identifies structural, invisible, line-separator, and bidirectional controls in paths', () => {
+		for (const code of [0x09, 0x0a, 0x0d, 0x7f, 0x85, 0x2028, 0x2029, 0x202e, 0xfeff, 0xfffd]) {
 			expect(unsafePathCodepoints(`bad${String.fromCharCode(code)}.txt`)).toHaveLength(1);
 		}
 	});

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -809,6 +809,10 @@ async function runCommand(
  * Prettier 3.9.5, `scripts/[ab].ts` checks `scripts/a.ts` and exits 0 after the named file
  * is deleted, while the escaped form exits 2 with "No files matching the pattern".
  *
+ * `+` is in the list because it quantifies whatever precedes it, and after an escape that
+ * is the class rather than a literal: measured, `[+.ts` escaped to `[[]+.ts` matched the
+ * neighbouring `[.ts` and exited 0 while the requested file stayed unformatted.
+ *
  * The escape cannot be a backslash. Prettier hands an unresolvable argument to
  * `normalizeToPosix`, which on Windows replaces every backslash with a slash
  * (prettier/internal/legacy-cli.mjs), so a backslash-escaped SvelteKit route such as
@@ -818,6 +822,7 @@ async function runCommand(
  */
 const GLOB_CLASS_ESCAPES = new Map<string, string>([
 	['*', '[*]'],
+	['+', '[+]'],
 	['?', '[?]'],
 	['[', '[[]'],
 	[']', '[]]'],
@@ -846,6 +851,17 @@ export function prettierLiteralPattern(file: string): string {
 		else if (character === '"') pattern += '@(\\")';
 		else if (character === '!') pattern += '@(!)';
 		else pattern += GLOB_CLASS_ESCAPES.get(character) ?? character;
+	}
+	// The pattern is only unambiguous while no file is named exactly like it. Prettier
+	// resolves an argument as a path before expanding it, so a repository holding both
+	// `[ab].ts` and `[[]ab[]].ts` would check the second and report on the first. Nothing
+	// downstream could tell, since the ledger counts the path that was asked for.
+	if (pattern !== file && existsSync(path.join(REPO_ROOT, pattern))) {
+		fail(
+			`Two repository paths collide under formatter escaping: ${formatPathForDiagnostic(file)}`,
+			`  Its escaped pattern names a second real file (${formatPathForDiagnostic(pattern)}),\n` +
+				'  and Prettier would check that one instead. Rename either path.'
+		);
 	}
 	return pattern;
 }

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -907,7 +907,9 @@ const GLOB_CLASS_ESCAPES = new Map<string, string>([
 ]);
 
 /**
- * Turn a repository path into the glob pattern that can only match that same path.
+ * For a stable filesystem snapshot, turn a repository path into a glob pattern that can
+ * only match that same path. Synchronized mutations between this check and child launch are
+ * tracked in #875 and require a file-descriptor/stdin formatter path rather than more escaping.
  *
  * `!`, `]`, a literal backslash and a double quote take an extglob rather than a class.
  * `[!]` opens a negated class and the last two cannot appear inside one. `./` is not an
@@ -1121,17 +1123,18 @@ async function main(): Promise<void> {
 
 	const fullRepositoryPaths = mode === 'full' ? repositoryPaths() : [];
 	const fullExistingPaths = existingRepositoryPaths(fullRepositoryPaths);
-	const fullFormatPaths =
-		scope === 'format' && mode === 'full' ? prettierTraversalPaths(REPO_ROOT, true) : [];
+	const countFullFormatter = mode === 'full' && (scope === 'format' || shouldRunLint);
+	const fullFormatPaths = countFullFormatter ? prettierTraversalPaths(REPO_ROOT, true) : [];
 	if (scope !== 'format') assertSafePaths(mode === 'full' ? fullRepositoryPaths : inputs);
 
-	// Every file-scoped run needs the formatter route for the zero-work invariant. A full
-	// format run counts the same filesystem traversal Prettier performs, independent of
-	// local or global Git exclude files that Prettier never reads.
-	const ledgerInputs = scope === 'format' && mode === 'full' ? fullFormatPaths : inputs;
+	// Every file-scoped run needs the formatter route for the zero-work invariant. Every full
+	// run that includes lint counts the same filesystem traversal Prettier performs. Keeping
+	// this on `--scope format` alone left the required `--scope lint` workflow reporting
+	// "whole project" and exiting 0 when `.prettierignore` matched every file.
+	const ledgerInputs = countFullFormatter ? fullFormatPaths : inputs;
 	const prettierInputs = prettierProjectPaths(ledgerInputs, REPO_ROOT, scopedMode);
 	const formattable = await prettierFormattableFiles(prettierInputs);
-	if (scope === 'format') assertSafePaths(formattable);
+	if (shouldRunLint) assertSafePaths(formattable);
 	const ledger = new Ledger(mode, ledgerInputs, formattable);
 
 	console.log('======================================================');
@@ -1314,7 +1317,7 @@ async function main(): Promise<void> {
 			const files = ledger.filesFor('prettier');
 			if (!scopedMode) {
 				await runPrettier(formatFlag);
-				ledger.ran('prettier');
+				ledger.ran('prettier', formattable.length);
 			} else if (files.length > 0) {
 				await runPrettier(formatFlag, files);
 				ledger.ran('prettier', files.length);

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -334,12 +334,15 @@ export function resolveInputs(
 	origin: string,
 	baseDirectory = process.cwd(),
 	directoryPaths: (directory: string) => string[] = repositoryPaths,
-	// Only the formatter refuses to descend through a symlinked directory, because Prettier
-	// itself does (`followSymbolicLinks: false`, and an explicitly named link is an error).
-	// Lint and types have always expanded one, and .claude/skills is a tracked directory
-	// symlink whose target holds TypeScript, so refusing it here would drop those files from
-	// a types run that still reports success.
-	expandSymlinkedDirectories = true
+	// Only the formatter refuses to resolve a symlink, because Prettier itself does
+	// (`followSymbolicLinks: false`, and an explicitly named link is an error): it has to see
+	// the link's own path so its ignore rules and its diagnostics name what was typed. Every
+	// other scope routes by extension and needs the target. Lint and types have always
+	// expanded a directory link, and .claude/skills is a tracked one whose target holds
+	// TypeScript, so refusing it here would drop those files from a types run that still
+	// reports success. A leaf link is the same question: `probe.md -> probe.ts` under the
+	// link's own name reaches no checker at all and the run exits 0 having checked nothing.
+	followSymbolicLinks = true
 ): string[] {
 	const out = new Set<string>();
 
@@ -383,9 +386,10 @@ export function resolveInputs(
 			);
 		}
 		const isSymlink = lstatSync(absolute).isSymbolicLink();
-		const located = isSymlink
-			? path.join(realpathSync(path.dirname(absolute)), path.basename(absolute))
-			: real;
+		const located =
+			isSymlink && !followSymbolicLinks
+				? path.join(realpathSync(path.dirname(absolute)), path.basename(absolute))
+				: real;
 		const native = path.relative(REPO_ROOT, located);
 		const relative = toPosix(native);
 		if (isOutside(native)) {
@@ -395,7 +399,7 @@ export function resolveInputs(
 			);
 		}
 
-		if (target.isDirectory() && (expandSymlinkedDirectories || !isSymlink)) {
+		if (target.isDirectory() && (followSymbolicLinks || !isSymlink)) {
 			let matched = false;
 			// The resolved target, not the name that was typed. Git lists a directory symlink
 			// as one entry and knows nothing below it, so a prefix built from the link matches
@@ -825,7 +829,6 @@ const GLOB_CLASS_ESCAPES = new Map<string, string>([
 	['+', '[+]'],
 	['?', '[?]'],
 	['[', '[[]'],
-	[']', '[]]'],
 	['(', '[(]'],
 	[')', '[)]'],
 	['{', '[{]'],
@@ -836,13 +839,22 @@ const GLOB_CLASS_ESCAPES = new Map<string, string>([
 /**
  * Turn a repository path into the glob pattern that can only match that same path.
  *
- * `!`, a literal backslash and a double quote take an extglob rather than a class, because
- * `[!]` opens a negated class and the other two cannot appear inside one. `./` is not an
+ * `!`, `]`, a literal backslash and a double quote take an extglob rather than a class.
+ * `[!]` opens a negated class and the last two cannot appear inside one. `./` is not an
  * option for the `!`: measured with Prettier 3.9.5, `./!a[[]b[]].ts` still reads as a
  * negation, so a run whose named file had vanished matched every other root file and exited
  * 0, while `@(!)a[[]b[]].ts` exits 2 with "No files matching the pattern". A backslash and
  * a quote are unrepresentable in a Windows filename, so those two branches are reachable on
  * POSIX alone, where Prettier's `normalizeToPosix` is the identity.
+ *
+ * `]` is the one that has to be an extglob for a reason outside its own escape. The POSIX
+ * form `[]]` is correct on its own, and it composes wrongly with the `{` and `}` classes
+ * because fast-glob runs `micromatch.braces()` over the whole pattern before picomatch sees
+ * it, and that pass reads the braces inside `[{]` and `[}]` as a brace expression. Measured
+ * with Prettier 3.9.5: `[]][{][}].ts` selected the neighbouring `{}.ts` and reported it
+ * clean, and `[{][]][}].ts` and `[{][}][]].ts` matched nothing at all. Over every ordered
+ * triple of the ten metacharacters plus `!`, `\\` and `"`, the class form fails those three
+ * and the extglob form fails none.
  */
 export function prettierLiteralPattern(file: string): string {
 	let pattern = '';
@@ -850,6 +862,7 @@ export function prettierLiteralPattern(file: string): string {
 		if (character === '\\') pattern += '@(\\\\)';
 		else if (character === '"') pattern += '@(\\")';
 		else if (character === '!') pattern += '@(!)';
+		else if (character === ']') pattern += '@(])';
 		else pattern += GLOB_CLASS_ESCAPES.get(character) ?? character;
 	}
 	// The pattern is only unambiguous while no file is named exactly like it. Prettier

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -10,7 +10,7 @@
  *   bun scripts/static-checks.ts --scope format files  - Assert formatting only
  *   bun scripts/static-checks.ts --staged              - Check only staged files (pre-commit)
  *   bun scripts/static-checks.ts file1.ts file2.svelte - Check specific files
- *   ... | bun scripts/static-checks.ts --files-from -  - Check a computed list of files
+ *   ... | bun scripts/static-checks.ts --files-from -  - Check a NUL-separated computed list
  *
  * Flags:
  *   --ci         Assert mode: uses --check for formatting, omits --fix for ESLint.
@@ -21,10 +21,10 @@
  *                (prettier), or full-project-only "compat" (Convex consumer compatibility).
  *                Lint and types run svelte-kit sync first.
  *                Omit to run lint and types.
- *   --files-from Read newline-separated paths from a file, or from stdin with "-".
- *                Use this for a COMPUTED list: unlike positionals, this channel can
- *                carry an empty list, which is an honest no-op instead of a silent
- *                zero-file run.
+ *   --files-from Read NUL-separated UTF-8 paths from a file, or from stdin with "-".
+ *                This matches `git diff --name-only --diff-filter=d -z` without
+ *                quoting, deleted paths, or delimiter ambiguity. Records are
+ *                repository-relative. An empty stream is an honest no-op.
  *
  * Paths are validated and normalized at intake (see resolveInputs). An empty
  * argument, a newline-joined blob, a missing path, or a path outside the repo is a
@@ -32,7 +32,7 @@
  */
 
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync, realpathSync, statSync } from 'fs';
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
 import path from 'path';
 import { getFileInfo } from 'prettier';
 import { fileURLToPath } from 'url';
@@ -149,6 +149,8 @@ function unsafePathCodepoint(code: number): boolean {
 		(code >= 0x80 && code <= 0x9f) ||
 		code === 0x2028 ||
 		code === 0x2029 ||
+		code === 0xfeff ||
+		code === 0xfffd ||
 		PATH_BIDI.has(code)
 	);
 }
@@ -184,18 +186,77 @@ export function assertSafePaths(files: string[]): void {
 	}
 }
 
+function decodeUtf8(bytes: Uint8Array, error: string): string {
+	try {
+		return new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes);
+	} catch {
+		fail(error);
+	}
+}
+
 export function repositoryPaths(): string[] {
 	const result = spawnSync('git', ['ls-files', '-co', '--exclude-standard', '-z'], {
 		cwd: REPO_ROOT,
-		env: sanitizedGitEnv(),
-		encoding: 'utf8'
+		env: sanitizedGitEnv()
 	});
 	if (result.status !== 0) fail('Failed to list repository paths.');
-	return result.stdout.split('\0').filter(Boolean);
+	return decodeUtf8(result.stdout, 'Repository contains a path whose bytes are not valid UTF-8.')
+		.split('\0')
+		.filter(Boolean);
 }
 
 export function existingRepositoryPaths(files: string[]): string[] {
 	return files.filter((file) => existsSync(path.join(REPO_ROOT, file)));
+}
+
+/** Paths Prettier's `.` traversal can visit; it does not follow symbolic links. */
+export function prettierProjectPaths(
+	files: string[],
+	cwd = REPO_ROOT,
+	failOnMissing = false
+): string[] {
+	return files.filter((file) => {
+		try {
+			return !lstatSync(path.join(cwd, file)).isSymbolicLink();
+		} catch {
+			if (failOnMissing) {
+				fail(`Named path disappeared before formatter routing: ${formatPathForDiagnostic(file)}.`);
+			}
+			return false;
+		}
+	});
+}
+
+/** Files reachable by Prettier's directory traversal before file-level classification. */
+export function prettierTraversalPaths(
+	cwd = REPO_ROOT,
+	skipSessionArtifacts = false,
+	relativeTo = cwd
+): string[] {
+	const files: string[] = [];
+	const skippedDirectories = new Set(['.git', '.hg', '.jj', '.sl', '.svn', 'node_modules']);
+	const walk = (directory: string, prefix: string): void => {
+		for (const rawName of readdirSync(directory, { encoding: 'buffer' })) {
+			const name = decodeUtf8(
+				rawName,
+				'Repository contains a path whose bytes are not valid UTF-8.'
+			);
+			const absolute = path.join(directory, name);
+			const entry = lstatSync(absolute);
+			if (entry.isSymbolicLink()) continue;
+			const relative = prefix ? `${prefix}/${name}` : name;
+			if (entry.isDirectory()) {
+				if (skippedDirectories.has(name) || (skipSessionArtifacts && relative === 'scratch')) {
+					continue;
+				}
+				walk(absolute, relative);
+				continue;
+			}
+			if (entry.isFile()) files.push(relative);
+		}
+	};
+	walk(cwd, toPosix(path.relative(relativeTo, cwd)));
+	return files.sort();
 }
 
 function toPosix(p: string): string {
@@ -223,11 +284,16 @@ function toPosix(p: string): string {
  * Normalizing here fixes (2) for every prefix gate at once, including the ones a fork
  * adds later, without touching a single gate.
  */
-export function resolveInputs(raw: string[], origin: string): string[] {
+export function resolveInputs(
+	raw: string[],
+	origin: string,
+	baseDirectory = process.cwd(),
+	directoryPaths: (directory: string) => string[] = repositoryPaths
+): string[] {
 	const out = new Set<string>();
 
 	for (const arg of raw) {
-		if (arg.trim() === '') {
+		if (arg === '') {
 			fail(
 				`Empty path in ${origin}.`,
 				'  An empty string is not a file. This is usually a caller expanding an empty\n' +
@@ -239,8 +305,8 @@ export function resolveInputs(raw: string[], origin: string): string[] {
 		if (/[\r\n]/.test(arg)) {
 			fail(
 				`Newline inside a single path argument (${origin}): ${JSON.stringify(arg.slice(0, 40))}`,
-				'  A newline-separated list arrived as ONE argument. Leave the expansion\n' +
-					'  unquoted, or pipe it: `git diff --name-only | ... --files-from -`.'
+				"  A computed list arrived as one positional argument. Pipe Git's native\n" +
+					'  path records instead: `git diff --name-only --diff-filter=d -z | ... --files-from -`.'
 			);
 		}
 
@@ -248,32 +314,42 @@ export function resolveInputs(raw: string[], origin: string): string[] {
 		// then re-express against the repo root (what every gate below assumes).
 		// realpath both sides so a checkout reached through a symlink (/tmp ->
 		// /private/tmp, a symlinked worktree) does not read as "outside the repo".
-		const absolute = path.resolve(arg);
+		const absolute = path.resolve(baseDirectory, arg);
 		if (!existsSync(absolute)) fail(`No such file (${origin}): ${formatPathForDiagnostic(arg)}`);
 
 		const real = realpathSync(absolute);
-		const native = path.relative(REPO_ROOT, real);
+		const target = statSync(real);
+		const isOutside = (native: string): boolean => {
+			const relative = toPosix(native);
+			return relative === '..' || relative.startsWith('../') || path.isAbsolute(native);
+		};
+		// The resolved target and the named path must both live in the repository. Checking
+		// only the latter would let an in-repository symlink expose an external file.
+		if (isOutside(path.relative(REPO_ROOT, real))) {
+			fail(
+				`Path is outside the repository (${origin}): ${formatPathForDiagnostic(arg)}`,
+				`  Repo root: ${formatPathForDiagnostic(REPO_ROOT)}`
+			);
+		}
+		const isSymlink = lstatSync(absolute).isSymbolicLink();
+		const located = isSymlink
+			? path.join(realpathSync(path.dirname(absolute)), path.basename(absolute))
+			: real;
+		const native = path.relative(REPO_ROOT, located);
 		const relative = toPosix(native);
-		// Only an empty result, a bare "..", a real ".." segment, or an absolute result
-		// (a different Windows drive) leaves the repository. A "startsWith('..')" prefix
-		// test also rejects "..valid.ts", which is an ordinary file at the root.
-		if (
-			relative === '' ||
-			relative === '..' ||
-			relative.startsWith('../') ||
-			path.isAbsolute(native)
-		) {
+		if (isOutside(native)) {
 			fail(
 				`Path is outside the repository (${origin}): ${formatPathForDiagnostic(arg)}`,
 				`  Repo root: ${formatPathForDiagnostic(REPO_ROOT)}`
 			);
 		}
 
-		if (statSync(real).isDirectory()) {
+		if (target.isDirectory() && !isSymlink) {
 			let matched = false;
-			const prefix = `${relative}/`;
-			for (const file of repositoryPaths()) {
-				if (!file.startsWith(prefix) || !existsSync(path.join(REPO_ROOT, file))) continue;
+			const prefix = relative === '' ? '' : `${relative}/`;
+			for (const file of directoryPaths(real)) {
+				if ((prefix && !file.startsWith(prefix)) || !existsSync(path.join(REPO_ROOT, file)))
+					continue;
 				if (NEVER_WALK.some((skip) => file.includes(skip))) continue;
 				matched = true;
 				out.add(file);
@@ -289,19 +365,31 @@ export function resolveInputs(raw: string[], origin: string): string[] {
 	return [...out].sort();
 }
 
-/** Newline-separated paths from a file, or from stdin with "-". An empty list is legal. */
+/** NUL-separated paths from a file, or from stdin with "-". An empty list is legal. */
 function readFilesFrom(source: string): string[] {
-	const raw =
+	const bytes =
 		source === '-'
-			? readFileSync(0, 'utf-8')
+			? readFileSync(0)
 			: existsSync(path.resolve(source))
-				? readFileSync(path.resolve(source), 'utf-8')
+				? readFileSync(path.resolve(source))
 				: fail(`--files-from: no such file: ${formatPathForDiagnostic(source)}`);
+	// `ignoreBOM: true` keeps U+FEFF visible so the explicit ambiguity check below runs.
+	const raw = decodeUtf8(bytes, '--files-from contains bytes that are not valid UTF-8.');
 
-	return raw
-		.split('\n')
-		.map((line) => line.trim())
-		.filter((line) => line !== '');
+	if (raw.charCodeAt(0) === 0xfeff) {
+		fail(
+			'--files-from must be UTF-8 without a byte-order mark.',
+			'  A leading U+FEFF is ambiguous with a repository filename. Write BOM-less UTF-8.'
+		);
+	}
+
+	if (raw === '') return [];
+	const records = raw.split('\0');
+	if (records.at(-1) === '') records.pop();
+	if (records.some((record) => record === '')) {
+		fail('--files-from contains an empty path record.');
+	}
+	return records;
 }
 
 // ===========================================================================
@@ -658,6 +746,21 @@ async function runCommand(
 	}
 }
 
+const POSIX_GLOB_SYMBOLS = /(\\?)([()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
+const WINDOWS_GLOB_SYMBOLS = /(\\?)([()[\]{}]|^!|[!+@](?=\())/g;
+
+/**
+ * Escape a repository path with the same pattern grammar Prettier delegates to fast-glob.
+ * Prettier checks an existing path literally, then falls back to glob expansion if that
+ * path disappears. An escaped pattern can only rediscover the originally named path.
+ */
+export function prettierLiteralPattern(file: string): string {
+	return file.replace(
+		process.platform === 'win32' ? WINDOWS_GLOB_SYMBOLS : POSIX_GLOB_SYMBOLS,
+		'\\$2'
+	);
+}
+
 /**
  * One formatter contract, whether the run names files or the whole project.
  *
@@ -673,7 +776,9 @@ export function prettierArguments(formatFlag: '--check' | '--write', files?: str
 	// Everything after the separator is a path. Without it Prettier reads a leading-dash
 	// filename as an option, discards it with a warning, finds nothing left to check and
 	// exits 0, so a repository file named "--anything.ts" is never looked at.
-	return files === undefined ? [...invocation, '.'] : [...invocation, '--', ...files];
+	return files === undefined
+		? [...invocation, '.']
+		: [...invocation, '--', ...files.map(prettierLiteralPattern)];
 }
 
 async function runPrettier(formatFlag: '--check' | '--write', files?: string[]): Promise<void> {
@@ -682,7 +787,7 @@ async function runPrettier(formatFlag: '--check' | '--write', files?: string[]):
 		return;
 	}
 	const baseArguments = prettierArguments(formatFlag, []);
-	for (const batch of argumentBatches(files, baseArguments)) {
+	for (const batch of argumentBatches(files.map(prettierLiteralPattern), baseArguments)) {
 		await runCommand('bun', [...baseArguments, ...batch]);
 	}
 }
@@ -755,9 +860,14 @@ async function main(): Promise<void> {
 			process.exit(0);
 		}
 		assertSafePaths(raw);
+		const baseDirectory = filesFrom !== undefined ? REPO_ROOT : process.cwd();
 		inputs = resolveInputs(
 			raw,
-			filesFrom !== undefined ? `--files-from ${filesFrom}` : 'arguments'
+			filesFrom !== undefined ? `--files-from ${filesFrom}` : 'arguments',
+			baseDirectory,
+			scope === 'format'
+				? (directory) => prettierTraversalPaths(directory, false, REPO_ROOT)
+				: repositoryPaths
 		);
 	}
 
@@ -798,13 +908,18 @@ async function main(): Promise<void> {
 
 	const fullRepositoryPaths = mode === 'full' ? repositoryPaths() : [];
 	const fullExistingPaths = existingRepositoryPaths(fullRepositoryPaths);
-	assertSafePaths(mode === 'full' ? fullRepositoryPaths : inputs);
+	const fullFormatPaths =
+		scope === 'format' && mode === 'full' ? prettierTraversalPaths(REPO_ROOT, true) : [];
+	if (scope !== 'format') assertSafePaths(mode === 'full' ? fullRepositoryPaths : inputs);
 
 	// Every file-scoped run needs the formatter route for the zero-work invariant. A full
-	// format run also needs the repository preflight set so it can prove Prettier had at
-	// least one supported, nonignored file to check.
-	const ledgerInputs = scope === 'format' && mode === 'full' ? fullExistingPaths : inputs;
-	const ledger = new Ledger(mode, ledgerInputs, await prettierFormattableFiles(ledgerInputs));
+	// format run counts the same filesystem traversal Prettier performs, independent of
+	// local or global Git exclude files that Prettier never reads.
+	const ledgerInputs = scope === 'format' && mode === 'full' ? fullFormatPaths : inputs;
+	const prettierInputs = prettierProjectPaths(ledgerInputs, REPO_ROOT, scopedMode);
+	const formattable = await prettierFormattableFiles(prettierInputs);
+	if (scope === 'format') assertSafePaths(formattable);
+	const ledger = new Ledger(mode, ledgerInputs, formattable);
 
 	console.log('======================================================');
 	console.log(
@@ -844,7 +959,7 @@ async function main(): Promise<void> {
 			// honest; failing would make a caller that passes a mixed file list unusable.
 			console.log(
 				`No formatter work: Prettier formats none of the ${ledger.named} named file(s) ` +
-					'(unknown file type, or excluded by .prettierignore or .gitignore).'
+					'(unknown file type, symbolic link, or excluded by .prettierignore or .gitignore).'
 			);
 			ledger.ran('prettier', 0);
 			ledger.noWork(`Prettier formats none of the ${ledger.named} named file(s)`);

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -584,9 +584,9 @@ export async function prettierFormattableFiles(
 	// path made a full-format preflight retain an ignored generated tree at once and roughly
 	// doubled the peak memory of direct Prettier in the reproducer. Keep only as many
 	// classifications active as the host can run in parallel; result slots preserve order.
-	const infos: Array<Awaited<ReturnType<typeof getFileInfo>> | undefined> = new Array(
-		candidates.length
-	);
+	const infos: Array<Awaited<ReturnType<typeof getFileInfo>> | undefined> = Array.from({
+		length: candidates.length
+	});
 	let cursor = 0;
 	await Promise.all(
 		Array.from({ length: Math.min(candidates.length, availableParallelism()) }, async () => {
@@ -706,11 +706,11 @@ class Ledger {
 	/**
 	 * Record a reason this run legitimately had nothing to do.
 	 *
-	 * The zero-work invariant asks whether a check COULD have run over the named files,
-	 * and only a single-check scope can answer that from one check. A `--scope format` run
-	 * over files Prettier does not format is such an answer, and it is the caller's answer
-	 * rather than a hole in the gate. Nothing else may call this: for a lint or types run,
-	 * "no check ran" is still the bug it always was.
+	 * The zero-work invariant asks whether a check COULD have run over the named files. A
+	 * `--scope format` run over files Prettier does not format is the caller's answer rather
+	 * than a hole in the gate. A deletion-only staged change is the other honest zero: no
+	 * deleted bytes exist in the final index to check, while the final-index knowledge scan
+	 * still verifies that removing their paths broke no links. Nothing else may call this.
 	 */
 	noWork(reason: string): void {
 		this.honestNoWork.push(reason);
@@ -1080,6 +1080,7 @@ async function main(): Promise<void> {
 	let inputs: string[] = [];
 	// Staged mode keeps the exact Git paths and the complete starting index state.
 	let stagedIndexPaths: string[] = [];
+	let stagedDeletionOnly = false;
 	let stagedIndexFingerprint: string | undefined;
 	let stagedEnv: NodeJS.ProcessEnv | undefined;
 	if (mode === 'files') {
@@ -1118,6 +1119,7 @@ async function main(): Promise<void> {
 			console.log('No staged files to check');
 			process.exit(0);
 		}
+		stagedDeletionOnly = stagedChanges.every((change) => change.status === 'D');
 		// Keep the original index paths. resolveInputs realpaths symlinks, while
 		// later comparisons must address the paths recorded by Git.
 		stagedIndexPaths = getStagedFiles(REPO_ROOT, stagedEnv);
@@ -1152,8 +1154,11 @@ async function main(): Promise<void> {
 	const ledgerInputs = countFullFormatter ? fullFormatPaths : inputs;
 	const prettierInputs = prettierProjectPaths(ledgerInputs, REPO_ROOT, scopedMode);
 	const formattable = await prettierFormattableFiles(prettierInputs);
-	if (shouldRunLint) assertSafePaths(formattable);
+	assertSafePaths(formattable);
 	const ledger = new Ledger(mode, ledgerInputs, formattable);
+	if (stagedDeletionOnly) {
+		ledger.noWork('staged changes only delete paths absent from the final index');
+	}
 
 	console.log('======================================================');
 	console.log(

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -415,7 +415,19 @@ export function resolveInputs(
 		// ignored target under `scratch/` made a direct Prettier failure into a zero-file pass.
 		// A relative argument can be re-rooted through a symlinked invocation cwd without
 		// resolving any component it names. Absolute arguments keep their own spelling.
-		const named = path.isAbsolute(arg) ? absolute : path.resolve(realpathSync(invocationBase), arg);
+		const fromInvocation = path.relative(invocationBase, absolute);
+		const insideInvocation =
+			fromInvocation === '' ||
+			(fromInvocation !== '..' &&
+				!fromInvocation.startsWith(`..${path.sep}`) &&
+				!path.isAbsolute(fromInvocation));
+		const absoluteInsideRepository = !isOutside(path.relative(REPO_ROOT, absolute));
+		const named =
+			!path.isAbsolute(arg) || insideInvocation
+				? path.resolve(realpathSync(invocationBase), fromInvocation)
+				: absoluteInsideRepository
+					? absolute
+					: real;
 		const located = followSymbolicLinks ? real : named;
 		const native = path.relative(REPO_ROOT, located);
 		const relative = toPosix(native);
@@ -439,12 +451,23 @@ export function resolveInputs(
 			// checked nothing; see #865, which is where that whole semantics belongs.
 			const walked = toPosix(path.relative(REPO_ROOT, real));
 			const prefix = walked === '' ? '' : `${walked}/`;
+			const namedDirectory = toPosix(path.relative(REPO_ROOT, located));
 			for (const file of directoryPaths(real)) {
 				if ((prefix && !file.startsWith(prefix)) || !existsSync(path.join(REPO_ROOT, file)))
 					continue;
 				if (isNeverWalked(file)) continue;
 				matched = true;
-				out.add(file);
+				// Prettier traverses the caller-visible directory. The traversal function walks the
+				// resolved target so it can read the filesystem, then this maps each child back under
+				// the alias the caller named. Without that mapping, `alias/subdir` targeting root
+				// `scratch/` was classified under the target ignore rule and exited 0 on an
+				// unformatted file direct Prettier found through the alias.
+				if (!followSymbolicLinks) {
+					const suffix = prefix === '' ? file : file.slice(prefix.length);
+					out.add(namedDirectory === '' ? suffix : `${namedDirectory}/${suffix}`);
+				} else {
+					out.add(file);
+				}
 			}
 			if (!matched)
 				fail(`Directory contains no files to check (${origin}): ${formatPathForDiagnostic(arg)}`);
@@ -521,15 +544,6 @@ export const ROUTES = {
 const PRETTIER_IGNORE_FILES = ['.gitignore', '.prettierignore'];
 
 /**
- * Components, which Prettier has no built-in language for. The parser comes from
- * prettier-plugin-svelte, and .prettierrc declares both the plugin and the `*.svelte`
- * parser override; loading either to answer a routing question would run a configuration
- * file and a plugin inside the checker. The checker asserts the convention instead, and
- * static-checks.test.ts pins the declaration it stands on.
- */
-const SVELTE_COMPONENT = /\.svelte$/i;
-
-/**
  * The files Prettier would actually format, answered by Prettier.
  *
  * This used to be an extension grammar maintained here by hand, which is a copy of a
@@ -537,10 +551,12 @@ const SVELTE_COMPONENT = /\.svelte$/i;
  * .babelrc, .geojson and .mjml are all formatted by Prettier and none of them matched, so
  * a file-scoped run skipped them and reported success.
  *
- * `resolveConfig: false` keeps repository configuration and its plugins out of this
- * process: a routing question should not be able to take the run down before the checks
- * it classifies for ever start. The ignore files are still consulted, because they are
- * read as data and because a file the command will skip is not work this run may claim.
+ * Configuration resolution is part of the routing answer. A parser override can make a
+ * filename with no built-in language format-capable, and classifying with `resolveConfig:
+ * false` silently removed it from a computed list that the real CLI rejected as unformatted.
+ * The config and plugins are project-owned executable inputs that the formatter itself runs;
+ * classification must use the same ones. Ignore files are consulted for the same reason: a
+ * file the command skips is not work this run may claim.
  */
 export async function prettierFormattableFiles(
 	files: string[],
@@ -560,7 +576,7 @@ export async function prettierFormattableFiles(
 				const index = cursor++;
 				infos[index] = await getFileInfo(path.resolve(cwd, files[index]!), {
 					ignorePath,
-					resolveConfig: false
+					resolveConfig: true
 				});
 			}
 		})
@@ -568,7 +584,7 @@ export async function prettierFormattableFiles(
 	return files.filter((file, index) => {
 		const info = infos[index]!;
 		if (info.ignored) return false;
-		return info.inferredParser !== null || SVELTE_COMPONENT.test(file);
+		return info.inferredParser !== null;
 	});
 }
 

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -44,6 +44,7 @@
 
 import { spawnSync } from 'child_process';
 import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
+import { availableParallelism } from 'os';
 import path from 'path';
 import { getFileInfo } from 'prettier';
 import { fileURLToPath } from 'url';
@@ -516,7 +517,7 @@ const PRETTIER_IGNORE_FILES = ['.gitignore', '.prettierignore'];
  * file and a plugin inside the checker. The checker asserts the convention instead, and
  * static-checks.test.ts pins the declaration it stands on.
  */
-const SVELTE_COMPONENT = /\.svelte$/;
+const SVELTE_COMPONENT = /\.svelte$/i;
 
 /**
  * The files Prettier would actually format, answered by Prettier.
@@ -537,8 +538,22 @@ export async function prettierFormattableFiles(
 ): Promise<string[]> {
 	if (files.length === 0) return [];
 	const ignorePath = PRETTIER_IGNORE_FILES.map((file) => path.join(cwd, file));
-	const infos = await Promise.all(
-		files.map((file) => getFileInfo(path.resolve(cwd, file), { ignorePath, resolveConfig: false }))
+	// `getFileInfo` reads ignore files and may load parser metadata. Starting one promise per
+	// path made a full-format preflight retain an ignored generated tree at once and roughly
+	// doubled the peak memory of direct Prettier in the reproducer. Keep only as many
+	// classifications active as the host can run in parallel; result slots preserve order.
+	const infos: Array<Awaited<ReturnType<typeof getFileInfo>> | undefined> = new Array(files.length);
+	let cursor = 0;
+	await Promise.all(
+		Array.from({ length: Math.min(files.length, availableParallelism()) }, async () => {
+			while (cursor < files.length) {
+				const index = cursor++;
+				infos[index] = await getFileInfo(path.resolve(cwd, files[index]!), {
+					ignorePath,
+					resolveConfig: false
+				});
+			}
+		})
 	);
 	return files.filter((file, index) => {
 		const info = infos[index]!;

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -1120,10 +1120,13 @@ async function main(): Promise<void> {
 			process.exit(0);
 		}
 		stagedDeletionOnly = stagedChanges.every((change) => change.status === 'D');
+		const stagedDeletedPaths = stagedChanges
+			.filter((change) => change.status === 'D')
+			.map((change) => change.path);
 		// Keep the original index paths. resolveInputs realpaths symlinks, while
 		// later comparisons must address the paths recorded by Git.
 		stagedIndexPaths = getStagedFiles(REPO_ROOT, stagedEnv);
-		assertSafePaths(stagedIndexPaths);
+		assertSafePaths([...stagedIndexPaths, ...stagedDeletedPaths]);
 		const cleanFiltered = stagedFilesWithCleanFilters(stagedIndexPaths, REPO_ROOT, stagedEnv);
 		if (cleanFiltered.length > 0) {
 			fail(
@@ -1132,7 +1135,19 @@ async function main(): Promise<void> {
 			);
 		}
 		inputs = stagedIndexPaths.length > 0 ? resolveInputs(stagedIndexPaths, 'the git index') : [];
-		if (!stagedFilesMatchWorktree(stagedIndexPaths, REPO_ROOT, stagedEnv)) {
+		const deletedPathStillExists = stagedDeletedPaths.some((file) => {
+			try {
+				lstatSync(path.join(REPO_ROOT, file));
+				return true;
+			} catch (error) {
+				if (isMissingPathError(error)) return false;
+				throw error;
+			}
+		});
+		if (
+			deletedPathStillExists ||
+			!stagedFilesMatchWorktree(stagedIndexPaths, REPO_ROOT, stagedEnv)
+		) {
 			fail(
 				'Staged file contents differ from the worktree.',
 				'  Run the checks in fix mode, review the result, stage the intended bytes,\n' +

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -11,6 +11,8 @@
  *   bun scripts/static-checks.ts --staged              - Check only staged files (pre-commit)
  *   bun scripts/static-checks.ts file1.ts file2.svelte - Check specific files
  *   ... | bun scripts/static-checks.ts --files-from -  - Check a NUL-separated computed list
+ *                                                        (see --files-from on the producer's
+ *                                                        exit status, which a pipe discards)
  *
  * Flags:
  *   --ci         Assert mode: uses --check for formatting, omits --fix for ESLint.
@@ -27,7 +29,13 @@
  *                repository-relative, and --no-relative is what keeps them so: with
  *                diff.relative set, git strips the prefix of the current subdirectory
  *                and drops everything above it, so a record would name a same-named
- *                file at the root. An empty stream is an honest no-op.
+ *                file at the root. An empty stream is an honest no-op, and that is
+ *                what makes the producer's exit status the caller's job: a shell
+ *                without `pipefail` reports only the last command, so `git diff`
+ *                exiting 128 on a bad revision emits nothing, this checker exits 0
+ *                over an empty list, and the pipeline reads as a pass. Write the list
+ *                to a file and check git's status before invoking, or set `pipefail`.
+ *                Measured: pipeline_status=0 git_status=128 checker_status=0.
  *
  * Paths are validated and normalized at intake (see resolveInputs). An empty
  * argument, a newline-joined blob, a missing path, or a path outside the repo is a
@@ -230,6 +238,14 @@ export function existingRepositoryPaths(files: string[]): string[] {
 }
 
 /** Paths Prettier's `.` traversal can visit; it does not follow symbolic links. */
+/**
+ * The formatter's own view of a path list: symlinks removed, missing paths either fatal or
+ * dropped. Prettier exits 2 on an explicitly named symlink ("Explicitly specified pattern
+ * ... is a symbolic link"), and this deliberately differs: a link carries a target path
+ * rather than formattable source, so refusing one would fail a whole computed list over an
+ * entry that has nothing to format. A list that holds only links is therefore an honest
+ * zero, the same as a list of images.
+ */
 export function prettierProjectPaths(
 	files: string[],
 	cwd = REPO_ROOT,
@@ -248,6 +264,16 @@ export function prettierProjectPaths(
 }
 
 /** A path that vanished between two syscalls, which is the only traversal race to absorb. */
+/** Whether the path is a symlink, treating a vanished path as "not one". */
+function isSymbolicLinkAt(absolute: string): boolean {
+	try {
+		return lstatSync(absolute).isSymbolicLink();
+	} catch (error) {
+		if (isMissingPathError(error)) return false;
+		throw error;
+	}
+}
+
 function isMissingPathError(error: unknown): boolean {
 	return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT';
 }
@@ -345,8 +371,15 @@ export function resolveInputs(
 	followSymbolicLinks = true
 ): string[] {
 	const out = new Set<string>();
+	// Expanding a directory can produce another link, so the expansion feeds back into this
+	// same loop instead of trusting its own output. `expanded` stops a link that points at an
+	// ancestor from looping forever; it holds resolved directories, so two different links to
+	// the same target expand once.
+	const expanded = new Set<string>();
+	const queue = raw.map((value) => ({ value, base: baseDirectory, named: true }));
 
-	for (const arg of raw) {
+	while (queue.length > 0) {
+		const { value: arg, base, named } = queue.shift()!;
 		if (arg === '') {
 			fail(
 				`Empty path in ${origin}.`,
@@ -368,8 +401,13 @@ export function resolveInputs(
 		// then re-express against the repo root (what every gate below assumes).
 		// realpath both sides so a checkout reached through a symlink (/tmp ->
 		// /private/tmp, a symlinked worktree) does not read as "outside the repo".
-		const absolute = path.resolve(baseDirectory, arg);
-		if (!existsSync(absolute)) fail(`No such file (${origin}): ${formatPathForDiagnostic(arg)}`);
+		const absolute = path.resolve(base, arg);
+		// A named path that is not there is the caller's error. An expanded one can vanish
+		// between the listing and this line, and that race is not worth failing a whole run.
+		if (!existsSync(absolute)) {
+			if (!named) continue;
+			fail(`No such file (${origin}): ${formatPathForDiagnostic(arg)}`);
+		}
 
 		const real = realpathSync(absolute);
 		const target = statSync(real);
@@ -380,6 +418,10 @@ export function resolveInputs(
 		// The resolved target and the named path must both live in the repository. Checking
 		// only the latter would let an in-repository symlink expose an external file.
 		if (isOutside(path.relative(REPO_ROOT, real))) {
+			// A link that was typed is a mistake worth stopping for. One that an expansion
+			// produced is not the caller's doing, and it is the only reason a directory walk
+			// could hand an external file to a checker, so it is dropped instead.
+			if (!named) continue;
 			fail(
 				`Path is outside the repository (${origin}): ${formatPathForDiagnostic(arg)}`,
 				`  Repo root: ${formatPathForDiagnostic(REPO_ROOT)}`
@@ -393,6 +435,7 @@ export function resolveInputs(
 		const native = path.relative(REPO_ROOT, located);
 		const relative = toPosix(native);
 		if (isOutside(native)) {
+			if (!named) continue;
 			fail(
 				`Path is outside the repository (${origin}): ${formatPathForDiagnostic(arg)}`,
 				`  Repo root: ${formatPathForDiagnostic(REPO_ROOT)}`
@@ -400,6 +443,8 @@ export function resolveInputs(
 		}
 
 		if (target.isDirectory() && (followSymbolicLinks || !isSymlink)) {
+			if (expanded.has(real)) continue;
+			expanded.add(real);
 			let matched = false;
 			// The resolved target, not the name that was typed. Git lists a directory symlink
 			// as one entry and knows nothing below it, so a prefix built from the link matches
@@ -411,6 +456,15 @@ export function resolveInputs(
 					continue;
 				if (isNeverWalked(file)) continue;
 				matched = true;
+				// A child of the expansion can be a link of its own, and Git lists one as a single
+				// entry with nothing below it. Adding that name routes by the link's extension:
+				// `.claude/skills` holds eleven directory links, and expanding the parent used to
+				// yield eleven names and no TypeScript at all, so `--scope types` over it reported
+				// success having checked nothing. Feed it back through this loop instead.
+				if (followSymbolicLinks && isSymbolicLinkAt(path.join(REPO_ROOT, file))) {
+					queue.push({ value: file, base: REPO_ROOT, named: false });
+					continue;
+				}
 				out.add(file);
 			}
 			if (!matched)
@@ -768,12 +822,19 @@ function parseCli() {
 
 	// A staged run must end by proving the checked bytes are still the staged bytes, and
 	// that closing argument belongs to the lint-and-types path that owns it. Rather than
-	// spread it over a second exit, the combination is refused: --staged stays a lint
-	// consumer, and formatting a staged set is `--files-from -` over the staged names.
+	// spread it over a second exit, the combination is refused, and --staged stays a lint
+	// consumer.
+	//
+	// `--files-from` over the staged names is not a substitute, and the diagnostic must not
+	// read as one. It names paths, and every checker then reads the working tree: stage an
+	// unformatted file, format only the working copy, and a gate built that way passes while
+	// the unformatted blob is what gets committed. This scope is a push gate over paths that
+	// exist on disk, and there is no index-exact formatting mode.
 	if (scope === 'format' && mode === 'staged') {
 		fail(
 			'--scope format does not support --staged.',
-			'  It formats a full project or a named file list. Pass explicit paths or use --files-from.'
+			'  It formats a full project or a named file list, always as the files are on disk.\n' +
+				'  A gate over index bytes belongs to --staged, which the lint scope owns.'
 		);
 	}
 

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -22,9 +22,12 @@
  *                Lint and types run svelte-kit sync first.
  *                Omit to run lint and types.
  *   --files-from Read NUL-separated UTF-8 paths from a file, or from stdin with "-".
- *                This matches `git diff --name-only --diff-filter=d -z` without
- *                quoting, deleted paths, or delimiter ambiguity. Records are
- *                repository-relative. An empty stream is an honest no-op.
+ *                This matches `git diff --no-relative --name-only --diff-filter=d -z`
+ *                without quoting, deleted paths, or delimiter ambiguity. Records are
+ *                repository-relative, and --no-relative is what keeps them so: with
+ *                diff.relative set, git strips the prefix of the current subdirectory
+ *                and drops everything above it, so a record would name a same-named
+ *                file at the root. An empty stream is an honest no-op.
  *
  * Paths are validated and normalized at intake (see resolveInputs). An empty
  * argument, a newline-joined blob, a missing path, or a path outside the repo is a
@@ -127,7 +130,12 @@ const REPO_ROOT = realpathSync(path.resolve(path.dirname(fileURLToPath(import.me
 const USAGE = '  Flags: --ci, --staged, --scope <lint|types|format|compat>, --files-from <path|->';
 
 /** Directories never descended into when a directory argument is expanded. */
-const NEVER_WALK = ['node_modules/', '.git/', '.svelte-kit/', '.convex/', 'build/', 'dist/'];
+/**
+ * Directory names a directory expansion never descends into. Compared segment by segment:
+ * a substring test would read `src/redist/` as `dist/` and drop a real source file from a
+ * run that stays green because the other inputs pass.
+ */
+const NEVER_WALK = new Set(['node_modules', '.git', '.svelte-kit', '.convex', 'build', 'dist']);
 
 /**
  * Reject the run. A gate that cannot see its input must never report success.
@@ -242,7 +250,16 @@ export function prettierTraversalPaths(
 				'Repository contains a path whose bytes are not valid UTF-8.'
 			);
 			const absolute = path.join(directory, name);
-			const entry = lstatSync(absolute);
+			// Prettier reads this phase through its own `lstatSafe`, and a generated tree such
+			// as .svelte-kit can lose an entry to a concurrent sync between the readdir above
+			// and the stat below. Skipping matches what the formatter would have decided; an
+			// uncaught ENOENT would instead abort the whole check over an ignored file.
+			let entry;
+			try {
+				entry = lstatSync(absolute);
+			} catch {
+				continue;
+			}
 			if (entry.isSymbolicLink()) continue;
 			const relative = prefix ? `${prefix}/${name}` : name;
 			if (entry.isDirectory()) {
@@ -306,7 +323,7 @@ export function resolveInputs(
 			fail(
 				`Newline inside a single path argument (${origin}): ${JSON.stringify(arg.slice(0, 40))}`,
 				"  A computed list arrived as one positional argument. Pipe Git's native\n" +
-					'  path records instead: `git diff --name-only --diff-filter=d -z | ... --files-from -`.'
+					'  path records instead: `git diff --no-relative --name-only --diff-filter=d -z | ... --files-from -`.'
 			);
 		}
 
@@ -350,7 +367,7 @@ export function resolveInputs(
 			for (const file of directoryPaths(real)) {
 				if ((prefix && !file.startsWith(prefix)) || !existsSync(path.join(REPO_ROOT, file)))
 					continue;
-				if (NEVER_WALK.some((skip) => file.includes(skip))) continue;
+				if (file.split('/').some((segment) => NEVER_WALK.has(segment))) continue;
 				matched = true;
 				out.add(file);
 			}
@@ -746,19 +763,50 @@ async function runCommand(
 	}
 }
 
-const POSIX_GLOB_SYMBOLS = /(\\?)([()*?[\]{|}]|^!|[!+@](?=\()|\\(?![!()*+?@[\]{|}]))/g;
-const WINDOWS_GLOB_SYMBOLS = /(\\?)([()[\]{}]|^!|[!+@](?=\())/g;
+/**
+ * Every glob metacharacter, spelled as a one-character class rather than backslash-escaped.
+ *
+ * Prettier resolves an argument as a path first and expands it as a glob only once that
+ * path is gone, which is what lets a vanished file quietly match a neighbour: measured with
+ * Prettier 3.9.5, `scripts/[ab].ts` checks `scripts/a.ts` and exits 0 after the named file
+ * is deleted, while the escaped form exits 2 with "No files matching the pattern".
+ *
+ * The escape cannot be a backslash. Prettier hands an unresolvable argument to
+ * `normalizeToPosix`, which on Windows replaces every backslash with a slash
+ * (prettier/internal/legacy-cli.mjs), so a backslash-escaped SvelteKit route such as
+ * `src/routes/[[lang]]/(auth)/+page.svelte` would arrive with its escapes stripped and
+ * match nothing. A character class survives that rewrite, and it is also inert to the
+ * `path.resolve` Prettier runs before its own `lstat`, where a backslash is a separator.
+ */
+const GLOB_CLASS_ESCAPES = new Map<string, string>([
+	['*', '[*]'],
+	['?', '[?]'],
+	['[', '[[]'],
+	[']', '[]]'],
+	['(', '[(]'],
+	[')', '[)]'],
+	['{', '[{]'],
+	['}', '[}]'],
+	['|', '[|]']
+]);
 
 /**
- * Escape a repository path with the same pattern grammar Prettier delegates to fast-glob.
- * Prettier checks an existing path literally, then falls back to glob expansion if that
- * path disappears. An escaped pattern can only rediscover the originally named path.
+ * Turn a repository path into the glob pattern that can only match that same path.
+ *
+ * A literal backslash and a double quote take Prettier's own spelling for them, because a
+ * class cannot hold either: both are unrepresentable in a Windows filename, so the two
+ * branches are reachable on POSIX alone, where `normalizeToPosix` is the identity.
+ * A leading `!` is read as a negation before any of this applies, so such a path is
+ * prefixed instead; fast-glob drops the `./` again when it reports the match.
  */
 export function prettierLiteralPattern(file: string): string {
-	return file.replace(
-		process.platform === 'win32' ? WINDOWS_GLOB_SYMBOLS : POSIX_GLOB_SYMBOLS,
-		'\\$2'
-	);
+	let pattern = '';
+	for (const character of file) {
+		if (character === '\\') pattern += '@(\\\\)';
+		else if (character === '"') pattern += '@(\\")';
+		else pattern += GLOB_CLASS_ESCAPES.get(character) ?? character;
+	}
+	return pattern.startsWith('!') ? `./${pattern}` : pattern;
 }
 
 /**

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -433,13 +433,16 @@ export function resolveInputs(
 			(fromInvocation !== '..' &&
 				!fromInvocation.startsWith(`..${path.sep}`) &&
 				!path.isAbsolute(fromInvocation));
-		const absoluteInsideRepository = !isOutside(path.relative(REPO_ROOT, absolute));
 		const named =
 			!path.isAbsolute(arg) || insideInvocation
 				? path.resolve(realpathSync(invocationBase), fromInvocation)
-				: absoluteInsideRepository
-					? absolute
-					: real;
+				: absolute;
+		// An absolute alias outside the physical repository is rejected even when its target
+		// resolves inside. Preserving its spelling would require carrying absolute paths through
+		// a repository-relative ledger, while canonicalizing it changes anchored ignore rules:
+		// direct Prettier checked `alias/scratch/probe.ts`, the wrapper reclassified it as root
+		// `scratch/probe.ts`, and the ignored-path no-op exited 0. Failing closed is the only
+		// honest contract until the ledger can represent external aliases explicitly.
 		const located = followSymbolicLinks ? real : named;
 		const native = path.relative(REPO_ROOT, located);
 		const relative = toPosix(native);
@@ -1461,7 +1464,15 @@ async function main(): Promise<void> {
 			`Scanned ${result.filesEvaluated} knowledge-bearing files${scopeNote}: ` +
 				`${errors} error(s), ${warnings} warning(s)`
 		);
-		ledger.ran('knowledge-placement', result.filesEvaluated);
+		// Staged policy evaluation reads every knowledge candidate in the index so links resolve
+		// against the final committed tree. That project-wide count cannot earn green for an
+		// unrelated named input: a staged binary matched no lint route, while 1,164 Markdown
+		// files made `consumedAnything()` return true. In scoped modes only the named knowledge
+		// candidates count as consumed work; the broader scan remains visible in the log.
+		ledger.ran(
+			'knowledge-placement',
+			scopedMode ? ledger.filesFor('knowledge-placement').length : result.filesEvaluated
+		);
 		if (errors > 0) process.exit(1);
 		console.log('');
 	}

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -131,11 +131,23 @@ const USAGE = '  Flags: --ci, --staged, --scope <lint|types|format|compat>, --fi
 
 /** Directories never descended into when a directory argument is expanded. */
 /**
- * Directory names a directory expansion never descends into. Compared segment by segment:
- * a substring test would read `src/redist/` as `dist/` and drop a real source file from a
- * run that stays green because the other inputs pass.
+ * Directories a directory expansion never descends into, split the way .gitignore splits
+ * them: `/build`, `/dist` and `/.svelte-kit` are anchored there and a tracked
+ * `src/build/generator.ts` is an ordinary source file, while `node_modules`, `.git` and
+ * `.convex` are ignored at any depth. Comparing segments against one flat list dropped the
+ * former from a run that stayed green on its other inputs; comparing substrings, as this
+ * did before, also read `src/redist/` as `dist/`.
  */
-const NEVER_WALK = new Set(['node_modules', '.git', '.svelte-kit', '.convex', 'build', 'dist']);
+const NEVER_WALK_ANYWHERE = new Set(['node_modules', '.git', '.convex']);
+const NEVER_WALK_AT_ROOT = new Set(['.svelte-kit', 'build', 'dist']);
+
+export function isNeverWalked(file: string): boolean {
+	const segments = file.split('/');
+	return (
+		segments.some((segment) => NEVER_WALK_ANYWHERE.has(segment)) ||
+		NEVER_WALK_AT_ROOT.has(segments[0]!)
+	);
+}
 
 /**
  * Reject the run. A gate that cannot see its input must never report success.
@@ -235,6 +247,11 @@ export function prettierProjectPaths(
 	});
 }
 
+/** A path that vanished between two syscalls, which is the only traversal race to absorb. */
+function isMissingPathError(error: unknown): boolean {
+	return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT';
+}
+
 /** Files reachable by Prettier's directory traversal before file-level classification. */
 export function prettierTraversalPaths(
 	cwd = REPO_ROOT,
@@ -244,21 +261,32 @@ export function prettierTraversalPaths(
 	const files: string[] = [];
 	const skippedDirectories = new Set(['.git', '.hg', '.jj', '.sl', '.svn', 'node_modules']);
 	const walk = (directory: string, prefix: string): void => {
-		for (const rawName of readdirSync(directory, { encoding: 'buffer' })) {
+		// The same race in the other direction: the directory itself can be gone by the time
+		// the recursion reaches it, and only that case is a skip.
+		let names;
+		try {
+			names = readdirSync(directory, { encoding: 'buffer' });
+		} catch (error) {
+			if (isMissingPathError(error)) return;
+			throw error;
+		}
+		for (const rawName of names) {
 			const name = decodeUtf8(
 				rawName,
 				'Repository contains a path whose bytes are not valid UTF-8.'
 			);
 			const absolute = path.join(directory, name);
-			// Prettier reads this phase through its own `lstatSafe`, and a generated tree such
-			// as .svelte-kit can lose an entry to a concurrent sync between the readdir above
-			// and the stat below. Skipping matches what the formatter would have decided; an
-			// uncaught ENOENT would instead abort the whole check over an ignored file.
+			// Prettier reads this phase through its own `lstatSafe`, which swallows ENOENT and
+			// nothing else, and a generated tree such as .svelte-kit can lose an entry to a
+			// concurrent sync between the readdir above and the stat below. Skipping a vanished
+			// entry matches what the formatter would have decided; swallowing EACCES or EIO
+			// would instead hide a directory this ledger is supposed to account for.
 			let entry;
 			try {
 				entry = lstatSync(absolute);
-			} catch {
-				continue;
+			} catch (error) {
+				if (isMissingPathError(error)) continue;
+				throw error;
 			}
 			if (entry.isSymbolicLink()) continue;
 			const relative = prefix ? `${prefix}/${name}` : name;
@@ -305,7 +333,13 @@ export function resolveInputs(
 	raw: string[],
 	origin: string,
 	baseDirectory = process.cwd(),
-	directoryPaths: (directory: string) => string[] = repositoryPaths
+	directoryPaths: (directory: string) => string[] = repositoryPaths,
+	// Only the formatter refuses to descend through a symlinked directory, because Prettier
+	// itself does (`followSymbolicLinks: false`, and an explicitly named link is an error).
+	// Lint and types have always expanded one, and .claude/skills is a tracked directory
+	// symlink whose target holds TypeScript, so refusing it here would drop those files from
+	// a types run that still reports success.
+	expandSymlinkedDirectories = true
 ): string[] {
 	const out = new Set<string>();
 
@@ -361,13 +395,17 @@ export function resolveInputs(
 			);
 		}
 
-		if (target.isDirectory() && !isSymlink) {
+		if (target.isDirectory() && (expandSymlinkedDirectories || !isSymlink)) {
 			let matched = false;
-			const prefix = relative === '' ? '' : `${relative}/`;
+			// The resolved target, not the name that was typed. Git lists a directory symlink
+			// as one entry and knows nothing below it, so a prefix built from the link matches
+			// nothing and the expansion silently yields the link alone.
+			const walked = toPosix(path.relative(REPO_ROOT, real));
+			const prefix = walked === '' ? '' : `${walked}/`;
 			for (const file of directoryPaths(real)) {
 				if ((prefix && !file.startsWith(prefix)) || !existsSync(path.join(REPO_ROOT, file)))
 					continue;
-				if (file.split('/').some((segment) => NEVER_WALK.has(segment))) continue;
+				if (isNeverWalked(file)) continue;
 				matched = true;
 				out.add(file);
 			}
@@ -793,20 +831,23 @@ const GLOB_CLASS_ESCAPES = new Map<string, string>([
 /**
  * Turn a repository path into the glob pattern that can only match that same path.
  *
- * A literal backslash and a double quote take Prettier's own spelling for them, because a
- * class cannot hold either: both are unrepresentable in a Windows filename, so the two
- * branches are reachable on POSIX alone, where `normalizeToPosix` is the identity.
- * A leading `!` is read as a negation before any of this applies, so such a path is
- * prefixed instead; fast-glob drops the `./` again when it reports the match.
+ * `!`, a literal backslash and a double quote take an extglob rather than a class, because
+ * `[!]` opens a negated class and the other two cannot appear inside one. `./` is not an
+ * option for the `!`: measured with Prettier 3.9.5, `./!a[[]b[]].ts` still reads as a
+ * negation, so a run whose named file had vanished matched every other root file and exited
+ * 0, while `@(!)a[[]b[]].ts` exits 2 with "No files matching the pattern". A backslash and
+ * a quote are unrepresentable in a Windows filename, so those two branches are reachable on
+ * POSIX alone, where Prettier's `normalizeToPosix` is the identity.
  */
 export function prettierLiteralPattern(file: string): string {
 	let pattern = '';
 	for (const character of file) {
 		if (character === '\\') pattern += '@(\\\\)';
 		else if (character === '"') pattern += '@(\\")';
+		else if (character === '!') pattern += '@(!)';
 		else pattern += GLOB_CLASS_ESCAPES.get(character) ?? character;
 	}
-	return pattern.startsWith('!') ? `./${pattern}` : pattern;
+	return pattern;
 }
 
 /**
@@ -915,7 +956,8 @@ async function main(): Promise<void> {
 			baseDirectory,
 			scope === 'format'
 				? (directory) => prettierTraversalPaths(directory, false, REPO_ROOT)
-				: repositoryPaths
+				: repositoryPaths,
+			scope !== 'format'
 		);
 	}
 

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -264,16 +264,6 @@ export function prettierProjectPaths(
 }
 
 /** A path that vanished between two syscalls, which is the only traversal race to absorb. */
-/** Whether the path is a symlink, treating a vanished path as "not one". */
-function isSymbolicLinkAt(absolute: string): boolean {
-	try {
-		return lstatSync(absolute).isSymbolicLink();
-	} catch (error) {
-		if (isMissingPathError(error)) return false;
-		throw error;
-	}
-}
-
 function isMissingPathError(error: unknown): boolean {
 	return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT';
 }
@@ -371,15 +361,8 @@ export function resolveInputs(
 	followSymbolicLinks = true
 ): string[] {
 	const out = new Set<string>();
-	// Expanding a directory can produce another link, so the expansion feeds back into this
-	// same loop instead of trusting its own output. `expanded` stops a link that points at an
-	// ancestor from looping forever; it holds resolved directories, so two different links to
-	// the same target expand once.
-	const expanded = new Set<string>();
-	const queue = raw.map((value) => ({ value, base: baseDirectory, named: true }));
 
-	while (queue.length > 0) {
-		const { value: arg, base, named } = queue.shift()!;
+	for (const arg of raw) {
 		if (arg === '') {
 			fail(
 				`Empty path in ${origin}.`,
@@ -401,13 +384,8 @@ export function resolveInputs(
 		// then re-express against the repo root (what every gate below assumes).
 		// realpath both sides so a checkout reached through a symlink (/tmp ->
 		// /private/tmp, a symlinked worktree) does not read as "outside the repo".
-		const absolute = path.resolve(base, arg);
-		// A named path that is not there is the caller's error. An expanded one can vanish
-		// between the listing and this line, and that race is not worth failing a whole run.
-		if (!existsSync(absolute)) {
-			if (!named) continue;
-			fail(`No such file (${origin}): ${formatPathForDiagnostic(arg)}`);
-		}
+		const absolute = path.resolve(baseDirectory, arg);
+		if (!existsSync(absolute)) fail(`No such file (${origin}): ${formatPathForDiagnostic(arg)}`);
 
 		const real = realpathSync(absolute);
 		const target = statSync(real);
@@ -418,10 +396,6 @@ export function resolveInputs(
 		// The resolved target and the named path must both live in the repository. Checking
 		// only the latter would let an in-repository symlink expose an external file.
 		if (isOutside(path.relative(REPO_ROOT, real))) {
-			// A link that was typed is a mistake worth stopping for. One that an expansion
-			// produced is not the caller's doing, and it is the only reason a directory walk
-			// could hand an external file to a checker, so it is dropped instead.
-			if (!named) continue;
 			fail(
 				`Path is outside the repository (${origin}): ${formatPathForDiagnostic(arg)}`,
 				`  Repo root: ${formatPathForDiagnostic(REPO_ROOT)}`
@@ -435,7 +409,6 @@ export function resolveInputs(
 		const native = path.relative(REPO_ROOT, located);
 		const relative = toPosix(native);
 		if (isOutside(native)) {
-			if (!named) continue;
 			fail(
 				`Path is outside the repository (${origin}): ${formatPathForDiagnostic(arg)}`,
 				`  Repo root: ${formatPathForDiagnostic(REPO_ROOT)}`
@@ -443,12 +416,16 @@ export function resolveInputs(
 		}
 
 		if (target.isDirectory() && (followSymbolicLinks || !isSymlink)) {
-			if (expanded.has(real)) continue;
-			expanded.add(real);
 			let matched = false;
 			// The resolved target, not the name that was typed. Git lists a directory symlink
 			// as one entry and knows nothing below it, so a prefix built from the link matches
 			// nothing and the expansion silently yields the link alone.
+			//
+			// A child of the expansion that is itself a link keeps the name Git listed, which is
+			// this repository's own view of it and the path every route is written against. It
+			// also means a directory link among those children is not descended into, so a
+			// `--scope types` run over a directory of directory links reports success having
+			// checked nothing; see #865, which is where that whole semantics belongs.
 			const walked = toPosix(path.relative(REPO_ROOT, real));
 			const prefix = walked === '' ? '' : `${walked}/`;
 			for (const file of directoryPaths(real)) {
@@ -456,15 +433,6 @@ export function resolveInputs(
 					continue;
 				if (isNeverWalked(file)) continue;
 				matched = true;
-				// A child of the expansion can be a link of its own, and Git lists one as a single
-				// entry with nothing below it. Adding that name routes by the link's extension:
-				// `.claude/skills` holds eleven directory links, and expanding the parent used to
-				// yield eleven names and no TypeScript at all, so `--scope types` over it reported
-				// success having checked nothing. Feed it back through this loop instead.
-				if (followSymbolicLinks && isSymbolicLinkAt(path.join(REPO_ROOT, file))) {
-					queue.push({ value: file, base: REPO_ROOT, named: false });
-					continue;
-				}
 				out.add(file);
 			}
 			if (!matched)

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -275,6 +275,18 @@ function isMissingPathError(error: unknown): boolean {
 	return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT';
 }
 
+/**
+ * Directory segments Prettier's CLI skips before glob expansion, whether or not an ignore
+ * file names them. `getFileInfo()` applies node_modules and ignore files but not this VCS
+ * list, so explicit paths need the same closed set here or the ledger counts work the CLI
+ * silently discards. Pinned against Prettier 3.9.5's DirectoryIgnorer in the contract tests.
+ */
+const PRETTIER_ALWAYS_IGNORED_DIRECTORIES = new Set(['.git', '.sl', '.svn', '.hg', '.jj']);
+
+function isPrettierAlwaysIgnoredPath(file: string): boolean {
+	return file.split('/').some((segment) => PRETTIER_ALWAYS_IGNORED_DIRECTORIES.has(segment));
+}
+
 /** Files reachable by Prettier's directory traversal before file-level classification. */
 export function prettierTraversalPaths(
 	cwd = REPO_ROOT,
@@ -282,7 +294,7 @@ export function prettierTraversalPaths(
 	relativeTo = cwd
 ): string[] {
 	const files: string[] = [];
-	const skippedDirectories = new Set(['.git', '.hg', '.jj', '.sl', '.svn', 'node_modules']);
+	const skippedDirectories = new Set([...PRETTIER_ALWAYS_IGNORED_DIRECTORIES, 'node_modules']);
 	const walk = (directory: string, prefix: string): void => {
 		// The same race in the other direction: the directory itself can be gone by the time
 		// the recursion reaches it, and only that case is a skip.
@@ -562,26 +574,29 @@ export async function prettierFormattableFiles(
 	files: string[],
 	cwd = REPO_ROOT
 ): Promise<string[]> {
-	if (files.length === 0) return [];
+	const candidates = files.filter((file) => !isPrettierAlwaysIgnoredPath(file));
+	if (candidates.length === 0) return [];
 	const ignorePath = PRETTIER_IGNORE_FILES.map((file) => path.join(cwd, file));
 	// `getFileInfo` reads ignore files and may load parser metadata. Starting one promise per
 	// path made a full-format preflight retain an ignored generated tree at once and roughly
 	// doubled the peak memory of direct Prettier in the reproducer. Keep only as many
 	// classifications active as the host can run in parallel; result slots preserve order.
-	const infos: Array<Awaited<ReturnType<typeof getFileInfo>> | undefined> = new Array(files.length);
+	const infos: Array<Awaited<ReturnType<typeof getFileInfo>> | undefined> = new Array(
+		candidates.length
+	);
 	let cursor = 0;
 	await Promise.all(
-		Array.from({ length: Math.min(files.length, availableParallelism()) }, async () => {
-			while (cursor < files.length) {
+		Array.from({ length: Math.min(candidates.length, availableParallelism()) }, async () => {
+			while (cursor < candidates.length) {
 				const index = cursor++;
-				infos[index] = await getFileInfo(path.resolve(cwd, files[index]!), {
+				infos[index] = await getFileInfo(path.resolve(cwd, candidates[index]!), {
 					ignorePath,
 					resolveConfig: true
 				});
 			}
 		})
 	);
-	return files.filter((file, index) => {
+	return candidates.filter((file, index) => {
 		const info = infos[index]!;
 		if (info.ignored) return false;
 		return info.inferredParser !== null;

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -254,8 +254,14 @@ export function prettierProjectPaths(
 ): string[] {
 	return files.filter((file) => {
 		try {
-			return !lstatSync(path.join(cwd, file)).isSymbolicLink();
-		} catch {
+			const entry = lstatSync(path.join(cwd, file));
+			if (entry.isSymbolicLink()) return false;
+			if (!entry.isFile()) {
+				fail(`Named formatter path is not a regular file: ${formatPathForDiagnostic(file)}.`);
+			}
+			return true;
+		} catch (error) {
+			if (!isMissingPathError(error)) throw error;
 			if (failOnMissing) {
 				fail(`Named path disappeared before formatter routing: ${formatPathForDiagnostic(file)}.`);
 			}
@@ -385,7 +391,8 @@ export function resolveInputs(
 		// then re-express against the repo root (what every gate below assumes).
 		// realpath both sides so a checkout reached through a symlink (/tmp ->
 		// /private/tmp, a symlinked worktree) does not read as "outside the repo".
-		const absolute = path.resolve(baseDirectory, arg);
+		const invocationBase = path.resolve(baseDirectory);
+		const absolute = path.resolve(invocationBase, arg);
 		if (!existsSync(absolute)) fail(`No such file (${origin}): ${formatPathForDiagnostic(arg)}`);
 
 		const real = realpathSync(absolute);
@@ -403,10 +410,13 @@ export function resolveInputs(
 			);
 		}
 		const isSymlink = lstatSync(absolute).isSymbolicLink();
-		const located =
-			isSymlink && !followSymbolicLinks
-				? path.join(realpathSync(path.dirname(absolute)), path.basename(absolute))
-				: real;
+		// The formatter must classify the path the caller named, including every symlinked
+		// ancestor, because ignore rules are path rules. Canonicalizing `alias/probe.ts` to an
+		// ignored target under `scratch/` made a direct Prettier failure into a zero-file pass.
+		// A relative argument can be re-rooted through a symlinked invocation cwd without
+		// resolving any component it names. Absolute arguments keep their own spelling.
+		const named = path.isAbsolute(arg) ? absolute : path.resolve(realpathSync(invocationBase), arg);
+		const located = followSymbolicLinks ? real : named;
 		const native = path.relative(REPO_ROOT, located);
 		const relative = toPosix(native);
 		if (isOutside(native)) {
@@ -943,13 +953,37 @@ export function prettierArguments(formatFlag: '--check' | '--write', files?: str
 		: [...invocation, '--', ...files.map(prettierLiteralPattern)];
 }
 
+function assertRegularFormatterPaths(files: string[]): void {
+	for (const file of files) {
+		let entry;
+		try {
+			entry = lstatSync(path.join(REPO_ROOT, file));
+		} catch (error) {
+			if (isMissingPathError(error)) {
+				fail(`Named path disappeared before formatter launch: ${formatPathForDiagnostic(file)}.`);
+			}
+			throw error;
+		}
+		if (!entry.isFile()) {
+			fail(`Named formatter path is not a regular file: ${formatPathForDiagnostic(file)}.`);
+		}
+	}
+}
+
 async function runPrettier(formatFlag: '--check' | '--write', files?: string[]): Promise<void> {
 	if (files === undefined) {
 		await runCommand('bun', prettierArguments(formatFlag));
 		return;
 	}
 	const baseArguments = prettierArguments(formatFlag, []);
-	for (const batch of argumentBatches(files.map(prettierLiteralPattern), baseArguments)) {
+	const patterns = files.map(prettierLiteralPattern);
+	let offset = 0;
+	for (const batch of argumentBatches(patterns, baseArguments)) {
+		// Prettier silently drops FIFOs, sockets and other special files when another argument
+		// matches, so the batch can exit 0 while the ledger counts a file it never checked.
+		// Revalidate immediately before each launch, after parser and ignore classification.
+		assertRegularFormatterPaths(files.slice(offset, offset + batch.length));
+		offset += batch.length;
 		await runCommand('bun', [...baseArguments, ...batch]);
 	}
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -376,6 +376,7 @@ export default defineConfig(async ({ mode }) => {
 				'dist/**',
 				'.{idea,git,cache,output,temp}/**',
 				'docs/**',
+				'scratch/**',
 				'.opencode/**',
 				'references/**',
 				// Skills live in .agents/skills/ and are symlinked into .claude/skills/;


### PR DESCRIPTION
Regression guard: added real Prettier and staged-index contract tests

Explicit formatter checks could reinterpret repository filenames as globs, lose caller-visible paths through directory aliases, count ignored or special files as checked, and validate staged content under a configuration deleted from the final index. Those gaps made a narrow format gate capable of reporting success without checking the intended bytes.

The formatter scope now accepts BOM-less NUL-separated input, preserves repository-relative paths, derives parser and ignore behavior from Prettier, escapes literal filenames against the real glob stack, rejects unsafe aliases and non-regular files, and records numeric work. Staged checks also account for final-index knowledge inputs, honest deletion-only runs, and deleted paths that remain in the worktree.

Verified with 1,752 unit tests, full changed-file static checks, type checks, and real Prettier 3.9.5 runs over the affected path families.
