### PR TITLE
fix(lint): Preserve quoted consumer paths

### DIFF
--- a/scripts/convex-consumer-compat.ts
+++ b/scripts/convex-consumer-compat.ts
@@ -423,8 +423,8 @@ function isConsumerSource(line: string): boolean {
 }
 
 function consumerReferencesAt(commit: string): ConsumerReferences {
-	const files = git(['ls-tree', '-r', '--name-only', commit, '--', CONSUMER_ROOT])
-		.split('\n')
+	const files = git(['ls-tree', '-r', '-z', '--name-only', commit, '--', CONSUMER_ROOT])
+		.split('\0')
 		.filter(isConsumerSource);
 	const references: Reference[] = [];
 	const namespaces: NamespaceReference[] = [];

--- a/scripts/static-checks.compat.test.ts
+++ b/scripts/static-checks.compat.test.ts
@@ -327,6 +327,79 @@ describe('Convex compatibility static-check entrypoint', () => {
 	);
 
 	it.skipIf(process.platform === 'win32')(
+		'keeps a Unicode consumer path in the deployed contract',
+		() => {
+			const checkout = createCheckerClone();
+			const env = sanitizedGitEnv();
+			delete env.CI;
+			delete env.CONVEX_COMPAT_BASE;
+			const git = (args: string[]) =>
+				spawnSync('git', args, {
+					cwd: checkout.repository,
+					env,
+					encoding: 'utf8'
+				});
+			const commit = (message: string) =>
+				git([
+					'-c',
+					'user.name=Probe',
+					'-c',
+					'user.email=probe@example.com',
+					'commit',
+					'--quiet',
+					'--no-gpg-sign',
+					'--no-verify',
+					'-m',
+					message
+				]);
+			try {
+				const convexRoot = path.join(checkout.repository, 'src', 'lib', 'convex');
+				const target = path.join(convexRoot, 'compatUnicodeTarget.ts');
+				const route = path.join(checkout.repository, 'src', 'routes', 'überblick');
+				mkdirSync(route, { recursive: true });
+				writeFileSync(
+					target,
+					`import { query } from './_generated/server';
+
+export const viewer = query({ args: {}, handler: async () => null });
+`
+				);
+				writeFileSync(
+					path.join(route, '+page.server.ts'),
+					`import { api } from '$lib/convex/_generated/api';
+
+void api.compatUnicodeTarget.viewer;
+`
+				);
+				expect(git(['add', '--all']).status).toBe(0);
+				expect(commit('Add Unicode consumer').status).toBe(0);
+				const baseline = git(['rev-parse', 'HEAD']).stdout.trim();
+				rmSync(target);
+				expect(git(['add', '--all']).status).toBe(0);
+				expect(commit('Remove referenced function').status).toBe(0);
+
+				const result = spawnSync(
+					BUN,
+					[path.join(checkout.repository, 'scripts', 'convex-consumer-compat.ts')],
+					{
+						cwd: checkout.repository,
+						env: { ...env, CONVEX_COMPAT_BASE: baseline },
+						encoding: 'utf8',
+						timeout: 180_000
+					}
+				);
+				const output = `${result.stdout}${result.stderr}`;
+				expect(result.status, output).toBe(1);
+				expect(output).toContain('compatUnicodeTarget:viewer');
+				expect(output).toContain('src/routes/überblick/+page.server.ts');
+			} finally {
+				rmSync(checkout.directory, { recursive: true, force: true });
+			}
+		},
+		240_000
+	);
+
+	it.skipIf(process.platform === 'win32')(
 		'rejects an unsafe repository path before the compatibility child runs',
 		() => {
 			const checkout = createCheckerClone();


### PR DESCRIPTION
Regression guard: added a real Unicode-path compatibility fixture

The compatibility checker read `git ls-tree` as newline-separated display text. Git quotes non-ASCII and control-character paths by default, so the extension filter silently dropped a valid consumer such as `src/routes/überblick/+page.server.ts`. Removing the function it referenced could then pass the deployment gate.

The baseline scan now requests NUL-separated path records and passes each unchanged path to `git show`. The process fixture commits a Unicode route, removes its referenced Convex function, and proves that the real checker reports both the function and original path.

Verified with 1,825 passing unit tests, the real compatibility check, changed-file static checks, type checks, and an independent review with no findings.
