### PR TITLE
feat(ai-chat): Add AI disclosure

### DIFF
--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -210,6 +210,11 @@
 					}
 				}}
 			/>
+			<p
+				class="pointer-events-none mt-1.5 px-4 pb-2 text-center text-[11px] text-balance text-muted-foreground"
+			>
+				{$t('support.chatbar.disclosure')}
+			</p>
 		</div>
 	</ChatRoot>
 </div>


### PR DESCRIPTION
Adds the existing localized AI disclosure below the standalone AI Chat composer so users see the same transparency notice as in the support widget.

The notice reuses `support.chatbar.disclosure` and keeps a small gap below the composer so its shadow does not overlap the text.

<!-- pr-media:start -->
| AI disclosure |
| --- |
| <img width="1800" alt="AI disclosure" src="https://github.com/user-attachments/assets/279cbdd2-e6ee-40d6-9863-8f911beee61e" /> |
<!-- pr-media:end -->

Verified with the repository static checks, the full type check, and an authenticated local browser pass.
