### PR TITLE
fix(motion): Stabilize interaction states

### DIFF
--- a/src/lib/components/customer-support/threads-overview.svelte
+++ b/src/lib/components/customer-support/threads-overview.svelte
@@ -233,7 +233,7 @@
 					<!-- Presentation only: the faces say who will answer, they are not a choice
 					     the user can make, so the row lifts on hover and carries no cursor,
 					     focus ring or click target. -->
-					<div class="mb-6 flex -space-x-3" use:avatarGroupHover>
+					<div class="mb-6 flex -space-x-3" {@attach avatarGroupHover}>
 						{#if showBotIcon}
 							<!-- Avatar 1: Bot icon (only shown when <3 admins) -->
 							<motion.div

--- a/src/lib/components/motion/avatar-group-hover.svelte.ts
+++ b/src/lib/components/motion/avatar-group-hover.svelte.ts
@@ -1,3 +1,4 @@
+import type { Attachment } from 'svelte/attachments';
 import { motionEase, motionValue } from './motion-tokens.js';
 
 /**
@@ -10,7 +11,7 @@ import { motionEase, motionValue } from './motion-tokens.js';
  * Presentation only. It binds no click handler and sets no cursor, so a row
  * the user cannot act on does not start advertising that they can.
  */
-export function avatarGroupHover(node: HTMLElement) {
+export const avatarGroupHover: Attachment<HTMLElement> = (node) => {
 	let items: HTMLElement[] = [];
 
 	function setShifts(activeIndex: number | null, phase: 'in' | 'out') {
@@ -91,10 +92,8 @@ export function avatarGroupHover(node: HTMLElement) {
 	hoverCapable.addEventListener('change', syncCapability);
 	syncCapability();
 
-	return {
-		destroy() {
-			hoverCapable.removeEventListener('change', syncCapability);
-			disable();
-		}
+	return () => {
+		hoverCapable.removeEventListener('change', syncCapability);
+		disable();
 	};
-}
+};

--- a/src/lib/components/motion/learn-more-chevron.svelte
+++ b/src/lib/components/motion/learn-more-chevron.svelte
@@ -4,11 +4,12 @@
 	/**
 	 * The trailing chevron of a "Learn more" style control. On hover it slides
 	 * along the reading direction and its two arms spread apart into an arrow.
+	 * Fine-pointer hover and keyboard focus drive the same decorative state.
 	 *
 	 * Drawn as two separate strokes rather than one polyline because the arms
 	 * have to rotate independently about the apex at (10, 8). Purely decorative:
-	 * the motion is hover-only, so nothing it conveys is lost on keyboard or
-	 * touch. Requires `t-learn` on the hovered ancestor.
+	 * the motion conveys no state, so coarse pointers keep the resting shape.
+	 * Requires `t-learn` on the interactive ancestor.
 	 */
 	let { class: className }: { class?: string } = $props();
 </script>

--- a/src/lib/components/motion/motion-a11y.test.ts
+++ b/src/lib/components/motion/motion-a11y.test.ts
@@ -75,20 +75,26 @@ describe('motion attachments', () => {
 	it('owns the thinking entrance through an attachment cleanup', () => {
 		expect(thinking).toContain('Attachment<HTMLElement>');
 		expect(thinking).toContain('{@attach line.entrance}');
+		expect(thinking).toContain('clearTimeout(held);');
+		expect(thinking).toContain('cancelAnimationFrame(frame);');
 		expect(thinking).not.toContain('use:enter');
 	});
 
-	it('keeps the thinking entrance attachment stable across line replacement', () => {
+	it('keeps the thinking entrance attachment stable across keyed line replacement', () => {
 		expect(thinking).toContain('entrance: Attachment<HTMLElement>');
 		expect(thinking).toContain('entrance: enter(true)');
+		expect(thinking).toContain('{#each lines as line (line.id)}');
 		expect(thinking).toContain(
 			'...untrack(() => lines).map((line) => ({ ...line, exiting: true }))'
 		);
 		expect(thinking).not.toMatch(/\{@attach\s+enter\(/);
 	});
 
-	it('attaches the avatar lifecycle instead of using a legacy action', () => {
+	it('attaches and tears down the avatar lifecycle', () => {
 		expect(avatar).toContain('Attachment<HTMLElement>');
+		expect(avatar).toContain("hoverCapable.removeEventListener('change', syncCapability);");
+		expect(avatar).toContain('observer?.disconnect();');
+		expect(avatar).toContain('disable();');
 		expect(overview).toContain('{@attach avatarGroupHover}');
 		expect(overview).not.toContain('use:avatarGroupHover');
 	});

--- a/src/lib/components/motion/motion-a11y.test.ts
+++ b/src/lib/components/motion/motion-a11y.test.ts
@@ -74,8 +74,14 @@ describe('motion attachments', () => {
 
 	it('owns the thinking entrance through an attachment cleanup', () => {
 		expect(thinking).toContain('Attachment<HTMLElement>');
-		expect(thinking).toContain('{@attach enter(line.entering)}');
+		expect(thinking).toContain('{@attach line.entrance}');
 		expect(thinking).not.toContain('use:enter');
+	});
+
+	it('keeps the thinking entrance attachment stable across line replacement', () => {
+		expect(thinking).toContain('entrance: Attachment<HTMLElement>');
+		expect(thinking).toContain('entrance: enter(true)');
+		expect(thinking).not.toMatch(/\{@attach\s+enter\(/);
 	});
 
 	it('attaches the avatar lifecycle instead of using a legacy action', () => {

--- a/src/lib/components/motion/motion-a11y.test.ts
+++ b/src/lib/components/motion/motion-a11y.test.ts
@@ -81,6 +81,9 @@ describe('motion attachments', () => {
 	it('keeps the thinking entrance attachment stable across line replacement', () => {
 		expect(thinking).toContain('entrance: Attachment<HTMLElement>');
 		expect(thinking).toContain('entrance: enter(true)');
+		expect(thinking).toContain(
+			'...untrack(() => lines).map((line) => ({ ...line, exiting: true }))'
+		);
 		expect(thinking).not.toMatch(/\{@attach\s+enter\(/);
 	});
 

--- a/src/lib/components/motion/motion-a11y.test.ts
+++ b/src/lib/components/motion/motion-a11y.test.ts
@@ -66,3 +66,21 @@ describe('thinking states', () => {
 		expect(labelBefore(template, 't-think')).toBe(true);
 	});
 });
+
+describe('motion attachments', () => {
+	const thinking = readFileSync(join(dir, 'thinking-states.svelte'), 'utf8');
+	const avatar = readFileSync(join(dir, 'avatar-group-hover.svelte.ts'), 'utf8');
+	const overview = readFileSync(join(dir, '../customer-support/threads-overview.svelte'), 'utf8');
+
+	it('owns the thinking entrance through an attachment cleanup', () => {
+		expect(thinking).toContain('Attachment<HTMLElement>');
+		expect(thinking).toContain('{@attach enter(line.entering)}');
+		expect(thinking).not.toContain('use:enter');
+	});
+
+	it('attaches the avatar lifecycle instead of using a legacy action', () => {
+		expect(avatar).toContain('Attachment<HTMLElement>');
+		expect(overview).toContain('{@attach avatarGroupHover}');
+		expect(overview).not.toContain('use:avatarGroupHover');
+	});
+});

--- a/src/lib/components/motion/thinking-states.svelte
+++ b/src/lib/components/motion/thinking-states.svelte
@@ -32,14 +32,19 @@
 		class?: string;
 	} = $props();
 
-	type Line = { id: number; text: string; entering: boolean; exiting: boolean };
+	type Line = {
+		id: number;
+		text: string;
+		entrance: Attachment<HTMLElement>;
+		exiting: boolean;
+	};
 
 	let nextId = 1;
 	// The first line is the mount value, not a reactive read: later values arrive
 	// through the effect below, which has to know the previous one to animate it out.
 	const initial = untrack(() => text);
 	let shown = initial;
-	let lines = $state<Line[]>([{ id: 0, text: initial, entering: false, exiting: false }]);
+	let lines = $state<Line[]>([{ id: 0, text: initial, entrance: enter(false), exiting: false }]);
 
 	$effect(() => {
 		const next = text;
@@ -48,7 +53,7 @@
 
 		lines = [
 			...untrack(() => lines).map((line) => ({ ...line, exiting: true })),
-			{ id: nextId++, text: next, entering: true, exiting: false }
+			{ id: nextId++, text: next, entrance: enter(true), exiting: false }
 		];
 
 		// The exit runs for `--think-swap`, the entrance starts `--think-gap` later
@@ -76,6 +81,11 @@
 	 * put an already-entered line in the entrance branch forever, so from the
 	 * second swap on the outgoing label never got `is-exit`: it stayed put under
 	 * the incoming one and then vanished when the settle timer removed it.
+	 *
+	 * The attachment factory result lives on the keyed line so copying that line
+	 * into its exiting state preserves the function identity. Calling the factory
+	 * from the markup would reattach the surviving line and restore the entrance
+	 * class while its exit is running.
 	 */
 	function enter(active: boolean): Attachment<HTMLElement> {
 		return (node) => {
@@ -116,7 +126,7 @@
 			class="t-think-text"
 			class:is-exit={line.exiting}
 			data-text={line.text}
-			{@attach enter(line.entering)}>{line.text}</span
+			{@attach line.entrance}>{line.text}</span
 		>
 	{/each}
 </span>

--- a/src/lib/components/motion/thinking-states.svelte
+++ b/src/lib/components/motion/thinking-states.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
+	import type { Attachment } from 'svelte/attachments';
 	import { cn } from '$lib/utils.js';
 	import { motionValue } from './motion-tokens.js';
 
@@ -76,21 +77,21 @@
 	 * second swap on the outgoing label never got `is-exit`: it stayed put under
 	 * the incoming one and then vanished when the settle timer removed it.
 	 */
-	function enter(node: HTMLElement, active: boolean) {
-		if (!active) return;
-		node.classList.add('is-enter-start');
-		let frame = 0;
-		const held = setTimeout(
-			() => {
-				frame = requestAnimationFrame(() => node.classList.remove('is-enter-start'));
-			},
-			motionValue('--think-gap', 50)
-		);
-		return {
-			destroy: () => {
+	function enter(active: boolean): Attachment<HTMLElement> {
+		return (node) => {
+			if (!active) return;
+			node.classList.add('is-enter-start');
+			let frame = 0;
+			const held = setTimeout(
+				() => {
+					frame = requestAnimationFrame(() => node.classList.remove('is-enter-start'));
+				},
+				motionValue('--think-gap', 50)
+			);
+			return () => {
 				clearTimeout(held);
 				cancelAnimationFrame(frame);
-			}
+			};
 		};
 	}
 </script>
@@ -115,7 +116,7 @@
 			class="t-think-text"
 			class:is-exit={line.exiting}
 			data-text={line.text}
-			use:enter={line.entering}>{line.text}</span
+			{@attach enter(line.entering)}>{line.text}</span
 		>
 	{/each}
 </span>

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -998,18 +998,42 @@
 	vector-effect: non-scaling-stroke;
 	transition: transform var(--learn-out) var(--learn-ease);
 }
-.t-learn:hover .t-learn-chevron {
+.t-learn:focus-visible .t-learn-chevron {
 	transform: translateX(var(--learn-shift));
 	transition-duration: var(--learn-in);
 }
-.t-learn:hover .t-learn-arm {
+.t-learn:focus-visible .t-learn-arm {
 	transition-duration: var(--learn-in);
 }
-.t-learn:hover .t-learn-arm-top {
+.t-learn:focus-visible .t-learn-arm-top {
 	transform: rotate(var(--learn-spread));
 }
-.t-learn:hover .t-learn-arm-bot {
+.t-learn:focus-visible .t-learn-arm-bot {
 	transform: rotate(calc(var(--learn-spread) * -1));
+}
+:where([dir='rtl']) .t-learn-chevron {
+	transform: scaleX(-1);
+}
+:where([dir='rtl']) .t-learn:focus-visible .t-learn-chevron {
+	transform: translateX(calc(var(--learn-shift) * -1)) scaleX(-1);
+}
+@media (hover: hover) and (pointer: fine) {
+	.t-learn:hover .t-learn-chevron {
+		transform: translateX(var(--learn-shift));
+		transition-duration: var(--learn-in);
+	}
+	.t-learn:hover .t-learn-arm {
+		transition-duration: var(--learn-in);
+	}
+	.t-learn:hover .t-learn-arm-top {
+		transform: rotate(var(--learn-spread));
+	}
+	.t-learn:hover .t-learn-arm-bot {
+		transform: rotate(calc(var(--learn-spread) * -1));
+	}
+	:where([dir='rtl']) .t-learn:hover .t-learn-chevron {
+		transform: translateX(calc(var(--learn-shift) * -1)) scaleX(-1);
+	}
 }
 /* Checkbox check: the box fills, then the tick draws itself. `--check-len`
    is the path's own getTotalLength() rounded up, so the stroke neither

--- a/src/routes/layout.motion-hooks.test.ts
+++ b/src/routes/layout.motion-hooks.test.ts
@@ -25,6 +25,21 @@ function componentFiles(dir: string, out: string[] = []): string[] {
 	return out;
 }
 
+function blockBody(source: string, marker: string, from = 0): string {
+	const markerIndex = source.indexOf(marker, from);
+	if (markerIndex === -1) throw new Error(`Missing CSS block ${marker}`);
+	const open = source.indexOf('{', markerIndex);
+	if (open === -1) throw new Error(`Missing opening brace for ${marker}`);
+	let depth = 0;
+	for (let index = open; index < source.length; index += 1) {
+		if (source[index] === '{') depth += 1;
+		if (source[index] !== '}') continue;
+		depth -= 1;
+		if (depth === 0) return source.slice(open + 1, index);
+	}
+	throw new Error(`Missing closing brace for ${marker}`);
+}
+
 /**
  * Only what a component actually renders counts. Three kinds of text mention a
  * hook without applying it, and each of them let a real miss through when it was
@@ -113,31 +128,72 @@ describe('checkbox tick draw order', () => {
 
 describe('learn-more interaction parity', () => {
 	const learnMoreStart = css.indexOf('/* Learn more hover:');
-	const hoverCapabilityStart = css.indexOf(
-		'@media (hover: hover) and (pointer: fine)',
-		learnMoreStart
-	);
+	const hoverMarker = '@media (hover: hover) and (pointer: fine)';
+	const hoverCapabilityStart = css.indexOf(hoverMarker, learnMoreStart);
+	const hoverCss = blockBody(css, hoverMarker, learnMoreStart);
 
-	it('moves on keyboard focus without requiring hover capability', () => {
+	it('moves and spreads both arms on keyboard focus outside hover capability', () => {
 		const focusRule = css.indexOf('.t-learn:focus-visible .t-learn-chevron {', learnMoreStart);
 		expect(focusRule).toBeGreaterThan(learnMoreStart);
 		expect(focusRule).toBeLessThan(hoverCapabilityStart);
-		expect(css).toMatch(/\.t-learn:focus-visible \.t-learn-arm-top \{/);
+		expect(blockBody(css, '.t-learn:focus-visible .t-learn-chevron', learnMoreStart)).toMatch(
+			/translateX\(var\(--learn-shift\)\)/
+		);
+		expect(blockBody(css, '.t-learn:focus-visible .t-learn-arm', learnMoreStart)).toMatch(
+			/transition-duration:\s*var\(--learn-in\)/
+		);
+		expect(blockBody(css, '.t-learn:focus-visible .t-learn-arm-top', learnMoreStart)).toMatch(
+			/rotate\(var\(--learn-spread\)\)/
+		);
+		expect(blockBody(css, '.t-learn:focus-visible .t-learn-arm-bot', learnMoreStart)).toMatch(
+			/rotate\(calc\(var\(--learn-spread\) \* -1\)\)/
+		);
 	});
 
-	it('limits hover motion to a fine hover-capable pointer', () => {
-		expect(css).toMatch(
-			/@media \(hover: hover\) and \(pointer: fine\) \{[\s\S]*?\.t-learn:hover \.t-learn-chevron/
+	it('keeps the complete hover motion inside fine-pointer capability', () => {
+		expect(blockBody(hoverCss, '.t-learn:hover .t-learn-chevron')).toMatch(
+			/translateX\(var\(--learn-shift\)\)/
+		);
+		expect(blockBody(hoverCss, '.t-learn:hover .t-learn-arm')).toMatch(
+			/transition-duration:\s*var\(--learn-in\)/
+		);
+		expect(blockBody(hoverCss, '.t-learn:hover .t-learn-arm-top')).toMatch(
+			/rotate\(var\(--learn-spread\)\)/
+		);
+		expect(blockBody(hoverCss, '.t-learn:hover .t-learn-arm-bot')).toMatch(
+			/rotate\(calc\(var\(--learn-spread\) \* -1\)\)/
 		);
 	});
 
 	it('points and moves along the RTL reading direction', () => {
-		expect(css).toMatch(/:where\(\[dir='rtl'\]\) \.t-learn-chevron \{[^}]*scaleX\(-1\)/s);
-		expect(css).toMatch(
-			/:where\(\[dir='rtl'\]\) \.t-learn:focus-visible \.t-learn-chevron \{[^}]*translateX\(calc\(var\(--learn-shift\) \* -1\)\)[^}]*scaleX\(-1\)/s
+		expect(blockBody(css, ":where([dir='rtl']) .t-learn-chevron", learnMoreStart)).toMatch(
+			/scaleX\(-1\)/
 		);
-		expect(css.slice(hoverCapabilityStart)).toMatch(
-			/:where\(\[dir='rtl'\]\) \.t-learn:hover \.t-learn-chevron \{[^}]*translateX\(calc\(var\(--learn-shift\) \* -1\)\)[^}]*scaleX\(-1\)/s
+		expect(
+			blockBody(css, ":where([dir='rtl']) .t-learn:focus-visible .t-learn-chevron", learnMoreStart)
+		).toMatch(/translateX\(calc\(var\(--learn-shift\) \* -1\)\).*scaleX\(-1\)/s);
+		expect(blockBody(hoverCss, ":where([dir='rtl']) .t-learn:hover .t-learn-chevron")).toMatch(
+			/translateX\(calc\(var\(--learn-shift\) \* -1\)\).*scaleX\(-1\)/s
 		);
+	});
+});
+
+describe('learn-more consumers', () => {
+	const hero = readFileSync(join(root, 'src/blocks/hero/hero-five.svelte'), 'utf8');
+	const integration = readFileSync(
+		join(root, 'src/blocks/integration/card/integration-card.svelte'),
+		'utf8'
+	);
+	const support = readFileSync(
+		join(root, 'src/lib/components/customer-support/threads-overview.svelte'),
+		'utf8'
+	);
+	const wiredControl =
+		/<(?:Button|button)\b[^>]*class="[^"]*\bt-learn\b[^"]*"[^>]*>[\s\S]*?<LearnMoreChevron\b[\s\S]*?<\/(?:Button|button)>/g;
+
+	it('keeps every real chevron below a focusable motion owner', () => {
+		expect(hero.match(wiredControl)).toHaveLength(1);
+		expect(integration.match(wiredControl)).toHaveLength(2);
+		expect(support.match(wiredControl)).toHaveLength(1);
 	});
 });

--- a/src/routes/layout.motion-hooks.test.ts
+++ b/src/routes/layout.motion-hooks.test.ts
@@ -110,3 +110,23 @@ describe('checkbox tick draw order', () => {
 		expect(icon).toContain('"d": "M20 6 9 17l-5-5"');
 	});
 });
+
+describe('learn-more interaction parity', () => {
+	it('moves on keyboard focus without requiring hover capability', () => {
+		expect(css).toMatch(/\.t-learn:focus-visible \.t-learn-chevron \{/);
+		expect(css).toMatch(/\.t-learn:focus-visible \.t-learn-arm-top \{/);
+	});
+
+	it('limits hover motion to a fine hover-capable pointer', () => {
+		expect(css).toMatch(
+			/@media \(hover: hover\) and \(pointer: fine\) \{[\s\S]*?\.t-learn:hover \.t-learn-chevron/
+		);
+	});
+
+	it('points and moves along the RTL reading direction', () => {
+		expect(css).toMatch(/:where\(\[dir='rtl'\]\) \.t-learn-chevron \{[^}]*scaleX\(-1\)/s);
+		expect(css).toMatch(
+			/:where\(\[dir='rtl'\]\) \.t-learn:focus-visible \.t-learn-chevron \{[^}]*translateX\(calc\(var\(--learn-shift\) \* -1\)\)[^}]*scaleX\(-1\)/s
+		);
+	});
+});

--- a/src/routes/layout.motion-hooks.test.ts
+++ b/src/routes/layout.motion-hooks.test.ts
@@ -112,8 +112,16 @@ describe('checkbox tick draw order', () => {
 });
 
 describe('learn-more interaction parity', () => {
+	const learnMoreStart = css.indexOf('/* Learn more hover:');
+	const hoverCapabilityStart = css.indexOf(
+		'@media (hover: hover) and (pointer: fine)',
+		learnMoreStart
+	);
+
 	it('moves on keyboard focus without requiring hover capability', () => {
-		expect(css).toMatch(/\.t-learn:focus-visible \.t-learn-chevron \{/);
+		const focusRule = css.indexOf('.t-learn:focus-visible .t-learn-chevron {', learnMoreStart);
+		expect(focusRule).toBeGreaterThan(learnMoreStart);
+		expect(focusRule).toBeLessThan(hoverCapabilityStart);
 		expect(css).toMatch(/\.t-learn:focus-visible \.t-learn-arm-top \{/);
 	});
 
@@ -127,6 +135,9 @@ describe('learn-more interaction parity', () => {
 		expect(css).toMatch(/:where\(\[dir='rtl'\]\) \.t-learn-chevron \{[^}]*scaleX\(-1\)/s);
 		expect(css).toMatch(
 			/:where\(\[dir='rtl'\]\) \.t-learn:focus-visible \.t-learn-chevron \{[^}]*translateX\(calc\(var\(--learn-shift\) \* -1\)\)[^}]*scaleX\(-1\)/s
+		);
+		expect(css.slice(hoverCapabilityStart)).toMatch(
+			/:where\(\[dir='rtl'\]\) \.t-learn:hover \.t-learn-chevron \{[^}]*translateX\(calc\(var\(--learn-shift\) \* -1\)\)[^}]*scaleX\(-1\)/s
 		);
 	});
 });


### PR DESCRIPTION
Regression guard: added motion interaction contract tests

Several motion helpers still used legacy Svelte actions, and the Learn More chevron only matched mouse hover. Repeated Thinking state changes could also reattach an entering line and suppress its exit.

This change moves DOM lifecycles to Svelte 5 attachments, preserves attachment identity across keyed state changes, gates decorative avatar hover to fine pointers, and aligns Learn More across keyboard focus, RTL, and touch-capability boundaries. Regression tests pin lifecycle cleanup, each real consumer, and the complete focus and hover arm motion.

Verified with changed-file static checks, full type checks, a browser regression probe, 1,832 passing unit tests, and independent review rounds with no remaining production defect.
