### PR TITLE
fix(auth): Encrypt OAuth tokens by default

### DIFF
--- a/.env-convex.schema
+++ b/.env-convex.schema
@@ -13,6 +13,10 @@
 # @required @sensitive
 BETTER_AUTH_SECRET=
 
+# Versioned keyring for non-destructive secret rotation
+# @optional @sensitive
+BETTER_AUTH_SECRETS=
+
 # Base URL for OAuth redirects and deep links
 # @type=url @required
 SITE_URL=

--- a/.env.convex.example
+++ b/.env.convex.example
@@ -56,6 +56,13 @@ EMAIL_ASSET_URL=https://yourdomain.com
 # Command: bunx convex env set BETTER_AUTH_SECRET your-secure-random-string-here
 BETTER_AUTH_SECRET=your-secure-random-string-here
 
+# Better Auth Versioned Secrets (OPTIONAL)
+# Set this before rotating BETTER_AUTH_SECRET so encrypted OAuth tokens remain readable.
+# List the current key first and retain prior keys: 2:new-secret,1:previous-secret
+# Keep BETTER_AUTH_SECRET set to the previous secret while legacy data may remain.
+# Command: bunx convex env set BETTER_AUTH_SECRETS '2:new-secret,1:previous-secret'
+BETTER_AUTH_SECRETS=
+
 # ====================================
 # OAuth (OPTIONAL)
 # ====================================

--- a/src/lib/convex/__tests__/accountLinking.test.ts
+++ b/src/lib/convex/__tests__/accountLinking.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { describe, expect, it, vi } from 'vitest';
-import { handleOAuthUserInfo } from 'better-auth/oauth2';
+import { decryptOAuthToken, handleOAuthUserInfo } from 'better-auth/oauth2';
 
 /**
  * Contract test against the installed Better Auth.
@@ -36,7 +36,10 @@ vi.mock('../_generated/server', () => ({
 const { createAuthOptions } = await import('../auth');
 
 const appOptions = createAuthOptions({} as never) as {
-	account?: { accountLinking?: { requireLocalEmailVerified?: boolean } };
+	account?: {
+		encryptOAuthTokens?: boolean;
+		accountLinking?: { requireLocalEmailVerified?: boolean };
+	};
 };
 
 type LinkContext = Parameters<typeof handleOAuthUserInfo>[0];
@@ -55,6 +58,8 @@ const providerAccount = {
 	scope: 'openid email profile'
 };
 
+type LinkedAccountWrite = typeof providerAccount & { userId: string };
+
 const providerUserInfo = {
 	id: 'google-account-id',
 	email: 'squatted@example.com',
@@ -71,7 +76,10 @@ function createContext(localUser: { id: string; email: string; emailVerified: bo
 			accounts: [{ providerId: 'credential', accountId: localUser.id }],
 			linkedAccount: undefined
 		})),
-		linkAccount: vi.fn(async () => ({ id: 'linked-account-id' })),
+		linkAccount: vi.fn(async (account: LinkedAccountWrite) => ({
+			id: 'linked-account-id',
+			...account
+		})),
 		updateUser: vi.fn(async () => localUser),
 		updateAccount: vi.fn(async () => undefined),
 		createSession: vi.fn(async () => ({ id: 'session-id', userId: localUser.id }))
@@ -88,6 +96,7 @@ function createContext(localUser: { id: string; email: string; emailVerified: bo
 			options: { account: appOptions.account },
 			baseURL: 'https://example.test/api/auth',
 			secret: 'test-secret',
+			secretConfig: 'test-secret',
 			logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }
 		}
 	};
@@ -121,7 +130,7 @@ describe('implicit OAuth account linking', () => {
 		expect(internalAdapter.createSession).not.toHaveBeenCalled();
 	});
 
-	it('still links into a local user that did verify its email', async () => {
+	it('links a verified local user with encrypted OAuth tokens', async () => {
 		const { context, internalAdapter } = createContext({
 			id: 'local-user-id',
 			email: 'squatted@example.com',
@@ -132,6 +141,18 @@ describe('implicit OAuth account linking', () => {
 
 		expect(result.error).toBeNull();
 		expect(internalAdapter.linkAccount).toHaveBeenCalledTimes(1);
+		const linkedAccount = internalAdapter.linkAccount.mock.calls[0]?.[0];
+		if (!linkedAccount) throw new Error('Better Auth did not write the linked account');
+		expect(typeof linkedAccount.accessToken).toBe('string');
+		expect(typeof linkedAccount.refreshToken).toBe('string');
+		expect(linkedAccount.accessToken).not.toBe(providerAccount.accessToken);
+		expect(linkedAccount.refreshToken).not.toBe(providerAccount.refreshToken);
+		expect(await decryptOAuthToken(linkedAccount.accessToken, context.context)).toBe(
+			providerAccount.accessToken
+		);
+		expect(await decryptOAuthToken(linkedAccount.refreshToken, context.context)).toBe(
+			providerAccount.refreshToken
+		);
 		expect(internalAdapter.createSession).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -385,6 +385,9 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>) => {
 				}
 			}
 		},
+		account: {
+			encryptOAuthTokens: true
+		},
 		emailAndPassword: {
 			enabled: true,
 			minPasswordLength: 10,

--- a/src/lib/convex/convex.config.ts
+++ b/src/lib/convex/convex.config.ts
@@ -33,6 +33,7 @@ const app = defineApp({
 		AUTUMN_SECRET_KEY: v.string(),
 		OPENROUTER_API_KEY: v.string(),
 		// Optional
+		BETTER_AUTH_SECRETS: v.optional(v.string()),
 		RESEND_WEBHOOK_SECRET: v.optional(v.string()),
 		AUTH_GOOGLE_ID: v.optional(v.string()),
 		AUTH_GOOGLE_SECRET: v.optional(v.string()),


### PR DESCRIPTION
Regression guard: added OAuth token encryption assertions to the installed Better Auth account-linking contract test.

Better Auth stores provider access and refresh tokens as plaintext unless OAuth token encryption is enabled. The template now enables its encryption path before the Convex adapter writes either token.

Versioned Better Auth secrets allow non-destructive rotation, with the singular secret kept as the fallback for legacy ciphertext. The contract test proves both stored tokens differ from provider plaintext and decrypt to their original values.

Verified with targeted unit tests, a negative control, changed-file static checks, full type checks, the Convex type check, and direct rotation probes.