### PR TITLE
fix(e2e): Enforce the backend readiness deadline

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -24,6 +24,7 @@ import type { TestCredentials } from './utils/types';
 import { resolveConvexUrl } from './utils/convex-url';
 import { resolveSiteUrl } from './utils/site-url';
 import { getPreviewBypass, fetchVercelBypassCookie } from './utils/preview-bypass';
+import { waitForBackendReady } from './utils/backend-readiness';
 
 function isTransientSetupError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
@@ -96,57 +97,6 @@ async function fetchWithRetry(url: string, init: RequestInit, label: string): Pr
 	}
 }
 
-/**
- * Wait until the Convex backend reports ready via api.tests.health.
- *
- * The convex-vite-plugin starts backend deploy asynchronously after vite begins
- * serving (node_modules/convex-vite-plugin/src/index.ts:302), so Playwright's
- * webServer port-check on the test vite port (derived per project, see
- * scripts/dev-ports.ts) succeeds well before Convex is reachable. Without
- * this gate, the first signup HTTP call can hit a 500 from a not-yet-ready
- * backend and globalSetup's existing retry only covers transient network errors.
- *
- * The probe also doubles as a propagation check: if AUTH_E2E_TEST_SECRET didn't
- * reach the backend (vite.config.ts envVars wiring), the call returns
- * Unauthorized and we fail fast with a clear error.
- */
-async function waitForBackendReady(client: ConvexHttpClient, secret: string): Promise<void> {
-	const TIMEOUT_MS = 90_000;
-	const POLL_INTERVAL_MS = 1000;
-	const start = Date.now();
-	let lastError: unknown;
-	console.log('[Setup] Waiting for Convex backend readiness (api.tests.health)...');
-	while (true) {
-		try {
-			const r = await client.query(api.tests.health, { secret });
-			if (r?.ok) {
-				console.log(`[Setup] Backend ready after ${Date.now() - start}ms`);
-				return;
-			}
-		} catch (err) {
-			// Distinguish auth failure (config bug, fail fast) from cold-boot/network errors (retry).
-			// A backend that returns "Unauthorized" is already serving — polling won't fix it.
-			const message = err instanceof Error ? err.message : String(err);
-			if (message.includes('Unauthorized: Invalid test secret')) {
-				throw new Error(
-					'Test backend rejected AUTH_E2E_TEST_SECRET. The secret in .env.test does not ' +
-						'match what the backend received from vite.config.ts envVars. Check that ' +
-						'`bun run dev:test` is running and that AUTH_E2E_TEST_SECRET is set in .env.test.',
-					{ cause: err }
-				);
-			}
-			lastError = err;
-		}
-		if (Date.now() - start > TIMEOUT_MS) {
-			console.error('[Setup] Last error from health probe:', lastError);
-			throw new Error(
-				`Test backend never reported ready (api.tests.health) within ${TIMEOUT_MS}ms`
-			);
-		}
-		await sleep(POLL_INTERVAL_MS);
-	}
-}
-
 async function globalSetup() {
 	const testSecret = process.env.AUTH_E2E_TEST_SECRET;
 	const convexUrl = resolveConvexUrl();
@@ -170,7 +120,7 @@ async function globalSetup() {
 	const client = new ConvexHttpClient(convexUrl);
 
 	// Gate user creation on real backend readiness (not just the vite port being open).
-	await waitForBackendReady(client, testSecret);
+	await waitForBackendReady(convexUrl, testSecret);
 
 	const timestamp = Date.now();
 

--- a/e2e/utils/backend-readiness.ts
+++ b/e2e/utils/backend-readiness.ts
@@ -1,0 +1,106 @@
+import { ConvexHttpClient } from 'convex/browser';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { api } from '../../src/lib/convex/_generated/api';
+
+const DEFAULT_TIMEOUT_MS = 90_000;
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+
+export interface BackendReadinessOptions {
+	/** Gesamtbudget für alle Versuche. Nur Tests weichen vom Default ab. */
+	timeoutMs?: number;
+	/** Pause zwischen zwei Health-Abfragen. Nur Tests weichen vom Default ab. */
+	pollIntervalMs?: number;
+}
+
+/**
+ * Wait until the Convex backend reports ready via api.tests.health.
+ *
+ * The convex-vite-plugin starts backend deploy asynchronously after vite begins
+ * serving (node_modules/convex-vite-plugin/src/index.ts:302), so Playwright's
+ * webServer port-check on the test vite port (derived per project, see
+ * scripts/dev-ports.ts) succeeds well before Convex is reachable. Without
+ * this gate, the first signup HTTP call can hit a 500 from a not-yet-ready
+ * backend and globalSetup's existing retry only covers transient network errors.
+ *
+ * The probe also doubles as a propagation check: if AUTH_E2E_TEST_SECRET didn't
+ * reach the backend (vite.config.ts envVars wiring), the call returns
+ * Unauthorized and we fail fast with a clear error.
+ *
+ * Das Zeitbudget ist verbindlich: ConvexHttpClient.query kennt selbst keine
+ * Frist, also hängt hier alles an einem AbortController, den ein Gesamttimer
+ * auslöst. Ein Backend, das die Verbindung annimmt und dann schweigt, ließ den
+ * Aufruf sonst über die Frist hinaus warten, weil sie erst nach der Abfrage
+ * geprüft wurde.
+ */
+export async function waitForBackendReady(
+	convexUrl: string,
+	secret: string,
+	options: BackendReadinessOptions = {}
+): Promise<void> {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+	const controller = new AbortController();
+	const deadlineTimer = setTimeout(() => controller.abort(), timeoutMs);
+
+	// Eigener Client nur für die Readiness-Schleife: sein Transport hängt am
+	// Signal, der reguläre Setup-Client des Aufrufers bleibt davon unberührt und
+	// überlebt den Abbruch.
+	const client = new ConvexHttpClient(convexUrl, {
+		fetch: (input, init) => fetch(input, { ...init, signal: controller.signal })
+	});
+
+	const start = Date.now();
+	// Der Timer allein genügt nicht: läuft das Budget zwischen zwei Ticks ab,
+	// dürfen weder eine weitere Abfrage starten noch eine späte Antwort als
+	// Erfolg zählen.
+	const pastDeadline = () => controller.signal.aborted || Date.now() - start >= timeoutMs;
+
+	let lastError: unknown;
+	console.log('[Setup] Waiting for Convex backend readiness (api.tests.health)...');
+
+	try {
+		while (!pastDeadline()) {
+			try {
+				const r = await client.query(api.tests.health, { secret });
+				if (pastDeadline()) break;
+				if (r?.ok) {
+					console.log(`[Setup] Backend ready after ${Date.now() - start}ms`);
+					return;
+				}
+			} catch (err) {
+				// Ein Abbruch ist die abgelaufene Frist, kein Backend-Fehler.
+				if (pastDeadline()) break;
+
+				// Distinguish auth failure (config bug, fail fast) from cold-boot/network errors (retry).
+				// A backend that returns "Unauthorized" is already serving — polling won't fix it.
+				const message = err instanceof Error ? err.message : String(err);
+				if (message.includes('Unauthorized: Invalid test secret')) {
+					throw new Error(
+						'Test backend rejected AUTH_E2E_TEST_SECRET. The secret in .env.test does not ' +
+							'match what the backend received from vite.config.ts envVars. Check that ' +
+							'`bun run dev:test` is running and that AUTH_E2E_TEST_SECRET is set in .env.test.',
+						{ cause: err }
+					);
+				}
+				lastError = err;
+			}
+
+			try {
+				// Die Pause hängt am selben Signal, damit der Timer sie beendet, statt
+				// einen unbeobachteten Verlierer eines Promise-Rennens zu hinterlassen.
+				await sleep(pollIntervalMs, undefined, { signal: controller.signal });
+			} catch {
+				break;
+			}
+		}
+
+		console.error('[Setup] Last error from health probe:', lastError);
+		throw new Error(`Test backend never reported ready (api.tests.health) within ${timeoutMs}ms`);
+	} finally {
+		clearTimeout(deadlineTimer);
+		// Beendet einen noch laufenden Request samt offenem Antwortbody, auch wenn
+		// die Schleife über den Auth-Fehlerpfad verlassen wird.
+		controller.abort();
+	}
+}

--- a/scripts/e2e-backend-readiness.test.ts
+++ b/scripts/e2e-backend-readiness.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment node
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { Socket } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { waitForBackendReady } from '../e2e/utils/backend-readiness';
+
+// Aufgenommen von einem echten lokalen Convex-1.42.1-Backend über
+// POST /api/query für tests:health. Beide Envelopes kamen mit HTTP 200; die
+// Fehlerform ist damit die reale UDF-Form, keine nachgebaute Annahme.
+const HEALTH_READY_ENVELOPE = { status: 'success', value: { ok: true } };
+const UNAUTHORIZED_ENVELOPE = {
+	status: 'error',
+	errorMessage:
+		'[Request ID: cb3118f2c52765d7] Server Error\nUncaught Error: Unauthorized: Invalid test secret\n' +
+		'    at requireTestSecret (../src/lib/convex/tests.ts:16:0)\n' +
+		'    at handler (../src/lib/convex/tests.ts:35:1)\n'
+};
+
+const SECRET = 'test-secret';
+// Headroom over the configured deadline for client and server work. Anything
+// above this means the deadline is not what ended the wait.
+const RUNTIME_BUDGET_MS = 3000;
+
+interface TestBackend {
+	url: string;
+	requestCount: () => number;
+	/** Resolves when the server sees the client end a still-open response. */
+	clientDisconnected: Promise<void>;
+	close: () => Promise<void>;
+}
+
+const backends: TestBackend[] = [];
+
+async function startBackend(
+	handler: (request: IncomingMessage, response: ServerResponse) => void
+): Promise<TestBackend> {
+	let requestCount = 0;
+	const sockets = new Set<Socket>();
+	let markDisconnected: () => void;
+	const clientDisconnected = new Promise<void>((resolve) => {
+		markDisconnected = resolve;
+	});
+
+	const server = createServer((request, response) => {
+		requestCount += 1;
+		// 'close' feuert auch nach einer vollständigen Antwort, deshalb zählt nur
+		// der Fall, in dem die Verbindung vor dem Ende der Antwort wegbricht.
+		response.on('close', () => {
+			if (!response.writableFinished) markDisconnected();
+		});
+		handler(request, response);
+	});
+	server.on('connection', (socket) => {
+		sockets.add(socket);
+		socket.on('close', () => sockets.delete(socket));
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const { port } = server.address() as AddressInfo;
+
+	const backend: TestBackend = {
+		url: `http://127.0.0.1:${port}`,
+		requestCount: () => requestCount,
+		clientDisconnected,
+		close: async () => {
+			for (const socket of sockets) socket.destroy();
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			});
+		}
+	};
+	backends.push(backend);
+	return backend;
+}
+
+function respondJson(response: ServerResponse, body: unknown): void {
+	const payload = JSON.stringify(body);
+	response.writeHead(200, {
+		'content-type': 'application/json',
+		'content-length': Buffer.byteLength(payload)
+	});
+	response.end(payload);
+}
+
+afterEach(async () => {
+	while (backends.length > 0) await backends.pop()!.close();
+});
+
+describe('waitForBackendReady deadline', { timeout: 20_000 }, () => {
+	it('ends the wait when the backend accepts the connection and never answers', async () => {
+		// Absichtlich keine Antwort: der Client wartet ohne Frist ewig auf sie.
+		const backend = await startBackend(() => {});
+
+		const started = Date.now();
+		await expect(
+			waitForBackendReady(backend.url, SECRET, { timeoutMs: 300, pollIntervalMs: 50 })
+		).rejects.toThrow('Test backend never reported ready (api.tests.health) within 300ms');
+		expect(Date.now() - started).toBeLessThan(300 + RUNTIME_BUDGET_MS);
+
+		// Vor dem eigenen Cleanup: der Abbruch muss vom Client kommen.
+		await backend.clientDisconnected;
+	});
+
+	it('ends the wait when headers are flushed and the response body stays open', async () => {
+		const backend = await startBackend((_request, response) => {
+			response.writeHead(200, { 'content-type': 'application/json' });
+			// Unvollständiges JSON: die Antwort ist angefangen und wird nie beendet,
+			// der Client hängt also im Lesen des Bodys statt im Request.
+			response.write('{"status":"suc');
+		});
+
+		const started = Date.now();
+		await expect(
+			waitForBackendReady(backend.url, SECRET, { timeoutMs: 300, pollIntervalMs: 50 })
+		).rejects.toThrow('Test backend never reported ready (api.tests.health) within 300ms');
+		expect(Date.now() - started).toBeLessThan(300 + RUNTIME_BUDGET_MS);
+
+		await backend.clientDisconnected;
+	});
+
+	it('ends the polling pause instead of waiting out the interval', async () => {
+		// Erste Abfrage scheitert transient, danach würde die Pause weit über die
+		// Frist hinaus laufen.
+		const backend = await startBackend((request) => request.socket.destroy());
+
+		const started = Date.now();
+		await expect(
+			waitForBackendReady(backend.url, SECRET, { timeoutMs: 400, pollIntervalMs: 30_000 })
+		).rejects.toThrow('Test backend never reported ready (api.tests.health) within 400ms');
+
+		const elapsed = Date.now() - started;
+		expect(elapsed).toBeLessThan(400 + RUNTIME_BUDGET_MS);
+		expect(elapsed).toBeLessThan(30_000);
+		expect(backend.requestCount()).toBe(1);
+	});
+
+	it('returns after a single query once the backend reports ready', async () => {
+		const backend = await startBackend((_request, response) =>
+			respondJson(response, HEALTH_READY_ENVELOPE)
+		);
+
+		await expect(
+			waitForBackendReady(backend.url, SECRET, { timeoutMs: 5000, pollIntervalMs: 50 })
+		).resolves.toBeUndefined();
+		expect(backend.requestCount()).toBe(1);
+	});
+
+	it('retries a transient network failure and then succeeds', async () => {
+		let attempts = 0;
+		const backend = await startBackend((request, response) => {
+			attempts += 1;
+			if (attempts === 1) {
+				request.socket.destroy();
+				return;
+			}
+			respondJson(response, HEALTH_READY_ENVELOPE);
+		});
+
+		await expect(
+			waitForBackendReady(backend.url, SECRET, { timeoutMs: 5000, pollIntervalMs: 50 })
+		).resolves.toBeUndefined();
+		expect(backend.requestCount()).toBe(2);
+	});
+
+	it('fails fast when the backend rejects the test secret', async () => {
+		const backend = await startBackend((_request, response) =>
+			respondJson(response, UNAUTHORIZED_ENVELOPE)
+		);
+
+		await expect(
+			waitForBackendReady(backend.url, SECRET, { timeoutMs: 5000, pollIntervalMs: 50 })
+		).rejects.toThrow('Test backend rejected AUTH_E2E_TEST_SECRET');
+		expect(backend.requestCount()).toBe(1);
+	});
+});


### PR DESCRIPTION
Regression guard: added `scripts/e2e-backend-readiness.test.ts`

The backend readiness gate checked its 90-second budget only after the Convex query returned. A server that accepted the connection and stopped responding could keep E2E setup waiting beyond that deadline.

The wait now owns a dedicated client and one abortable budget for requests, response bodies and polling pauses. Invalid test secrets still fail immediately, and subsequent setup calls use an independent client.

Verified with the local transport tests, the unit suite, 110 local E2E tests, full static checks and the type scope.
