### PR TITLE
docs(upstream-report): Record measured fetch costs

### DIFF
--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -272,20 +272,25 @@ well as spelling. Ref backing files also pin mode, size, mtime, and ctime. It re
 remote reads, while a retargeted alias stays bound to the location first validated.
 
 Fetch disables automatic maintenance because the private ref namespace does not describe which
-objects the real repository still needs. Fetched objects land in the real object store, so a fork
-that shares no commit with its template takes the full object closure of upstream `main` (not its
-tags, and not branches it never asks for) on the run that first needs it. Measured against a
-384 MiB parent: 152 KiB before, 385 MiB after. Later runs transfer nothing while the advertised
-commit and everything it reaches are already present, because Git decides that from the objects it
-can reach rather than from the private ref namespace. The 30-second deadline bounds time and not
-received bytes, so check free disk space before `--fetch` when the configured parent may be
+objects the real repository still needs. Fetched objects land in the real object store. For a
+complete, readable upstream, a fork that shares no commit with its template takes the full object
+closure of upstream `main` (not its tags, and not branches it never asks for) on the run that first
+needs it. Measured against a 384 MiB parent: 152 KiB before, 385 MiB after. Later runs normally
+transfer nothing while the advertised commit and everything it reaches are present, because Git
+decides that from object presence rather than the private ref namespace. Presence does not prove
+that an object is readable, and a repeated fetch need not repair corruption.
+
+The report checks the fetched tip's object type before persisting its tracking ref; it does not
+validate every reachable object. A shallow or corrupt upstream can therefore leave that ref with
+unreadable history. Use a complete, healthy mirror. The 30-second deadline bounds fetch time and
+not received bytes, so check free disk space before `--fetch` when the configured parent may be
 unusually large.
 
 An interrupted transfer may leave no object-store residue when the receiver has not started
 writing. Once it has, Git's built-in 100-object threshold selects the form: below 100 objects Git
 writes loose files, while at 100 or above `index-pack` writes a partial `tmp_pack_*`. The report
-copies neither `fetch.unpackLimit` nor `transfer.unpackLimit` into its transport config and reads no
-global config, so that threshold holds whatever the caller configured. A 400 MiB transfer below it
+copies neither `fetch.unpackLimit` nor `transfer.unpackLimit` into its transport config. The fetch
+subprocess reads no global config, so that threshold holds whatever the caller configured. A 400 MiB transfer below it
 left 60 MiB of unreachable loose objects after a 30-second interruption. Transfers at or above it
 left 11 MiB and 81 MiB partial packs after 3.5 and 5 seconds against a 287 MiB parent. A check that
 fails after a completed fetch leaves whatever the fork's own refs do not reach. Ordinary `git gc`

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -272,10 +272,11 @@ well as spelling. Ref backing files also pin mode, size, mtime, and ctime. It re
 remote reads, while a retargeted alias stays bound to the location first validated.
 
 Fetch disables automatic maintenance because the private ref namespace does not describe which
-objects the real repository still needs. Fetched objects still land in the real object store. The
-30-second deadline stops the direct Git process. It does not limit received pack bytes or guarantee
-that every remote-helper descendant has exited. Check free disk space before `--fetch` when the
-configured parent may be unusually large.
+objects the real repository still needs. Fetched objects still land in the real object store, and a
+fork that shares no commit with its template receives the whole upstream history on the first run.
+The 30-second deadline bounds time, not bytes, so check free disk space before `--fetch` when the
+configured parent may be unusually large. A check that fails after a completed fetch leaves those
+objects unreachable in the shared store, where only `git gc --prune=now` reclaims them.
 It reads the advertised `main` SHA before and after an object-only fetch that writes neither
 `FETCH_HEAD` nor a tracking ref. It verifies that exact commit before creating a missing shared
 remote. The URL it just wrote remains the expected value, so a concurrent replacement cannot be

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -276,17 +276,28 @@ objects the real repository still needs. Fetched objects land in the real object
 that shares no commit with its template takes the full object closure of upstream `main` (not its
 tags, and not branches it never asks for) on the run that first needs it. Measured against a
 384 MiB parent: 152 KiB before, 385 MiB after. Later runs transfer nothing while the advertised
-commit is already present, because Git decides that from the objects it can reach rather than from
-the private ref namespace. The 30-second deadline bounds time and not received bytes, so check free
-disk space before `--fetch` when the configured parent may be unusually large.
+commit and everything it reaches are already present, because Git decides that from the objects it
+can reach rather than from the private ref namespace. The 30-second deadline bounds time and not
+received bytes, so check free disk space before `--fetch` when the configured parent may be
+unusually large.
 
-Two kinds of leftovers survive a failure. An abort during the transfer leaves `index-pack`'s
-partial `tmp_pack_*` in the object store; measured at 11 MiB and 81 MiB for 3.5 and 5 second
-deadlines against a 287 MiB parent. A check that fails after a completed fetch leaves whatever the
-fork's own refs do not reach. Ordinary `git gc` clears both once its grace period expires, which is
-two weeks for unreachable objects by default. Pruning earlier needs a quiet repository: Git can
-corrupt an object store when `--prune=now` races a process that is writing objects before it
-creates the ref that reaches them.
+Three kinds of leftovers survive a failure, and object count decides between the first two. Git
+unpacks a transfer below 100 objects into loose files and runs `index-pack` at 100 or above; the
+report copies neither `fetch.unpackLimit` nor `transfer.unpackLimit` into its transport config and
+reads no global config, so that built-in threshold holds whatever the caller configured. Below it
+an abort leaves unreachable loose objects, measured at 60 MiB after interrupting a 400 MiB transfer
+at 30 seconds. At or above it an abort leaves `index-pack`'s partial `tmp_pack_*`, measured at
+11 MiB and 81 MiB for 3.5 and 5 second deadlines against a 287 MiB parent. A check that fails after
+a completed fetch leaves whatever the fork's own refs do not reach. Ordinary `git gc` clears all
+three once its grace period expires, which is two weeks for unreachable objects by default. Pruning
+earlier needs a quiet repository: Git can corrupt an object store when `--prune=now` races a process
+that is writing objects before it creates the ref that reaches them.
+
+The deadline ends the report's wait and not the transfer. `git-upload-pack` and its `git
+pack-objects` child keep running after the report kills the fetch and exits, measured at 4.9 seconds
+across three runs against a 400 MiB local parent, because they only stop once their side of the pipe
+closes. A caller that retries `--fetch` in a loop can therefore stack transports it can no longer
+see.
 It reads the advertised `main` SHA before and after an object-only fetch that writes neither
 `FETCH_HEAD` nor a tracking ref. It verifies that exact commit before creating a missing shared
 remote. The URL it just wrote remains the expected value, so a concurrent replacement cannot be

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -281,23 +281,23 @@ can reach rather than from the private ref namespace. The 30-second deadline bou
 received bytes, so check free disk space before `--fetch` when the configured parent may be
 unusually large.
 
-Three kinds of leftovers survive a failure, and object count decides between the first two. Git
-unpacks a transfer below 100 objects into loose files and runs `index-pack` at 100 or above; the
-report copies neither `fetch.unpackLimit` nor `transfer.unpackLimit` into its transport config and
-reads no global config, so that built-in threshold holds whatever the caller configured. Below it
-an abort leaves unreachable loose objects, measured at 60 MiB after interrupting a 400 MiB transfer
-at 30 seconds. At or above it an abort leaves `index-pack`'s partial `tmp_pack_*`, measured at
-11 MiB and 81 MiB for 3.5 and 5 second deadlines against a 287 MiB parent. A check that fails after
-a completed fetch leaves whatever the fork's own refs do not reach. Ordinary `git gc` clears all
-three once its grace period expires, which is two weeks for unreachable objects by default. Pruning
-earlier needs a quiet repository: Git can corrupt an object store when `--prune=now` races a process
-that is writing objects before it creates the ref that reaches them.
+An interrupted transfer may leave no object-store residue when the receiver has not started
+writing. Once it has, Git's built-in 100-object threshold selects the form: below 100 objects Git
+writes loose files, while at 100 or above `index-pack` writes a partial `tmp_pack_*`. The report
+copies neither `fetch.unpackLimit` nor `transfer.unpackLimit` into its transport config and reads no
+global config, so that threshold holds whatever the caller configured. A 400 MiB transfer below it
+left 60 MiB of unreachable loose objects after a 30-second interruption. Transfers at or above it
+left 11 MiB and 81 MiB partial packs after 3.5 and 5 seconds against a 287 MiB parent. A check that
+fails after a completed fetch leaves whatever the fork's own refs do not reach. Ordinary `git gc`
+clears these residues once its grace period expires, which is two weeks for unreachable objects by
+default. Pruning earlier needs a quiet repository: Git can corrupt an object store when
+`--prune=now` races a process that is writing objects before it creates the ref that reaches them.
 
-The deadline ends the report's wait and not the transfer. `git-upload-pack` and its `git
-pack-objects` child keep running after the report kills the fetch and exits, measured at 4.9 seconds
-across three runs against a 400 MiB local parent, because they only stop once their side of the pipe
-closes. A caller that retries `--fetch` in a loop can therefore stack transports it can no longer
-see.
+The deadline terminates the `git fetch` process, but its `git-upload-pack` and `git pack-objects`
+descendants stop independently as their pipe closes. Their lifetime relative to the report varies:
+three runs against a 382 MiB local parent ended before the report returned, while another against a
+287 MiB parent outlived it by 0.208 seconds. Avoid a tight retry loop that assumes the previous
+transport has already exited.
 It reads the advertised `main` SHA before and after an object-only fetch that writes neither
 `FETCH_HEAD` nor a tracking ref. It verifies that exact commit before creating a missing shared
 remote. The URL it just wrote remains the expected value, so a concurrent replacement cannot be

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -272,11 +272,21 @@ well as spelling. Ref backing files also pin mode, size, mtime, and ctime. It re
 remote reads, while a retargeted alias stays bound to the location first validated.
 
 Fetch disables automatic maintenance because the private ref namespace does not describe which
-objects the real repository still needs. Fetched objects still land in the real object store, and a
-fork that shares no commit with its template receives the whole upstream history on the first run.
-The 30-second deadline bounds time, not bytes, so check free disk space before `--fetch` when the
-configured parent may be unusually large. A check that fails after a completed fetch leaves those
-objects unreachable in the shared store, where only `git gc --prune=now` reclaims them.
+objects the real repository still needs. Fetched objects land in the real object store, so a fork
+that shares no commit with its template takes the full object closure of upstream `main` (not its
+tags, and not branches it never asks for) on the run that first needs it. Measured against a
+384 MiB parent: 152 KiB before, 385 MiB after. Later runs transfer nothing while the advertised
+commit is already present, because Git decides that from the objects it can reach rather than from
+the private ref namespace. The 30-second deadline bounds time and not received bytes, so check free
+disk space before `--fetch` when the configured parent may be unusually large.
+
+Two kinds of leftovers survive a failure. An abort during the transfer leaves `index-pack`'s
+partial `tmp_pack_*` in the object store; measured at 11 MiB and 81 MiB for 3.5 and 5 second
+deadlines against a 287 MiB parent. A check that fails after a completed fetch leaves whatever the
+fork's own refs do not reach. Ordinary `git gc` clears both once its grace period expires, which is
+two weeks for unreachable objects by default. Pruning earlier needs a quiet repository: Git can
+corrupt an object store when `--prune=now` races a process that is writing objects before it
+creates the ref that reaches them.
 It reads the advertised `main` SHA before and after an object-only fetch that writes neither
 `FETCH_HEAD` nor a tracking ref. It verifies that exact commit before creating a missing shared
 remote. The URL it just wrote remains the expected value, so a concurrent replacement cannot be

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -2151,6 +2151,15 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 		const transport = transportRemote(transportUrl);
 		console.error(`Fetching upstream (${terminalUrl(upstreamUrl)}) ...`);
 		const expected = advertisedMainAt(transportUrl);
+		// A content-copy fork shares no commit with its template, so negotiation
+		// finds nothing to exclude and the first fetch transfers the whole upstream
+		// history into this repository's object store. Measured against a 384 MiB
+		// parent: 152 KiB before, 385 MiB after. The deadline below bounds time, not
+		// bytes. An abort during the transfer is clean, because Git removes its
+		// temporary pack on SIGTERM, but a check that fails after the fetch leaves
+		// those objects unreachable in the shared store, where a plain `git gc` does
+		// not reclaim them and grows the store while trying. Only
+		// `git gc --prune=now` frees them.
 		try {
 			rejectTransportCommandOverrides();
 			verifyLocalRemoteSnapshot(transportUrl);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -2156,8 +2156,7 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 		// copied transport config carries neither unpack limit, so Git's built-in
 		// threshold of 100 objects selects the receiver and therefore the residue
 		// form if that receiver starts writing. The fetched tip is persisted without
-		// checking every reachable object for readability. The skill carries that
-		// limitation alongside the measurements, cleanup, and process lifetime.
+		// checking every reachable object for readability.
 		try {
 			rejectTransportCommandOverrides();
 			verifyLocalRemoteSnapshot(transportUrl);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -2154,9 +2154,9 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 		// This writes into the caller's own object store, and the deadline below
 		// bounds time rather than received bytes. Global config is off here and the
 		// copied transport config carries neither unpack limit, so Git's built-in
-		// threshold of 100 objects decides what an interrupted transfer leaves
-		// behind whatever the caller configured. The skill carries the sizes, the
-		// cleanup, and the transport processes that outlive the deadline.
+		// threshold of 100 objects selects the receiver and therefore the residue
+		// form if that receiver starts writing. The skill carries the measurements,
+		// cleanup, and descendant-process lifetime.
 		try {
 			rejectTransportCommandOverrides();
 			verifyLocalRemoteSnapshot(transportUrl);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -2155,8 +2155,9 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 		// bounds time rather than received bytes. Global config is off here and the
 		// copied transport config carries neither unpack limit, so Git's built-in
 		// threshold of 100 objects selects the receiver and therefore the residue
-		// form if that receiver starts writing. The skill carries the measurements,
-		// cleanup, and descendant-process lifetime.
+		// form if that receiver starts writing. The fetched tip is persisted without
+		// checking every reachable object for readability. The skill carries that
+		// limitation alongside the measurements, cleanup, and process lifetime.
 		try {
 			rejectTransportCommandOverrides();
 			verifyLocalRemoteSnapshot(transportUrl);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -2151,15 +2151,13 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 		const transport = transportRemote(transportUrl);
 		console.error(`Fetching upstream (${terminalUrl(upstreamUrl)}) ...`);
 		const expected = advertisedMainAt(transportUrl);
-		// A content-copy fork shares no commit with its template, so negotiation
-		// finds nothing to exclude and the first fetch transfers the whole upstream
-		// history into this repository's object store. Measured against a 384 MiB
-		// parent: 152 KiB before, 385 MiB after. The deadline below bounds time, not
-		// bytes. An abort during the transfer is clean, because Git removes its
-		// temporary pack on SIGTERM, but a check that fails after the fetch leaves
-		// those objects unreachable in the shared store, where a plain `git gc` does
-		// not reclaim them and grows the store while trying. Only
-		// `git gc --prune=now` frees them.
+		// This writes into the caller's own object store, and the deadline below
+		// bounds time rather than received bytes. A fork sharing no commit with its
+		// template therefore takes the full closure of upstream `main` on the run
+		// that first needs it. Aborting mid-transfer leaves `index-pack`'s partial
+		// `tmp_pack_*` behind, measured at 11 MiB and 81 MiB for 3.5 and 5 second
+		// deadlines against a 287 MiB parent. The skill carries the size and cleanup
+		// guidance a caller needs.
 		try {
 			rejectTransportCommandOverrides();
 			verifyLocalRemoteSnapshot(transportUrl);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -2152,12 +2152,11 @@ function ensureUpstream(root: string, upstreamUrl: string, allowFetch: boolean):
 		console.error(`Fetching upstream (${terminalUrl(upstreamUrl)}) ...`);
 		const expected = advertisedMainAt(transportUrl);
 		// This writes into the caller's own object store, and the deadline below
-		// bounds time rather than received bytes. A fork sharing no commit with its
-		// template therefore takes the full closure of upstream `main` on the run
-		// that first needs it. Aborting mid-transfer leaves `index-pack`'s partial
-		// `tmp_pack_*` behind, measured at 11 MiB and 81 MiB for 3.5 and 5 second
-		// deadlines against a 287 MiB parent. The skill carries the size and cleanup
-		// guidance a caller needs.
+		// bounds time rather than received bytes. Global config is off here and the
+		// copied transport config carries neither unpack limit, so Git's built-in
+		// threshold of 100 objects decides what an interrupted transfer leaves
+		// behind whatever the caller configured. The skill carries the sizes, the
+		// cleanup, and the transport processes that outlive the deadline.
 		try {
 			rejectTransportCommandOverrides();
 			verifyLocalRemoteSnapshot(transportUrl);


### PR DESCRIPTION
Regression guard: not warranted, comment and documentation only

The report's `--fetch` writes into the caller's object store, but the skill did not state its disk cost, failure residue, process lifetime, or graph-integrity limit. Two issue drafts had guessed at those behaviors rather than measuring them.

The updated guidance records the measured first-fetch cost and repeat behavior, distinguishes loose-object and partial-pack residue, explains ordinary garbage collection and the `--prune=now` race, and qualifies transport shutdown timing. It also states the current integrity boundary: the report validates the fetched tip's type without checking every reachable object, so a shallow or corrupt upstream can leave unreadable tracking history and a repeated fetch need not repair corruption. The source comment keeps only the implementation-local facts.

Verified with changed-file static checks and direct full-path measurements against shallow and corrupt upstream fixtures.
