### PR TITLE
fix(admin): Fill support filter bar

### DIFF
--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -160,15 +160,15 @@
 			onValueChange={(v) => onFilterChange(v as 'all' | 'unassigned' | 'my-inbox')}
 		>
 			<Tabs.List class="w-full">
-				<Tabs.Trigger value="my-inbox" class="min-w-0 px-1 text-xs"
-					><T keyName="admin.support.filter.my_inbox" /></Tabs.Trigger
-				>
-				<Tabs.Trigger value="all" class="min-w-0 px-1 text-xs"
-					><T keyName="admin.support.filter.all" /></Tabs.Trigger
-				>
-				<Tabs.Trigger value="unassigned" class="min-w-0 px-1 text-xs"
-					><T keyName="admin.support.filter.unassigned" /></Tabs.Trigger
-				>
+				<Tabs.Trigger value="my-inbox" class="min-w-0 overflow-hidden px-1 text-xs">
+					<span class="min-w-0 truncate"><T keyName="admin.support.filter.my_inbox" /></span>
+				</Tabs.Trigger>
+				<Tabs.Trigger value="all" class="min-w-0 overflow-hidden px-1 text-xs">
+					<span class="min-w-0 truncate"><T keyName="admin.support.filter.all" /></span>
+				</Tabs.Trigger>
+				<Tabs.Trigger value="unassigned" class="min-w-0 overflow-hidden px-1 text-xs">
+					<span class="min-w-0 truncate"><T keyName="admin.support.filter.unassigned" /></span>
+				</Tabs.Trigger>
 			</Tabs.List>
 		</Tabs.Root>
 	</div>

--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -159,17 +159,14 @@
 			value={filterMode}
 			onValueChange={(v) => onFilterChange(v as 'all' | 'unassigned' | 'my-inbox')}
 		>
-			<!-- Full-width bar, but each trigger hugs its label (flex-none) and the
-			     three are spread evenly, so the active pill wraps only the label
-			     instead of filling a rigid third. -->
-			<Tabs.List class="w-full justify-evenly">
-				<Tabs.Trigger value="my-inbox" class="flex-none"
+			<Tabs.List class="w-full">
+				<Tabs.Trigger value="my-inbox" class="min-w-0 px-1 text-xs"
 					><T keyName="admin.support.filter.my_inbox" /></Tabs.Trigger
 				>
-				<Tabs.Trigger value="all" class="flex-none"
+				<Tabs.Trigger value="all" class="min-w-0 px-1 text-xs"
 					><T keyName="admin.support.filter.all" /></Tabs.Trigger
 				>
-				<Tabs.Trigger value="unassigned" class="flex-none"
+				<Tabs.Trigger value="unassigned" class="min-w-0 px-1 text-xs"
 					><T keyName="admin.support.filter.unassigned" /></Tabs.Trigger
 				>
 			</Tabs.List>

--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { mergeProps } from 'bits-ui';
 	import { Input } from '$lib/components/ui/input';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import * as Tooltip from '$lib/components/ui/tooltip';
@@ -21,6 +22,8 @@
 	const dateFnsLocale = $derived(getDateFnsLocale(page.data.lang));
 
 	const { t } = getTranslate();
+
+	type FilterMode = 'all' | 'unassigned' | 'my-inbox';
 
 	interface Thread {
 		_id: string;
@@ -66,7 +69,7 @@
 		onThreadSelect,
 		onLoadMore
 	}: {
-		filterMode: 'all' | 'unassigned' | 'my-inbox';
+		filterMode: FilterMode;
 		statusFilter: 'open' | 'done';
 		searchQuery: string;
 		threads?: Thread[];
@@ -75,12 +78,41 @@
 		error?: Error | undefined;
 		isDone?: boolean;
 		cachedCount?: number;
-		onFilterChange: (mode: 'all' | 'unassigned' | 'my-inbox') => void;
+		onFilterChange: (mode: FilterMode) => void;
 		onStatusChange: (status: 'open' | 'done') => void;
 		onSearchChange: (query: string) => void;
 		onThreadSelect: (id: string) => void;
 		onLoadMore: (numItems: number) => boolean;
 	} = $props();
+
+	// Bits UI drops touch pointers in its hover handlers, so the truncated filter
+	// labels are unreachable on a phone. Drive the tooltips from one open mode
+	// instead: hover, focus and outside dismissal keep writing through the
+	// binding, and a tap re-opens the tooltip that the trigger's own click
+	// handler closes.
+	let openLabel = $state<FilterMode | null>(null);
+	let tapPointerType: string | null = null;
+
+	function setLabelOpen(mode: FilterMode, open: boolean) {
+		if (open) {
+			openLabel = mode;
+		} else if (openLabel === mode) {
+			openLabel = null;
+		}
+	}
+
+	function labelTapProps(mode: FilterMode) {
+		return {
+			onpointerdown: (event: PointerEvent) => {
+				tapPointerType = event.pointerType;
+			},
+			onclick: () => {
+				const wasTap = tapPointerType === 'touch';
+				tapPointerType = null;
+				if (wasTap) openLabel = mode;
+			}
+		};
+	}
 
 	// Skeleton count: use cached count or default to 6
 	const skeletonCount = $derived(cachedCount ?? 6);
@@ -156,16 +188,19 @@
 		</div>
 
 		<!-- Filter Tabs -->
-		<Tabs.Root
-			value={filterMode}
-			onValueChange={(v) => onFilterChange(v as 'all' | 'unassigned' | 'my-inbox')}
-		>
+		<Tabs.Root value={filterMode} onValueChange={(v) => onFilterChange(v as FilterMode)}>
 			<Tabs.List class="w-full">
-				<Tooltip.Root delayDuration={400}>
+				<Tooltip.Root
+					delayDuration={400}
+					bind:open={() => openLabel === 'my-inbox', (open) => setLabelOpen('my-inbox', open)}
+				>
 					<Tooltip.Trigger>
 						{#snippet child({ props })}
+							<!-- The tooltip trigger props carry data-slot="tooltip-trigger"; restate the
+								 tabs slot after them so tabs-list.svelte still finds the active trigger. -->
 							<Tabs.Trigger
-								{...props}
+								{...mergeProps(props, labelTapProps('my-inbox'))}
+								data-slot="tabs-trigger"
 								value="my-inbox"
 								class="min-w-0 overflow-hidden px-1 text-xs"
 							>
@@ -175,21 +210,33 @@
 					</Tooltip.Trigger>
 					<Tooltip.Content side="bottom">{$t('admin.support.filter.my_inbox')}</Tooltip.Content>
 				</Tooltip.Root>
-				<Tooltip.Root delayDuration={400}>
+				<Tooltip.Root
+					delayDuration={400}
+					bind:open={() => openLabel === 'all', (open) => setLabelOpen('all', open)}
+				>
 					<Tooltip.Trigger>
 						{#snippet child({ props })}
-							<Tabs.Trigger {...props} value="all" class="min-w-0 overflow-hidden px-1 text-xs">
+							<Tabs.Trigger
+								{...mergeProps(props, labelTapProps('all'))}
+								data-slot="tabs-trigger"
+								value="all"
+								class="min-w-0 overflow-hidden px-1 text-xs"
+							>
 								<span class="min-w-0 truncate"><T keyName="admin.support.filter.all" /></span>
 							</Tabs.Trigger>
 						{/snippet}
 					</Tooltip.Trigger>
 					<Tooltip.Content side="bottom">{$t('admin.support.filter.all')}</Tooltip.Content>
 				</Tooltip.Root>
-				<Tooltip.Root delayDuration={400}>
+				<Tooltip.Root
+					delayDuration={400}
+					bind:open={() => openLabel === 'unassigned', (open) => setLabelOpen('unassigned', open)}
+				>
 					<Tooltip.Trigger>
 						{#snippet child({ props })}
 							<Tabs.Trigger
-								{...props}
+								{...mergeProps(props, labelTapProps('unassigned'))}
+								data-slot="tabs-trigger"
 								value="unassigned"
 								class="min-w-0 overflow-hidden px-1 text-xs"
 							>

--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -92,6 +92,7 @@
 	// handler closes.
 	let openLabel = $state<FilterMode | null>(null);
 	let tapPointerType: string | null = null;
+	let isPointerDown = false;
 
 	function setLabelOpen(mode: FilterMode, open: boolean) {
 		if (open) {
@@ -105,10 +106,27 @@
 		return {
 			onpointerdown: (event: PointerEvent) => {
 				tapPointerType = event.pointerType;
+				isPointerDown = true;
+			},
+			onpointerup: () => {
+				isPointerDown = false;
+			},
+			// A canceled touch never reaches pointerup, so Bits UI keeps its own
+			// pointer-down flag raised and drops every focus that follows. Clear the
+			// local tap state here and let the focus handler below open the tooltip.
+			onpointercancel: () => {
+				tapPointerType = null;
+				isPointerDown = false;
+			},
+			// Guarded by the pointer state so a press still reveals the tooltip on its
+			// own click instead of flashing it on the focus that precedes the click.
+			onfocus: () => {
+				if (!isPointerDown) openLabel = mode;
 			},
 			onclick: () => {
 				const wasTap = tapPointerType === 'touch';
 				tapPointerType = null;
+				isPointerDown = false;
 				if (wasTap) openLabel = mode;
 			}
 		};
@@ -197,10 +215,14 @@
 					<Tooltip.Trigger>
 						{#snippet child({ props })}
 							<!-- The tooltip trigger props carry data-slot="tooltip-trigger"; restate the
-								 tabs slot after them so tabs-list.svelte still finds the active trigger. -->
+								 tabs slot after them so tabs-list.svelte still finds the active trigger.
+								 They also carry an empty aria-describedby, because Bits UI strips the id
+								 from the rendered tooltip content. Drop the dangling reference and hide
+								 the content: each tab already exposes its full label. -->
 							<Tabs.Trigger
 								{...mergeProps(props, labelTapProps('my-inbox'))}
 								data-slot="tabs-trigger"
+								aria-describedby={undefined}
 								value="my-inbox"
 								class="min-w-0 overflow-hidden px-1 text-xs"
 							>
@@ -208,7 +230,9 @@
 							</Tabs.Trigger>
 						{/snippet}
 					</Tooltip.Trigger>
-					<Tooltip.Content side="bottom">{$t('admin.support.filter.my_inbox')}</Tooltip.Content>
+					<Tooltip.Content side="bottom" aria-hidden="true"
+						>{$t('admin.support.filter.my_inbox')}</Tooltip.Content
+					>
 				</Tooltip.Root>
 				<Tooltip.Root
 					delayDuration={400}
@@ -219,6 +243,7 @@
 							<Tabs.Trigger
 								{...mergeProps(props, labelTapProps('all'))}
 								data-slot="tabs-trigger"
+								aria-describedby={undefined}
 								value="all"
 								class="min-w-0 overflow-hidden px-1 text-xs"
 							>
@@ -226,7 +251,9 @@
 							</Tabs.Trigger>
 						{/snippet}
 					</Tooltip.Trigger>
-					<Tooltip.Content side="bottom">{$t('admin.support.filter.all')}</Tooltip.Content>
+					<Tooltip.Content side="bottom" aria-hidden="true"
+						>{$t('admin.support.filter.all')}</Tooltip.Content
+					>
 				</Tooltip.Root>
 				<Tooltip.Root
 					delayDuration={400}
@@ -237,6 +264,7 @@
 							<Tabs.Trigger
 								{...mergeProps(props, labelTapProps('unassigned'))}
 								data-slot="tabs-trigger"
+								aria-describedby={undefined}
 								value="unassigned"
 								class="min-w-0 overflow-hidden px-1 text-xs"
 							>
@@ -245,7 +273,9 @@
 							</Tabs.Trigger>
 						{/snippet}
 					</Tooltip.Trigger>
-					<Tooltip.Content side="bottom">{$t('admin.support.filter.unassigned')}</Tooltip.Content>
+					<Tooltip.Content side="bottom" aria-hidden="true"
+						>{$t('admin.support.filter.unassigned')}</Tooltip.Content
+					>
 				</Tooltip.Root>
 			</Tabs.List>
 		</Tabs.Root>

--- a/src/routes/[[lang]]/admin/support/thread-list.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-list.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Input } from '$lib/components/ui/input';
 	import * as Tabs from '$lib/components/ui/tabs';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Skeleton } from '$lib/components/ui/skeleton';
@@ -160,15 +161,45 @@
 			onValueChange={(v) => onFilterChange(v as 'all' | 'unassigned' | 'my-inbox')}
 		>
 			<Tabs.List class="w-full">
-				<Tabs.Trigger value="my-inbox" class="min-w-0 overflow-hidden px-1 text-xs">
-					<span class="min-w-0 truncate"><T keyName="admin.support.filter.my_inbox" /></span>
-				</Tabs.Trigger>
-				<Tabs.Trigger value="all" class="min-w-0 overflow-hidden px-1 text-xs">
-					<span class="min-w-0 truncate"><T keyName="admin.support.filter.all" /></span>
-				</Tabs.Trigger>
-				<Tabs.Trigger value="unassigned" class="min-w-0 overflow-hidden px-1 text-xs">
-					<span class="min-w-0 truncate"><T keyName="admin.support.filter.unassigned" /></span>
-				</Tabs.Trigger>
+				<Tooltip.Root delayDuration={400}>
+					<Tooltip.Trigger>
+						{#snippet child({ props })}
+							<Tabs.Trigger
+								{...props}
+								value="my-inbox"
+								class="min-w-0 overflow-hidden px-1 text-xs"
+							>
+								<span class="min-w-0 truncate"><T keyName="admin.support.filter.my_inbox" /></span>
+							</Tabs.Trigger>
+						{/snippet}
+					</Tooltip.Trigger>
+					<Tooltip.Content side="bottom">{$t('admin.support.filter.my_inbox')}</Tooltip.Content>
+				</Tooltip.Root>
+				<Tooltip.Root delayDuration={400}>
+					<Tooltip.Trigger>
+						{#snippet child({ props })}
+							<Tabs.Trigger {...props} value="all" class="min-w-0 overflow-hidden px-1 text-xs">
+								<span class="min-w-0 truncate"><T keyName="admin.support.filter.all" /></span>
+							</Tabs.Trigger>
+						{/snippet}
+					</Tooltip.Trigger>
+					<Tooltip.Content side="bottom">{$t('admin.support.filter.all')}</Tooltip.Content>
+				</Tooltip.Root>
+				<Tooltip.Root delayDuration={400}>
+					<Tooltip.Trigger>
+						{#snippet child({ props })}
+							<Tabs.Trigger
+								{...props}
+								value="unassigned"
+								class="min-w-0 overflow-hidden px-1 text-xs"
+							>
+								<span class="min-w-0 truncate"><T keyName="admin.support.filter.unassigned" /></span
+								>
+							</Tabs.Trigger>
+						{/snippet}
+					</Tooltip.Trigger>
+					<Tooltip.Content side="bottom">{$t('admin.support.filter.unassigned')}</Tooltip.Content>
+				</Tooltip.Root>
 			</Tabs.List>
 		</Tabs.Root>
 	</div>


### PR DESCRIPTION
Regression guard: not warranted, this is a localized visual layout detail without a published DOM contract.

The support inbox filters distributed label-width pills across a fixed sidebar, leaving the active state narrower than the available segments.

The support list now fills its row and lets each trigger shrink to an equal third. Compact spacing and contained labels keep localized copy inside each segment while preserving the settings tabs' `w-fit`, horizontally scrollable behavior. Hover, keyboard focus, and touch taps expose each full localized label.

<!-- pr-media:start -->
| Support filter segments |
| --- |
| <img width="1800" alt="Support filter segments" src="https://github.com/user-attachments/assets/a30e73fe-0e7c-43d6-b2c0-9561d7997612" /> |
<!-- pr-media:end -->

Verified with changed-file static checks, full type checks, and browser measurements across every filter state and the minimum desktop pane width. Labels stay within their segments, pointer targets remain aligned, the active indicator follows selection, tooltips work with pointer, keyboard, and touch input, and the console is clear.