### PR TITLE
fix(skills): Scope the upstream-report shell grant

### DIFF
--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -32,8 +32,7 @@ cd <printed root>
 bun run upstream:report
 ```
 
-Arguments go after `--` and are repository-relative in this form. Invoked by its own absolute
-path instead, the script keeps them relative to your directory.
+Arguments go after `--` and are repository-relative.
 
 With no arguments it takes every file changed against the merge-base with `origin/main`,
 plus staged, unstaged, and untracked work, and both sides of a rename. Pass explicit paths

--- a/.agents/skills/upstream-report/SKILL.md
+++ b/.agents/skills/upstream-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: upstream-report
 description: Always load in a content-copy fork before acting on any work that might also matter to the base project, or as soon as that possibility appears. Treat uncertain ownership as possible relevance. Do not load in the base project itself.
-allowed-tools: Bash, Read, Grep, Glob
+allowed-tools: Bash(bun run upstream:report:*), Bash(gh search issues:*), Bash(gh issue list:*), Read, Grep, Glob
 ---
 
 # Report a fix upstream
@@ -21,11 +21,14 @@ bun run upstream:report
 ```
 
 Run the package script from the repository root. Bun resolves scripts from the current
-package, so a nested package such as `voice-gateway/` cannot see this one. Move to the root
-first when needed:
+package, so a nested package such as `voice-gateway/` cannot see this one. From a nested
+package, print the root and change to that literal path first. A command substitution such
+as `cd "$(git rev-parse --show-toplevel)"` cannot be matched against this skill's command
+grant and prompts for permission instead:
 
 ```bash
-cd "$(git rev-parse --show-toplevel)"
+git rev-parse --show-toplevel
+cd <printed root>
 bun run upstream:report
 ```
 


### PR DESCRIPTION
Regression guard: not warranted, no repository check parses skill frontmatter grants; the grant behavior was measured by hand on Claude Code 2.1.258.

The skill description now fires before any work that might matter to the base project, so the frontmatter grant activates far more often than at the two lifecycle points it was written for. A bare `Bash` grant pre-approves every shell command for a user-invoked run of the skill, including commands shaped by untrusted repository content.

The grant is limited to the three commands the skill body runs: the detector and the two read-only issue searches. The root transition for nested packages no longer uses a command substitution, which the permission matcher rejects even with an explicit `cd` grant; the body prints the root and changes to the literal path instead.

Measured on Claude Code 2.1.258 with a fixture skill: the grant applies only to user-invoked runs, the scoped form is enforced there, and a second unlisted command prompts. Changed-file static checks pass.
