### PR TITLE
fix(lint): Isolate compatibility Git reads

### DIFF
--- a/scripts/convex-consumer-compat.test.ts
+++ b/scripts/convex-consumer-compat.test.ts
@@ -8,6 +8,7 @@ import {
 	expandNamespaceReferences,
 	identifiersIn,
 	namespaceReferencesIn,
+	registeredWorktreePaths,
 	scheduledIdentifiersIn
 } from './convex-consumer-compat';
 import type { Surface } from './convex-surface';
@@ -25,6 +26,53 @@ function compatibilityFixtureEnv(): NodeJS.ProcessEnv {
 	delete env.CONVEX_COMPAT_BASE;
 	return env;
 }
+
+describe('worktree cleanup', () => {
+	it('recognizes a locked administrative entry that prune retains', () => {
+		const scratch = path.join(ROOT, 'scratch');
+		mkdirSync(scratch, { recursive: true });
+		const directory = mkdtempSync(path.join(scratch, 'convex-compat-locked-'));
+		const repository = path.join(directory, 'repository');
+		const checkout = path.join(directory, 'checkout');
+		const env = compatibilityFixtureEnv();
+		const git = (args: string[]) =>
+			spawnSync('git', args, { cwd: repository, env, encoding: 'utf8' });
+		try {
+			mkdirSync(repository);
+			expect(git(['init', '--quiet', '--initial-branch=main']).status).toBe(0);
+			writeFileSync(path.join(repository, 'README.md'), 'fixture\n');
+			expect(git(['add', '--', 'README.md']).status).toBe(0);
+			expect(
+				git([
+					'-c',
+					'user.name=Probe',
+					'-c',
+					'user.email=probe@example.com',
+					'commit',
+					'--quiet',
+					'--no-gpg-sign',
+					'--no-verify',
+					'-m',
+					'Initial'
+				]).status
+			).toBe(0);
+			expect(git(['worktree', 'add', '--detach', '--quiet', checkout, 'HEAD']).status).toBe(0);
+			expect(git(['worktree', 'lock', checkout]).status).toBe(0);
+			rmSync(checkout, { recursive: true, force: true });
+
+			// A locked entry is valid administrative state to Git. Prune evaluates it, returns 0,
+			// and deliberately keeps it, so command status alone cannot prove cleanup.
+			expect(git(['worktree', 'prune']).status).toBe(0);
+			const listed = git(['worktree', 'list', '--porcelain', '-z']);
+			expect(listed.status, listed.stderr).toBe(0);
+			expect(registeredWorktreePaths(listed.stdout)).toContain(path.normalize(checkout));
+		} finally {
+			git(['worktree', 'unlock', checkout]);
+			git(['worktree', 'prune']);
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});
 
 describe('Convex consumer references', () => {
 	it('reads a direct public or internal function path', () => {

--- a/scripts/convex-consumer-compat.test.ts
+++ b/scripts/convex-consumer-compat.test.ts
@@ -276,6 +276,99 @@ describe('Convex compatibility entrypoint', () => {
 		}
 	}, 30_000);
 
+	it('fetches a baseline that only global transport configuration can reach', () => {
+		const scratch = path.join(ROOT, 'scratch');
+		mkdirSync(scratch, { recursive: true });
+		const directory = mkdtempSync(path.join(scratch, 'convex-compat-transport-'));
+		const source = path.join(directory, 'source');
+		const consumer = path.join(directory, 'consumer');
+		const config = path.join(directory, 'global.gitconfig');
+		const env = compatibilityFixtureEnv();
+		const git = (cwd: string, args: string[]) =>
+			spawnSync('git', args, { cwd, env, encoding: 'utf8' });
+		const commit = (cwd: string, message: string) =>
+			git(cwd, [
+				'-c',
+				'user.name=Probe',
+				'-c',
+				'user.email=probe@example.com',
+				'commit',
+				'--quiet',
+				'--no-gpg-sign',
+				'--no-verify',
+				'-m',
+				message
+			]);
+		try {
+			mkdirSync(source);
+			expect(git(source, ['init', '--quiet', '--initial-branch=main']).status).toBe(0);
+			writeFileSync(path.join(source, 'README.md'), 'one\n');
+			expect(git(source, ['add', '--', 'README.md']).status).toBe(0);
+			expect(commit(source, 'Initial').status).toBe(0);
+			expect(
+				spawnSync(
+					'git',
+					[
+						'-c',
+						'protocol.file.allow=always',
+						'clone',
+						'--quiet',
+						pathToFileURL(source).href,
+						consumer
+					],
+					{ env, encoding: 'utf8' }
+				).status
+			).toBe(0);
+
+			// Only reachable through the source repository, and only after a fetch.
+			writeFileSync(path.join(source, 'README.md'), 'two\n');
+			expect(git(source, ['add', '--', 'README.md']).status).toBe(0);
+			expect(commit(source, 'Deployed').status).toBe(0);
+			const deployed = git(source, ['rev-parse', 'HEAD']).stdout.trim();
+
+			// The remote is a name no transport understands. Resolving it lives entirely in
+			// global configuration, which is exactly what an isolated environment removes.
+			expect(git(consumer, ['remote', 'set-url', 'origin', 'probe:repository']).status).toBe(0);
+			expect(
+				spawnSync(
+					'git',
+					[
+						'config',
+						'--file',
+						config,
+						`url.${pathToFileURL(source).href}.insteadOf`,
+						'probe:repository'
+					],
+					{ env, encoding: 'utf8' }
+				).status
+			).toBe(0);
+			expect(
+				spawnSync('git', ['config', '--file', config, 'protocol.file.allow', 'always'], {
+					env,
+					encoding: 'utf8'
+				}).status
+			).toBe(0);
+
+			const result = spawnSync(BUN, [SCRIPT], {
+				cwd: consumer,
+				encoding: 'utf8',
+				env: {
+					...env,
+					CI: 'true',
+					CONVEX_COMPAT_BASE: deployed,
+					GIT_CONFIG_GLOBAL: config
+				}
+			});
+			const output = `${result.stdout}${result.stderr}`;
+
+			expect(output, output).not.toContain('is unreachable');
+			expect(output).not.toContain('using the trunk instead');
+			expect(git(consumer, ['rev-parse', '--verify', `${deployed}^{commit}`]).status).toBe(0);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	}, 60_000);
+
 	it('accepts a shallow clone whose HEAD is a genuine root commit', () => {
 		const scratch = path.join(ROOT, 'scratch');
 		mkdirSync(scratch, { recursive: true });

--- a/scripts/convex-consumer-compat.ts
+++ b/scripts/convex-consumer-compat.ts
@@ -434,17 +434,20 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 	const tempRoot = mkdtempSync(path.join(tmpdir(), 'convex-compat-'));
 	const dir = path.join(tempRoot, 'baseline');
 	const hooks = path.join(tempRoot, 'hooks');
+	let worktreeAdded = false;
 	try {
 		mkdirSync(hooks);
-		// A template-free shared clone borrows objects without inheriting the source
-		// repository's local configuration. The isolated attribute sources and empty hook
-		// directory keep the detached checkout independent of machine-local Git behavior.
-		git(
-			['clone', '--template=', '--quiet', '--shared', '--no-checkout', '.', dir],
-			process.cwd(),
-			hooks
-		);
-		git(['checkout', '--quiet', '--detach', commit], dir, hooks);
+		// A linked worktree of this repository, not a clone of it. A clone has to reach the
+		// baseline commit through a transport, and measured with git 2.55.0 that loses two
+		// things this check depends on: a shared clone of a shallow repository writes no
+		// `objects/info/alternates`, so a commit only `FETCH_HEAD` reaches disappears, and a
+		// shared clone of a partial one borrows the incomplete object store without inheriting
+		// `remote.origin.promisor`, so a missing blob can never be fetched. Both fail a
+		// baseline the surrounding repository resolved perfectly well. The empty hook
+		// directory and the isolated attribute sources are what keep the checkout itself
+		// independent of machine-local Git behavior.
+		git(['worktree', 'add', '--detach', '--quiet', dir, commit], process.cwd(), hooks);
+		worktreeAdded = true;
 		const childEnv = { ...isolatedGitEnv(), HUSKY: '0' };
 		try {
 			execFileSync(process.execPath, ['install', '--frozen-lockfile'], {
@@ -474,7 +477,31 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 		});
 		return new Map(JSON.parse(serialized) as Array<[string, Registration]>);
 	} finally {
-		rmSync(tempRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+		if (worktreeAdded) {
+			try {
+				git(['worktree', 'remove', '--force', dir], process.cwd(), hooks);
+			} catch {
+				rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+				try {
+					git(['worktree', 'prune'], process.cwd(), hooks);
+				} catch {
+					// A stale administrative entry is the repository's to clean up later. It
+					// cannot change this run's verdict, which is already decided above.
+				}
+			}
+		}
+		// Cleanup reports, it does not decide. Throwing from here would discard an answer the
+		// checker already computed and replace the install or checkout diagnostic that
+		// preceded it, turning a compatible surface into a red check over a locked file.
+		try {
+			rmSync(tempRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+		} catch (error) {
+			console.error(
+				`convex-consumer-compat: could not remove the baseline directory ${tempRoot}: ${
+					error instanceof Error ? error.message : String(error)
+				}`
+			);
+		}
 	}
 }
 

--- a/scripts/convex-consumer-compat.ts
+++ b/scripts/convex-consumer-compat.ts
@@ -47,7 +47,7 @@ import {
 	type Surface,
 	type Visibility
 } from './convex-surface';
-import { isolatedGitEnv } from './git-context';
+import { isolatedGitEnv, sanitizedGitEnv } from './git-context';
 
 const CONVEX_ROOT = 'src/lib/convex';
 // App sources contribute direct and namespace-adapter references. Convex source
@@ -59,7 +59,12 @@ export type Reference = { identifier: string; visibility: Visibility; file: stri
 export type NamespaceReference = { prefix: string; visibility: Visibility; file: string };
 type ConsumerReferences = { references: Reference[]; namespaces: NamespaceReference[] };
 
-function git(args: string[], cwd = process.cwd(), hooksPath?: string): string {
+function git(
+	args: string[],
+	cwd = process.cwd(),
+	hooksPath?: string,
+	env = isolatedGitEnv()
+): string {
 	// stderr captured, not inherited: a probing rev-parse is allowed to fail
 	// without printing git's `fatal:` above this script's own explanation. The exact
 	// checkout remains usable when its owner differs from the process uid.
@@ -68,10 +73,22 @@ function git(args: string[], cwd = process.cwd(), hooksPath?: string): string {
 	return execFileSync('git', [...configuration, ...args], {
 		cwd,
 		encoding: 'utf8',
-		env: isolatedGitEnv(),
+		env,
 		maxBuffer: 32 * 1024 * 1024,
 		stdio: ['ignore', 'pipe', 'pipe']
 	});
+}
+
+/**
+ * The one call that has to reach the network, and so the one that cannot run under the
+ * isolated environment. Emptying the global and system config also empties `url.*.insteadOf`,
+ * the credential helpers and the proxy and CA settings, and a fetch that fails for want of
+ * them falls back to the trunk: measured, a baseline reachable only through an insteadOf
+ * rule went unfetched and the check certified the trunk instead. Every reader that decides
+ * the verdict stays isolated; this one only has to bring objects in.
+ */
+function gitFetch(args: string[]): string {
+	return git(args, process.cwd(), undefined, sanitizedGitEnv());
 }
 
 type Baseline = { commit: string } | { root: true } | { unavailable: string } | null;
@@ -92,7 +109,7 @@ function resolveBaseline(): Baseline {
 			return { commit: git(['rev-parse', '--verify', `${override}^{commit}`]).trim() };
 		} catch {
 			try {
-				git(['fetch', '--quiet', 'origin', override]);
+				gitFetch(['fetch', '--quiet', 'origin', override]);
 				return { commit: git(['rev-parse', '--verify', `${override}^{commit}`]).trim() };
 			} catch {
 				if (process.env.CI) {
@@ -435,6 +452,8 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 	const dir = path.join(tempRoot, 'baseline');
 	const hooks = path.join(tempRoot, 'hooks');
 	let worktreeAdded = false;
+	let cleanupFailure: string | undefined;
+	let surface: Surface;
 	try {
 		mkdirSync(hooks);
 		// A linked worktree of this repository, not a clone of it. A clone has to reach the
@@ -475,7 +494,7 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 				CONVEX_SURFACE_PROTECTED_IDENTIFIERS: JSON.stringify([...protectedIdentifiers])
 			}
 		});
-		return new Map(JSON.parse(serialized) as Array<[string, Registration]>);
+		surface = new Map(JSON.parse(serialized) as Array<[string, Registration]>);
 	} finally {
 		if (worktreeAdded) {
 			try {
@@ -484,15 +503,21 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 				rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 				try {
 					git(['worktree', 'prune'], process.cwd(), hooks);
-				} catch {
-					// A stale administrative entry is the repository's to clean up later. It
-					// cannot change this run's verdict, which is already decided above.
+				} catch (error) {
+					// Everything else this function leaves behind lives in the system temporary
+					// directory, but an unpruned entry is state inside the repository being
+					// checked, and a later `git worktree` there reads it. Reported here so it
+					// survives a primary failure, and raised below when there is none.
+					cleanupFailure = `convex-consumer-compat: left an administrative worktree entry for ${dir}: ${
+						error instanceof Error ? error.message : String(error)
+					}`;
+					console.error(cleanupFailure);
 				}
 			}
 		}
-		// Cleanup reports, it does not decide. Throwing from here would discard an answer the
-		// checker already computed and replace the install or checkout diagnostic that
-		// preceded it, turning a compatible surface into a red check over a locked file.
+		// The temporary root is outside the repository, so failing to remove it changes
+		// nothing a later command can read. Throwing here would discard an answer the checker
+		// already computed and replace the install or checkout diagnostic that preceded it.
 		try {
 			rmSync(tempRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 		} catch (error) {
@@ -503,6 +528,8 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 			);
 		}
 	}
+	if (cleanupFailure) throw new Error(cleanupFailure);
+	return surface;
 }
 
 export async function main(): Promise<void> {

--- a/scripts/convex-consumer-compat.ts
+++ b/scripts/convex-consumer-compat.ts
@@ -439,33 +439,18 @@ function consumerReferencesAt(commit: string): ConsumerReferences {
 	return { references, namespaces };
 }
 
-/**
- * Baseline paths a local attribute rule would rewrite as the checkout materializes them.
- *
- * The system and global attribute files are already off, and neither covers
- * `$GIT_DIR/info/attributes`, which a linked worktree shares with the repository being
- * checked, nor a `.gitattributes` committed into the baseline itself. A `filter` from
- * either runs its smudge command over the baseline source, and no environment variable
- * turns that off. Measured with git 2.55.0: a filter that deleted an export made the
- * checker read the same deletion in the current commit as one that was never published,
- * and it exited 0 reporting the surface unchanged. `ident` is checked with it because it
- * rewrites content the same way. Detection is the fix here: refusing loudly is correct,
- * and a filter over the Convex sources has no legitimate use this check could honour.
- */
-function attributeRewrittenPaths(checkout: string, paths: string[]): string[] {
-	const affected = new Set<string>();
-	for (let index = 0; index < paths.length; index += 200) {
-		const batch = paths.slice(index, index + 200);
-		const records = git(['check-attr', '-z', 'filter', 'ident', '--', ...batch], checkout).split(
-			'\0'
-		);
-		// Records come in path, attribute, value triples, and the stream ends with a NUL.
-		for (let cursor = 0; cursor + 2 < records.length; cursor += 3) {
-			const value = records[cursor + 2]!;
-			if (value !== 'unspecified' && value !== 'unset') affected.add(records[cursor]!);
-		}
-	}
-	return [...affected].sort();
+/** Paths registered by `git worktree list --porcelain -z`. */
+export function registeredWorktreePaths(porcelain: string): string[] {
+	return porcelain
+		.split('\0')
+		.filter((record) => record.startsWith('worktree '))
+		.map((record) => path.normalize(record.slice('worktree '.length)));
+}
+
+function worktreeRegistrationExists(directory: string): boolean {
+	return registeredWorktreePaths(git(['worktree', 'list', '--porcelain', '-z'])).includes(
+		directory
+	);
 }
 
 /**
@@ -482,7 +467,12 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 	const dir = path.join(tempRoot, 'baseline');
 	const hooks = path.join(tempRoot, 'hooks');
 	let worktreeAdded = false;
+	let registeredDir: string | undefined;
 	let cleanupFailure: string | undefined;
+	const rememberCleanupFailure = (message: string): void => {
+		console.error(message);
+		cleanupFailure ??= message;
+	};
 	let surface: Surface;
 	try {
 		mkdirSync(hooks);
@@ -493,8 +483,12 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 		// shared clone of a partial one borrows the incomplete object store without inheriting
 		// `remote.origin.promisor`, so a missing blob can never be fetched. Both fail a
 		// baseline the surrounding repository resolved perfectly well. The empty hook
-		// directory and the isolated attribute sources are what keep the checkout itself
-		// independent of machine-local Git behavior.
+		// directory suppresses checkout hooks, and the child commands below ignore global and
+		// system configuration. A linked worktree still shares repository-local mechanisms:
+		// attributes, filters, fsmonitor and install scripts can rewrite its files or shared Git
+		// state. Fixing that requires separating materialization from execution and is tracked in
+		// #863; a partial guard here was rolled back after three consecutive review rounds each
+		// found another way around it.
 		//
 		// `core.sparseCheckout` is turned off for this one command because a linked worktree
 		// inherits it from the shared repository. Measured with git 2.55.0: a checkout whose
@@ -505,25 +499,11 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 			'core.sparseCheckout=false'
 		]);
 		worktreeAdded = true;
-		const rewritten = attributeRewrittenPaths(
-			dir,
-			git(['ls-tree', '-r', '--name-only', '-z', commit, '--', CONVEX_ROOT])
-				.split('\0')
-				.filter(Boolean)
-		);
-		if (rewritten.length > 0) {
-			throw new Error(
-				`convex-consumer-compat: a local attribute rule rewrites the baseline before it can be read (${rewritten
-					.slice(0, 3)
-					.join(', ')}${rewritten.length > 3 ? `, +${rewritten.length - 3} more` : ''}). ` +
-					'Remove the filter or ident attribute covering these paths; a rewritten baseline can ' +
-					'report a deleted function as one that was never published.'
-			);
-		}
+		registeredDir = realpathSync(dir);
 		// The install resolves the baseline lockfile, which may name a Git dependency, so it
 		// gets the transport-capable environment for the same reason the baseline fetch does.
-		// Nothing it reads decides the verdict: the surface reader below does, and that only
-		// reads files the checkout already materialized.
+		// Baseline package scripts execute here and can change the checkout or its shared Git
+		// directory; #863 owns the isolated materialization this function still needs.
 		const childEnv = { ...sanitizedGitEnv(), HUSKY: '0' };
 		try {
 			execFileSync(process.execPath, ['install', '--frozen-lockfile'], {
@@ -568,10 +548,11 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 					// directory still exists, because the registration is still valid, so leaving
 					// this to the prune below would end the run successfully with the checkout and
 					// its administrative entry both retained.
-					cleanupFailure = `convex-consumer-compat: could not remove the baseline checkout ${dir}: ${
-						error instanceof Error ? error.message : String(error)
-					}`;
-					console.error(cleanupFailure);
+					rememberCleanupFailure(
+						`convex-consumer-compat: could not remove the baseline checkout ${dir}: ${
+							error instanceof Error ? error.message : String(error)
+						}`
+					);
 				}
 				try {
 					git(['worktree', 'prune'], process.cwd(), hooks);
@@ -580,10 +561,29 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 					// directory, but an unpruned entry is state inside the repository being
 					// checked, and a later `git worktree` there reads it. Reported here so it
 					// survives a primary failure, and raised below when there is none.
-					cleanupFailure = `convex-consumer-compat: left an administrative worktree entry for ${dir}: ${
-						error instanceof Error ? error.message : String(error)
-					}`;
-					console.error(cleanupFailure);
+					rememberCleanupFailure(
+						`convex-consumer-compat: could not prune the administrative worktree entry for ${dir}: ${
+							error instanceof Error ? error.message : String(error)
+						}`
+					);
+				}
+			}
+			// `git worktree prune` returning 0 only means it evaluated every entry. A locked
+			// registration is intentionally retained and still returns 0, so the command status
+			// cannot prove cleanup. Ask the registry itself before a successful verdict leaves.
+			if (registeredDir) {
+				try {
+					if (worktreeRegistrationExists(registeredDir)) {
+						rememberCleanupFailure(
+							`convex-consumer-compat: left an administrative worktree entry for ${registeredDir}`
+						);
+					}
+				} catch (error) {
+					rememberCleanupFailure(
+						`convex-consumer-compat: could not verify worktree cleanup for ${registeredDir}: ${
+							error instanceof Error ? error.message : String(error)
+						}`
+					);
 				}
 			}
 		}

--- a/scripts/convex-consumer-compat.ts
+++ b/scripts/convex-consumer-compat.ts
@@ -440,6 +440,35 @@ function consumerReferencesAt(commit: string): ConsumerReferences {
 }
 
 /**
+ * Baseline paths a local attribute rule would rewrite as the checkout materializes them.
+ *
+ * The system and global attribute files are already off, and neither covers
+ * `$GIT_DIR/info/attributes`, which a linked worktree shares with the repository being
+ * checked, nor a `.gitattributes` committed into the baseline itself. A `filter` from
+ * either runs its smudge command over the baseline source, and no environment variable
+ * turns that off. Measured with git 2.55.0: a filter that deleted an export made the
+ * checker read the same deletion in the current commit as one that was never published,
+ * and it exited 0 reporting the surface unchanged. `ident` is checked with it because it
+ * rewrites content the same way. Detection is the fix here: refusing loudly is correct,
+ * and a filter over the Convex sources has no legitimate use this check could honour.
+ */
+function attributeRewrittenPaths(checkout: string, paths: string[]): string[] {
+	const affected = new Set<string>();
+	for (let index = 0; index < paths.length; index += 200) {
+		const batch = paths.slice(index, index + 200);
+		const records = git(['check-attr', '-z', 'filter', 'ident', '--', ...batch], checkout).split(
+			'\0'
+		);
+		// Records come in path, attribute, value triples, and the stream ends with a NUL.
+		for (let cursor = 0; cursor + 2 < records.length; cursor += 3) {
+			const value = records[cursor + 2]!;
+			if (value !== 'unspecified' && value !== 'unset') affected.add(records[cursor]!);
+		}
+	}
+	return [...affected].sort();
+}
+
+/**
  * The surface at the baseline commit, from an isolated checkout.
  *
  * The checkout lives outside the current repository so module resolution cannot
@@ -476,6 +505,21 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 			'core.sparseCheckout=false'
 		]);
 		worktreeAdded = true;
+		const rewritten = attributeRewrittenPaths(
+			dir,
+			git(['ls-tree', '-r', '--name-only', '-z', commit, '--', CONVEX_ROOT])
+				.split('\0')
+				.filter(Boolean)
+		);
+		if (rewritten.length > 0) {
+			throw new Error(
+				`convex-consumer-compat: a local attribute rule rewrites the baseline before it can be read (${rewritten
+					.slice(0, 3)
+					.join(', ')}${rewritten.length > 3 ? `, +${rewritten.length - 3} more` : ''}). ` +
+					'Remove the filter or ident attribute covering these paths; a rewritten baseline can ' +
+					'report a deleted function as one that was never published.'
+			);
+		}
 		// The install resolves the baseline lockfile, which may name a Git dependency, so it
 		// gets the transport-capable environment for the same reason the baseline fetch does.
 		// Nothing it reads decides the verdict: the surface reader below does, and that only
@@ -520,11 +564,14 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 				try {
 					rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 				} catch (error) {
-					console.error(
-						`convex-consumer-compat: could not remove the baseline checkout ${dir}: ${
-							error instanceof Error ? error.message : String(error)
-						}`
-					);
+					// Recorded, not merely logged. `git worktree prune` returns 0 while the checkout
+					// directory still exists, because the registration is still valid, so leaving
+					// this to the prune below would end the run successfully with the checkout and
+					// its administrative entry both retained.
+					cleanupFailure = `convex-consumer-compat: could not remove the baseline checkout ${dir}: ${
+						error instanceof Error ? error.message : String(error)
+					}`;
+					console.error(cleanupFailure);
 				}
 				try {
 					git(['worktree', 'prune'], process.cwd(), hooks);

--- a/scripts/convex-consumer-compat.ts
+++ b/scripts/convex-consumer-compat.ts
@@ -35,7 +35,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { copyFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import ts from 'typescript';
@@ -47,6 +47,7 @@ import {
 	type Surface,
 	type Visibility
 } from './convex-surface';
+import { isolatedGitEnv } from './git-context';
 
 const CONVEX_ROOT = 'src/lib/convex';
 // App sources contribute direct and namespace-adapter references. Convex source
@@ -58,11 +59,16 @@ export type Reference = { identifier: string; visibility: Visibility; file: stri
 export type NamespaceReference = { prefix: string; visibility: Visibility; file: string };
 type ConsumerReferences = { references: Reference[]; namespaces: NamespaceReference[] };
 
-function git(args: string[]): string {
+function git(args: string[], cwd = process.cwd(), hooksPath?: string): string {
 	// stderr captured, not inherited: a probing rev-parse is allowed to fail
-	// without printing git's `fatal:` above this script's own explanation.
-	return execFileSync('git', args, {
+	// without printing git's `fatal:` above this script's own explanation. The exact
+	// checkout remains usable when its owner differs from the process uid.
+	const configuration = ['-c', `safe.directory=${realpathSync(cwd)}`];
+	if (hooksPath) configuration.unshift('-c', `core.hooksPath=${hooksPath}`);
+	return execFileSync('git', [...configuration, ...args], {
+		cwd,
 		encoding: 'utf8',
+		env: isolatedGitEnv(),
 		maxBuffer: 32 * 1024 * 1024,
 		stdio: ['ignore', 'pipe', 'pipe']
 	});
@@ -427,14 +433,24 @@ function consumerReferencesAt(commit: string): ConsumerReferences {
 function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): Surface {
 	const tempRoot = mkdtempSync(path.join(tmpdir(), 'convex-compat-'));
 	const dir = path.join(tempRoot, 'baseline');
-	let worktreeAdded = false;
+	const hooks = path.join(tempRoot, 'hooks');
 	try {
-		git(['worktree', 'add', '--detach', '--quiet', dir, commit]);
-		worktreeAdded = true;
+		mkdirSync(hooks);
+		// A template-free shared clone borrows objects without inheriting the source
+		// repository's local configuration. The isolated attribute sources and empty hook
+		// directory keep the detached checkout independent of machine-local Git behavior.
+		git(
+			['clone', '--template=', '--quiet', '--shared', '--no-checkout', '.', dir],
+			process.cwd(),
+			hooks
+		);
+		git(['checkout', '--quiet', '--detach', commit], dir, hooks);
+		const childEnv = { ...isolatedGitEnv(), HUSKY: '0' };
 		try {
-			execFileSync('bun', ['install', '--frozen-lockfile'], {
+			execFileSync(process.execPath, ['install', '--frozen-lockfile'], {
 				cwd: dir,
 				encoding: 'utf8',
+				env: childEnv,
 				maxBuffer: 32 * 1024 * 1024,
 				stdio: ['ignore', 'pipe', 'pipe']
 			});
@@ -446,27 +462,19 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 
 		const reader = path.join(dir, '.convex-surface-reader.ts');
 		copyFileSync(path.join(process.cwd(), 'scripts/convex-surface.ts'), reader);
-		const serialized = execFileSync('bun', [reader, path.join(dir, CONVEX_ROOT)], {
+		const serialized = execFileSync(process.execPath, [reader, path.join(dir, CONVEX_ROOT)], {
 			cwd: dir,
 			encoding: 'utf8',
 			maxBuffer: 32 * 1024 * 1024,
 			stdio: ['ignore', 'pipe', 'pipe'],
 			env: {
-				...process.env,
+				...childEnv,
 				CONVEX_SURFACE_PROTECTED_IDENTIFIERS: JSON.stringify([...protectedIdentifiers])
 			}
 		});
 		return new Map(JSON.parse(serialized) as Array<[string, Registration]>);
 	} finally {
-		if (worktreeAdded) {
-			try {
-				git(['worktree', 'remove', '--force', dir]);
-			} catch {
-				rmSync(dir, { recursive: true, force: true });
-				git(['worktree', 'prune']);
-			}
-		}
-		rmSync(tempRoot, { recursive: true, force: true });
+		rmSync(tempRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 	}
 }
 

--- a/scripts/convex-consumer-compat.ts
+++ b/scripts/convex-consumer-compat.ts
@@ -63,12 +63,13 @@ function git(
 	args: string[],
 	cwd = process.cwd(),
 	hooksPath?: string,
-	env = isolatedGitEnv()
+	env = isolatedGitEnv(),
+	extraConfiguration: string[] = []
 ): string {
 	// stderr captured, not inherited: a probing rev-parse is allowed to fail
 	// without printing git's `fatal:` above this script's own explanation. The exact
 	// checkout remains usable when its owner differs from the process uid.
-	const configuration = ['-c', `safe.directory=${realpathSync(cwd)}`];
+	const configuration = ['-c', `safe.directory=${realpathSync(cwd)}`, ...extraConfiguration];
 	if (hooksPath) configuration.unshift('-c', `core.hooksPath=${hooksPath}`);
 	return execFileSync('git', [...configuration, ...args], {
 		cwd,
@@ -465,9 +466,21 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 		// baseline the surrounding repository resolved perfectly well. The empty hook
 		// directory and the isolated attribute sources are what keep the checkout itself
 		// independent of machine-local Git behavior.
-		git(['worktree', 'add', '--detach', '--quiet', dir, commit], process.cwd(), hooks);
+		//
+		// `core.sparseCheckout` is turned off for this one command because a linked worktree
+		// inherits it from the shared repository. Measured with git 2.55.0: a checkout whose
+		// sparse patterns exclude a directory produces a baseline missing every file under it,
+		// and a function deleted from there reads as one that was never published.
+		git(['worktree', 'add', '--detach', '--quiet', dir, commit], process.cwd(), hooks, undefined, [
+			'-c',
+			'core.sparseCheckout=false'
+		]);
 		worktreeAdded = true;
-		const childEnv = { ...isolatedGitEnv(), HUSKY: '0' };
+		// The install resolves the baseline lockfile, which may name a Git dependency, so it
+		// gets the transport-capable environment for the same reason the baseline fetch does.
+		// Nothing it reads decides the verdict: the surface reader below does, and that only
+		// reads files the checkout already materialized.
+		const childEnv = { ...sanitizedGitEnv(), HUSKY: '0' };
 		try {
 			execFileSync(process.execPath, ['install', '--frozen-lockfile'], {
 				cwd: dir,
@@ -500,7 +513,19 @@ function surfaceAt(commit: string, protectedIdentifiers: ReadonlySet<string>): S
 			try {
 				git(['worktree', 'remove', '--force', dir], process.cwd(), hooks);
 			} catch {
-				rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+				// Guarded, because an unguarded throw here escapes the `finally`, replaces the
+				// install or surface diagnostic that brought us in, and skips both the prune
+				// below and the temporary-root removal. Windows returns EPERM for a locked
+				// dependency file, which is exactly when the Git removal has already failed.
+				try {
+					rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+				} catch (error) {
+					console.error(
+						`convex-consumer-compat: could not remove the baseline checkout ${dir}: ${
+							error instanceof Error ? error.message : String(error)
+						}`
+					);
+				}
 				try {
 					git(['worktree', 'prune'], process.cwd(), hooks);
 				} catch (error) {

--- a/scripts/convex-consumer-compat.ts
+++ b/scripts/convex-consumer-compat.ts
@@ -81,12 +81,13 @@ function git(
 }
 
 /**
- * The one call that has to reach the network, and so the one that cannot run under the
- * isolated environment. Emptying the global and system config also empties `url.*.insteadOf`,
- * the credential helpers and the proxy and CA settings, and a fetch that fails for want of
- * them falls back to the trunk: measured, a baseline reachable only through an insteadOf
- * rule went unfetched and the check certified the trunk instead. Every reader that decides
- * the verdict stays isolated; this one only has to bring objects in.
+ * The explicit baseline fetch is the transport-requiring call that can safely run outside
+ * the isolated environment: it brings objects in and decides no verdict itself. Emptying
+ * global and system config also empties `url.*.insteadOf`, credential helpers, proxies and
+ * CA settings; measured, a baseline reachable only through an insteadOf rule went unfetched
+ * and the check certified the trunk instead. A partial clone can also lazy-fetch during
+ * isolated verdict reads; that path fails closed when it needs external transport config and
+ * remains part of the materialization boundary tracked in #863.
  */
 function gitFetch(args: string[]): string {
 	return git(args, process.cwd(), undefined, sanitizedGitEnv());

--- a/scripts/git-context.test.ts
+++ b/scripts/git-context.test.ts
@@ -23,7 +23,6 @@ import {
 
 const SCRUBBED = [
 	'GIT_ALTERNATE_OBJECT_DIRECTORIES',
-	'GIT_ATTR_NOSYSTEM',
 	'GIT_ATTR_SOURCE',
 	'GIT_COMMON_DIR',
 	'GIT_CONFIG',
@@ -48,17 +47,15 @@ const SCRUBBED_CONFIG = [
 	'GIT_CONFIG_KEY_0',
 	'GIT_CONFIG_VALUE_0'
 ] as const;
+/**
+ * A caller that exports this has turned the system attributes file off for its own run. It
+ * names no repository, so scrubbing it would only re-enable that file for our children.
+ */
+const PRESERVED_HARDENING = ['GIT_ATTR_NOSYSTEM'] as const;
 const EXTERNAL_INDEX_OPT_IN = 'STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX';
 
 function isolatedValue(key: string): string | undefined {
-	if (
-		[
-			'GIT_ATTR_NOSYSTEM',
-			'GIT_NO_REPLACE_OBJECTS',
-			'GIT_CONFIG_NOSYSTEM',
-			'GIT_CONFIG_COUNT'
-		].includes(key)
-	) {
+	if (['GIT_NO_REPLACE_OBJECTS', 'GIT_CONFIG_NOSYSTEM', 'GIT_CONFIG_COUNT'].includes(key)) {
 		return '1';
 	}
 	if (key === 'GIT_CONFIG_KEY_0') return 'core.attributesFile';
@@ -80,7 +77,9 @@ describe('sanitizedGitEnv', () => {
 	const saved = new Map<string, string | undefined>();
 
 	beforeEach(() => {
-		for (const key of [...SCRUBBED, ...SCRUBBED_CONFIG]) saved.set(key, process.env[key]);
+		for (const key of [...SCRUBBED, ...SCRUBBED_CONFIG, ...PRESERVED_HARDENING]) {
+			saved.set(key, process.env[key]);
+		}
 	});
 
 	afterEach(() => {
@@ -119,6 +118,16 @@ describe('sanitizedGitEnv', () => {
 		for (const key of [...SCRUBBED, ...SCRUBBED_CONFIG]) {
 			expect(env[key], key).toBe(isolatedValue(key));
 		}
+	});
+
+	it('keeps an inherited attribute hardening and enforces it when isolating', () => {
+		process.env.GIT_ATTR_NOSYSTEM = '1';
+
+		expect(sanitizedGitEnv().GIT_ATTR_NOSYSTEM).toBe('1');
+
+		delete process.env.GIT_ATTR_NOSYSTEM;
+		expect(sanitizedGitEnv().GIT_ATTR_NOSYSTEM).toBeUndefined();
+		expect(isolatedGitEnv().GIT_ATTR_NOSYSTEM).toBe('1');
 	});
 
 	it('disables external Git attribute sources for isolated children', () => {

--- a/scripts/git-context.test.ts
+++ b/scripts/git-context.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
 	activeGitIndexFingerprint,
 	getStagedFiles,
+	isolatedGitEnv,
 	sanitizedGitEnv,
 	stagedFilesMatchWorktree,
 	stagedFilesWithCleanFilters,
@@ -22,6 +23,8 @@ import {
 
 const SCRUBBED = [
 	'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+	'GIT_ATTR_NOSYSTEM',
+	'GIT_ATTR_SOURCE',
 	'GIT_COMMON_DIR',
 	'GIT_CONFIG',
 	'GIT_DIR',
@@ -33,9 +36,39 @@ const SCRUBBED = [
 	'GIT_PREFIX',
 	'GIT_REPLACE_REF_BASE',
 	'GIT_SHALLOW_FILE',
+	'GIT_TEMPLATE_DIR',
 	'GIT_WORK_TREE'
 ] as const;
+const SCRUBBED_CONFIG = [
+	'GIT_CONFIG_PARAMETERS',
+	'GIT_CONFIG_COUNT',
+	'GIT_CONFIG_GLOBAL',
+	'GIT_CONFIG_SYSTEM',
+	'GIT_CONFIG_NOSYSTEM',
+	'GIT_CONFIG_KEY_0',
+	'GIT_CONFIG_VALUE_0'
+] as const;
 const EXTERNAL_INDEX_OPT_IN = 'STATIC_CHECKS_ALLOW_EXTERNAL_GIT_INDEX';
+
+function isolatedValue(key: string): string | undefined {
+	if (
+		[
+			'GIT_ATTR_NOSYSTEM',
+			'GIT_NO_REPLACE_OBJECTS',
+			'GIT_CONFIG_NOSYSTEM',
+			'GIT_CONFIG_COUNT'
+		].includes(key)
+	) {
+		return '1';
+	}
+	if (key === 'GIT_CONFIG_KEY_0') return 'core.attributesFile';
+	if (
+		['GIT_GRAFT_FILE', 'GIT_CONFIG_GLOBAL', 'GIT_CONFIG_SYSTEM', 'GIT_CONFIG_VALUE_0'].includes(key)
+	) {
+		return '';
+	}
+	return undefined;
+}
 
 function git(cwd: string, args: string[], env: NodeJS.ProcessEnv = sanitizedGitEnv()): string {
 	const result = spawnSync('git', args, { cwd, env, encoding: 'utf-8' });
@@ -47,7 +80,7 @@ describe('sanitizedGitEnv', () => {
 	const saved = new Map<string, string | undefined>();
 
 	beforeEach(() => {
-		for (const key of SCRUBBED) saved.set(key, process.env[key]);
+		for (const key of [...SCRUBBED, ...SCRUBBED_CONFIG]) saved.set(key, process.env[key]);
 	});
 
 	afterEach(() => {
@@ -78,6 +111,32 @@ describe('sanitizedGitEnv', () => {
 		delete process.env.GIT_CONFIG_COUNT;
 		delete process.env.GIT_CONFIG_KEY_0;
 		delete process.env.GIT_CONFIG_VALUE_0;
+	});
+
+	it('isolates command configuration and pins real ancestry', () => {
+		for (const key of [...SCRUBBED, ...SCRUBBED_CONFIG]) process.env[key] = 'parent-value';
+		const env = isolatedGitEnv();
+		for (const key of [...SCRUBBED, ...SCRUBBED_CONFIG]) {
+			expect(env[key], key).toBe(isolatedValue(key));
+		}
+	});
+
+	it('disables external Git attribute sources for isolated children', () => {
+		process.env.GIT_ATTR_SOURCE = 'HEAD';
+		const env = isolatedGitEnv();
+		const globalAttributes = spawnSync('git', ['var', 'GIT_ATTR_GLOBAL'], {
+			env,
+			encoding: 'utf8'
+		});
+		const systemAttributes = spawnSync('git', ['var', 'GIT_ATTR_SYSTEM'], {
+			env,
+			encoding: 'utf8'
+		});
+
+		expect(env.GIT_ATTR_SOURCE).toBeUndefined();
+		expect(globalAttributes.status).toBe(0);
+		expect(globalAttributes.stdout.trim()).toBe('');
+		expect(systemAttributes.status).not.toBe(0);
 	});
 
 	it('removes Git context regardless of environment-name casing', () => {

--- a/scripts/git-context.ts
+++ b/scripts/git-context.ts
@@ -13,6 +13,8 @@ import path from 'path';
 
 const SCRUBBED = [
 	'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+	'GIT_ATTR_NOSYSTEM',
+	'GIT_ATTR_SOURCE',
 	'GIT_COMMON_DIR',
 	'GIT_CONFIG',
 	'GIT_DIR',
@@ -24,8 +26,17 @@ const SCRUBBED = [
 	'GIT_PREFIX',
 	'GIT_REPLACE_REF_BASE',
 	'GIT_SHALLOW_FILE',
+	'GIT_TEMPLATE_DIR',
 	'GIT_WORK_TREE'
 ] as const;
+const SCRUBBED_CONFIG = [
+	'GIT_CONFIG_PARAMETERS',
+	'GIT_CONFIG_COUNT',
+	'GIT_CONFIG_GLOBAL',
+	'GIT_CONFIG_SYSTEM',
+	'GIT_CONFIG_NOSYSTEM'
+] as const;
+const SCRUBBED_CONFIG_PREFIXES = ['GIT_CONFIG_KEY_', 'GIT_CONFIG_VALUE_'] as const;
 
 /** process.env with externally set Git context variables removed. */
 export function sanitizedGitEnv(): NodeJS.ProcessEnv {
@@ -34,6 +45,35 @@ export function sanitizedGitEnv(): NodeJS.ProcessEnv {
 	for (const key of Object.keys(env)) {
 		if (scrubbed.has(key.toUpperCase())) delete env[key];
 	}
+	return env;
+}
+
+/** A Git environment that reads only the discovered repository's real history. */
+export function isolatedGitEnv(): NodeJS.ProcessEnv {
+	const env = sanitizedGitEnv();
+	const scrubbed = new Set<string>(SCRUBBED_CONFIG);
+	for (const key of Object.keys(env)) {
+		const upper = key.toUpperCase();
+		if (
+			scrubbed.has(upper) ||
+			SCRUBBED_CONFIG_PREFIXES.some((prefix) => upper.startsWith(prefix))
+		) {
+			delete env[key];
+		}
+	}
+	// Replacement refs and legacy grafts rewrite ancestry without redirecting discovery.
+	env.GIT_NO_REPLACE_OBJECTS = '1';
+	env.GIT_GRAFT_FILE = '';
+	env.GIT_ATTR_NOSYSTEM = '1';
+	env.GIT_CONFIG_GLOBAL = '';
+	env.GIT_CONFIG_SYSTEM = '';
+	env.GIT_CONFIG_NOSYSTEM = '1';
+	// Git attributes have global and system sources independent of config-file loading.
+	// Install one trusted command-scoped value so every descendant also ignores the
+	// caller's global attributes file while retaining the repository's own attributes.
+	env.GIT_CONFIG_COUNT = '1';
+	env.GIT_CONFIG_KEY_0 = 'core.attributesFile';
+	env.GIT_CONFIG_VALUE_0 = '';
 	return env;
 }
 

--- a/scripts/git-context.ts
+++ b/scripts/git-context.ts
@@ -13,7 +13,6 @@ import path from 'path';
 
 const SCRUBBED = [
 	'GIT_ALTERNATE_OBJECT_DIRECTORIES',
-	'GIT_ATTR_NOSYSTEM',
 	'GIT_ATTR_SOURCE',
 	'GIT_COMMON_DIR',
 	'GIT_CONFIG',
@@ -36,6 +35,14 @@ const SCRUBBED_CONFIG = [
 	'GIT_CONFIG_SYSTEM',
 	'GIT_CONFIG_NOSYSTEM'
 ] as const;
+/**
+ * `GIT_ATTR_NOSYSTEM` is deliberately absent above. It redirects nothing: it only turns the
+ * system attributes file off, so a caller that exports it has hardened its own run. Removing
+ * it would switch that file back on for our children and let a system-wide `filter=` rewrite
+ * a blob between the checks and the `git add` that commits it. `GIT_ATTR_SOURCE` is a
+ * redirection and stays scrubbed; `isolatedGitEnv()` sets `GIT_ATTR_NOSYSTEM` itself for a
+ * child that must read nothing external at all.
+ */
 const SCRUBBED_CONFIG_PREFIXES = ['GIT_CONFIG_KEY_', 'GIT_CONFIG_VALUE_'] as const;
 
 /** process.env with externally set Git context variables removed. */

--- a/scripts/static-checks.compat.test.ts
+++ b/scripts/static-checks.compat.test.ts
@@ -336,7 +336,17 @@ describe('Convex compatibility static-check entrypoint', () => {
 			const checkout = createCheckerClone();
 			const env = sanitizedGitEnv();
 			delete env.CI;
-			delete env.CONVEX_COMPAT_BASE;
+			// The baseline is named rather than discovered. A CI checkout is detached with no
+			// local trunk, and `git clone` does not carry the source's remote-tracking refs, so
+			// the clone has nothing for `resolveBaseline` to find: the checker would exit on
+			// "no trunk to compare against" long before reaching the attribute rule under test.
+			const head = spawnSync('git', ['rev-parse', 'HEAD'], {
+				cwd: checkout.repository,
+				env,
+				encoding: 'utf8'
+			});
+			expect(head.status, head.stderr).toBe(0);
+			env.CONVEX_COMPAT_BASE = head.stdout.trim();
 			try {
 				const filter = path.join(checkout.directory, 'baseline-smudge');
 				writeFileSync(filter, '#!/bin/sh\ncat\n');

--- a/scripts/static-checks.compat.test.ts
+++ b/scripts/static-checks.compat.test.ts
@@ -12,7 +12,7 @@ import {
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { sanitizedGitEnv } from './git-context';
+import { isolatedGitEnv, sanitizedGitEnv } from './git-context';
 import { compatibilityInvocation } from './static-checks';
 import { testExecutable } from './test-executable';
 
@@ -82,33 +82,35 @@ describe('Convex compatibility static-check entrypoint', () => {
 		}
 	);
 
-	it('builds the sanitized child invocation', () => {
-		const savedDir = process.env.GIT_DIR;
-		const savedWorktree = process.env.GIT_WORK_TREE;
-		process.env.GIT_DIR = path.join(ROOT, 'scratch', 'foreign.git');
-		process.env.GIT_WORK_TREE = path.join(ROOT, 'scratch', 'foreign-worktree');
+	it('scrubs the child environment without blanking its transport configuration', () => {
+		const saved = new Map<string, string | undefined>();
+		const overrides = {
+			GIT_DIR: path.join(ROOT, 'scratch', 'foreign.git'),
+			GIT_WORK_TREE: path.join(ROOT, 'scratch', 'foreign-worktree'),
+			GIT_CONFIG_GLOBAL: path.join(ROOT, 'scratch', 'caller.gitconfig')
+		};
+		for (const [key, value] of Object.entries(overrides)) {
+			saved.set(key, process.env[key]);
+			process.env[key] = value;
+		}
 		try {
 			const invocation = compatibilityInvocation(true);
 			expect(invocation.command).toBe(process.execPath);
 			expect(invocation.args).toEqual(['scripts/convex-consumer-compat.ts']);
+			// Repository redirections are removed here, because nothing downstream wants them.
 			expect(invocation.options.env?.GIT_DIR).toBeUndefined();
 			expect(invocation.options.env?.GIT_WORK_TREE).toBeUndefined();
-			expect(invocation.options.env?.GIT_ATTR_NOSYSTEM).toBe('1');
 			expect(invocation.options.env?.GIT_ATTR_SOURCE).toBeUndefined();
-			expect(invocation.options.env?.GIT_NO_REPLACE_OBJECTS).toBe('1');
-			expect(invocation.options.env?.GIT_GRAFT_FILE).toBe('');
-			expect(invocation.options.env?.GIT_CONFIG_GLOBAL).toBe('');
-			expect(invocation.options.env?.GIT_CONFIG_SYSTEM).toBe('');
-			expect(invocation.options.env?.GIT_CONFIG_NOSYSTEM).toBe('1');
-			expect(invocation.options.env?.GIT_CONFIG_COUNT).toBe('1');
-			expect(invocation.options.env?.GIT_CONFIG_KEY_0).toBe('core.attributesFile');
-			expect(invocation.options.env?.GIT_CONFIG_VALUE_0).toBe('');
+			// Configuration is not blanked here. The child needs it for the baseline fetch and
+			// isolates every verdict-deciding read for itself; a blank path cannot be undone.
+			expect(invocation.options.env?.GIT_CONFIG_GLOBAL).toBe(overrides.GIT_CONFIG_GLOBAL);
+			expect(invocation.options.env?.GIT_CONFIG_NOSYSTEM).toBeUndefined();
 			expect(invocation.options.env?.CI).toBe('true');
 		} finally {
-			if (savedDir === undefined) delete process.env.GIT_DIR;
-			else process.env.GIT_DIR = savedDir;
-			if (savedWorktree === undefined) delete process.env.GIT_WORK_TREE;
-			else process.env.GIT_WORK_TREE = savedWorktree;
+			for (const [key, value] of saved) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
 		}
 	});
 
@@ -180,7 +182,7 @@ describe('Convex compatibility static-check entrypoint', () => {
 			expect(git(['replace', 'HEAD', replacement]).status).toBe(0);
 			expect(git(['rev-parse', 'HEAD~1']).status).not.toBe(0);
 
-			const isolated = compatibilityInvocation().options.env!;
+			const isolated = isolatedGitEnv();
 			const replacementParent = git(['rev-parse', 'HEAD~1'], isolated);
 			expect(replacementParent.status, replacementParent.stderr).toBe(0);
 			expect(replacementParent.stdout.trim()).toBe(realParent);

--- a/scripts/static-checks.compat.test.ts
+++ b/scripts/static-checks.compat.test.ts
@@ -123,8 +123,9 @@ describe('Convex compatibility static-check entrypoint', () => {
 			expect(invocation.options.env?.GIT_DIR).toBeUndefined();
 			expect(invocation.options.env?.GIT_WORK_TREE).toBeUndefined();
 			expect(invocation.options.env?.GIT_ATTR_SOURCE).toBeUndefined();
-			// Configuration is not blanked here. The child needs it for the baseline fetch and
-			// isolates every verdict-deciding read for itself; a blank path cannot be undone.
+			// Configuration is not blanked here. The child needs it for the explicit baseline
+			// fetch and isolates verdict reads from external configuration for itself; a blank
+			// path cannot be undone. Repository-local materialization remains tracked in #863.
 			expect(invocation.options.env?.GIT_CONFIG_GLOBAL).toBe(overrides.GIT_CONFIG_GLOBAL);
 			expect(invocation.options.env?.GIT_CONFIG_NOSYSTEM).toBeUndefined();
 			expect(invocation.options.env?.CI).toBe('true');
@@ -221,7 +222,7 @@ describe('Convex compatibility static-check entrypoint', () => {
 	}, 30_000);
 
 	it.skipIf(process.platform === 'win32')(
-		'protects the direct checker from local ancestry and checkout configuration',
+		'protects the direct checker from rewritten ancestry and external checkout configuration',
 		() => {
 			const checkout = createCheckerClone();
 			const env = sanitizedGitEnv();
@@ -366,10 +367,24 @@ describe('Convex compatibility static-check entrypoint', () => {
 	});
 
 	// The fixture above lives in the temporary directory, and session artifacts still land in
-	// `scratch/`. Vitest walking those would collect a stale copy of this very file.
+	// `scratch/`. Ask Vitest rather than searching configuration text: the string can survive
+	// in a comment after the effective exclusion is removed.
 	it('keeps session scratch out of Vitest discovery', () => {
-		const config = readFileSync(path.join(ROOT, 'vite.config.ts'), 'utf8');
-		expect(config).toContain("'scratch/**'");
+		const directory = path.join(ROOT, 'scratch', `compat-discovery-${process.pid}`);
+		const relative = `scratch/compat-discovery-${process.pid}/sentinel.test.ts`;
+		mkdirSync(directory, { recursive: true });
+		try {
+			writeFileSync(path.join(ROOT, relative), "throw new Error('collected scratch sentinel');\n");
+			const result = spawnSync(BUN, ['vitest', 'list', '--filesOnly'], {
+				cwd: ROOT,
+				env: sanitizedGitEnv(),
+				encoding: 'utf8'
+			});
+			expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+			expect(`${result.stdout}${result.stderr}`).not.toContain('sentinel.test.ts');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 
 	it('owns the package alias', () => {

--- a/scripts/static-checks.compat.test.ts
+++ b/scripts/static-checks.compat.test.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from 'node:child_process';
 import {
 	chmodSync,
-	copyFileSync,
+	cpSync,
+	mkdtempSync,
 	existsSync,
 	mkdirSync,
 	readFileSync,
@@ -9,6 +10,7 @@ import {
 	symlinkSync,
 	writeFileSync
 } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -30,10 +32,17 @@ function run(args: string[], env = sanitizedGitEnv()) {
 	});
 }
 
+/**
+ * A second checkout of this repository to run the checker against, outside the repository
+ * rather than under its `scratch/`. Inside it, the clone is a whole extra copy of the tree
+ * that every project-wide tool walks: measured, a full-project format run racing this
+ * fixture read the clone's own files and failed a suite whose tracked tree was clean.
+ * Killing the test run leaves the copy behind either way, and in the temporary directory
+ * that is the operating system's problem instead of the next `eslint .`.
+ */
 function createCheckerClone(): { directory: string; repository: string } {
-	const directory = path.join(ROOT, 'scratch', `static-compat-${process.pid}-${Date.now()}`);
+	const directory = mkdtempSync(path.join(tmpdir(), 'static-compat-'));
 	const repository = path.join(directory, 'repository');
-	mkdirSync(directory, { recursive: true });
 	try {
 		const result = spawnSync(
 			'git',
@@ -46,9 +55,14 @@ function createCheckerClone(): { directory: string; repository: string } {
 			path.join(repository, 'node_modules'),
 			process.platform === 'win32' ? 'junction' : 'dir'
 		);
-		for (const file of ['static-checks.ts', 'convex-consumer-compat.ts', 'git-context.ts']) {
-			copyFileSync(path.join(ROOT, 'scripts', file), path.join(repository, 'scripts', file));
-		}
+		// Every script, not the three the checker is spelled in. It imports `convex-surface.ts`
+		// and `terminal-output.ts` among others, and copying only the entrypoints left those at
+		// the committed revision: measured, a working-tree change that made the surface reader
+		// throw was invisible to this fixture while the direct checker exited 1 on it.
+		cpSync(path.join(ROOT, 'scripts'), path.join(repository, 'scripts'), {
+			recursive: true,
+			dereference: true
+		});
 		return { directory, repository };
 	} catch (error) {
 		rmSync(directory, { recursive: true, force: true });
@@ -89,9 +103,17 @@ describe('Convex compatibility static-check entrypoint', () => {
 			GIT_WORK_TREE: path.join(ROOT, 'scratch', 'foreign-worktree'),
 			GIT_CONFIG_GLOBAL: path.join(ROOT, 'scratch', 'caller.gitconfig')
 		};
+		// `GIT_CONFIG_NOSYSTEM` is asserted absent below and is legitimate hardening for a
+		// developer or a runner to export, so the test controls it rather than reading whatever
+		// the ambient environment happens to hold.
+		const cleared = ['GIT_CONFIG_NOSYSTEM', 'GIT_CONFIG_SYSTEM', 'GIT_CONFIG_COUNT'];
 		for (const [key, value] of Object.entries(overrides)) {
 			saved.set(key, process.env[key]);
 			process.env[key] = value;
+		}
+		for (const key of cleared) {
+			saved.set(key, process.env[key]);
+			delete process.env[key];
 		}
 		try {
 			const invocation = compatibilityInvocation(true);
@@ -303,6 +325,49 @@ describe('Convex compatibility static-check entrypoint', () => {
 		120_000
 	);
 
+	// `$GIT_DIR/info/attributes` is shared with every linked worktree and has no environment
+	// switch, so the baseline checkout reads it however isolated the rest of the run is. A
+	// smudge filter selected there rewrites the baseline source before the surface is built:
+	// measured with git 2.55.0, a filter that deleted an export made the checker report the
+	// same deletion in the current commit as one that was never published, and it exited 0.
+	it.skipIf(process.platform === 'win32')(
+		'refuses a baseline a local attribute rule would rewrite',
+		() => {
+			const checkout = createCheckerClone();
+			const env = sanitizedGitEnv();
+			delete env.CI;
+			delete env.CONVEX_COMPAT_BASE;
+			try {
+				const filter = path.join(checkout.directory, 'baseline-smudge');
+				writeFileSync(filter, '#!/bin/sh\ncat\n');
+				chmodSync(filter, 0o755);
+				writeFileSync(
+					path.join(checkout.repository, '.git', 'info', 'attributes'),
+					'src/lib/convex/*.ts filter=baseline-probe\n'
+				);
+				const configure = spawnSync('git', ['config', 'filter.baseline-probe.smudge', filter], {
+					cwd: checkout.repository,
+					env,
+					encoding: 'utf8'
+				});
+				expect(configure.status, configure.stderr).toBe(0);
+
+				const result = spawnSync(
+					BUN,
+					[path.join(checkout.repository, 'scripts', 'convex-consumer-compat.ts')],
+					{ cwd: checkout.repository, env, encoding: 'utf8', timeout: 110_000 }
+				);
+				const output = `${result.stdout}${result.stderr}`;
+				expect(result.status, output).not.toBe(0);
+				expect(output).toContain('a local attribute rule rewrites the baseline');
+				expect(output).not.toContain('referenced functions still published unchanged');
+			} finally {
+				rmSync(checkout.directory, { recursive: true, force: true });
+			}
+		},
+		120_000
+	);
+
 	it.skipIf(process.platform === 'win32')(
 		'rejects an unsafe repository path before the compatibility child runs',
 		() => {
@@ -343,7 +408,9 @@ describe('Convex compatibility static-check entrypoint', () => {
 		expect(output).not.toContain('Convex consumer compatibility');
 	});
 
-	it('keeps abandoned checker clones out of Vitest discovery', () => {
+	// The fixture above lives in the temporary directory, and session artifacts still land in
+	// `scratch/`. Vitest walking those would collect a stale copy of this very file.
+	it('keeps session scratch out of Vitest discovery', () => {
 		const config = readFileSync(path.join(ROOT, 'vite.config.ts'), 'utf8');
 		expect(config).toContain("'scratch/**'");
 	});

--- a/scripts/static-checks.compat.test.ts
+++ b/scripts/static-checks.compat.test.ts
@@ -201,6 +201,10 @@ describe('Convex compatibility static-check entrypoint', () => {
 		() => {
 			const checkout = createCheckerClone();
 			const env = sanitizedGitEnv();
+			// The fixture below is the checker's entire history. `CI` and `CONVEX_COMPAT_BASE`
+			// survive the scrub by design and would each steer it at a different baseline.
+			delete env.CI;
+			delete env.CONVEX_COMPAT_BASE;
 			const foreignRepository = path.join(checkout.directory, 'foreign-repository');
 			const git = (args: string[], childEnv = env) =>
 				spawnSync('git', ['-c', 'core.useReplaceRefs=true', ...args], {

--- a/scripts/static-checks.compat.test.ts
+++ b/scripts/static-checks.compat.test.ts
@@ -325,59 +325,6 @@ describe('Convex compatibility static-check entrypoint', () => {
 		120_000
 	);
 
-	// `$GIT_DIR/info/attributes` is shared with every linked worktree and has no environment
-	// switch, so the baseline checkout reads it however isolated the rest of the run is. A
-	// smudge filter selected there rewrites the baseline source before the surface is built:
-	// measured with git 2.55.0, a filter that deleted an export made the checker report the
-	// same deletion in the current commit as one that was never published, and it exited 0.
-	it.skipIf(process.platform === 'win32')(
-		'refuses a baseline a local attribute rule would rewrite',
-		() => {
-			const checkout = createCheckerClone();
-			const env = sanitizedGitEnv();
-			delete env.CI;
-			// The baseline is named rather than discovered. A CI checkout is detached with no
-			// local trunk, and `git clone` does not carry the source's remote-tracking refs, so
-			// the clone has nothing for `resolveBaseline` to find: the checker would exit on
-			// "no trunk to compare against" long before reaching the attribute rule under test.
-			const head = spawnSync('git', ['rev-parse', 'HEAD'], {
-				cwd: checkout.repository,
-				env,
-				encoding: 'utf8'
-			});
-			expect(head.status, head.stderr).toBe(0);
-			env.CONVEX_COMPAT_BASE = head.stdout.trim();
-			try {
-				const filter = path.join(checkout.directory, 'baseline-smudge');
-				writeFileSync(filter, '#!/bin/sh\ncat\n');
-				chmodSync(filter, 0o755);
-				writeFileSync(
-					path.join(checkout.repository, '.git', 'info', 'attributes'),
-					'src/lib/convex/*.ts filter=baseline-probe\n'
-				);
-				const configure = spawnSync('git', ['config', 'filter.baseline-probe.smudge', filter], {
-					cwd: checkout.repository,
-					env,
-					encoding: 'utf8'
-				});
-				expect(configure.status, configure.stderr).toBe(0);
-
-				const result = spawnSync(
-					BUN,
-					[path.join(checkout.repository, 'scripts', 'convex-consumer-compat.ts')],
-					{ cwd: checkout.repository, env, encoding: 'utf8', timeout: 110_000 }
-				);
-				const output = `${result.stdout}${result.stderr}`;
-				expect(result.status, output).not.toBe(0);
-				expect(output).toContain('a local attribute rule rewrites the baseline');
-				expect(output).not.toContain('referenced functions still published unchanged');
-			} finally {
-				rmSync(checkout.directory, { recursive: true, force: true });
-			}
-		},
-		120_000
-	);
-
 	it.skipIf(process.platform === 'win32')(
 		'rejects an unsafe repository path before the compatibility child runs',
 		() => {

--- a/scripts/static-checks.compat.test.ts
+++ b/scripts/static-checks.compat.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import {
 	chmodSync,
 	copyFileSync,
+	existsSync,
 	mkdirSync,
 	readFileSync,
 	rmSync,
@@ -18,6 +19,8 @@ import { testExecutable } from './test-executable';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SCRIPT = path.join(ROOT, 'scripts', 'static-checks.ts');
 const BUN = testExecutable('bun');
+const ESCAPE = String.fromCharCode(0x1b);
+const BELL = String.fromCharCode(0x07);
 
 function run(args: string[], env = sanitizedGitEnv()) {
 	return spawnSync(BUN, [SCRIPT, ...args], {
@@ -43,7 +46,9 @@ function createCheckerClone(): { directory: string; repository: string } {
 			path.join(repository, 'node_modules'),
 			process.platform === 'win32' ? 'junction' : 'dir'
 		);
-		copyFileSync(SCRIPT, path.join(repository, 'scripts', 'static-checks.ts'));
+		for (const file of ['static-checks.ts', 'convex-consumer-compat.ts', 'git-context.ts']) {
+			copyFileSync(path.join(ROOT, 'scripts', file), path.join(repository, 'scripts', file));
+		}
 		return { directory, repository };
 	} catch (error) {
 		rmSync(directory, { recursive: true, force: true });
@@ -51,36 +56,32 @@ function createCheckerClone(): { directory: string; repository: string } {
 	}
 }
 
-function writeFakeBun(directory: string): void {
-	if (process.platform === 'win32') {
-		const source = path.join(directory, 'fake-bun.ts');
-		writeFileSync(
-			source,
-			String.raw`import { writeFileSync } from 'node:fs';
-const log = process.env.STATIC_CHECK_LOG;
-if (!log) process.exit(42);
-writeFileSync(log, [process.argv[1] ?? '', process.env.GIT_DIR ?? '', process.env.GIT_WORK_TREE ?? '', process.env.CI ?? ''].join('\n') + '\n');
-`
-		);
-		const result = spawnSync(
-			BUN,
-			['build', '--compile', source, '--outfile', path.join(directory, 'bun.exe')],
-			{
-				encoding: 'utf8'
-			}
-		);
-		if (result.status !== 0) throw new Error(`Failed to compile fake Bun: ${result.stderr}`);
-		return;
-	}
-	const command = path.join(directory, 'bun');
-	writeFileSync(
-		command,
-		'#!/bin/sh\nprintf \'%s\\n%s\\n%s\\n%s\\n\' "$1" "${GIT_DIR-}" "${GIT_WORK_TREE-}" "${CI-}" > "$STATIC_CHECK_LOG"\n'
-	);
-	chmodSync(command, 0o755);
-}
-
 describe('Convex compatibility static-check entrypoint', () => {
+	it.skipIf(process.platform === 'win32')(
+		'resolves relative and empty PATH entries absolutely',
+		() => {
+			const directory = path.join(ROOT, 'scratch', `test-executable-${process.pid}-${Date.now()}`);
+			const tools = path.join(directory, 'tools');
+			const decoy = path.join(directory, 'decoy', 'probe');
+			const relativeCommand = path.join(tools, 'probe');
+			const currentCommand = path.join(directory, 'current-probe');
+			mkdirSync(decoy, { recursive: true });
+			mkdirSync(tools, { recursive: true });
+			writeFileSync(relativeCommand, '#!/bin/sh\n');
+			writeFileSync(currentCommand, '#!/bin/sh\n');
+			chmodSync(relativeCommand, 0o755);
+			chmodSync(currentCommand, 0o755);
+			try {
+				expect(testExecutable('probe', directory, { PATH: `decoy${path.delimiter}tools` })).toBe(
+					relativeCommand
+				);
+				expect(testExecutable('current-probe', directory, { PATH: '' })).toBe(currentCommand);
+			} finally {
+				rmSync(directory, { recursive: true, force: true });
+			}
+		}
+	);
+
 	it('builds the sanitized child invocation', () => {
 		const savedDir = process.env.GIT_DIR;
 		const savedWorktree = process.env.GIT_WORK_TREE;
@@ -88,10 +89,20 @@ describe('Convex compatibility static-check entrypoint', () => {
 		process.env.GIT_WORK_TREE = path.join(ROOT, 'scratch', 'foreign-worktree');
 		try {
 			const invocation = compatibilityInvocation(true);
-			expect(invocation.command).toBe('bun');
+			expect(invocation.command).toBe(process.execPath);
 			expect(invocation.args).toEqual(['scripts/convex-consumer-compat.ts']);
 			expect(invocation.options.env?.GIT_DIR).toBeUndefined();
 			expect(invocation.options.env?.GIT_WORK_TREE).toBeUndefined();
+			expect(invocation.options.env?.GIT_ATTR_NOSYSTEM).toBe('1');
+			expect(invocation.options.env?.GIT_ATTR_SOURCE).toBeUndefined();
+			expect(invocation.options.env?.GIT_NO_REPLACE_OBJECTS).toBe('1');
+			expect(invocation.options.env?.GIT_GRAFT_FILE).toBe('');
+			expect(invocation.options.env?.GIT_CONFIG_GLOBAL).toBe('');
+			expect(invocation.options.env?.GIT_CONFIG_SYSTEM).toBe('');
+			expect(invocation.options.env?.GIT_CONFIG_NOSYSTEM).toBe('1');
+			expect(invocation.options.env?.GIT_CONFIG_COUNT).toBe('1');
+			expect(invocation.options.env?.GIT_CONFIG_KEY_0).toBe('core.attributesFile');
+			expect(invocation.options.env?.GIT_CONFIG_VALUE_0).toBe('');
 			expect(invocation.options.env?.CI).toBe('true');
 		} finally {
 			if (savedDir === undefined) delete process.env.GIT_DIR;
@@ -101,32 +112,190 @@ describe('Convex compatibility static-check entrypoint', () => {
 		}
 	});
 
-	it('runs the compatibility child with the sanitized CI environment', () => {
-		const directory = path.join(ROOT, 'scratch', `compat-child-${process.pid}-${Date.now()}`);
-		const log = path.join(directory, 'child.log');
-		mkdirSync(directory, { recursive: true });
-		try {
-			writeFakeBun(directory);
-			const env = sanitizedGitEnv();
-			env.PATH = `${directory}${path.delimiter}${env.PATH ?? ''}`;
-			env.STATIC_CHECK_LOG = log;
-			env.GIT_DIR = path.join(directory, 'foreign.git');
-			env.GIT_WORK_TREE = path.join(directory, 'foreign-worktree');
-			const result = run(['--ci', '--scope', 'compat'], env);
-			const output = `${result.stdout}${result.stderr}`;
-			const [argument, gitDir, gitWorktree, ci] = readFileSync(log, 'utf8').trimEnd().split('\n');
+	it('uses the running Bun executable and sanitizes child diagnostics without PATH lookup', () => {
+		const env = sanitizedGitEnv();
+		env.PATH = '';
+		env.CI = 'true';
+		env.CONVEX_COMPAT_BASE = `missing ref${ESCAPE}]0;OWNED${BELL}`;
+		const result = run(['--scope', 'compat'], env);
+		const output = `${result.stdout}${result.stderr}`;
 
-			expect(result.status, output).toBe(0);
-			expect(argument).toBe('scripts/convex-consumer-compat.ts');
-			expect(gitDir).toBe('');
-			expect(gitWorktree).toBe('');
-			expect(ci).toBe('true');
-			expect(output).toContain('Convex consumer compatibility');
-			expect(output).not.toContain('SvelteKit sync');
+		expect(result.status, output).toBe(1);
+		expect(output).toContain('Convex consumer compatibility');
+		expect(output).toContain('CONVEX_COMPAT_BASE=missing refU+001B]0;OWNEDU+0007');
+		expect(output).not.toContain('Executable not found');
+		expect(output).not.toContain(`${ESCAPE}]0;OWNED`);
+		expect(output).not.toContain(BELL);
+	}, 30_000);
+
+	it('reads real ancestry through local replacements and grafts', () => {
+		const directory = path.join(ROOT, 'scratch', `compat-history-${process.pid}-${Date.now()}`);
+		mkdirSync(directory, { recursive: true });
+		const env = sanitizedGitEnv();
+		const git = (args: string[], childEnv = env) =>
+			spawnSync('git', ['-c', 'core.useReplaceRefs=true', ...args], {
+				cwd: directory,
+				env: childEnv,
+				encoding: 'utf8'
+			});
+		try {
+			expect(git(['init', '--quiet', '--initial-branch=main']).status).toBe(0);
+			for (const [message, contents] of [
+				['Initial', 'one\n'],
+				['Middle', 'two\n'],
+				['Current', 'three\n']
+			] as const) {
+				writeFileSync(path.join(directory, 'README.md'), contents);
+				expect(git(['add', '--', 'README.md']).status).toBe(0);
+				expect(
+					git([
+						'-c',
+						'user.name=Probe',
+						'-c',
+						'user.email=probe@example.com',
+						'commit',
+						'--quiet',
+						'--no-gpg-sign',
+						'--no-verify',
+						'-m',
+						message
+					]).status
+				).toBe(0);
+			}
+
+			const head = git(['rev-parse', 'HEAD']).stdout.trim();
+			const realParent = git(['rev-parse', 'HEAD~1']).stdout.trim();
+			const oldest = git(['rev-parse', 'HEAD~2']).stdout.trim();
+			const tree = git(['write-tree']).stdout.trim();
+			const replacement = git([
+				'-c',
+				'user.name=Probe',
+				'-c',
+				'user.email=probe@example.com',
+				'commit-tree',
+				tree,
+				'-m',
+				'Replacement root'
+			]).stdout.trim();
+			expect(git(['replace', 'HEAD', replacement]).status).toBe(0);
+			expect(git(['rev-parse', 'HEAD~1']).status).not.toBe(0);
+
+			const isolated = compatibilityInvocation().options.env!;
+			const replacementParent = git(['rev-parse', 'HEAD~1'], isolated);
+			expect(replacementParent.status, replacementParent.stderr).toBe(0);
+			expect(replacementParent.stdout.trim()).toBe(realParent);
+
+			expect(git(['replace', '-d', 'HEAD']).status).toBe(0);
+			writeFileSync(path.join(directory, '.git', 'info', 'grafts'), `${head} ${oldest}\n`);
+			expect(git(['rev-parse', 'HEAD~1']).stdout.trim()).toBe(oldest);
+			const graftParent = git(['rev-parse', 'HEAD~1'], isolated);
+			expect(graftParent.status, graftParent.stderr).toBe(0);
+			expect(graftParent.stdout.trim()).toBe(realParent);
 		} finally {
 			rmSync(directory, { recursive: true, force: true });
 		}
-	});
+	}, 30_000);
+
+	it.skipIf(process.platform === 'win32')(
+		'protects the direct checker from local ancestry and checkout configuration',
+		() => {
+			const checkout = createCheckerClone();
+			const env = sanitizedGitEnv();
+			const foreignRepository = path.join(checkout.directory, 'foreign-repository');
+			const git = (args: string[], childEnv = env) =>
+				spawnSync('git', ['-c', 'core.useReplaceRefs=true', ...args], {
+					cwd: checkout.repository,
+					env: childEnv,
+					encoding: 'utf8'
+				});
+			const foreignGit = (args: string[]) =>
+				spawnSync('git', args, { cwd: foreignRepository, env, encoding: 'utf8' });
+			try {
+				mkdirSync(foreignRepository, { recursive: true });
+				expect(foreignGit(['init', '--quiet', '--initial-branch=main']).status).toBe(0);
+				expect(foreignGit(['config', 'core.hooksPath', 'original-hooks']).status).toBe(0);
+				const tree = git(['write-tree']).stdout.trim();
+				const commit = (message: string, parent?: string) =>
+					git([
+						'-c',
+						'user.name=Probe',
+						'-c',
+						'user.email=probe@example.com',
+						'commit-tree',
+						tree,
+						...(parent ? ['-p', parent] : []),
+						'-m',
+						message
+					]).stdout.trim();
+				const root = commit('Root');
+				const parent = commit('Parent', root);
+				const head = commit('Head', parent);
+				expect(git(['update-ref', 'refs/heads/main', head]).status).toBe(0);
+				expect(git(['update-ref', 'refs/remotes/origin/main', head]).status).toBe(0);
+				expect(git(['checkout', '--quiet', '--detach', head]).status).toBe(0);
+
+				const replacement = commit('Replacement root');
+				expect(git(['replace', head, replacement]).status).toBe(0);
+				expect(git(['rev-parse', 'HEAD~1']).status).not.toBe(0);
+
+				const hookDirectory = path.join(checkout.directory, 'hooks');
+				const marker = path.join(checkout.directory, 'post-checkout-ran');
+				const filterMarker = path.join(checkout.directory, 'smudge-filter-ran');
+				const filter = path.join(checkout.directory, 'smudge-filter');
+				const attributes = path.join(checkout.directory, 'global-attributes');
+				const template = path.join(checkout.directory, 'template');
+				const config = path.join(checkout.directory, 'global.gitconfig');
+				mkdirSync(hookDirectory, { recursive: true });
+				writeFileSync(
+					path.join(hookDirectory, 'post-checkout'),
+					`#!/bin/sh\nprintf hook > ${JSON.stringify(marker)}\n`
+				);
+				chmodSync(path.join(hookDirectory, 'post-checkout'), 0o755);
+				writeFileSync(filter, `#!/bin/sh\ncat\nprintf filter > ${JSON.stringify(filterMarker)}\n`);
+				chmodSync(filter, 0o755);
+				writeFileSync(attributes, '*.ts filter=compat-probe\n');
+				mkdirSync(path.join(template, 'info'), { recursive: true });
+				writeFileSync(
+					path.join(template, 'config'),
+					`[filter "compat-probe"]\n\tsmudge = ${JSON.stringify(filter)}\n\trequired = true\n`
+				);
+				writeFileSync(path.join(template, 'info', 'attributes'), '*.ts filter=compat-probe\n');
+				expect(git(['config', '--file', config, 'core.hooksPath', hookDirectory]).status).toBe(0);
+				expect(git(['config', 'core.attributesFile', attributes]).status).toBe(0);
+				expect(git(['config', 'filter.compat-probe.smudge', filter]).status).toBe(0);
+
+				const childEnv = {
+					...env,
+					GIT_CONFIG_GLOBAL: config,
+					GIT_DIR: path.join(foreignRepository, '.git'),
+					GIT_TEMPLATE_DIR: template,
+					GIT_TEST_ASSUME_DIFFERENT_OWNER: '1'
+				};
+				const result = spawnSync(
+					BUN,
+					[path.join(checkout.repository, 'scripts', 'convex-consumer-compat.ts')],
+					{
+						cwd: checkout.repository,
+						env: childEnv,
+						encoding: 'utf8',
+						timeout: 110_000
+					}
+				);
+				const output = `${result.stdout}${result.stderr}`;
+				expect(result.status, output).toBe(0);
+				expect(output).toContain('referenced functions still published unchanged');
+				expect(output).not.toContain('root commit, nothing promised yet');
+				expect(existsSync(marker)).toBe(false);
+				expect(existsSync(filterMarker)).toBe(false);
+				expect(foreignGit(['config', '--get', 'core.hooksPath']).stdout.trim()).toBe(
+					'original-hooks'
+				);
+			} finally {
+				rmSync(checkout.directory, { recursive: true, force: true });
+			}
+		},
+		120_000
+	);
 
 	it.skipIf(process.platform === 'win32')(
 		'rejects an unsafe repository path before the compatibility child runs',
@@ -166,6 +335,11 @@ describe('Convex compatibility static-check entrypoint', () => {
 		expect(result.status).toBe(1);
 		expect(output).toContain('--scope compat only supports a full-project run');
 		expect(output).not.toContain('Convex consumer compatibility');
+	});
+
+	it('keeps abandoned checker clones out of Vitest discovery', () => {
+		const config = readFileSync(path.join(ROOT, 'vite.config.ts'), 'utf8');
+		expect(config).toContain("'scratch/**'");
 	});
 
 	it('owns the package alias', () => {

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -55,7 +55,6 @@ import {
 	activeGitIndexFingerprint,
 	getStagedChanges,
 	getStagedFiles,
-	isolatedGitEnv,
 	sanitizedGitEnv,
 	stagedFilesMatchWorktree,
 	stagedFilesWithCleanFilters,
@@ -1025,8 +1024,19 @@ async function runPrettier(formatFlag: '--check' | '--write', files?: string[]):
 	}
 }
 
+/**
+ * The compatibility child gets a scrubbed environment, not an isolated one. Isolating here
+ * would be irreversible: `isolatedGitEnv()` blanks the global and system config paths, and a
+ * child cannot recover what its own environment no longer names. The checker needs that
+ * configuration for exactly one call, the baseline fetch, which relies on `url.*.insteadOf`,
+ * the credential helper, the proxy and the CA bundle. Measured through this wrapper, a
+ * baseline reachable only through a rewrite rule went unfetched: CI failed closed with "is
+ * unreachable" and a local run fell back to the trunk and certified a different baseline.
+ * Isolation belongs to the child, which applies it per call and knows which calls decide the
+ * verdict; see `isolatedGitEnv()` in `convex-consumer-compat.ts`.
+ */
 export function compatibilityInvocation(ciMode = false) {
-	const env = isolatedGitEnv();
+	const env = sanitizedGitEnv();
 	if (ciMode) env.CI = 'true';
 	return {
 		command: process.execPath,

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -55,6 +55,7 @@ import {
 	activeGitIndexFingerprint,
 	getStagedChanges,
 	getStagedFiles,
+	isolatedGitEnv,
 	sanitizedGitEnv,
 	stagedFilesMatchWorktree,
 	stagedFilesWithCleanFilters,
@@ -1025,10 +1026,10 @@ async function runPrettier(formatFlag: '--check' | '--write', files?: string[]):
 }
 
 export function compatibilityInvocation(ciMode = false) {
-	const env = sanitizedGitEnv();
+	const env = isolatedGitEnv();
 	if (ciMode) env.CI = 'true';
 	return {
-		command: 'bun',
+		command: process.execPath,
 		args: ['scripts/convex-consumer-compat.ts'],
 		options: { env } satisfies SanitizedCommandOptions
 	};

--- a/scripts/static-checks.ts
+++ b/scripts/static-checks.ts
@@ -1028,12 +1028,13 @@ async function runPrettier(formatFlag: '--check' | '--write', files?: string[]):
  * The compatibility child gets a scrubbed environment, not an isolated one. Isolating here
  * would be irreversible: `isolatedGitEnv()` blanks the global and system config paths, and a
  * child cannot recover what its own environment no longer names. The checker needs that
- * configuration for exactly one call, the baseline fetch, which relies on `url.*.insteadOf`,
- * the credential helper, the proxy and the CA bundle. Measured through this wrapper, a
- * baseline reachable only through a rewrite rule went unfetched: CI failed closed with "is
+ * configuration for its explicit baseline fetch, which relies on `url.*.insteadOf`, the
+ * credential helper, the proxy and the CA bundle. Measured through this wrapper, a baseline
+ * reachable only through a rewrite rule went unfetched: CI failed closed with "is
  * unreachable" and a local run fell back to the trunk and certified a different baseline.
- * Isolation belongs to the child, which applies it per call and knows which calls decide the
- * verdict; see `isolatedGitEnv()` in `convex-consumer-compat.ts`.
+ * Isolation belongs to the child, which applies it per call. Partial-clone lazy reads remain
+ * isolated and can fail closed when they need external transport configuration; see #863 and
+ * `isolatedGitEnv()` in `convex-consumer-compat.ts`.
  */
 export function compatibilityInvocation(ciMode = false) {
 	const env = sanitizedGitEnv();

--- a/scripts/test-executable.ts
+++ b/scripts/test-executable.ts
@@ -1,19 +1,23 @@
-import { accessSync, constants } from 'node:fs';
+import { accessSync, constants, statSync } from 'node:fs';
 import path from 'node:path';
 
 /** Resolve a test dependency without relying on the optional `which` utility. */
-export function testExecutable(name: string): string {
+export function testExecutable(
+	name: string,
+	cwd = process.cwd(),
+	env: NodeJS.ProcessEnv = process.env
+): string {
 	const extensions =
 		process.platform === 'win32'
-			? (process.env.PATHEXT ?? '.COM;.EXE')
+			? (env.PATHEXT ?? '.COM;.EXE')
 					.split(';')
 					.filter((extension) => ['.COM', '.EXE'].includes(extension.toUpperCase()))
 			: [''];
-	for (const directory of (process.env.PATH ?? '').split(path.delimiter)) {
-		if (!directory) continue;
+	for (const directory of (env.PATH ?? '').split(path.delimiter)) {
 		for (const extension of extensions) {
-			const candidate = path.join(directory, `${name}${extension.toLowerCase()}`);
+			const candidate = path.resolve(cwd, directory || '.', `${name}${extension.toLowerCase()}`);
 			try {
+				if (!statSync(candidate).isFile()) continue;
 				accessSync(candidate, constants.X_OK);
 				return candidate;
 			} catch {


### PR DESCRIPTION
Regression guard: added real Git context, transport, checkout, and cleanup tests

Closes #848

The Convex compatibility checker could inherit foreign repository state, rewritten ancestry, local checkout behavior, or terminal control characters and still look like a valid compatibility verdict.

The package alias now routes through the shared terminal boundary. Verdict-deciding Git reads ignore replacement refs, grafts, foreign object stores, templates, hooks, and external attribute sources while the baseline fetch and frozen install retain the transport configuration they need. The baseline uses a sparse-checkout-disabled linked worktree, the running Bun executable, bounded buffers, and registry-verified cleanup. Fixture clones run outside the repository and carry every transitive checker script. Full linked-worktree materialization isolation remains tracked in #863.

Verified with 1,761 passing unit tests, the real compatibility check, changed-file static checks, shallow and transport fixtures, locked-worktree probes, Windows lifecycle CI, and independent review rounds.

