### PR TITLE
chore(chat): Check the active chat tree

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -23,7 +23,11 @@ export default {
 		// knip cannot trace. Naming the roots lets it check everything below them.
 		'src/lib/components/customer-support/customer-support.svelte',
 		'src/lib/components/customer-support/screenshot-editor/ScreenshotEditor.svelte',
-		'src/lib/components/global-search/command-menu.svelte'
+		'src/lib/components/global-search/command-menu.svelte',
+
+		// Chat-Beispiel zum Kopieren und Anpassen. Keine Route bindet es ein, daher hält
+		// die Nennung als Entry es am Leben, während src/lib/chat sonst geprüft bleibt.
+		'src/lib/chat/examples/SimpleChat.svelte'
 	],
 	project: ['src/**/*.{ts,svelte}', 'scripts/**/*.ts', 'e2e/**/*.ts'],
 	ignore: [
@@ -44,10 +48,7 @@ export default {
 		// its importer. Guarded live by motion-a11y.test.ts.
 		'src/lib/components/motion/shimmer-text.svelte',
 		// Template block kept as a starting point; not mounted by any route.
-		'src/blocks/team/team-two.svelte',
-		// Scaffolded chat module. Its example component and unused core exports are a
-		// pruning decision of their own, so knip skips the tree until that lands.
-		'src/lib/chat/**'
+		'src/blocks/team/team-two.svelte'
 	],
 	ignoreDependencies: [
 		// Tailwind v4 plugins referenced via CSS @plugin, not JS imports.

--- a/src/lib/chat/core/chat-core.svelte.ts
+++ b/src/lib/chat/core/chat-core.svelte.ts
@@ -313,10 +313,3 @@ export class ChatCore {
 		this.streamCache.clear();
 	}
 }
-
-/**
- * Create a new ChatCore instance
- */
-export function createChatCore(options: ChatCoreOptions): ChatCore {
-	return new ChatCore(options);
-}

--- a/src/lib/chat/core/index.ts
+++ b/src/lib/chat/core/index.ts
@@ -16,7 +16,6 @@ export type {
 	TextUIPart,
 	ReasoningUIPart,
 	MessagePart,
-	PaginationState,
 	StreamStatus,
 	SendMessageOptions,
 	SendMessageResult,
@@ -61,7 +60,7 @@ export { uploadFileWithProgress, uploadToStorage, UploadError } from './file-upl
 // Chat core
 export type { ChatCoreAPI, ChatCoreOptions, CreateThreadResult } from './chat-core.svelte.ts';
 
-export { ChatCore, createChatCore } from './chat-core.svelte.ts';
+export { ChatCore } from './chat-core.svelte.ts';
 
 // Composer persistence
 export { ChatDraftManager } from './chat-draft-manager.svelte.ts';

--- a/src/lib/chat/core/optimistic.ts
+++ b/src/lib/chat/core/optimistic.ts
@@ -9,7 +9,7 @@
  */
 
 import type { OptimisticLocalStore } from 'convex/browser';
-import type { FunctionReference, PaginationResult } from 'convex/server';
+import type { FunctionReference } from 'convex/server';
 import type { ChatMessage, Attachment } from './types.js';
 
 /**
@@ -20,17 +20,6 @@ export interface ListMessagesArgs {
 	anonymousUserId?: string;
 	paginationOpts: { numItems: number; cursor: string | null };
 	streamArgs: { kind: 'list'; startOrder: number };
-}
-
-/**
- * Query result shape for listMessages queries (paginated with streams)
- */
-export interface ListMessagesResult extends PaginationResult<ChatMessage> {
-	streams: {
-		kind: 'list' | 'deltas';
-		messages?: unknown[];
-		deltas?: unknown[];
-	};
 }
 
 /**

--- a/src/lib/chat/core/types.ts
+++ b/src/lib/chat/core/types.ts
@@ -174,15 +174,6 @@ export type MessagePart =
 	TextUIPart | ReasoningUIPart | ToolCallPart | { type: string; [key: string]: unknown };
 
 /**
- * Pagination state
- */
-export interface PaginationState {
-	hasMore: boolean;
-	continueCursor: string | null;
-	isLoadingMore: boolean;
-}
-
-/**
  * Stream status
  */
 export type StreamStatus = 'streaming' | 'finished' | 'aborted';

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -25,9 +25,9 @@
  *
  * @example Using core without UI
  * ```typescript
- * import { ChatCore, createChatCore } from '$lib/chat/core';
+ * import { ChatCore } from '$lib/chat/core';
  *
- * const core = createChatCore({
+ * const core = new ChatCore({
  *   threadId: 'thread_123',
  *   api: { sendMessage: api.support.messages.sendMessage }
  * });
@@ -50,7 +50,6 @@ export type {
 	TextUIPart,
 	ReasoningUIPart,
 	MessagePart,
-	PaginationState,
 	StreamStatus,
 	SendMessageOptions,
 	SendMessageResult,
@@ -84,14 +83,13 @@ export {
 	uploadToStorage,
 	UploadError,
 	ChatCore,
-	createChatCore,
 	ChatDraftManager,
 	ChatAttachmentStore,
 	clearPersistedChatState
 } from './core/index.js';
 
 // UI exports
-export type { UploadConfig, FileMetadataMap } from './ui/index.js';
+export type { UploadConfig } from './ui/index.js';
 
 export {
 	ChatUIContext,

--- a/src/lib/chat/ui/index.ts
+++ b/src/lib/chat/ui/index.ts
@@ -15,14 +15,6 @@ export {
 	tryGetChatUIContext
 } from './chat-context.svelte.ts';
 
-// Types
-/**
- * File metadata for dimension lookup
- * Map of URL -> { width, height }. Keyed by URL because UIMessage file parts
- * carry no fileId (see ChatMessages.defaultExtractAttachments).
- */
-export type FileMetadataMap = Record<string, { width?: number; height?: number }>;
-
 // Components
 export { default as ChatRoot } from './ChatRoot.svelte';
 export { default as ChatMessages } from './ChatMessages.svelte';

--- a/src/lib/components/customer-support/support-thread-context.svelte.ts
+++ b/src/lib/components/customer-support/support-thread-context.svelte.ts
@@ -15,22 +15,6 @@ import { isSupportAiEnabled } from '$lib/config/support';
 export type SupportView = 'overview' | 'chat' | 'compose';
 
 /**
- * Thread summary for the overview list
- */
-export interface ThreadSummary {
-	_id: string;
-	_creationTime: number;
-	userId?: string;
-	title?: string;
-	summary?: string;
-	status: 'active' | 'archived';
-	lastAgentName?: string;
-	lastMessageRole?: 'user' | 'assistant' | 'tool' | 'system';
-	lastMessage?: string;
-	lastMessageAt?: number;
-}
-
-/**
  * Thread context state
  */
 export class SupportThreadContext {

--- a/src/lib/components/customer-support/use-support-url-state.svelte.ts
+++ b/src/lib/components/customer-support/use-support-url-state.svelte.ts
@@ -31,5 +31,3 @@ export function useSupportUrlState() {
 		noScroll: true
 	});
 }
-
-export type SupportUrlState = ReturnType<typeof useSupportUrlState>;

--- a/src/lib/utils/fade-on-load.svelte.ts
+++ b/src/lib/utils/fade-on-load.svelte.ts
@@ -7,7 +7,7 @@
  * @example
  * ```typescript
  * // In a context class
- * threadsFade = new FadeOnLoad<ThreadSummary[]>();
+ * threadsFade = new FadeOnLoad();
  *
  * async loadThreads(client: ConvexClient) {
  *   this.threadsFade.setLoading(true);


### PR DESCRIPTION
Closes #892

The broad Knip exception for `src/lib/chat` hid unused declarations in active chat code. The example still needs to remain available as a starting point for applications.

`SimpleChat` is now an explicit entry. Confirmed unused wrappers and types were removed, so Knip checks the complete chat tree again. Components and streaming behavior remain unchanged.

Verified with 293 chat and support tests, complete static and type checks, and 1,882 passing unit tests. A temporary orphaned chat module makes Knip fail as expected. The independent review is complete.
