### PR TITLE
fix(chat): Keep part keys stable across the handover

### DIFF
--- a/src/lib/chat/core/reasoning-handover.contract.test.ts
+++ b/src/lib/chat/core/reasoning-handover.contract.test.ts
@@ -19,6 +19,8 @@ import { readUIMessageStream } from 'ai';
 import { toUIMessages } from '@convex-dev/agent';
 import type { UIMessage } from '@convex-dev/agent';
 import { mergeAssistantMessageParts } from './stream-materialization.js';
+import { getReasoningKey } from '../ui/reasoning-parts.js';
+import type { MessagePart } from './types.js';
 
 /** The wire chunks a two-step tool response produces, in order. */
 function responseChunks(firstThought: string, secondThought: string) {
@@ -145,6 +147,12 @@ function readPersistedMessage(first: string, second: string): UIMessage {
 	return assistant[0]!;
 }
 
+function reasoningKeys(parts: MessagePart[]): string[] {
+	return parts.flatMap((part, index) =>
+		part.type === 'reasoning' ? [getReasoningKey(parts, index)] : []
+	);
+}
+
 describe('the reasoning shapes the two producers emit', () => {
 	// The asymmetry the whole merge is built around. If an upgrade makes the two
 	// sides agree, the id-blind matching below stops being necessary; if it makes
@@ -183,5 +191,20 @@ describe.each(RESPONSES)('the persisted and streamed handover of $name', ({ firs
 
 		expect(merged.filter((part) => part.type === 'reasoning')).toHaveLength(2);
 		expect(merged.filter((part) => part.type === 'text')).toHaveLength(1);
+	});
+
+	// A key that moves remounts the block closed and discards the open state of a
+	// reader who had expanded it, so it has to survive the whole transition: live
+	// snapshot, merged view, persisted row.
+	it('keeps every reasoning key across the transition', async () => {
+		const live = await readLiveMessage(first, second);
+		const persisted = readPersistedMessage(first, second);
+
+		const merged = mergeAssistantMessageParts(persisted.parts, live.parts);
+
+		const whileLive = reasoningKeys(live.parts as MessagePart[]);
+		expect(whileLive).toHaveLength(2);
+		expect(reasoningKeys(merged as MessagePart[])).toEqual(whileLive);
+		expect(reasoningKeys(persisted.parts as MessagePart[])).toEqual(whileLive);
 	});
 });

--- a/src/lib/chat/ui/ordered-parts.test.ts
+++ b/src/lib/chat/ui/ordered-parts.test.ts
@@ -35,7 +35,7 @@ describe('deriveOrderedParts', () => {
 		expect(result[0]).toMatchObject({ key: LEADING_REASONING_KEY });
 	});
 
-	it('keeps the real part key for a non-leading reasoning block', () => {
+	it('keys a non-leading reasoning block by its ordinal', () => {
 		const result = deriveOrderedParts(
 			[
 				{ type: 'reasoning', text: 'First', streamPartId: 'r1' },
@@ -46,7 +46,22 @@ describe('deriveOrderedParts', () => {
 		);
 		const reasoning = result.filter((p) => p.kind === 'reasoning');
 		expect(reasoning[0]).toMatchObject({ key: LEADING_REASONING_KEY });
-		expect(reasoning[1]).toMatchObject({ key: 'reasoning-r2' });
+		expect(reasoning[1]).toMatchObject({ key: 'reasoning-1' });
+	});
+
+	// The persisted copy of the same message carries no part ids and no step-start,
+	// so a key read off either would move when it takes over from the live snapshot.
+	it('keeps the reasoning keys when the ids and step boundaries are gone', () => {
+		const result = deriveOrderedParts(
+			[
+				{ type: 'reasoning', text: 'First' },
+				{ type: 'tool-getWeather', toolCallId: 't1', state: 'output-available' },
+				{ type: 'reasoning', text: 'Second' }
+			] as MessagePart[],
+			'success'
+		);
+		const reasoning = result.filter((p) => p.kind === 'reasoning');
+		expect(reasoning.map((p) => p.key)).toEqual([LEADING_REASONING_KEY, 'reasoning-1']);
 	});
 
 	it('marks the trailing reasoning part as streaming only while in progress', () => {

--- a/src/lib/chat/ui/ordered-parts.test.ts
+++ b/src/lib/chat/ui/ordered-parts.test.ts
@@ -49,12 +49,15 @@ describe('deriveOrderedParts', () => {
 		expect(reasoning[1]).toMatchObject({ key: 'reasoning-1' });
 	});
 
-	// The persisted copy of the same message carries no part ids and no step-start,
-	// so a key read off either would move when it takes over from the live snapshot.
+	// The persisted copy of the same message carries no part ids, and it opens its
+	// step before the tool call rather than before the thought (measured against
+	// `toUIMessages`), so a key read off an id or an array index would move when it
+	// takes over from the live snapshot.
 	it('keeps the reasoning keys when the ids and step boundaries are gone', () => {
 		const result = deriveOrderedParts(
 			[
 				{ type: 'reasoning', text: 'First' },
+				{ type: 'step-start' },
 				{ type: 'tool-getWeather', toolCallId: 't1', state: 'output-available' },
 				{ type: 'reasoning', text: 'Second' }
 			] as MessagePart[],
@@ -62,6 +65,22 @@ describe('deriveOrderedParts', () => {
 		);
 		const reasoning = result.filter((p) => p.kind === 'reasoning');
 		expect(reasoning.map((p) => p.key)).toEqual([LEADING_REASONING_KEY, 'reasoning-1']);
+	});
+
+	// Reasoning, text and tool items are siblings in one keyed block, so a tool call
+	// id that looks like a reasoning ordinal would key two of them the same and put
+	// Svelte into its duplicate-key path.
+	it('keeps a tool call id out of the reasoning key namespace', () => {
+		const result = deriveOrderedParts(
+			[
+				{ type: 'reasoning', text: 'First' },
+				{ type: 'tool-lookup', toolCallId: 'reasoning-1', state: 'output-available' },
+				{ type: 'reasoning', text: 'Second' }
+			] as MessagePart[],
+			'success'
+		);
+
+		expect(new Set(result.map((p) => p.key)).size).toBe(result.length);
 	});
 
 	it('marks the trailing reasoning part as streaming only while in progress', () => {

--- a/src/lib/chat/ui/ordered-parts.test.ts
+++ b/src/lib/chat/ui/ordered-parts.test.ts
@@ -68,19 +68,60 @@ describe('deriveOrderedParts', () => {
 	});
 
 	// Reasoning, text and tool items are siblings in one keyed block, so a tool call
-	// id that looks like a reasoning ordinal would key two of them the same and put
-	// Svelte into its duplicate-key path.
-	it('keeps a tool call id out of the reasoning key namespace', () => {
-		const result = deriveOrderedParts(
+	// id that looks like a reasoning key would key two of them the same and put
+	// Svelte into its duplicate-key path. Both spellings a reasoning key ever had
+	// are covered, because the provider only promises the id is unique among tool
+	// calls, not that it avoids another kind's key space.
+	it.each(['reasoning-1', 'reasoning-r-second'])(
+		'keeps the tool call id %s out of the reasoning key namespace',
+		(toolCallId) => {
+			const result = deriveOrderedParts(
+				[
+					{ type: 'step-start' },
+					{ type: 'reasoning', text: 'First', id: 'r-first', state: 'done' },
+					{
+						type: 'tool-lookup',
+						toolCallId,
+						state: 'output-available',
+						input: {},
+						output: {}
+					},
+					{ type: 'step-start' },
+					{ type: 'reasoning', text: 'Second', id: 'r-second', state: 'streaming' }
+				] as MessagePart[],
+				'streaming'
+			);
+
+			expect(new Set(result.map((p) => p.key)).size).toBe(result.length);
+		}
+	);
+
+	// The answer is the part a reader is most likely to have selected or scrolled,
+	// and it moves index between the two views for the same reason the thoughts do.
+	it('keys text blocks by their ordinal so the answer survives the handover', () => {
+		const live = deriveOrderedParts(
 			[
-				{ type: 'reasoning', text: 'First' },
-				{ type: 'tool-lookup', toolCallId: 'reasoning-1', state: 'output-available' },
-				{ type: 'reasoning', text: 'Second' }
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'First', id: 'r-first', state: 'done' },
+				{ type: 'tool-lookup', toolCallId: 't1', state: 'output-available', input: {}, output: {} },
+				{ type: 'step-start' },
+				{ type: 'reasoning', text: 'Second', id: 'r-second', state: 'done' },
+				{ type: 'text', text: 'the answer', state: 'done' }
+			] as MessagePart[],
+			'success'
+		);
+		const persisted = deriveOrderedParts(
+			[
+				{ type: 'reasoning', text: 'First', state: 'done' },
+				{ type: 'step-start' },
+				{ type: 'tool-lookup', toolCallId: 't1', state: 'output-available', input: {}, output: {} },
+				{ type: 'reasoning', text: 'Second', state: 'done' },
+				{ type: 'text', text: 'the answer', state: 'done' }
 			] as MessagePart[],
 			'success'
 		);
 
-		expect(new Set(result.map((p) => p.key)).size).toBe(result.length);
+		expect(live.map((p) => p.key)).toEqual(persisted.map((p) => p.key));
 	});
 
 	it('marks the trailing reasoning part as streaming only while in progress', () => {

--- a/src/lib/chat/ui/ordered-parts.ts
+++ b/src/lib/chat/ui/ordered-parts.ts
@@ -30,6 +30,21 @@ export type OrderedPart =
  * `step-start` returns `[]` and the caller keeps the connecting fallback mounted instead
  * of rendering an empty list.
  */
+/**
+ * How many parts of `type` come before `index`. The array position itself cannot
+ * key a part, because the views of one message place their `step-start` parts
+ * differently: the live stream opens a step before each thought, the persisted
+ * row before each tool call (measured), so the same answer sits at a different
+ * index in each and a keyed block would remount it mid-handover.
+ */
+function ordinalAmongType(parts: MessagePart[], index: number, type: string): number {
+	let ordinal = 0;
+	for (let before = 0; before < index; before += 1) {
+		if (parts[before]?.type === type) ordinal += 1;
+	}
+	return ordinal;
+}
+
 function toolPartKey(
 	toolCallId: string | undefined,
 	streamId: string | undefined,
@@ -70,7 +85,7 @@ export function deriveOrderedParts(
 					kind: 'text',
 					text: (p as { text?: string }).text ?? '',
 					isStreaming: idx === activeTextIndex,
-					key: `text-${idx}`
+					key: `text-${ordinalAmongType(messageParts, idx, 'text')}`
 				};
 			}
 			if (typeof p.type === 'string' && p.type.startsWith('tool-') && 'state' in p) {

--- a/src/lib/chat/ui/ordered-parts.ts
+++ b/src/lib/chat/ui/ordered-parts.ts
@@ -15,8 +15,8 @@ export { LEADING_REASONING_KEY };
  * `key` is both the Svelte `{#each}` identity and the suffix of the accordion open-state
  * key (`${message.id}:${key}`). The leading reasoning block keys to
  * {@link LEADING_REASONING_KEY} (see `getReasoningKey`), so it stays mounted and keeps its
- * open-state across the connecting → thinking transition; later reasoning blocks keep their
- * per-part key.
+ * open-state across the connecting → thinking transition; later reasoning blocks are keyed
+ * by their ordinal among the reasoning blocks, which survives the same transition.
  */
 export type OrderedPart =
 	| { kind: 'reasoning'; text: string; isStreaming: boolean; hasContent: boolean; key: string }
@@ -37,9 +37,9 @@ export function deriveOrderedParts(
 	const messageParts = parts ?? [];
 	const isMessageInProgress = status === 'pending' || status === 'streaming';
 	const activeReasoningIndex = getActiveStreamingReasoningIndex(messageParts, isMessageInProgress);
-	// Source, file and data parts annotate an open text stream; step-start, tools
-	// and unknown parts remain boundaries. The shared selector follows that AI
-	// SDK lifecycle for text and reasoning alike.
+	// Source, file and data parts annotate an open text stream and a step-start
+	// only opens the next step; tools and unknown parts remain boundaries. The
+	// shared selector follows that AI SDK lifecycle for text and reasoning alike.
 	const activePartIndex = getActiveStreamingPartIndex(messageParts, isMessageInProgress);
 	const activeTextIndex = messageParts[activePartIndex]?.type === 'text' ? activePartIndex : -1;
 

--- a/src/lib/chat/ui/ordered-parts.ts
+++ b/src/lib/chat/ui/ordered-parts.ts
@@ -30,6 +30,16 @@ export type OrderedPart =
  * `step-start` returns `[]` and the caller keeps the connecting fallback mounted instead
  * of rendering an empty list.
  */
+function toolPartKey(
+	toolCallId: string | undefined,
+	streamId: string | undefined,
+	index: number
+): string {
+	if (toolCallId) return `tool-call-${toolCallId}`;
+	if (streamId) return `tool-stream-${streamId}`;
+	return `tool-index-${index}`;
+}
+
 export function deriveOrderedParts(
 	parts: MessagePart[] | undefined,
 	status: MessageStatus
@@ -74,10 +84,14 @@ export function deriveOrderedParts(
 						toolCallId: (p as { toolCallId?: string }).toolCallId,
 						errorText: (p as { errorText?: string }).errorText
 					},
-					key:
-						(p as { toolCallId?: string }).toolCallId ??
-						(p as { streamId?: string }).streamId ??
-						`tool-${idx}`
+					// Every kind prefixes its own key, because all of them are siblings in one
+					// keyed block. A raw tool call id shares that namespace with the reasoning
+					// and text keys, and the provider decides what it contains.
+					key: toolPartKey(
+						(p as { toolCallId?: string }).toolCallId,
+						(p as { streamId?: string }).streamId,
+						idx
+					)
 				};
 			}
 			return null;

--- a/src/lib/chat/ui/reasoning-accordion-sync.test.ts
+++ b/src/lib/chat/ui/reasoning-accordion-sync.test.ts
@@ -141,7 +141,7 @@ describe('syncReasoningAccordionState', () => {
 			controller
 		);
 		expect(openState.has('msg-1:reasoning-lead')).toBe(false);
-		expect(openState.has('msg-1:reasoning-reason-2')).toBe(true);
+		expect(openState.has('msg-1:reasoning-1')).toBe(true);
 
 		syncReasoningAccordionState(
 			[
@@ -157,7 +157,7 @@ describe('syncReasoningAccordionState', () => {
 			],
 			controller
 		);
-		expect(openState.has('msg-1:reasoning-reason-2')).toBe(false);
+		expect(openState.has('msg-1:reasoning-1')).toBe(false);
 
 		syncReasoningAccordionState(
 			[
@@ -174,8 +174,8 @@ describe('syncReasoningAccordionState', () => {
 			controller
 		);
 		expect(openState.has('msg-1:reasoning-lead')).toBe(false);
-		expect(openState.has('msg-1:reasoning-reason-2')).toBe(false);
-		expect(openState.has('msg-1:reasoning-reason-3')).toBe(true);
+		expect(openState.has('msg-1:reasoning-1')).toBe(false);
+		expect(openState.has('msg-1:reasoning-2')).toBe(true);
 	});
 
 	it('keeps the message-level fallback behavior for messages without parts', () => {
@@ -328,9 +328,9 @@ describe('syncReasoningAccordionState', () => {
 			controller
 		);
 
-		// reason-1 should stay as user left it (closed), reason-2 should auto-open
+		// The first block stays as the user left it (closed), the second auto-opens
 		expect(openState.has('msg-1:reasoning-lead')).toBe(false);
-		expect(openState.has('msg-1:reasoning-reason-2')).toBe(true);
+		expect(openState.has('msg-1:reasoning-1')).toBe(true);
 	});
 
 	it('removes stale userToggled keys when reasoning parts disappear', () => {

--- a/src/lib/chat/ui/reasoning-parts.test.ts
+++ b/src/lib/chat/ui/reasoning-parts.test.ts
@@ -91,11 +91,16 @@ describe('reasoning keys', () => {
 		const live = [
 			{ type: 'step-start' },
 			{ type: 'reasoning', text: 'First', id: 'r-first' },
+			{ type: 'tool-lookup', toolCallId: 't1', state: 'output-available' },
 			{ type: 'step-start' },
 			{ type: 'reasoning', text: 'Second', id: 'r-second' }
 		] as MessagePart[];
+		// Measured against `toUIMessages`: the persisted copy drops the ids and opens
+		// its step before the tool call instead of before the thought.
 		const persisted = [
 			{ type: 'reasoning', text: 'First' },
+			{ type: 'step-start' },
+			{ type: 'tool-lookup', toolCallId: 't1', state: 'output-available' },
 			{ type: 'reasoning', text: 'Second' }
 		] as MessagePart[];
 

--- a/src/lib/chat/ui/reasoning-parts.test.ts
+++ b/src/lib/chat/ui/reasoning-parts.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import type { MessagePart } from '../core/types.js';
 import {
 	getActiveStreamingPartIndex,
-	getActiveStreamingReasoningIndex
+	getActiveStreamingReasoningIndex,
+	getReasoningKey,
+	LEADING_REASONING_KEY
 } from './reasoning-parts.js';
 
 const metadata = [
@@ -64,5 +66,43 @@ describe('active streaming content', () => {
 
 	it('returns no active content after completion', () => {
 		expect(getActiveStreamingPartIndex([{ type: 'text', text: 'done' }], false)).toBe(-1);
+	});
+});
+
+describe('reasoning keys', () => {
+	const keysOf = (parts: MessagePart[]) =>
+		parts.flatMap((part, index) =>
+			part.type === 'reasoning' ? [getReasoningKey(parts, index)] : []
+		);
+
+	it('keys reasoning blocks by their ordinal, leading block first', () => {
+		const parts = [
+			{ type: 'reasoning', text: 'First' },
+			{ type: 'tool-lookup', toolCallId: 't1', state: 'output-available' },
+			{ type: 'reasoning', text: 'Second' },
+			{ type: 'reasoning', text: 'Third' }
+		] as MessagePart[];
+		expect(keysOf(parts)).toEqual([LEADING_REASONING_KEY, 'reasoning-1', 'reasoning-2']);
+	});
+
+	// The live snapshot and the persisted row of one message differ in exactly these
+	// two ways, so a key that reads either would move at the handover.
+	it('ignores part ids and step boundaries', () => {
+		const live = [
+			{ type: 'step-start' },
+			{ type: 'reasoning', text: 'First', id: 'r-first' },
+			{ type: 'step-start' },
+			{ type: 'reasoning', text: 'Second', id: 'r-second' }
+		] as MessagePart[];
+		const persisted = [
+			{ type: 'reasoning', text: 'First' },
+			{ type: 'reasoning', text: 'Second' }
+		] as MessagePart[];
+
+		expect(keysOf(live)).toEqual(keysOf(persisted));
+	});
+
+	it('treats a missing parts array as an empty one', () => {
+		expect(getReasoningKey(undefined, 0)).toBe(LEADING_REASONING_KEY);
 	});
 });

--- a/src/lib/chat/ui/reasoning-parts.ts
+++ b/src/lib/chat/ui/reasoning-parts.ts
@@ -9,31 +9,26 @@ import type { MessagePart } from '../core/types.js';
  */
 export const LEADING_REASONING_KEY = 'reasoning-lead';
 
-export function getReasoningPartKey(part: MessagePart, index: number): string {
-	if (part.type === 'reasoning') {
-		const record = part as { streamPartId?: unknown; id?: unknown };
-		const partId = record.streamPartId ?? record.id;
-		if (typeof partId === 'string') {
-			return `reasoning-${partId}`;
-		}
-	}
-
-	return `reasoning-${index}`;
-}
-
 /**
- * Key for a reasoning part at `index` within `parts`. The first reasoning part gets the
- * stable {@link LEADING_REASONING_KEY}; later reasoning blocks keep their per-part key.
- * Single source of truth shared by rendering (ordered-parts) and accordion sync, so both
- * agree on the leading reasoning key.
+ * Key for the reasoning part at `index` within `parts`. The first reasoning block gets the
+ * stable {@link LEADING_REASONING_KEY}; every later block is keyed by its ordinal among the
+ * reasoning blocks of the message. Single source of truth shared by rendering
+ * (ordered-parts) and accordion sync, so both agree on every reasoning key.
+ *
+ * The ordinal is the only part of a reasoning block that survives the handover from the
+ * live snapshot to the persisted row. A key built from the part id flips once the persisted
+ * copy takes over, because `toUIMessages` reconstructs reasoning without an id; a key built
+ * from the array index flips because the live snapshot carries `step-start` parts that the
+ * persisted row does not. Either flip remounts the block closed and discards the open state
+ * of a reader who had expanded it.
  */
 export function getReasoningKey(parts: MessagePart[] | undefined, index: number): string {
 	const list = parts ?? [];
-	const firstReasoningIndex = list.findIndex((p) => p.type === 'reasoning');
-	if (index === firstReasoningIndex) {
-		return LEADING_REASONING_KEY;
+	let ordinal = 0;
+	for (let before = 0; before < index; before += 1) {
+		if (list[before]?.type === 'reasoning') ordinal += 1;
 	}
-	return getReasoningPartKey(list[index]!, index);
+	return ordinal === 0 ? LEADING_REASONING_KEY : `reasoning-${ordinal}`;
 }
 
 /**


### PR DESCRIPTION
Closes #887

Regression guard: added `keeps the reasoning keys when the ids and step boundaries are gone`, `keys text blocks by their ordinal so the answer survives the handover` and `keeps the tool call id %s out of the reasoning key namespace`

A part's `{#each}` key decides whether its component instance survives the handover between the views of one message, and a reasoning key also scopes the accordion open state. Both previous key sources moved: a key built from the part id, because the persisted reconstruction has none, and a key built from the array index, because the views place their step boundaries differently. The live stream opens a step before each thought, the persisted row before each tool call, so the same answer sits at a different index in each.

Reasoning and text blocks are now keyed by their ordinal among their own kind, which every view agrees on. Tool parts keep their call id but in a prefixed key space, since all kinds are siblings in one keyed block and only the tool key carried a raw provider value.

Full unit suite green, static checks including types clean.