### PR TITLE
fix(chat): Preserve bottom following during reflow

### DIFF
--- a/src/lib/chat/ui/ChatMessages.svelte
+++ b/src/lib/chat/ui/ChatMessages.svelte
@@ -189,7 +189,7 @@
 
 <div bind:this={wrapperEl} class="relative h-full {className}">
 	<ChatContainerRoot ctx={chatCtx} class="h-full">
-		<ChatContainerContent class="!h-full">
+		<ChatContainerContent>
 			{#if ctx.displayMessages.length === 0}
 				<!-- Empty state -->
 				{#if emptyState}

--- a/src/lib/components/prompt-kit/chat-container/chat-container-content.svelte
+++ b/src/lib/components/prompt-kit/chat-container/chat-container-content.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import { watch } from 'runed';
+	import { chatContainerContext } from './chat-container-context.svelte.ts';
 
 	import type { Snippet } from 'svelte';
 	let {
@@ -11,8 +13,21 @@
 		class?: string;
 		[key: string]: any;
 	} = $props();
+	const context = chatContainerContext.get();
+	let element: HTMLDivElement | null = $state(null);
+	watch(
+		() => element,
+		(value) => {
+			context.setContentElement(value);
+			return () => context.setContentElement(null);
+		}
+	);
 </script>
 
-<div class={cn('flex w-full flex-col', className)} {...restProps}>
+<div
+	bind:this={element}
+	class={cn('flex min-h-full w-full shrink-0 flex-col', className)}
+	{...restProps}
+>
 	{@render children?.()}
 </div>

--- a/src/lib/components/prompt-kit/chat-container/chat-container-context.svelte.ts
+++ b/src/lib/components/prompt-kit/chat-container/chat-container-context.svelte.ts
@@ -1,20 +1,17 @@
-import {
-	watch,
-	Context,
-	useEventListener,
-	useIntersectionObserver,
-	useMutationObserver,
-	useResizeObserver
-} from 'runed';
+import { watch, Context, useEventListener, useResizeObserver } from 'runed';
+import { prefersReducedMotion } from 'svelte/motion';
 
 type ResizeMode = 'smooth' | 'instant';
 type InitialMode = 'smooth' | 'instant';
 
 export class ChatContainerContext {
 	#element: HTMLElement | null = $state(null);
+	#content: HTMLElement | null = $state(null);
 	#isAtBottom = $state(true);
-	#sentinel: HTMLElement | null = $state(null);
-	#userHasScrolled = $state(false);
+	// Following is user intent, independent of geometry during reflow or a smooth scroll.
+	#following = true;
+	#lastScrollTop = 0;
+	#lastScrollHeight = 0;
 	#resizeMode: ResizeMode = 'smooth';
 	#initialMode: InitialMode = 'instant';
 	#isInitialized = false;
@@ -22,71 +19,43 @@ export class ChatContainerContext {
 	isAtBottom = $derived(this.#isAtBottom);
 
 	constructor(resizeMode: ResizeMode = 'smooth', initialMode: InitialMode = 'instant') {
-		this.#resizeMode = resizeMode;
-		this.#initialMode = initialMode;
+		this.setModes(resizeMode, initialMode);
 
-		// Sentinel lifecycle. Declared before the observers below so the initial
-		// append happens before the MutationObserver starts watching.
 		watch(
 			() => this.#element,
 			(element) => {
 				if (!element) return;
-
-				this.#sentinel = this.#createSentinel(element);
-
-				// Initial scroll to bottom
-				requestAnimationFrame(() => {
-					this.#checkScrollPosition();
-					this.scrollToBottom();
+				this.#following = true;
+				this.#isInitialized = false;
+				this.#rememberPosition();
+				const frame = requestAnimationFrame(() => {
+					if (this.#following) this.scrollToBottom();
 				});
-
-				return () => {
-					if (this.#sentinel && element.contains(this.#sentinel)) {
-						element.removeChild(this.#sentinel);
-					}
-					this.#sentinel = null;
-				};
+				return () => cancelAnimationFrame(frame);
 			}
 		);
 
 		useEventListener(() => this.#element, 'scroll', this.#handleScroll, { passive: true });
+		useEventListener(
+			() => this.#element,
+			'wheel',
+			(event) => {
+				if (event.deltaY < 0) this.#stopFollowing();
+			},
+			{ passive: true }
+		);
 
+		// Observe the natural content height as well as the viewport. This also catches
+		// image loads, font reflow and expanding tool results without a DOM mutation.
 		useResizeObserver(
-			() => this.#element,
-			() => {
-				this.#checkScrollPosition();
-				if (this.#isAtBottom && !this.#userHasScrolled) {
-					const behavior = this.#resizeMode === 'smooth' ? 'smooth' : 'instant';
-					this.scrollToBottom(behavior);
-				}
-			}
-		);
-
-		useMutationObserver(
-			() => this.#element,
-			() => {
-				requestAnimationFrame(() => {
-					const shouldAutoScroll = this.#isAtBottom && !this.#userHasScrolled;
-					this.#checkScrollPosition();
-
-					if (shouldAutoScroll) {
-						this.scrollToBottom('smooth');
-					}
-				});
-			},
-			{ childList: true, subtree: true, characterData: true }
-		);
-
-		useIntersectionObserver(
-			() => this.#sentinel,
+			() => [this.#element, this.#content].filter((el): el is HTMLElement => el !== null),
 			(entries) => {
-				const entry = entries[0]!;
-				if (entry.isIntersecting && !this.#userHasScrolled) {
-					this.#isAtBottom = true;
+				if (this.#following) {
+					const viewportChanged = entries.some((entry) => entry.target === this.#element);
+					this.scrollToBottom(viewportChanged ? 'instant' : this.#resizeMode);
 				}
-			},
-			// Explicit threshold: 0 to keep the previous observer's behavior (runed defaults to 0.1)
-			{ threshold: 0, root: () => this.#element }
+				this.#rememberPosition();
+			}
 		);
 	}
 
@@ -95,68 +64,51 @@ export class ChatContainerContext {
 		this.#initialMode = initialMode;
 	}
 
-	setElement(element: HTMLElement) {
+	setElement(element: HTMLElement | null) {
 		this.#element = element;
+	}
+
+	setContentElement(element: HTMLElement | null) {
+		this.#content = element;
 	}
 
 	scrollToBottom = (behavior?: ScrollBehavior) => {
 		if (!this.#element) return;
-
-		// Use initial mode for first scroll, then use provided behavior or resize mode
-		let scrollBehavior: ScrollBehavior;
-		if (!this.#isInitialized) {
-			scrollBehavior = this.#initialMode === 'instant' ? 'instant' : 'smooth';
-			this.#isInitialized = true;
-		} else {
-			scrollBehavior = behavior || (this.#resizeMode === 'smooth' ? 'smooth' : 'instant');
-		}
-
-		this.#userHasScrolled = false;
+		const mode = this.#isInitialized ? (behavior ?? this.#resizeMode) : this.#initialMode;
+		this.#isInitialized = true;
+		this.#following = true;
 		this.#element.scrollTo({
 			top: this.#element.scrollHeight,
-			behavior: scrollBehavior
+			behavior: prefersReducedMotion.current ? 'instant' : mode
 		});
+		this.#rememberPosition();
 	};
+
+	#stopFollowing() {
+		this.#following = false;
+		// Cancel an in-flight smooth scroll before it can fight the user's gesture.
+		this.#element?.scrollTo({ top: this.#element.scrollTop, behavior: 'instant' });
+	}
 
 	#handleScroll = () => {
 		if (!this.#element) return;
-
-		const { scrollTop, scrollHeight, clientHeight } = this.#element;
-		const threshold = 50;
-		const isAtBottom = scrollTop + clientHeight >= scrollHeight - threshold;
-
-		this.#isAtBottom = isAtBottom;
-
-		if (!isAtBottom) {
-			this.#userHasScrolled = true;
-		} else if (isAtBottom && this.#userHasScrolled) {
-			this.#userHasScrolled = false;
-		}
+		const { scrollTop, scrollHeight } = this.#element;
+		// A shorter document can clamp scrollTop. That is reflow, not a scroll up.
+		const movedUp = scrollTop < this.#lastScrollTop - 1 && scrollHeight === this.#lastScrollHeight;
+		const movedDown = scrollTop > this.#lastScrollTop;
+		this.#rememberPosition();
+		if (movedUp) this.#stopFollowing();
+		else if (this.#isAtBottom && movedDown) this.#following = true;
 	};
 
-	#createSentinel(element: HTMLElement): HTMLElement {
-		const sentinel = document.createElement('div');
-		sentinel.style.height = '1px';
-		sentinel.style.width = '100%';
-		sentinel.style.pointerEvents = 'none';
-		sentinel.style.opacity = '0';
-		sentinel.setAttribute('data-chat-container-sentinel', '');
-
-		element.appendChild(sentinel);
-		return sentinel;
-	}
-
-	#checkScrollPosition() {
+	#rememberPosition() {
 		if (!this.#element) return;
-
 		const { scrollTop, scrollHeight, clientHeight } = this.#element;
-		const threshold = 50;
-		const isAtBottom = scrollTop + clientHeight >= scrollHeight - threshold;
-
-		this.#isAtBottom = isAtBottom;
+		this.#isAtBottom = scrollTop + clientHeight >= scrollHeight - 50;
+		this.#lastScrollTop = scrollTop;
+		this.#lastScrollHeight = scrollHeight;
 	}
 }
 
 export const chatContainerContext = new Context<ChatContainerContext>('chat-container');
-
 export type { ResizeMode, InitialMode };

--- a/src/lib/components/prompt-kit/chat-container/chat-container-context.test.ts
+++ b/src/lib/components/prompt-kit/chat-container/chat-container-context.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { prefersReducedMotion } from 'svelte/motion';
+import { ChatContainerContext } from './chat-container-context.svelte.ts';
+
+// Replay browser geometry at observer/event boundaries. Chromium emits downward
+// scroll events before a smooth scroll reaches its target; none is user input.
+const callbacks = vi.hoisted(() => ({
+	resize: (_entries: Array<{ target: HTMLElement }>) => {},
+	events: new Map<string, (event?: { deltaY: number }) => void>()
+}));
+vi.mock('runed', () => ({
+	Context: class {},
+	watch: () => {},
+	useEventListener: (_target: unknown, event: string, callback: () => void) => {
+		callbacks.events.set(event, callback);
+	},
+	useResizeObserver: (_target: unknown, callback: typeof callbacks.resize) => {
+		callbacks.resize = callback;
+	}
+}));
+vi.mock('svelte/motion', () => ({ prefersReducedMotion: { current: false } }));
+
+function viewport() {
+	return Object.assign(document.createElement('div'), {
+		scrollTo: vi.fn()
+	});
+}
+
+describe('chat bottom following', () => {
+	let context: ChatContainerContext;
+	let element: ReturnType<typeof viewport>;
+	let content: HTMLElement;
+	let height: number;
+	let viewportHeight: number;
+
+	beforeEach(() => {
+		callbacks.events.clear();
+		(prefersReducedMotion as { current: boolean }).current = false;
+		element = viewport();
+		content = document.createElement('div');
+		height = 1200;
+		viewportHeight = 400;
+		Object.defineProperties(element, {
+			scrollHeight: { get: () => height },
+			clientHeight: { get: () => viewportHeight }
+		});
+		element.scrollTop = 800;
+		context = new ChatContainerContext();
+		context.setElement(element);
+		context.setContentElement(content);
+		context.scrollToBottom();
+		element.scrollTo.mockClear();
+	});
+
+	function scroll(top: number) {
+		element.scrollTop = top;
+		callbacks.events.get('scroll')!();
+	}
+
+	it('keeps following through intermediate downward smooth-scroll frames', () => {
+		height += 80;
+		callbacks.resize([{ target: content }]);
+		scroll(803);
+		height += 80;
+		callbacks.resize([{ target: content }]);
+		expect(element.scrollTo).toHaveBeenLastCalledWith({ top: 1360, behavior: 'smooth' });
+	});
+
+	it('preserves the bottom pin when the viewport shrinks', () => {
+		viewportHeight = 280;
+		callbacks.resize([{ target: element }]);
+		expect(element.scrollTo).toHaveBeenLastCalledWith({ top: 1200, behavior: 'instant' });
+	});
+
+	it('follows content resizing without a DOM mutation', () => {
+		height += 300;
+		callbacks.resize([{ target: content }]);
+		expect(element.scrollTo).toHaveBeenLastCalledWith({ top: 1500, behavior: 'smooth' });
+	});
+
+	it('leaves the reader in place after scrolling up, then resumes at the bottom', () => {
+		scroll(600);
+		element.scrollTo.mockClear();
+		height += 100;
+		callbacks.resize([{ target: content }]);
+		expect(element.scrollTo).not.toHaveBeenCalled();
+		scroll(900);
+		height += 100;
+		callbacks.resize([{ target: content }]);
+		expect(element.scrollTo).toHaveBeenLastCalledWith({ top: 1400, behavior: 'smooth' });
+	});
+
+	it('cancels a smooth scroll on upward wheel intent before content can pull it back', () => {
+		height += 100;
+		callbacks.resize([{ target: content }]);
+		callbacks.events.get('wheel')!({ deltaY: -50 });
+		expect(element.scrollTo).toHaveBeenLastCalledWith({ top: 800, behavior: 'instant' });
+		element.scrollTo.mockClear();
+		height += 100;
+		callbacks.resize([{ target: content }]);
+		expect(element.scrollTo).not.toHaveBeenCalled();
+		context.scrollToBottom();
+		expect(element.scrollTo).toHaveBeenLastCalledWith({ top: 1400, behavior: 'smooth' });
+	});
+
+	it('keeps following when shorter content clamps the scroll position', () => {
+		height -= 200;
+		scroll(600);
+		height += 100;
+		callbacks.resize([{ target: content }]);
+		expect(element.scrollTo).toHaveBeenLastCalledWith({ top: 1100, behavior: 'smooth' });
+	});
+	it('honors instant resize mode for new content', () => {
+		context.setModes('instant', 'instant');
+		height += 100;
+		callbacks.resize([{ target: content }]);
+		expect(element.scrollTo).toHaveBeenLastCalledWith({ top: 1300, behavior: 'instant' });
+	});
+
+	it('avoids smooth scrolling when reduced motion is requested', () => {
+		(prefersReducedMotion as { current: boolean }).current = true;
+		context.scrollToBottom('smooth');
+		expect(element.scrollTo).toHaveBeenLastCalledWith({ top: 1200, behavior: 'instant' });
+	});
+});

--- a/src/lib/components/prompt-kit/chat-container/chat-container-root.svelte
+++ b/src/lib/components/prompt-kit/chat-container/chat-container-root.svelte
@@ -37,9 +37,8 @@
 	watch(
 		() => ref,
 		() => {
-			if (ref) {
-				context.setElement(ref);
-			}
+			context.setElement(ref);
+			return () => context.setElement(null);
 		}
 	);
 </script>

--- a/src/routes/[[lang]]/app/community-chat/+page.svelte
+++ b/src/routes/[[lang]]/app/community-chat/+page.svelte
@@ -218,7 +218,7 @@
 		<!-- Messages area -->
 		<div bind:this={wrapperEl} class="relative flex-1 overflow-hidden">
 			<ChatContainerRoot ctx={chatCtx} class="h-full">
-				<ChatContainerContent class="!h-full">
+				<ChatContainerContent>
 					{#if messages.data && messages.data.length > 0}
 						<!-- data-tolgee-restricted: user text may contain ZWNJ/ZWJ (tolgee/tolgee-js#3475) -->
 						<div


### PR DESCRIPTION
Closes #709

Regression guard: added chat-container-context.test.ts

Streaming responses and viewport resizing could disable bottom following without any user scrolling, leaving the latest reply below the viewport.

Keep follow intent separate from scroll geometry and observe the natural content size, including delayed layout changes. Scrolling up preserves the reading position; returning to the bottom resumes following. Both chat consumers now let that content grow.

Verified the original failures in Chromium and their absence after the fix, keyboard interruption and recovery, eight focused tests, and static checks including types. Restoring the faulty geometry gate makes six regression tests fail.

![Browser reproduction before and after the scrolling fix](https://github.com/user-attachments/assets/74290e32-9ff7-47c3-9759-9ff11f0e4e0f)