### PR TITLE
fix(auth): Cache public JWKS responses briefly

### DIFF
--- a/src/lib/convex/__tests__/jwksCacheControl.test.ts
+++ b/src/lib/convex/__tests__/jwksCacheControl.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { betterAuth } from 'better-auth';
+import { memoryAdapter } from 'better-auth/adapters/memory';
+
+/**
+ * Wire-Vertrag der Cache-Policy auf dem öffentlichen JWKS-Endpunkt.
+ *
+ * Die Anfragen laufen durch den echten Better-Auth-Dispatcher mit den Optionen
+ * der Anwendung, also mit allen konfigurierten Plugins und deren Hooks. Das ist
+ * nötig, weil ein User-`hooks.after` vor jedem Plugin-`hooks.after` läuft
+ * (better-auth/dist/api/dispatch.mjs, `getHooks`): erst die fertige Antwort
+ * belegt, dass danach nichts mehr personalisiert oder ein Cookie setzt.
+ * Einzige Substitution ist der offizielle memoryAdapter, deshalb prüfen diese
+ * Tests HTTP- und Header-Policy und behaupten keinen Convex-Speichervertrag.
+ */
+
+const BASE_URL = 'https://jwks-cache.test';
+const CONVEX_SITE_URL = 'https://jwks-cache.convex.site';
+const JWKS_URL = `${BASE_URL}/api/auth/convex/jwks`;
+const EXPECTED_CACHE_CONTROL = 'public, max-age=60, must-revalidate';
+const PRIVATE_JWK_PARAMETERS = ['d', 'p', 'q', 'dp', 'dq', 'qi', 'k'];
+const STORED_KEY_ID = 'jwks-cache-control-test-key';
+
+// auth.config.ts liest CONVEX_SITE_URL schon beim Auswerten des Moduls, die
+// Umgebung muss also vor dem Import von ../auth stehen.
+vi.stubEnv('SITE_URL', BASE_URL);
+vi.stubEnv('BETTER_AUTH_SECRET', 'jwks-cache-control-test-secret-value');
+vi.stubEnv('CONVEX_SITE_URL', CONVEX_SITE_URL);
+
+const { createAuthOptions } = await import('../auth');
+
+type StoredJwk = {
+	id: string;
+	publicKey: string;
+	privateKey: string;
+	createdAt: Date;
+};
+
+/**
+ * Erzeugt ein echtes RS256-Schlüsselpaar (die Algorithmus-Wahl, die das
+ * Convex-Plugin für customJwt erzwingt) und legt es in der Form ab, die das
+ * jwt-Plugin schreibt und liest: `publicKey` und `privateKey` als JSON-Strings
+ * plus `createdAt`. Die private Hälfte liegt absichtlich unverschlüsselt im
+ * Fixture, damit eine Antwort mit Schlüsselmaterial an den Leak-Assertions
+ * scheitert statt sich hinter Ciphertext zu verstecken.
+ */
+async function createStoredJwk(): Promise<{ stored: StoredJwk; privateJwk: JsonWebKey }> {
+	const { publicKey, privateKey } = await crypto.subtle.generateKey(
+		{
+			name: 'RSASSA-PKCS1-v1_5',
+			modulusLength: 2048,
+			publicExponent: new Uint8Array([1, 0, 1]),
+			hash: 'SHA-256'
+		},
+		true,
+		['sign', 'verify']
+	);
+	const privateJwk = await crypto.subtle.exportKey('jwk', privateKey);
+	return {
+		stored: {
+			id: STORED_KEY_ID,
+			publicKey: JSON.stringify(await crypto.subtle.exportKey('jwk', publicKey)),
+			privateKey: JSON.stringify(privateJwk),
+			createdAt: new Date()
+		},
+		privateJwk
+	};
+}
+
+function createTestAuth(db: Record<string, unknown[]>) {
+	return betterAuth({ ...createAuthOptions({} as never), database: memoryAdapter(db) });
+}
+
+async function createSeededAuth() {
+	const { stored, privateJwk } = await createStoredJwk();
+	return { auth: createTestAuth({ jwks: [stored] }), privateJwk };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('public JWKS cache policy', () => {
+	it('marks the successful key set cacheable without personalizing it', async () => {
+		const { auth, privateJwk } = await createSeededAuth();
+
+		const response = await auth.handler(new Request(JWKS_URL, { method: 'GET' }));
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('cache-control')).toBe(EXPECTED_CACHE_CONTROL);
+		expect(response.headers.getSetCookie()).toEqual([]);
+
+		expect(body.keys).toHaveLength(1);
+		const [key] = body.keys as Array<Record<string, unknown>>;
+		expect(key.kid).toBe(STORED_KEY_ID);
+		expect(key.kty).toBe('RSA');
+		expect(key.alg).toBe('RS256');
+		for (const parameter of PRIVATE_JWK_PARAMETERS) {
+			expect(key).not.toHaveProperty(parameter);
+		}
+		expect(JSON.stringify(body)).not.toContain(privateJwk.d);
+	});
+
+	it('answers a cookie-bearing request with the identical public response', async () => {
+		const { auth } = await createSeededAuth();
+
+		const anonymous = await auth.handler(new Request(JWKS_URL, { method: 'GET' }));
+		const withCookie = await auth.handler(
+			new Request(JWKS_URL, {
+				method: 'GET',
+				headers: { cookie: '__Secure-better-auth.session_token=not-a-real-session' }
+			})
+		);
+
+		expect(withCookie.status).toBe(200);
+		expect(withCookie.headers.get('cache-control')).toBe(EXPECTED_CACHE_CONTROL);
+		expect(withCookie.headers.getSetCookie()).toEqual([]);
+		expect(await withCookie.json()).toEqual(await anonymous.json());
+	});
+
+	it('leaves the other auth endpoints on their own cache policy', async () => {
+		const { auth } = await createSeededAuth();
+
+		const openIdConfig = await auth.handler(
+			new Request(`${BASE_URL}/api/auth/convex/.well-known/openid-configuration`, {
+				method: 'GET'
+			})
+		);
+		expect(openIdConfig.status).toBe(200);
+		expect(openIdConfig.headers.get('cache-control')).toBeNull();
+
+		// get-session bringt sein eigenes no-store mit; der Hook darf es nicht aufweichen.
+		const session = await auth.handler(
+			new Request(`${BASE_URL}/api/auth/get-session`, { method: 'GET' })
+		);
+		expect(session.headers.get('cache-control')).toBe('no-store');
+	});
+
+	it('does not apply the policy to the JWKS path on another method', async () => {
+		const { auth } = await createSeededAuth();
+
+		const response = await auth.handler(new Request(JWKS_URL, { method: 'POST' }));
+
+		expect(response.status).toBe(404);
+		expect(response.headers.get('cache-control')).toBeNull();
+	});
+
+	it('leaves a failing key set request uncached', async () => {
+		// Das Convex-Plugin macht Adapter-Writes außerhalb eines Mutation-Kontexts
+		// zu No-Ops, ein leerer Speicher heilt sich hier also nicht selbst und der
+		// Endpunkt scheitert echt. Better Auth protokolliert das über
+		// console.error; stummgeschaltet, damit der erwartete Fehler nicht wie ein
+		// kaputter Testlauf aussieht.
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const auth = createTestAuth({ jwks: [] });
+
+		const response = await auth.handler(new Request(JWKS_URL, { method: 'GET' }));
+
+		expect(response.status).toBe(500);
+		expect(response.headers.get('cache-control')).toBeNull();
+	});
+});

--- a/src/lib/convex/__tests__/jwksCacheControl.test.ts
+++ b/src/lib/convex/__tests__/jwksCacheControl.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { betterAuth } from 'better-auth';
 import { memoryAdapter } from 'better-auth/adapters/memory';
 
@@ -39,12 +39,12 @@ type StoredJwk = {
 };
 
 /**
- * Erzeugt ein echtes RS256-Schlüsselpaar (die Algorithmus-Wahl, die das
- * Convex-Plugin für customJwt erzwingt) und legt es in der Form ab, die das
- * jwt-Plugin schreibt und liest: `publicKey` und `privateKey` als JSON-Strings
- * plus `createdAt`. Die private Hälfte liegt absichtlich unverschlüsselt im
- * Fixture, damit eine Antwort mit Schlüsselmaterial an den Leak-Assertions
- * scheitert statt sich hinter Ciphertext zu verstecken.
+ * Erzeugt ein echtes RS256-Schlüsselpaar nach der Vorgabe des Convex-Plugins
+ * für customJwt und legt es in der Form ab, die das jwt-Plugin schreibt und
+ * liest: `publicKey` und `privateKey` als JSON-Strings plus `createdAt`. Die
+ * private Hälfte liegt absichtlich unverschlüsselt im Fixture, damit eine
+ * Antwort mit Schlüsselmaterial an den Leak-Assertions scheitert statt sich
+ * hinter Ciphertext zu verstecken.
  */
 async function createStoredJwk(): Promise<{ stored: StoredJwk; privateJwk: JsonWebKey }> {
 	const { publicKey, privateKey } = await crypto.subtle.generateKey(
@@ -80,6 +80,14 @@ async function createSeededAuth() {
 
 afterEach(() => {
 	vi.restoreAllMocks();
+});
+
+// Alle Tests dieser Datei brauchen die oben gesetzten Env-Stubs, deshalb wird
+// erst am Dateiende aufgeräumt. Unter dem Standard-Pool (forks, isoliert)
+// bekommt ohnehin jede Datei ihren eigenen Prozess; mit `--no-isolate` teilen
+// sich die Dateien einen Prozess und sähen die Stubs sonst weiter.
+afterAll(() => {
+	vi.unstubAllEnvs();
 });
 
 describe('public JWKS cache policy', () => {

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -451,7 +451,7 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>) => {
 		},
 		hooks: {
 			// Das Schlüsselset ist für jeden Aufrufer identisch, deshalb darf der
-			// Consumer seinen eigenen HTTP-Cache nutzen statt vor jeder Verifikation
+			// Consumer seinen eigenen HTTP-Cache nutzen statt vor jeder Prüfung
 			// neu zu laden. Die 60 Sekunden begrenzen die normale Frische einer
 			// Kopie und sind keine Widerrufsfrist: ein frisch rotierter `kid` bleibt
 			// bis zum nächsten erfolgreichen Refetch abgewiesen, und ein Consumer

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -9,6 +9,7 @@ import type { GenericMutationCtx } from 'convex/server';
 import { passkey } from '@better-auth/passkey';
 import { admin } from 'better-auth/plugins/admin';
 import { betterAuth, type BetterAuthOptions } from 'better-auth';
+import { createAuthMiddleware } from 'better-auth/api';
 import authSchema from './betterAuth/schema';
 import authConfig from './auth.config';
 import { requireEnv, googleOAuth, githubOAuth } from './env';
@@ -360,6 +361,12 @@ function buildTrustedOrigins(): string[] {
 	}
 }
 
+// Das Convex-Plugin liefert das öffentliche Schlüsselset unter genau diesem
+// Pfad. Nur diese Antwort bekommt die kurze Cache-Policy; alle anderen
+// Auth-Endpunkte behalten ihre jeweils eigene.
+const JWKS_PATH = '/convex/jwks';
+const JWKS_CACHE_CONTROL = 'public, max-age=60, must-revalidate';
+
 // Creates Better Auth options object (used by adapter and betterAuth CLI).
 // Typed via `satisfies` (not a return annotation) so the concrete plugin
 // types survive into createAuth — admin/mutations.ts calls plugin endpoints
@@ -441,6 +448,23 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>) => {
 				clientId: githubOAuth.clientId as string,
 				clientSecret: githubOAuth.clientSecret as string
 			}
+		},
+		hooks: {
+			// Das Schlüsselset ist für jeden Aufrufer identisch, deshalb darf der
+			// Consumer seinen eigenen HTTP-Cache nutzen statt vor jeder Verifikation
+			// neu zu laden. Die 60 Sekunden begrenzen die normale Frische einer
+			// Kopie und sind keine Widerrufsfrist: ein frisch rotierter `kid` bleibt
+			// bis zum nächsten erfolgreichen Refetch abgewiesen, und ein Consumer
+			// mit anhaltenden 5xx durfte seine alte Kopie schon bisher unbegrenzt
+			// weiterverwenden. Nur die erfolgreiche Antwort trägt das `keys`-Array,
+			// die Fehlerform des Dispatchers nicht.
+			after: createAuthMiddleware(async (ctx) => {
+				if (ctx.path !== JWKS_PATH || ctx.method !== 'GET') return;
+				const returned = ctx.context.returned;
+				if (typeof returned !== 'object' || returned === null) return;
+				if (!Array.isArray((returned as { keys?: unknown }).keys)) return;
+				ctx.setHeader('Cache-Control', JWKS_CACHE_CONTROL);
+			})
 		},
 		plugins: [
 			// The Convex plugin is required for Convex compatibility


### PR DESCRIPTION
Regression guard: added `jwksCacheControl.test.ts`

The URL-based JWKS provider could revalidate unchanged keys on every token verification because the endpoint supplied no freshness policy.

Successful public key-set responses now receive a conservative 60-second cache policy. Session endpoints keep their existing policy and failures remain uncached. This is normal cache freshness, not an immediate key-revocation guarantee.

Verified through the real Better Auth handler with the application plugins, including cookie-bearing requests and failure responses, plus 1,901 passing unit tests, full static checks, the type scope and the Convex check.
