### PR TITLE
fix(chat): Reconcile the two views of one message

### DIFF
--- a/src/lib/chat/core/reasoning-handover.contract.test.ts
+++ b/src/lib/chat/core/reasoning-handover.contract.test.ts
@@ -1,0 +1,167 @@
+// The reasoning merge exists because the two producers describe the same
+// response differently, so the shapes it merges are drawn here from the real
+// producers instead of written by hand: `readUIMessageStream` from the AI SDK
+// for the live snapshot, `toUIMessages` from the Convex agent for the persisted
+// copy. A hand-written pair is a claim about those packages, and this file is
+// what turns the claim into something an upgrade can fail.
+
+import { describe, expect, it } from 'vitest';
+import { readUIMessageStream } from 'ai';
+import { toUIMessages } from '@convex-dev/agent';
+import type { UIMessage } from '@convex-dev/agent';
+import { mergeAssistantMessageParts } from './stream-materialization.js';
+
+/** The wire chunks a two-step tool response produces, in order. */
+function responseChunks(firstThought: string, secondThought: string) {
+	return [
+		{ type: 'start' },
+		{ type: 'start-step' },
+		{ type: 'reasoning-start', id: 'r-first' },
+		{ type: 'reasoning-delta', id: 'r-first', delta: firstThought },
+		{ type: 'reasoning-end', id: 'r-first' },
+		{ type: 'tool-input-start', toolCallId: 'call-1', toolName: 'lookup' },
+		{ type: 'tool-input-available', toolCallId: 'call-1', toolName: 'lookup', input: {} },
+		{ type: 'tool-output-available', toolCallId: 'call-1', output: { ok: true } },
+		{ type: 'finish-step' },
+		{ type: 'start-step' },
+		{ type: 'reasoning-start', id: 'r-second' },
+		{ type: 'reasoning-delta', id: 'r-second', delta: secondThought },
+		{ type: 'reasoning-end', id: 'r-second' },
+		{ type: 'text-start', id: 't-1' },
+		{ type: 'text-delta', id: 't-1', delta: 'the answer' },
+		{ type: 'text-end', id: 't-1' },
+		{ type: 'finish-step' },
+		{ type: 'finish' }
+	];
+}
+
+/** The stored rows the same response leaves behind, in order. */
+function responseRows(firstThought: string, secondThought: string) {
+	return [
+		{
+			_id: 'm1',
+			_creationTime: 1,
+			order: 0,
+			stepOrder: 0,
+			status: 'success',
+			threadId: 'thread-1',
+			// What the agent's `isTool` writes for a row whose content carries a
+			// tool call, and what keeps the three rows in one assistant group.
+			tool: true,
+			message: {
+				role: 'assistant',
+				content: [
+					{ type: 'reasoning', text: firstThought },
+					{ type: 'tool-call', toolCallId: 'call-1', toolName: 'lookup', input: {} }
+				]
+			}
+		},
+		{
+			_id: 'm2',
+			_creationTime: 2,
+			order: 0,
+			stepOrder: 1,
+			status: 'success',
+			threadId: 'thread-1',
+			tool: true,
+			message: {
+				role: 'tool',
+				content: [
+					{ type: 'tool-result', toolCallId: 'call-1', toolName: 'lookup', output: { ok: true } }
+				]
+			}
+		},
+		{
+			_id: 'm3',
+			_creationTime: 3,
+			order: 0,
+			stepOrder: 2,
+			status: 'success',
+			threadId: 'thread-1',
+			tool: false,
+			message: {
+				role: 'assistant',
+				content: [
+					{ type: 'reasoning', text: secondThought },
+					{ type: 'text', text: 'the answer' }
+				]
+			}
+		}
+	];
+}
+
+/**
+ * The same response in two vocabularies. A model that opens its second thought
+ * with the words of its first one gives the merge nothing to tell the two apart
+ * by, which is where the order the blocks arrive in becomes the only evidence
+ * left.
+ */
+const RESPONSES = [
+	{ name: 'thoughts that share no words', first: 'first thought', second: 'second thought' },
+	{
+		name: 'a second thought that repeats the first',
+		first: 'Analyze',
+		second: 'Analyze alternatives'
+	}
+];
+
+async function readLiveMessage(first: string, second: string): Promise<UIMessage> {
+	const stream = new ReadableStream({
+		start(controller) {
+			for (const chunk of responseChunks(first, second)) controller.enqueue(chunk);
+			controller.close();
+		}
+	});
+
+	let latest: UIMessage | undefined;
+	for await (const message of readUIMessageStream({ stream } as any)) {
+		latest = message as UIMessage;
+	}
+
+	if (!latest) throw new Error('the AI SDK reader produced no message');
+	return latest;
+}
+
+function readPersistedMessage(first: string, second: string): UIMessage {
+	const messages = toUIMessages(responseRows(first, second) as any) as UIMessage[];
+	const assistant = messages.filter((message) => message.role === 'assistant');
+	if (assistant.length !== 1) {
+		throw new Error(`expected one grouped assistant message, got ${assistant.length}`);
+	}
+	return assistant[0]!;
+}
+
+describe('the reasoning shapes the two producers emit', () => {
+	// The asymmetry the whole merge is built around. If an upgrade makes the two
+	// sides agree, the id-blind matching below stops being necessary; if it makes
+	// them disagree differently, the matching stops working. Either way this is
+	// the assertion that says so.
+	it('stamps an id on the live side and none on the persisted side', async () => {
+		const live = await readLiveMessage('first thought', 'second thought');
+		const persisted = readPersistedMessage('first thought', 'second thought');
+
+		const liveReasoning = live.parts.filter((part) => part.type === 'reasoning');
+		const persistedReasoning = persisted.parts.filter((part) => part.type === 'reasoning');
+
+		expect(liveReasoning).toHaveLength(2);
+		expect(persistedReasoning).toHaveLength(2);
+		for (const part of liveReasoning) {
+			expect(typeof (part as { id?: unknown }).id).toBe('string');
+		}
+		for (const part of persistedReasoning) {
+			expect((part as { id?: unknown }).id).toBeUndefined();
+		}
+	});
+});
+
+describe.each(RESPONSES)('the persisted and streamed handover of $name', ({ first, second }) => {
+	it('keeps one block per reasoning step', async () => {
+		const live = await readLiveMessage(first, second);
+		const persisted = readPersistedMessage(first, second);
+
+		const merged = mergeAssistantMessageParts(persisted.parts, live.parts);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toHaveLength(2);
+		expect(merged.filter((part) => part.type === 'text')).toHaveLength(1);
+	});
+});

--- a/src/lib/chat/core/reasoning-handover.contract.test.ts
+++ b/src/lib/chat/core/reasoning-handover.contract.test.ts
@@ -148,8 +148,14 @@ describe('the reasoning shapes the two producers emit', () => {
 		for (const part of liveReasoning) {
 			expect(typeof (part as { id?: unknown }).id).toBe('string');
 		}
+		// Both fields are identifiers to the merge (`getReasoningPartId` reads `id`
+		// and the legacy decoder's `streamPartId`), so pinning only one would let a
+		// release that starts stamping the other pass while the id-blind path it
+		// guards stops being exercised at all.
 		for (const part of persistedReasoning) {
-			expect((part as { id?: unknown }).id).toBeUndefined();
+			const record = part as { id?: unknown; streamPartId?: unknown };
+			expect(record.id).toBeUndefined();
+			expect(record.streamPartId).toBeUndefined();
 		}
 	});
 });

--- a/src/lib/chat/core/reasoning-handover.contract.test.ts
+++ b/src/lib/chat/core/reasoning-handover.contract.test.ts
@@ -1,9 +1,18 @@
 // The reasoning merge exists because the two producers describe the same
-// response differently, so the shapes it merges are drawn here from the real
-// producers instead of written by hand: `readUIMessageStream` from the AI SDK
-// for the live snapshot, `toUIMessages` from the Convex agent for the persisted
-// copy. A hand-written pair is a claim about those packages, and this file is
-// what turns the claim into something an upgrade can fail.
+// response differently, so the shapes it merges come from the real producers
+// here rather than from hand-written parts: `readUIMessageStream` from the AI
+// SDK for the live snapshot, `toUIMessages` from the Convex agent for the
+// persisted copy. A hand-written pair is a claim about those packages, and this
+// file is what turns the claim into something an upgrade can fail.
+//
+// The stored rows the persisted producer reads are the one hand-written input,
+// because the Convex agent does not export the serializer that writes them. The
+// two shapes a hand-written row gets wrong are pinned instead: a tool call
+// carries `input` and the deprecated `args`, and a tool result wraps its output
+// in a tagged `{ type, value }` envelope (both measured against the agent's
+// mapping). `toUIMessages` normalizes an untagged output, so a row that skipped
+// the envelope would stay green while exercising a legacy form the producer no
+// longer writes.
 
 import { describe, expect, it } from 'vitest';
 import { readUIMessageStream } from 'ai';
@@ -52,7 +61,7 @@ function responseRows(firstThought: string, secondThought: string) {
 				role: 'assistant',
 				content: [
 					{ type: 'reasoning', text: firstThought },
-					{ type: 'tool-call', toolCallId: 'call-1', toolName: 'lookup', input: {} }
+					{ type: 'tool-call', toolCallId: 'call-1', toolName: 'lookup', input: {}, args: {} }
 				]
 			}
 		},
@@ -67,7 +76,12 @@ function responseRows(firstThought: string, secondThought: string) {
 			message: {
 				role: 'tool',
 				content: [
-					{ type: 'tool-result', toolCallId: 'call-1', toolName: 'lookup', output: { ok: true } }
+					{
+						type: 'tool-result',
+						toolCallId: 'call-1',
+						toolName: 'lookup',
+						output: { type: 'json', value: { ok: true } }
+					}
 				]
 			}
 		},

--- a/src/lib/chat/core/stream-materialization.ts
+++ b/src/lib/chat/core/stream-materialization.ts
@@ -417,6 +417,14 @@ export async function deriveUIMessagesFromDeltas(
  *
  * Mirrors the upstream @convex-dev/agent `combineUIMessages` grouping semantics:
  * repeated assistant steps with the same order collapse into one grouped UI message.
+ *
+ * Two streams of one order do not occur here today: `@convex-dev/agent` opens one
+ * delta stream per `streamText` call with a fixed `stepOrder` and one call covers
+ * every step, both the AI chat and the support agent schedule one generation per
+ * prompt, and only streams with status `streaming` are materialized. Should that
+ * shape ever arrive, the merge below would apply heuristics written for the
+ * persisted and live pair of one stream to two unrelated ones, whose parts share
+ * no content to match on; upstream concatenates the non-tool parts instead.
  */
 export function combineStreamingUIMessages(messages: UIMessage[]): UIMessage[] {
 	const sortedMessages = [...messages].sort((a, b) => {
@@ -458,10 +466,26 @@ export function mergeAssistantMessageParts(
 	if (incomingParts.length === 0) return [...existingParts];
 
 	const compatiblePrefixLength = getCompatiblePrefixLength(existingParts, incomingParts);
-	if (compatiblePrefixLength > 0) {
+	// A prefix of step separators alone is no evidence that the two sides are
+	// snapshots of one sequence. Every step opens with one, so two steps that
+	// share nothing else still agree on it, and the shortcut would then drop
+	// every block the existing side holds behind that separator. At least one
+	// part carrying an id, a tool call or text has to line up first.
+	//
+	// A tool call behind the prefix rules the shortcut out as well. It closes the
+	// step the prefix belongs to, and an incoming side that ends before it is a
+	// later step whose opening words repeat the closed one, because text parts
+	// carry no id to tell the two apart. Taking the shortcut there overwrote the
+	// closed step's text and moved the later step in front of the tool call, so
+	// that input goes through the fallback, which keeps the tool boundary.
+	const prefixCarriesContent = existingParts
+		.slice(0, compatiblePrefixLength)
+		.some((part) => part.type !== 'step-start');
+
+	if (prefixCarriesContent && !hasToolPartAfter(existingParts, compatiblePrefixLength - 1)) {
 		const mergedPrefix = existingParts
 			.slice(0, compatiblePrefixLength)
-			.map((part, index) => mergeStreamParts(part, incomingParts[index]!));
+			.map((part, index) => mergeMatchedParts(part, incomingParts[index]!));
 
 		const tail =
 			incomingParts.length > compatiblePrefixLength
@@ -472,8 +496,19 @@ export function mergeAssistantMessageParts(
 	}
 
 	const mergedParts = [...existingParts];
+	// Blocks this snapshot has already spoken for, either by merging into them or
+	// by contributing them. One block can only be the continuation of one other,
+	// and without this a second incoming part whose text also grows out of the
+	// same block would swallow the first.
+	const claimedIndices = new Set<number>();
+	// The block the last incoming part matched. Everything the next one can
+	// continue sits behind it, because both sides list their blocks in the order
+	// the model produced them. A part this snapshot contributes leaves the cursor
+	// where it is, so a separator appended to the tail cannot hide the blocks that
+	// are still waiting for their continuation.
+	let cursor = -1;
 
-	for (const part of incomingParts) {
+	for (const [incomingIndex, part] of incomingParts.entries()) {
 		const toolCallId = getToolCallId(part);
 		if (toolCallId) {
 			const existingIndex = mergedParts.findIndex(
@@ -481,39 +516,192 @@ export function mergeAssistantMessageParts(
 			);
 
 			if (existingIndex === -1) {
+				claimedIndices.add(mergedParts.length);
 				mergedParts.push(part);
 			} else {
 				mergedParts[existingIndex] = mergeStreamParts(mergedParts[existingIndex]!, part);
+				claimedIndices.add(existingIndex);
+				cursor = Math.max(cursor, existingIndex);
 			}
 			continue;
 		}
 
-		const reasoningPartId = getReasoningPartId(part);
-		if (reasoningPartId) {
-			const existingIndex = mergedParts.findIndex(
-				(existingPart) => getReasoningPartId(existingPart) === reasoningPartId
+		if (part.type === 'reasoning' || part.type === 'text') {
+			if (part.type === 'reasoning') {
+				const reasoningPartId = getReasoningPartId(part);
+				const existingIndex = reasoningPartId
+					? mergedParts.findIndex(
+							(existingPart) => getReasoningPartId(existingPart) === reasoningPartId
+						)
+					: -1;
+
+				if (existingIndex !== -1) {
+					mergedParts[existingIndex] = mergeMatchedParts(mergedParts[existingIndex]!, part);
+					claimedIndices.add(existingIndex);
+					cursor = Math.max(cursor, existingIndex);
+					continue;
+				}
+			}
+
+			const counterpartIndex = findCounterpart(
+				mergedParts,
+				part,
+				claimedIndices,
+				cursor,
+				hasToolPartAfter(incomingParts, incomingIndex)
 			);
-
-			if (existingIndex === -1) {
-				mergedParts.push(part);
-			} else {
-				mergedParts[existingIndex] = mergeStreamParts(mergedParts[existingIndex]!, part);
+			if (counterpartIndex !== -1) {
+				mergedParts[counterpartIndex] = mergeMatchedParts(mergedParts[counterpartIndex]!, part);
+				claimedIndices.add(counterpartIndex);
+				cursor = Math.max(cursor, counterpartIndex);
+				continue;
 			}
-			continue;
 		}
 
-		const lastIndex = mergedParts.length - 1;
-		const lastPart = lastIndex >= 0 ? mergedParts[lastIndex] : undefined;
-
-		if (part.type === 'text' && lastPart?.type === 'text' && arePartsCompatible(lastPart, part)) {
-			mergedParts[lastIndex] = mergeStreamParts(lastPart, part);
-			continue;
-		}
-
+		claimedIndices.add(mergedParts.length);
 		mergedParts.push(part);
 	}
 
 	return mergedParts;
+}
+
+/**
+ * The block an incoming reasoning or text part continues, when no streaming id
+ * connects the two, or -1 when it opens a block of its own.
+ *
+ * The two sides carry the id inconsistently, which is what left one block
+ * rendering twice: a persisted message reconstructs reasoning without any id
+ * (`UIMessages.ts` in `@convex-dev/agent`), while the live stream stamps one on
+ * (`id` from the AI SDK, `streamPartId` from the legacy decoder). An id lookup
+ * across that pair matches nothing, so a text search is the only thing that can
+ * recognize the block, and without it the part falls through to the push and
+ * appends a second copy of what is already there.
+ *
+ * That search runs in order, from `cursor + 1`, and takes the first compatible
+ * block it finds. Both producers list reasoning and text in the order the model
+ * wrote them, and a live snapshot always carries whole steps, so the block the
+ * previous incoming part settled on is where the next one starts looking. A
+ * search that weighed the candidates instead let a short opening block claim the
+ * longer one further down, which left the block that owned it with nothing to
+ * merge into and appended it a second time.
+ *
+ * `cursor` moves on a match alone. A live snapshot opens each of its steps with
+ * a `step-start` the persisted side has no counterpart for, so that separator
+ * gets pushed onto the tail; moving the cursor there would carry the search past
+ * every block still waiting for its continuation.
+ *
+ * A block another part of the same snapshot already claimed is off limits, so
+ * two blocks growing out of the same opening words cost a missed merge and never
+ * a lost block. An empty incoming block never adopts a block that already
+ * carries text, because that would hand its id to text belonging to a block
+ * already finished. Two empty blocks in order are the same block that has only
+ * just opened on both sides: the provider opens one with an empty delta for a
+ * signature-only reasoning detail, and the persisted row keeps it, so rejecting
+ * every empty block rendered that one twice while the stream was open.
+ *
+ * `incomingPrecedesTool` carries the only ordering evidence the two sides share.
+ * Reasoning comes before its own step's tool calls, so a block with a tool call
+ * behind it is closed. An incoming part that also has one behind it can be that
+ * same closed block. One that has none can only be it while its text is a prefix
+ * of the block's, because a snapshot lagging one tool chunk behind holds a
+ * shorter copy of the words the block already has, and a later step that repeats
+ * those opening words extends them instead. Without the prefix condition, that
+ * later step would merge into the closed block and move itself in front of the
+ * tool call that ran between them.
+ *
+ * The price is a later step whose text is still a strict prefix of the block a
+ * tool call closed, which only two streams of one order combined can produce: it
+ * stays inside that closed block until its words grow past the ones they share,
+ * and nothing renders twice while it does. Only two streams of one order can
+ * produce it, which `combineStreamingUIMessages` above records as unreachable, so
+ * the rule is tuned for the one race that is reachable: the delta snapshot
+ * lagging one tool chunk behind the page.
+ */
+function findCounterpart(
+	parts: UIMessage['parts'],
+	incomingPart: UIMessage['parts'][number],
+	claimedIndices: ReadonlySet<number>,
+	cursor: number,
+	incomingPrecedesTool: boolean
+): number {
+	const incomingText = getPartText(incomingPart);
+	const incomingId = getReasoningPartId(incomingPart);
+
+	for (let index = cursor + 1; index < parts.length; index += 1) {
+		if (claimedIndices.has(index)) continue;
+
+		const candidate = parts[index]!;
+		if (candidate.type !== incomingPart.type) continue;
+		if (!incomingPrecedesTool && hasToolPartAfter(parts, index)) {
+			// The words of a later step repeat the closed block and grow past it,
+			// while a snapshot that lags one tool chunk behind stops short of it. Only
+			// the second one is this block, so the first stays behind the tool call
+			// and the second grows the block again instead of rendering a copy of it
+			// on the other side of the tool card.
+			if (!getPartText(candidate).startsWith(incomingText)) continue;
+		}
+		if (incomingText.length === 0 && getPartText(candidate).length > 0) continue;
+		// Two ids that disagree are two blocks, whatever the texts look like. A
+		// pair that shares one was already merged by the id lookup, so only the
+		// mixed case reaches the text heuristic.
+		if (incomingId !== undefined && getReasoningPartId(candidate) !== undefined) continue;
+
+		if (!areTextsCompatible(getPartText(candidate), incomingText)) continue;
+
+		return index;
+	}
+
+	return -1;
+}
+
+/** Whether a tool call closes the step the part at `index` belongs to. */
+function hasToolPartAfter(parts: UIMessage['parts'], index: number): boolean {
+	for (let cursor = index + 1; cursor < parts.length; cursor += 1) {
+		if (getToolCallId(parts[cursor]!)) return true;
+	}
+
+	return false;
+}
+
+function mergeMatchedParts(
+	existingPart: UIMessage['parts'][number],
+	incomingPart: UIMessage['parts'][number]
+): UIMessage['parts'][number] {
+	const carriesText =
+		existingPart.type === incomingPart.type &&
+		(existingPart.type === 'reasoning' || existingPart.type === 'text');
+	if (!carriesText) {
+		return mergeStreamParts(existingPart, incomingPart);
+	}
+
+	const merged = { ...mergeStreamParts(existingPart, incomingPart) } as Record<string, unknown>;
+	const existingText = getPartText(existingPart);
+
+	// The id belongs to the live snapshot, which goes away at the handover, and
+	// the persisted reconstruction has none of its own. A borrowed one reads as a
+	// live part to every consumer that matches on it, such as the delta
+	// application keyed by stream part id. The renderer keys by reasoning ordinal.
+	if (existingPart.type === 'reasoning' && getReasoningPartId(existingPart) === undefined) {
+		delete merged.streamPartId;
+		delete merged.id;
+	}
+
+	// The persisted row and the live stream reach the renderer through two
+	// independent reactive queries, so either side can be the older snapshot.
+	// Field-wise merging takes the incoming value wherever it is defined, which
+	// shortens a reasoning block or a finished answer whenever the live side is
+	// the older one and grows it back on the next frame. Text and state come from
+	// the same side, because text that is already complete must not fall back to
+	// a spinner.
+	if (existingText.length > getPartText(incomingPart).length) {
+		merged.text = existingText;
+		const existingState = asRecord(existingPart).state;
+		if (existingState !== undefined) {
+			merged.state = existingState;
+		}
+	}
+
+	return merged as UIMessage['parts'][number];
 }
 
 function getCompatiblePrefixLength(

--- a/src/lib/chat/core/stream-materialization.ts
+++ b/src/lib/chat/core/stream-materialization.ts
@@ -125,6 +125,16 @@ function getStreamPartId(part: UIMessage['parts'][number]): string | undefined {
 	return typeof streamPartId === 'string' ? streamPartId : undefined;
 }
 
+/**
+ * Whether the part comes from a live materialization rather than a persisted
+ * reconstruction. Only a live snapshot carries the AI SDK's part id, so only
+ * there does its lifecycle `state` report what the model actually did.
+ */
+function carriesStreamIdentity(part: UIMessage['parts'][number]): boolean {
+	const record = asRecord(part);
+	return typeof record.streamPartId === 'string' || typeof record.id === 'string';
+}
+
 function getReasoningPartId(part: UIMessage['parts'][number]): string | undefined {
 	if (part.type !== 'reasoning') return undefined;
 
@@ -693,12 +703,26 @@ function mergeMatchedParts(
 	// the older one and grows it back on the next frame. Text and state come from
 	// the same side, because text that is already complete must not fall back to
 	// a spinner.
-	if (existingText.length > getPartText(incomingPart).length) {
+	const incomingText = getPartText(incomingPart);
+	if (existingText.length > incomingText.length) {
 		merged.text = existingText;
 		const existingState = asRecord(existingPart).state;
 		if (existingState !== undefined) {
 			merged.state = existingState;
 		}
+	} else if (
+		existingText.length === incomingText.length &&
+		asRecord(existingPart).state === 'done' &&
+		carriesStreamIdentity(existingPart)
+	) {
+		// `reasoning-end` and `text-end` close a block without adding to its text, so
+		// the two snapshots read identically and length cannot say which is newer.
+		// A `done` means the block really closed only on a live snapshot: the message
+		// list materializes an active stream into its own page, so this side is a
+		// second live view that can be the newer one. The persisted reconstruction
+		// stamps `done` on everything it rebuilds, including a step still running
+		// (measured), and carries no id, which is what tells the two apart.
+		merged.state = 'done';
 	}
 
 	return merged as UIMessage['parts'][number];
@@ -761,10 +785,28 @@ function getToolCallId(part: UIMessage['parts'][number]) {
 	return isToolUIPart(part) ? (asRecord(part).toolCallId as string) : undefined;
 }
 
+/** The tool states that carry a result, after which the call cannot run again. */
+const TERMINAL_TOOL_STATES = new Set(['output-available', 'output-error']);
+
+function isSettledToolPart(part: UIMessage['parts'][number]): boolean {
+	if (!part.type.startsWith('tool-')) return false;
+	const state = asRecord(part).state;
+	return typeof state === 'string' && TERMINAL_TOOL_STATES.has(state);
+}
+
 function mergeStreamParts(
 	previousPart: UIMessage['parts'][number],
 	part: UIMessage['parts'][number]
 ): UIMessage['parts'][number] {
+	// A tool call runs once, so its result is the end of the sequence and the
+	// snapshot holding one is the newer of the two whichever way they arrived.
+	// Field-wise merging would take the incoming `input-streaming` and leave it
+	// next to the output the other side already had, which renders as a spinner
+	// above a finished result.
+	if (isSettledToolPart(previousPart) && !isSettledToolPart(part)) {
+		return previousPart;
+	}
+
 	const merged: Record<string, unknown> = { ...previousPart };
 	for (const [key, value] of Object.entries(part)) {
 		if (value !== undefined) {

--- a/src/lib/chat/core/stream-materialization.ts
+++ b/src/lib/chat/core/stream-materialization.ts
@@ -148,8 +148,15 @@ function getReasoningPartId(part: UIMessage['parts'][number]): string | undefine
 	return typeof id === 'string' ? id : undefined;
 }
 
+/**
+ * A tool call in either of the two type spellings the AI SDK uses: a statically
+ * named `tool-<name>` and the `dynamic-tool` a runtime-registered tool produces
+ * (measured). Both carry the `toolCallId` that identifies the call across the
+ * two views, so both have to be matched by it rather than appended twice.
+ */
 function isToolUIPart(part: UIMessage['parts'][number]): boolean {
-	return part.type.startsWith('tool-') && typeof asRecord(part).toolCallId === 'string';
+	const named = part.type.startsWith('tool-') || part.type === 'dynamic-tool';
+	return named && typeof asRecord(part).toolCallId === 'string';
 }
 
 /**
@@ -722,6 +729,12 @@ function mergeMatchedParts(
 		// second live view that can be the newer one. The persisted reconstruction
 		// stamps `done` on everything it rebuilds, including a step still running
 		// (measured), and carries no id, which is what tells the two apart.
+		//
+		// Only reasoning is covered, because only reasoning carries that id: a live
+		// text part holds nothing but its type, text and state (measured), so a
+		// settled answer can still be handed back its streaming presentation for one
+		// frame. Separating the two would need the caller to say which view each side
+		// came from, which is issue #893 rather than another guess here.
 		merged.state = 'done';
 	}
 
@@ -785,11 +798,17 @@ function getToolCallId(part: UIMessage['parts'][number]) {
 	return isToolUIPart(part) ? (asRecord(part).toolCallId as string) : undefined;
 }
 
-/** The tool states that carry a result, after which the call cannot run again. */
-const TERMINAL_TOOL_STATES = new Set(['output-available', 'output-error']);
+/**
+ * The states that end a tool call. A denied call is as final as a returned or
+ * failed one: the AI SDK settles it there and the persisted reconstruction
+ * rebuilds it as a denial, so letting a lagging snapshot pull it back to
+ * `approval-requested` would ask the reader to decide something they already
+ * decided.
+ */
+const TERMINAL_TOOL_STATES = new Set(['output-available', 'output-error', 'output-denied']);
 
 function isSettledToolPart(part: UIMessage['parts'][number]): boolean {
-	if (!part.type.startsWith('tool-')) return false;
+	if (!isToolUIPart(part)) return false;
 	const state = asRecord(part).state;
 	return typeof state === 'string' && TERMINAL_TOOL_STATES.has(state);
 }

--- a/src/lib/chat/core/stream-materialization.ts
+++ b/src/lib/chat/core/stream-materialization.ts
@@ -149,14 +149,14 @@ function getReasoningPartId(part: UIMessage['parts'][number]): string | undefine
 }
 
 /**
- * A tool call in either of the two type spellings the AI SDK uses: a statically
- * named `tool-<name>` and the `dynamic-tool` a runtime-registered tool produces
- * (measured). Both carry the `toolCallId` that identifies the call across the
- * two views, so both have to be matched by it rather than appended twice.
+ * A statically named tool call. A runtime-registered one carries the same
+ * `toolCallId` but spells its type `dynamic-tool`, so the two views of one such
+ * call are not matched and both are kept (issue #894). Matching them here is not
+ * enough on its own: the two views also disagree on the type itself, and the
+ * merged part then names a type the renderer drops.
  */
 function isToolUIPart(part: UIMessage['parts'][number]): boolean {
-	const named = part.type.startsWith('tool-') || part.type === 'dynamic-tool';
-	return named && typeof asRecord(part).toolCallId === 'string';
+	return part.type.startsWith('tool-') && typeof asRecord(part).toolCallId === 'string';
 }
 
 /**

--- a/src/lib/chat/core/stream-materialization.ts
+++ b/src/lib/chat/core/stream-materialization.ts
@@ -680,7 +680,7 @@ function mergeMatchedParts(
 	// The id belongs to the live snapshot, which goes away at the handover, and
 	// the persisted reconstruction has none of its own. A borrowed one reads as a
 	// live part to every consumer that matches on it, such as the delta
-	// application keyed by stream part id. The renderer keys by reasoning ordinal.
+	// application keyed by stream part id.
 	if (existingPart.type === 'reasoning' && getReasoningPartId(existingPart) === undefined) {
 		delete merged.streamPartId;
 		delete merged.id;

--- a/src/lib/chat/core/stream-processor.test.ts
+++ b/src/lib/chat/core/stream-processor.test.ts
@@ -1056,6 +1056,69 @@ describe('mergeAssistantMessageParts', () => {
 			{ type: 'text', text: 'answer' }
 		]);
 	});
+
+	// The message list materializes an active stream into its own page, so the
+	// existing side is a second live view that can be the newer one. `reasoning-end`
+	// closes a block without adding to its text (measured), so both sides read
+	// identically and only the state says the block finished.
+	it('keeps a closed live block closed when the other live view lags', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', id: 'r1', text: 'complete thought', state: 'done' }
+			] as unknown as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', id: 'r1', text: 'complete thought', state: 'streaming' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toMatchObject([
+			{ text: 'complete thought', state: 'done' }
+		]);
+	});
+
+	// The persisted reconstruction stamps `done` on every block it rebuilds, even
+	// one whose step is still running, and carries no id. Its state says nothing,
+	// so the live side still decides.
+	it('lets the live side reopen a block the persisted copy only calls done', () => {
+		const merged = mergeAssistantMessageParts(
+			[{ type: 'reasoning', text: 'Find coordinates', state: 'done' }] as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', id: 'r1', text: 'Find coordinates', state: 'streaming' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toMatchObject([
+			{ text: 'Find coordinates', state: 'streaming' }
+		]);
+	});
+
+	// A tool call runs once, so the side holding its result is the newer one. Taking
+	// the incoming state left a spinner sitting above a finished result.
+	it('keeps a settled tool call settled when the other side lags', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'step-start' },
+				{
+					type: 'tool-lookup',
+					toolCallId: 'call-1',
+					state: 'output-available',
+					input: { id: 'record-1' },
+					output: { found: true }
+				}
+			] as unknown as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'tool-lookup', toolCallId: 'call-1', state: 'input-streaming' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type.startsWith('tool-'))).toMatchObject([
+			{ state: 'output-available', output: { found: true } }
+		]);
+	});
 });
 
 // ─── extractUserMessageText ───────────────────────────────────────────────────

--- a/src/lib/chat/core/stream-processor.test.ts
+++ b/src/lib/chat/core/stream-processor.test.ts
@@ -466,6 +466,125 @@ describe('combineStreamingUIMessages', () => {
 		]);
 		expect(combined[0]!.text).toBe('It is 10.1C.');
 	});
+
+	it('keeps both steps when two streams open with the same separator', () => {
+		const messages: UIMessage[] = [
+			{
+				id: 'stream:1',
+				key: 'thread-1-1-0',
+				order: 1,
+				stepOrder: 0,
+				status: 'streaming',
+				agentName: 'assistant',
+				text: '',
+				_creationTime: 1,
+				role: 'assistant',
+				parts: [
+					{ type: 'step-start' },
+					{ type: 'reasoning', text: 'Look up the record', id: 'reason-1', state: 'done' },
+					{
+						type: 'tool-lookup',
+						toolCallId: 'call-1',
+						state: 'output-available',
+						input: { id: 'record-1' },
+						output: { found: true }
+					}
+				]
+			},
+			{
+				id: 'stream:2',
+				key: 'thread-1-1-1',
+				order: 1,
+				stepOrder: 1,
+				status: 'success',
+				agentName: 'assistant',
+				text: 'answer',
+				_creationTime: 2,
+				role: 'assistant',
+				parts: [
+					{ type: 'step-start' },
+					{ type: 'reasoning', text: 'Write the answer', id: 'reason-2', state: 'done' },
+					{ type: 'text', text: 'answer' }
+				]
+			}
+		] as unknown as UIMessage[];
+
+		const combined = combineStreamingUIMessages(messages);
+
+		expect(combined).toHaveLength(1);
+		expect(
+			combined[0]!.parts.map((part) => {
+				const record = part as unknown as Record<string, unknown>;
+				return [part.type, record.text ?? record.toolCallId ?? null];
+			})
+		).toEqual([
+			['step-start', null],
+			['reasoning', 'Look up the record'],
+			['tool-lookup', 'call-1'],
+			['step-start', null],
+			['reasoning', 'Write the answer'],
+			['text', 'answer']
+		]);
+	});
+
+	// Text parts carry no id, so the words a later step opens with line up with
+	// the text of the step a tool call already closed. Taking the shortcut across
+	// that tool call overwrote the first step's text and moved the answer in
+	// front of the call that produced it.
+	it('keeps the answer behind the tool call when its words repeat the step before', () => {
+		const messages: UIMessage[] = [
+			{
+				id: 'stream:1',
+				key: 'thread-1-1-0',
+				order: 1,
+				stepOrder: 0,
+				status: 'streaming',
+				agentName: 'assistant',
+				text: 'I will check',
+				_creationTime: 1,
+				role: 'assistant',
+				parts: [
+					{ type: 'step-start' },
+					{ type: 'text', text: 'I will check' },
+					{
+						type: 'tool-lookup',
+						toolCallId: 'call-1',
+						state: 'output-available',
+						input: {},
+						output: {}
+					}
+				]
+			},
+			{
+				id: 'stream:2',
+				key: 'thread-1-1-1',
+				order: 1,
+				stepOrder: 1,
+				status: 'success',
+				agentName: 'assistant',
+				text: 'I will check the result is ready',
+				_creationTime: 2,
+				role: 'assistant',
+				parts: [{ type: 'step-start' }, { type: 'text', text: 'I will check the result is ready' }]
+			}
+		] as unknown as UIMessage[];
+
+		const combined = combineStreamingUIMessages(messages);
+
+		expect(combined).toHaveLength(1);
+		expect(
+			combined[0]!.parts.map((part) => {
+				const record = part as unknown as Record<string, unknown>;
+				return [part.type, record.text ?? record.toolCallId ?? null];
+			})
+		).toEqual([
+			['step-start', null],
+			['text', 'I will check'],
+			['tool-lookup', 'call-1'],
+			['step-start', null],
+			['text', 'I will check the result is ready']
+		]);
+	});
 });
 
 describe('mergeAssistantMessageParts', () => {
@@ -535,6 +654,406 @@ describe('mergeAssistantMessageParts', () => {
 				output: { temperature: 62.6 }
 			},
 			{ type: 'reasoning', text: 'Draft final answer' }
+		]);
+	});
+
+	// The shapes the two sides really have, and the whole reason one block used to
+	// render twice. `display-message-processor` passes the persisted message
+	// first, whose reasoning `@convex-dev/agent` rebuilds with no id and no
+	// leading `step-start`, and the live stream second, which the AI SDK opens
+	// with that `step-start` and stamps an `id` on. Nothing lines the two up, and
+	// the step separator lands between them.
+	it('grows a persisted reasoning block across the step separator the live stream adds', () => {
+		const merged = mergeAssistantMessageParts(
+			[{ type: 'reasoning', text: 'Find coordinates', state: 'done' }] as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Find coordinates', id: 'reason-1', state: 'streaming' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toEqual([
+			{ type: 'reasoning', text: 'Find coordinates', state: 'streaming' }
+		]);
+	});
+
+	it('keeps a second live block apart across the step separator', () => {
+		const merged = mergeAssistantMessageParts(
+			[{ type: 'reasoning', text: 'Analyze', state: 'done' }] as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Analyze', id: 'reason-1', state: 'done' },
+				{ type: 'reasoning', text: 'Analyze alternatives', id: 'reason-2', state: 'streaming' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toEqual([
+			{ type: 'reasoning', text: 'Analyze', state: 'done' },
+			{ type: 'reasoning', text: 'Analyze alternatives', id: 'reason-2', state: 'streaming' }
+		]);
+	});
+
+	// The row and the deltas arrive through two independent reactive queries, so
+	// the live side is sometimes the older one. Taking its text would cut the
+	// block back and restore it on the next frame, which reads as flicker, and a
+	// finished block would start showing as still running.
+	it('keeps the longer text when the live snapshot lags behind the persisted one', () => {
+		const merged = mergeAssistantMessageParts(
+			[{ type: 'reasoning', text: 'Find coordinates', state: 'done' }] as UIMessage['parts'],
+			[
+				{ type: 'reasoning', text: 'Find coord', id: 'reason-1', state: 'streaming' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged).toEqual([{ type: 'reasoning', text: 'Find coordinates', state: 'done' }]);
+	});
+
+	it('grows a persisted reasoning block that the live stream carries an id for', () => {
+		const merged = mergeAssistantMessageParts(
+			[{ type: 'reasoning', text: 'Find coord' }] as UIMessage['parts'],
+			[
+				{ type: 'reasoning', text: 'Find coordinates', streamPartId: 'reason-1' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged).toEqual([{ type: 'reasoning', text: 'Find coordinates' }]);
+	});
+
+	it('grows a reasoning block whose snapshot dropped the streaming id', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', text: 'Find coord', streamPartId: 'reason-1' }
+			] as unknown as UIMessage['parts'],
+			[{ type: 'reasoning', text: 'Find coordinates' }] as UIMessage['parts']
+		);
+
+		expect(merged).toEqual([
+			{ type: 'reasoning', text: 'Find coordinates', streamPartId: 'reason-1' }
+		]);
+	});
+
+	it('keeps two reasoning blocks apart when only one carries a streaming id', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', text: 'Find coordinates', streamPartId: 'reason-1' }
+			] as unknown as UIMessage['parts'],
+			[{ type: 'reasoning', text: 'Check forecast' }] as UIMessage['parts']
+		);
+
+		expect(merged).toEqual([
+			{ type: 'reasoning', text: 'Find coordinates', streamPartId: 'reason-1' },
+			{ type: 'reasoning', text: 'Check forecast' }
+		]);
+	});
+
+	// Text growth is the only evidence available once the ids fail to line up, and
+	// two adjacent blocks can both grow out of the same opening words. The block a
+	// snapshot already claimed is off limits to the next one, so an overlap costs
+	// a missed merge and never a lost block.
+	it('does not fold two overlapping blocks into the one they both extend', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', text: 'Analyze', streamPartId: 'reason-1' }
+			] as unknown as UIMessage['parts'],
+			[
+				{ type: 'reasoning', text: 'Analyze' },
+				{ type: 'reasoning', text: 'Analyze alternatives' }
+			] as UIMessage['parts']
+		);
+
+		expect(merged).toEqual([
+			{ type: 'reasoning', text: 'Analyze', streamPartId: 'reason-1' },
+			{ type: 'reasoning', text: 'Analyze alternatives' }
+		]);
+	});
+
+	it('keeps a finished reasoning block when a later step opens an empty one', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', text: 'Check weather forecast' },
+				{
+					type: 'tool-getWeather',
+					toolCallId: 'tool-2',
+					state: 'output-available',
+					output: { temperature: 62.6 }
+				}
+			] as unknown as UIMessage['parts'],
+			[{ type: 'reasoning', text: '', streamPartId: 'reason-2' }] as unknown as UIMessage['parts']
+		);
+
+		expect(merged).toEqual([
+			{ type: 'reasoning', text: 'Check weather forecast' },
+			{
+				type: 'tool-getWeather',
+				toolCallId: 'tool-2',
+				state: 'output-available',
+				output: { temperature: 62.6 }
+			},
+			{ type: 'reasoning', text: '', streamPartId: 'reason-2' }
+		]);
+	});
+
+	it('does not let an empty reasoning snapshot erase the block it follows', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'tool-getWeather', toolCallId: 'tool-2', state: 'output-available' },
+				{ type: 'reasoning', text: 'Draft final answer' }
+			] as unknown as UIMessage['parts'],
+			[{ type: 'reasoning', text: '' }] as UIMessage['parts']
+		);
+
+		expect(merged).toEqual([
+			{ type: 'tool-getWeather', toolCallId: 'tool-2', state: 'output-available' },
+			{ type: 'reasoning', text: 'Draft final answer' },
+			{ type: 'reasoning', text: '' }
+		]);
+	});
+
+	// A signature-only reasoning detail reaches the provider as a block with an
+	// empty delta, and the persisted row keeps that empty block. Rejecting every
+	// empty incoming block left the live copy with nothing to merge into, so the
+	// one block rendered as two rows for as long as the stream was open.
+	it('matches an empty reasoning block to its empty copy', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', text: '', state: 'done' },
+				{ type: 'step-start' },
+				{
+					type: 'tool-lookup',
+					toolCallId: 'call-1',
+					state: 'output-available',
+					input: {},
+					output: {}
+				}
+			] as unknown as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: '', id: 'r1', state: 'done' },
+				{
+					type: 'tool-lookup',
+					toolCallId: 'call-1',
+					state: 'output-available',
+					input: {},
+					output: {}
+				},
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Next thought', id: 'r2', state: 'streaming' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toEqual([
+			{ type: 'reasoning', text: '', state: 'done' },
+			{ type: 'reasoning', text: 'Next thought', id: 'r2', state: 'streaming' }
+		]);
+		expect(merged.filter((part) => part.type === 'tool-lookup')).toHaveLength(1);
+	});
+
+	it('merges a grown reasoning block that follows a completed tool call', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'tool-getWeather', toolCallId: 'tool-2', state: 'output-available' },
+				{ type: 'reasoning', text: 'Draft final' }
+			] as unknown as UIMessage['parts'],
+			[{ type: 'reasoning', text: 'Draft final answer' }] as UIMessage['parts']
+		);
+
+		expect(merged).toEqual([
+			{ type: 'tool-getWeather', toolCallId: 'tool-2', state: 'output-available' },
+			{ type: 'reasoning', text: 'Draft final answer' }
+		]);
+	});
+
+	// A tool call closes the step its reasoning belongs to, so a fresh tail block
+	// whose opening words repeat that reasoning is a later step and not a
+	// continuation. Merging it backward would delete the earlier block and move
+	// the new one in front of the tool call that ran between them.
+	it('opens a new block when the words repeat one a tool call already closed', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', text: 'Analyze' },
+				{ type: 'tool-getGeocoding', toolCallId: 'tool-1', state: 'output-available' }
+			] as unknown as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Analyze alternatives', id: 'reason-2' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged).toEqual([
+			{ type: 'reasoning', text: 'Analyze' },
+			{ type: 'tool-getGeocoding', toolCallId: 'tool-1', state: 'output-available' },
+			{ type: 'step-start' },
+			{ type: 'reasoning', text: 'Analyze alternatives', id: 'reason-2' }
+		]);
+	});
+
+	// The same closed block is still the right target when the live snapshot
+	// carries the whole message, because there the tool call sits behind the
+	// incoming part too.
+	it('still grows a closed block when the snapshot repeats the tool call', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', text: 'Analyze' },
+				{ type: 'tool-getGeocoding', toolCallId: 'tool-1', state: 'output-available' }
+			] as unknown as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Analyze the options', id: 'reason-1' },
+				{ type: 'tool-getGeocoding', toolCallId: 'tool-1', state: 'output-available' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toEqual([
+			{ type: 'reasoning', text: 'Analyze the options' }
+		]);
+	});
+
+	// The page and the delta snapshot arrive through two queries, so the page can
+	// be one tool chunk ahead of the snapshot. The lagging copy is a prefix of the
+	// closed block and has to grow it; the sentence used to render a second time on
+	// the other side of the tool card until the next delta arrived.
+	it('grows a closed block from the snapshot that lags behind its tool call', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'step-start' },
+				{ type: 'text', text: 'I will check' },
+				{
+					type: 'tool-lookup',
+					toolCallId: 'call-1',
+					state: 'output-available',
+					input: {},
+					output: {}
+				}
+			] as unknown as UIMessage['parts'],
+			[{ type: 'step-start' }, { type: 'text', text: 'I will' }] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'text')).toEqual([
+			{ type: 'text', text: 'I will check' }
+		]);
+		expect(merged.filter((part) => part.type === 'tool-lookup')).toHaveLength(1);
+	});
+
+	// The same lag on a reasoning block, where the shorter copy also carries the
+	// live id and the streaming state. The longer text and its finished state win,
+	// and the persisted block keeps its own key.
+	it('keeps a lagging reasoning snapshot inside its closed block', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', text: 'Find coordinates', state: 'done' },
+				{ type: 'step-start' },
+				{
+					type: 'tool-lookup',
+					toolCallId: 'call-1',
+					state: 'output-available',
+					input: {},
+					output: {}
+				}
+			] as unknown as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Find coord', id: 'r1', state: 'streaming' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toEqual([
+			{ type: 'reasoning', text: 'Find coordinates', state: 'done' }
+		]);
+		expect(merged.filter((part) => part.type === 'tool-lookup')).toHaveLength(1);
+	});
+
+	// The id belongs to the live snapshot alone, and the persisted reconstruction
+	// carries no counterpart for it. A persisted block holding a borrowed id would
+	// read as a live part to any consumer that matches on `id` or `streamPartId`.
+	it('leaves a persisted block without the id of the snapshot it merged', () => {
+		const merged = mergeAssistantMessageParts(
+			[{ type: 'reasoning', text: 'Second block' }] as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Second block continues', id: 'reason-live' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toEqual([
+			{ type: 'reasoning', text: 'Second block continues' }
+		]);
+	});
+
+	// Both sides list their blocks in the order the model wrote them, so the
+	// second block belongs to the second incoming part. Weighing the candidates
+	// by length handed it to the first one, which left the second with nothing to
+	// merge into and appended a copy of the block and of the answer with it.
+	it('matches two blocks that share their opening words in order', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', text: 'Analyze' },
+				{ type: 'step-start' },
+				{ type: 'tool-lookup', toolCallId: 'call-1', state: 'output-available' },
+				{ type: 'reasoning', text: 'Analyze alternatives' },
+				{ type: 'text', text: 'the answer' }
+			] as unknown as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Analyze', id: 'r-first' },
+				{ type: 'tool-lookup', toolCallId: 'call-1', state: 'output-available' },
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Analyze alternatives', id: 'r-second' },
+				{ type: 'text', text: 'the answer' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toEqual([
+			{ type: 'reasoning', text: 'Analyze' },
+			{ type: 'reasoning', text: 'Analyze alternatives' }
+		]);
+		expect(merged.filter((part) => part.type === 'text')).toHaveLength(1);
+	});
+
+	// Two blocks of one step, where the first one's words open the second. The
+	// cursor keeps each incoming block behind the one its predecessor matched, so
+	// neither block can be overwritten by the words of the other.
+	it('keeps two blocks of one step apart when the words overlap', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', text: 'Analyze' },
+				{ type: 'reasoning', text: 'Analyze more' },
+				{ type: 'text', text: 'answer' }
+			] as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Analyze', id: 'r1' },
+				{ type: 'reasoning', text: 'Analyze more', id: 'r2' },
+				{ type: 'text', text: 'answer' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toEqual([
+			{ type: 'reasoning', text: 'Analyze' },
+			{ type: 'reasoning', text: 'Analyze more' }
+		]);
+		expect(merged.filter((part) => part.type === 'text')).toEqual([
+			{ type: 'text', text: 'answer' }
+		]);
+	});
+
+	// The separator the live stream opens its step with lands on the tail, which
+	// leaves the persisted answer one position further up. Merging text into the
+	// last part alone missed it there and rendered the answer a second time.
+	it('merges the answer across the separator pushed behind it', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', text: 'think' },
+				{ type: 'text', text: 'answer' }
+			] as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'think', id: 'r1' },
+				{ type: 'text', text: 'answer' }
+			] as unknown as UIMessage['parts']
+		);
+
+		expect(merged.filter((part) => part.type === 'text')).toEqual([
+			{ type: 'text', text: 'answer' }
 		]);
 	});
 });

--- a/src/lib/chat/ui/ordered-parts.test.ts
+++ b/src/lib/chat/ui/ordered-parts.test.ts
@@ -94,7 +94,10 @@ describe('deriveOrderedParts', () => {
 
 	it('does not replay settled text after a new step starts', () => {
 		const result = deriveOrderedParts(
-			[{ type: 'text', text: 'finished first step' }, { type: 'step-start' }] as MessagePart[],
+			[
+				{ type: 'text', text: 'finished first step', state: 'done' },
+				{ type: 'step-start' }
+			] as MessagePart[],
 			'streaming'
 		);
 

--- a/src/lib/chat/ui/reasoning-parts.test.ts
+++ b/src/lib/chat/ui/reasoning-parts.test.ts
@@ -32,13 +32,35 @@ describe('active streaming content', () => {
 		}
 	);
 
-	it.each([{ type: 'step-start' }, { type: 'tool-test', state: 'input-streaming' }])(
-		'keeps $type as a lifecycle boundary',
-		(tail) => {
-			const parts = [{ type: 'text', text: 'settled' }, tail] as MessagePart[];
-			expect(getActiveStreamingPartIndex(parts, true)).toBe(1);
-		}
-	);
+	it('keeps an unresolved tool part as a lifecycle boundary', () => {
+		const parts = [
+			{ type: 'text', text: 'settled', state: 'done' },
+			{ type: 'tool-test', state: 'input-streaming' }
+		] as MessagePart[];
+		expect(getActiveStreamingPartIndex(parts, true)).toBe(1);
+	});
+
+	// The merged view of the handover window puts a step-start behind the block the
+	// model is still writing, because the persisted row and the live snapshot place
+	// their step boundaries differently. Reading it as the tail rendered an actively
+	// streaming thought as a finished one.
+	it('does not let an opened step hide the content still being written', () => {
+		const parts = [
+			{ type: 'reasoning', text: 'first thought and more', state: 'streaming' },
+			{ type: 'step-start' }
+		] as MessagePart[];
+		expect(getActiveStreamingPartIndex(parts, true)).toBe(0);
+		expect(getActiveStreamingReasoningIndex(parts, true)).toBe(0);
+	});
+
+	it('ends active content when a step opens after finished content', () => {
+		const parts = [
+			{ type: 'reasoning', text: 'first thought', state: 'done' },
+			{ type: 'step-start' }
+		] as MessagePart[];
+		expect(getActiveStreamingPartIndex(parts, true)).toBe(-1);
+		expect(getActiveStreamingReasoningIndex(parts, true)).toBe(-1);
+	});
 
 	it('returns no active content after completion', () => {
 		expect(getActiveStreamingPartIndex([{ type: 'text', text: 'done' }], false)).toBe(-1);

--- a/src/lib/chat/ui/reasoning-parts.ts
+++ b/src/lib/chat/ui/reasoning-parts.ts
@@ -50,9 +50,20 @@ function isCompletedContentPart(part: MessagePart): boolean {
 }
 
 /**
+ * A step boundary says a step opened, never that the content before it closed. Merging the
+ * persisted row with the live snapshot leaves one behind the block that is still being
+ * written, because the two views place their `step-start` parts differently (measured), so
+ * reading it as the stream tail would render an actively streaming block as finished. The
+ * `state` of the content part before it decides instead.
+ */
+function isStepBoundary(part: MessagePart): boolean {
+	return part.type === 'step-start';
+}
+
+/**
  * Find the content or lifecycle boundary currently at the stream tail. Unknown
- * parts stay boundaries by default; only AI SDK metadata with measured
- * transparent behavior is skipped.
+ * parts stay boundaries by default; only step boundaries and AI SDK metadata
+ * with measured transparent behavior are skipped.
  */
 export function getActiveStreamingPartIndex(
 	parts: MessagePart[] | undefined,
@@ -62,7 +73,7 @@ export function getActiveStreamingPartIndex(
 
 	for (let index = parts.length - 1; index >= 0; index -= 1) {
 		const part = parts[index]!;
-		if (isTransparentStreamMetadata(part)) continue;
+		if (isTransparentStreamMetadata(part) || isStepBoundary(part)) continue;
 		return isCompletedContentPart(part) ? -1 : index;
 	}
 	return -1;


### PR DESCRIPTION
Regression guard: added `reasoning-handover.contract.test.ts`

The chat renderer receives one assistant message through two independent Convex subscriptions, and for an active stream both are live materializations of the same stream: the message-list query materializes the deltas into its own page and replaces the row's parts. Either side can be the older snapshot. `ai` 7 also began stamping an `id` on every reasoning part while `toUIMessages` still reconstructs persisted reasoning without one, so the merge stopped matching the two sides and every thought rendered twice for the length of the handover.

Reasoning now matches on content when no id connects the two sides, against a claimed-index set and an ordering anchor. A settled tool call and a closed live block are no longer undone by a lagging snapshot, and the streaming-boundary walk steps over a step separator, which says a step opened rather than that the content before it closed. The new contract test draws both shapes from the real producers, which is what the old fixtures could not do: they stayed green through the upgrade that broke this.

Two limits are noted at the code that has them and filed as #893 and #894.

Full unit suite green, static checks including types clean.

See also: #887