### PR TITLE
fix(auth): Preserve reset destination

### DIFF
--- a/e2e/forgot-reset-password.spec.ts
+++ b/e2e/forgot-reset-password.spec.ts
@@ -11,10 +11,15 @@ import { getPreviewBypass } from './utils/preview-bypass';
 // This test runs without auth state - tests unauthenticated behavior
 test.use({ storageState: { cookies: [], origins: [] } });
 
-// All gotos pin the locale to English: unprefixed paths are redirected by
+// All gotos pin the locale: unprefixed paths are redirected by
 // src/hooks.server.ts based on Accept-Language (see the precedent in
 // e2e/upgrade-checkout-failure.spec.ts), which would serve translated copy
 // on non-English runners.
+//
+// Überall Englisch außer im Recovery-Durchlauf unten, der bewusst Deutsch
+// festlegt: das Locale-Präfix gehört zu dem, was die Kette überleben muss, und
+// auf der Standardsprache sähen verlorenes und erhaltenes Präfix gleich aus.
+// Jener Test wählt über Test-IDs, die Übersetzung kostet ihn also nichts.
 
 import type { TestCredentials } from './utils/types';
 
@@ -245,10 +250,32 @@ test.describe('Reset Password', () => {
 		await expect(page).toHaveURL(/signin/);
 	});
 
-	test('resetting the password revokes other active sessions', async ({ page, playwright }) => {
+	/**
+	 * Cheaper layers rejected because: Hier versagt eine Kette echter Navigationen,
+	 * die keine billigere Schicht ausführt. Better Auths Redirect vom Reset-Link,
+	 * der Hook darauf und die folgende Anmeldung sind drei ausgelieferte Round
+	 * Trips, und geprüft wird die URL, auf der der Browser am Ende steht,
+	 * einschließlich Fragment: Browser-Zustand, kein Response-Body. Ein
+	 * Request-only-Spec erreicht das ebenfalls nicht, denn jeder Schritt läuft über
+	 * einen gerenderten Link, und genau ein gerenderter Link verlor das Ziel.
+	 *
+	 * Läuft auf dem Revocation-Setup mit, statt es zu wiederholen: Konto anlegen,
+	 * verifizieren und anmelden ist der größte Teil beider Kosten.
+	 */
+	test('recovering a password revokes other sessions and keeps the destination', async ({
+		page,
+		playwright
+	}) => {
 		const client = getConvexClient();
 		const siteUrl = resolveSiteUrl();
 		const bypass = getPreviewBypass();
+
+		// Tief, lokalisiert, mit Query und Fragment: das Fragment lehnt die
+		// Callback-Grammatik rundweg ab, und `tab=profile` kennt die Seite absichtlich
+		// nicht, damit jedes Neuberechnen statt Durchreichen auffällt.
+		const destination = '/de/app/settings?tab=profile#section';
+		const encodedDestination = encodeURIComponent(destination);
+		const resetCallback = `/de/reset-password?redirectTo=${encodedDestination}`;
 
 		// Dedicated user: resetting the shared test user's password would break other specs
 		const email = `test-reset-revoke-${Date.now()}@e2e.example.com`;
@@ -282,12 +309,46 @@ test.describe('Reset Password', () => {
 			const sessionBefore = await otherSession.get('/api/auth/get-session');
 			expect(await sessionBefore.json()).not.toBeNull();
 
-			// Request a reset token. Delivery is skipped for @e2e.example.com addresses,
-			// so the token is read from the backend's verification model instead.
-			const resetRequest = await otherSession.post('/api/auth/request-password-reset', {
-				data: { email, redirectTo: '/reset-password' }
+			// Start wie nach einem Gate: auf der Anmeldung, mit dem Ziel im Gepäck.
+			const signInPath = `/de/signin?redirectTo=${encodedDestination}`;
+
+			// Serverseitiges Markup, vor jedem Skript. Der hydrierte Href unten allein
+			// trennt die Fälle nicht: aus einem Browser-Cache gelesen bliebe er richtig,
+			// während der erste Paint das Ziel schon verloren hätte. `resolve` liefert
+			// beim SSR einen relativen Href, deshalb wird nur der Query geprüft.
+			const serverHtml = await (await page.request.get(signInPath)).text();
+			expect(serverHtml).toContain(`forgot-password?redirectTo=${encodedDestination}`);
+
+			await page.goto(signInPath);
+			await page.waitForLoadState('domcontentloaded');
+			const forgotLink = page.getByTestId('signin-forgot-password-link');
+			await expect(forgotLink).toHaveAttribute(
+				'href',
+				`/de/forgot-password?redirectTo=${encodedDestination}`
+			);
+
+			await forgotLink.click();
+			await expect(page).toHaveURL(`/de/forgot-password?redirectTo=${encodedDestination}`);
+
+			// Reset wie ein Nutzer anfordern und lesen, was die Seite wirklich sendet.
+			// Delivery is skipped for @e2e.example.com addresses, so the token is read
+			// from the backend's verification model instead of a mailbox.
+			await expect(page.getByTestId('forgot-password-email-input')).toBeEnabled({ timeout: 30000 });
+			await page.getByTestId('forgot-password-email-input').fill(email);
+			const resetRequest = page.waitForRequest(
+				(request) =>
+					request.url().includes('/request-password-reset') && request.method() === 'POST'
+			);
+			await page.getByTestId('forgot-password-submit-button').click();
+			await expect(page.getByTestId('forgot-password-success-message')).toBeVisible({
+				timeout: 10000
 			});
-			expect(resetRequest.ok()).toBeTruthy();
+			// Die Reset-SEITE mit dem Ziel eine Ebene tiefer. Das Ziel selbst hier
+			// einzutragen hieße, ein gültiges Token daran zu hängen.
+			expect((await resetRequest).postDataJSON()).toMatchObject({
+				email,
+				redirectTo: resetCallback
+			});
 
 			const { token } = await client.mutation(api.tests.getPasswordResetToken, {
 				email,
@@ -295,9 +356,17 @@ test.describe('Reset Password', () => {
 			});
 			expect(token).toBeTruthy();
 
-			// Complete the reset through the UI in a fresh browser session
-			await page.goto(`/en/reset-password?token=${token}`);
+			// Der Link aus der Mail, keine selbst gebaute Reset-URL: an diesem Endpunkt
+			// entscheidet Better Auth, was das Formular bekommt.
+			await page.goto(
+				`/api/auth/reset-password/${token}?callbackURL=${encodeURIComponent(resetCallback)}`
+			);
 			await page.waitForLoadState('domcontentloaded');
+			const onResetForm = new URL(page.url());
+			expect(onResetForm.pathname).toBe('/de/reset-password');
+			expect(onResetForm.searchParams.get('token')).toBeTruthy();
+			expect(onResetForm.searchParams.get('redirectTo')).toBe(destination);
+
 			await expect(page.getByTestId('reset-password-password-input')).toBeEnabled({
 				timeout: 30000
 			});
@@ -311,6 +380,36 @@ test.describe('Reset Password', () => {
 			// revokeSessionsOnPasswordReset must have invalidated the other session
 			const sessionAfter = await otherSession.get('/api/auth/get-session');
 			expect(await sessionAfter.json()).toBeNull();
+
+			// Das Angebot der Erfolgsmeldung, die letzte Stelle, an der das Ziel
+			// verloren gehen kann. Das verbrauchte Token bleibt zurück.
+			const signInLink = page.getByTestId('reset-password-signin-link');
+			await expect(signInLink).toHaveAttribute(
+				'href',
+				`/de/signin?redirectTo=${encodedDestination}`
+			);
+			await signInLink.click();
+			await expect(page).toHaveURL(`/de/signin?redirectTo=${encodedDestination}`);
+
+			await expect(page.getByTestId('email-input')).toBeEnabled({ timeout: 30000 });
+			await page.getByTestId('email-input').fill(email);
+			await page.getByTestId('password-input').fill(newPassword);
+			const signInSubmission = page.waitForRequest(
+				(request) => request.url().includes('/sign-in/email') && request.method() === 'POST'
+			);
+			await page.getByTestId('signin-button').click();
+
+			// Better Auth liest dieses Feld zweimal; auf dem Ablehnungspfad wird daraus
+			// der Recovery-Link. Es trägt das Ziel, statt es zu sein, weil die geprüfte
+			// Grammatik kein Fragment erlaubt. Feldweise gelesen, damit ein Fehlschlag
+			// nie den Body mit dem Passwort ausgibt.
+			const signInBody = (await signInSubmission).postDataJSON();
+			expect(signInBody.email).toBe(email);
+			expect(signInBody.callbackURL).toBe(`/de/signin?redirectTo=${encodedDestination}`);
+
+			await expect(page).toHaveURL(destination, { timeout: 30000 });
+			const landed = new URL(page.url());
+			expect(`${landed.pathname}${landed.search}${landed.hash}`).toBe(destination);
 		} finally {
 			await otherSession.dispose();
 			await client

--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -1,6 +1,9 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { betterAuth } from 'better-auth';
+import { memoryAdapter } from 'better-auth/adapters/memory';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { authPageURL } from '$lib/utils/url';
 import {
 	authPageRedirect,
 	resolveBarePathLanguage,
@@ -176,6 +179,172 @@ describe('verificationFailureRedirect', () => {
 		expect(verificationFailureRedirect('/de/app', '?error=INVALID_TOKEN', 'de')).toBe(
 			'/de/signin?redirectTo=%2Fde%2Fapp&error=INVALID_TOKEN'
 		);
+	});
+
+	/**
+	 * Eine Reset-Seite mit abgelehntem Token ist ebenfalls ein Wartezimmer: Better
+	 * Auth hängt `INVALID_TOKEN` an den Callback, statt ein Token mitzugeben. In
+	 * der Kette belassen endete die Reise auf einem Formular ohne Token.
+	 */
+	it('unwraps a rejected reset page rather than ending on it', () => {
+		expect(
+			verificationFailureRedirect(
+				'/de/reset-password',
+				'?redirectTo=%2Fde%2Fapp%2Fsettings%3Ftab%3Dprofile%23section&error=INVALID_TOKEN',
+				'de'
+			)
+		).toBe(
+			'/de/signin?redirectTo=%2Fde%2Fapp%2Fsettings%3Ftab%3Dprofile%23section&error=INVALID_TOKEN'
+		);
+	});
+
+	it('falls back when the rejected reset page carries nothing usable', () => {
+		expect(verificationFailureRedirect('/en/reset-password', '?error=INVALID_TOKEN', 'en')).toBe(
+			'/en/signin?redirectTo=%2Fen%2Fapp&error=INVALID_TOKEN'
+		);
+		expect(
+			verificationFailureRedirect(
+				'/en/reset-password',
+				'?redirectTo=%2F%2Fevil.com&error=INVALID_TOKEN',
+				'en'
+			)
+		).toBe('/en/signin?redirectTo=%2Fen%2Fapp&error=INVALID_TOKEN');
+		expect(
+			verificationFailureRedirect(
+				'/en/reset-password',
+				'?redirectTo=%2Fpricing&error=INVALID_TOKEN',
+				'en'
+			)
+		).toBe('/en/signin?redirectTo=%2Fen%2Fapp&error=INVALID_TOKEN');
+	});
+
+	/**
+	 * Nur `redirectTo` wird aus einer Schicht gelesen. Ein danebenstehendes Token
+	 * bliebe sonst in Link, Adresszeile und Referrer jeder Folgeseite stehen.
+	 */
+	it('leaves the token behind instead of carrying it into the destination', () => {
+		const redirect = verificationFailureRedirect(
+			'/de/reset-password',
+			'?redirectTo=%2Fde%2Fapp%2Fsettings&token=a-live-reset-token&error=INVALID_TOKEN',
+			'de'
+		);
+
+		expect(redirect).toBe('/de/signin?redirectTo=%2Fde%2Fapp%2Fsettings&error=INVALID_TOKEN');
+		expect(redirect).not.toContain('a-live-reset-token');
+	});
+
+	it('terminates on a chain that mixes both waiting rooms', () => {
+		const nested = (depth: number): string =>
+			depth === 0
+				? '/en/app/settings'
+				: `/en/${depth % 2 === 0 ? 'email-verified' : 'reset-password'}?redirectTo=${encodeURIComponent(nested(depth - 1))}`;
+
+		expect(
+			verificationFailureRedirect(
+				'/en/reset-password',
+				`?redirectTo=${encodeURIComponent(nested(2))}&error=INVALID_TOKEN`,
+				'en'
+			)
+		).toBe('/en/signin?redirectTo=%2Fen%2Fapp%2Fsettings&error=INVALID_TOKEN');
+
+		expect(
+			verificationFailureRedirect(
+				'/en/reset-password',
+				`?redirectTo=${encodeURIComponent(nested(6))}&error=INVALID_TOKEN`,
+				'en'
+			)
+		).toBe('/en/signin?redirectTo=%2Fen%2Fapp&error=INVALID_TOKEN');
+	});
+
+	// Eine Reset-Seite mit Token ist kein Fehlerfall: das Formular rendert und
+	// verbraucht das Token.
+	it('leaves a reset page that actually got a token alone', () => {
+		expect(
+			verificationFailureRedirect(
+				'/de/reset-password',
+				'?redirectTo=%2Fde%2Fapp%2Fsettings&token=a-live-reset-token',
+				'de'
+			)
+		).toBeNull();
+	});
+});
+
+/**
+ * Dieselben zwei URLs, wie das installierte Better Auth sie wirklich ausgibt.
+ *
+ * Der Handler liefert echten Reset-Link und echte Ablehnung, beide gehen
+ * unbearbeitet in den Hook. Ein handgebautes Paar würde nur die Annahme
+ * wiederholen, aus der der Fehler entstand.
+ */
+describe('verificationFailureRedirect against a real Better Auth redirect', () => {
+	const BASE = 'https://example.test';
+	const EMAIL = 'hook-recovery@example.test';
+	const DESTINATION = '/de/app/settings?tab=profile#section';
+
+	let sentURL = '';
+
+	const auth = betterAuth({
+		baseURL: BASE,
+		secret: 'test-secret-that-is-long-enough-for-signing',
+		database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+		emailAndPassword: {
+			enabled: true,
+			sendResetPassword: async ({ url }) => {
+				sentURL = url;
+			}
+		},
+		advanced: { disableOriginCheck: false }
+	});
+
+	beforeAll(async () => {
+		const signUp = await auth.handler(
+			new Request(`${BASE}/api/auth/sign-up/email`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json', origin: BASE },
+				body: JSON.stringify({
+					email: EMAIL,
+					password: 'correct-horse-battery-staple',
+					name: 'Hook Recovery'
+				})
+			})
+		);
+		expect(signUp.status, await signUp.text()).toBe(200);
+
+		const requested = await auth.handler(
+			new Request(`${BASE}/api/auth/request-password-reset`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json', origin: BASE },
+				body: JSON.stringify({
+					email: EMAIL,
+					redirectTo: authPageURL('/de/reset-password', DESTINATION)
+				})
+			})
+		);
+		expect(requested.status, await requested.text()).toBe(200);
+	});
+
+	/** Wohin der Handler den Browser für diesen Link schickt. */
+	async function landing(url: string | URL): Promise<URL> {
+		const response = await auth.handler(new Request(url));
+		expect(response.status).toBe(302);
+		return new URL(response.headers.get('location')!);
+	}
+
+	it('rescues the destination out of a rejection it really produced', async () => {
+		const rejected = new URL(sentURL);
+		rejected.pathname = rejected.pathname.replace(/[^/]+$/, 'not-a-real-token');
+		const landed = await landing(rejected);
+
+		expect(verificationFailureRedirect(landed.pathname, landed.search, 'de')).toBe(
+			`/de/signin?redirectTo=${encodeURIComponent(DESTINATION)}&error=INVALID_TOKEN`
+		);
+	});
+
+	it('stays out of the way of the link that worked', async () => {
+		const landed = await landing(sentURL);
+
+		expect(landed.searchParams.get('token')).toBeTruthy();
+		expect(verificationFailureRedirect(landed.pathname, landed.search, 'de')).toBeNull();
 	});
 });
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -288,12 +288,12 @@ export function verificationFailureRedirect(
 }
 
 /**
- * The real page behind a chain of verification interstitials.
+ * The real page behind a chain of auth interstitials.
  *
- * `/email-verified` is a waiting room rather than a destination, and carrying
- * one forward is what let a signed-in visitor be told an address had been
- * verified: sign-in sends an authenticated caller straight back to
- * `redirectTo`, and the failure code is not part of that value.
+ * `/email-verified` and `/reset-password` are waiting rooms rather than
+ * destinations, and carrying one forward is what let a signed-in visitor be told
+ * an address had been verified: sign-in sends an authenticated caller straight
+ * back to `redirectTo`, and the failure code is not part of that value.
  *
  * It repeats because one layer is not the limit. Sign-up accepts any
  * same-origin continuation, including another interstitial, so
@@ -313,7 +313,13 @@ function unwrapInterstitial(destination: string, lang: string): string {
 			return `/${lang}/app`;
 		}
 
-		if (!/^\/[a-z]{2}\/email-verified$/.test(parsed.pathname)) return current;
+		// Reset-Seite eingeschlossen: Better Auth hängt `INVALID_TOKEN` an den
+		// Reset-Callback (`requestPasswordResetCallback` in
+		// better-auth/dist/api/routes/password.mjs), womit ein Formular ohne Token
+		// sonst das Ende der Reise wäre.
+		if (!/^\/[a-z]{2}\/(email-verified|reset-password)$/.test(parsed.pathname)) return current;
+		// Nur `redirectTo`, damit ein danebenstehendes `token` liegen bleibt statt
+		// ins Ziel befördert zu werden.
 		current = safeAuthDestination(parsed.searchParams.get('redirectTo') ?? '', `/${lang}/app`);
 	}
 

--- a/src/lib/utils/__tests__/callback-url.contract.test.ts
+++ b/src/lib/utils/__tests__/callback-url.contract.test.ts
@@ -2,8 +2,8 @@
 
 import { betterAuth } from 'better-auth';
 import { memoryAdapter } from 'better-auth/adapters/memory';
-import { describe, expect, it } from 'vitest';
-import { callbackURLFor } from '../url';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { authPageURL, callbackURLFor } from '../url';
 
 /**
  * `callbackURLFor` carries a copy of a rule that lives in Better Auth, and a
@@ -82,5 +82,102 @@ describe('callbackURLFor against the installed Better Auth', () => {
 	it('falls back rather than sending something that would be refused', () => {
 		expect(callbackURLFor('/app#billing', '/de/app')).toBe('/de/app');
 		expect(callbackURLFor('/de/app/settings', '/de/app')).toBe('/de/app/settings');
+	});
+});
+
+/**
+ * Der Recovery-Durchlauf gegen denselben echten Handler.
+ *
+ * Der Reset-Callback muss zwei getrennte Prüfungen überstehen: `redirectTo` beim
+ * Anfordern und `callbackURL` beim Öffnen des Links (`originCheck` auf
+ * `/request-password-reset` und `/reset-password/:token` in
+ * better-auth/dist/api/routes/password.mjs). Ob der Wrapper akzeptiert wird,
+ * kann nur die Dependency selbst beantworten.
+ *
+ * Die Mail wird bei `sendResetPassword` abgegriffen statt versendet: kein
+ * Transport und keine Adresse, die etwas empfangen könnte.
+ */
+const RECOVERY_EMAIL = 'recovery@example.test';
+const RECOVERY_PASSWORD = 'correct-horse-battery-staple';
+const RECOVERY_DESTINATION = '/de/app/settings?tab=profile#section';
+
+let resetEmailURL = '';
+
+const recoveryAuth = betterAuth({
+	baseURL: BASE,
+	secret: 'test-secret-that-is-long-enough-for-signing',
+	database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+	emailAndPassword: {
+		enabled: true,
+		sendResetPassword: async ({ url }) => {
+			resetEmailURL = url;
+		}
+	},
+	advanced: { disableOriginCheck: false }
+});
+
+/** Das `redirectTo` einer URL, wie die Zielseite es lesen würde. */
+function carriedDestination(url: string): string | null {
+	return new URL(url, BASE).searchParams.get('redirectTo');
+}
+
+describe('the reset callback authPageURL builds', () => {
+	const resetCallback = authPageURL('/de/reset-password', RECOVERY_DESTINATION);
+
+	beforeAll(async () => {
+		const signUp = await recoveryAuth.handler(
+			new Request(`${BASE}/api/auth/sign-up/email`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json', origin: BASE },
+				body: JSON.stringify({
+					email: RECOVERY_EMAIL,
+					password: RECOVERY_PASSWORD,
+					name: 'Recovery Contract'
+				})
+			})
+		);
+		expect(signUp.status, await signUp.text()).toBe(200);
+
+		const requested = await recoveryAuth.handler(
+			new Request(`${BASE}/api/auth/request-password-reset`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json', origin: BASE },
+				body: JSON.stringify({ email: RECOVERY_EMAIL, redirectTo: resetCallback })
+			})
+		);
+		// Ein abgelehntes `redirectTo` wäre hier ein 403, also genau der Fehler,
+		// den der Wrapper verhindern soll.
+		expect(requested.status, await requested.text()).toBe(200);
+	});
+
+	it('is the callback the dependency puts in the mail', () => {
+		expect(resetEmailURL).not.toBe('');
+		expect(new URL(resetEmailURL).searchParams.get('callbackURL')).toBe(resetCallback);
+	});
+
+	it('sends a valid link on to the reset form with token and destination', async () => {
+		const response = await recoveryAuth.handler(new Request(resetEmailURL));
+		expect(response.status).toBe(302);
+
+		const location = new URL(response.headers.get('location')!);
+		expect(location.pathname).toBe('/de/reset-password');
+		expect(location.searchParams.get('token')).toBeTruthy();
+		expect(carriedDestination(location.href)).toBe(RECOVERY_DESTINATION);
+	});
+
+	it('reports a rejected link on the same page, still carrying the destination', async () => {
+		const rejected = new URL(resetEmailURL);
+		rejected.pathname = rejected.pathname.replace(/[^/]+$/, 'not-a-real-token');
+
+		const response = await recoveryAuth.handler(new Request(rejected));
+		expect(response.status).toBe(302);
+
+		const location = new URL(response.headers.get('location')!);
+		expect(location.pathname).toBe('/de/reset-password');
+		expect(location.searchParams.get('error')).toBe('INVALID_TOKEN');
+		// Kein Token: deshalb muss der Hook diese Seite auswickeln, statt sie das
+		// Ende der Reise sein zu lassen.
+		expect(location.searchParams.get('token')).toBeNull();
+		expect(carriedDestination(location.href)).toBe(RECOVERY_DESTINATION);
 	});
 });

--- a/src/lib/utils/__tests__/url.test.ts
+++ b/src/lib/utils/__tests__/url.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+	authPageURL,
+	callbackURLFor,
 	oauthErrorCallbackURL,
 	safeAuthDestination,
 	safeRedirectPath,
@@ -257,5 +259,102 @@ describe('safeAuthDestination', () => {
 		expect(safeAuthDestination('//evil.example/en/app', '/en/app')).toBe('/en/app');
 		expect(safeAuthDestination('https://evil.example/en/app', '/en/app')).toBe('/en/app');
 		expect(safeAuthDestination('', '/en/app')).toBe('/en/app');
+	});
+});
+
+describe('authPageURL', () => {
+	/** Das Ziel, wie die Seite am anderen Ende es zurückliest. */
+	function carried(url: string): string | null {
+		return new URL(url, 'https://redirect.invalid').searchParams.get('redirectTo');
+	}
+
+	it('hands a whole destination on to the next auth page', () => {
+		const url = authPageURL('/de/forgot-password', '/de/app/settings?tab=profile#section');
+
+		expect(url).toBe(
+			'/de/forgot-password?redirectTo=%2Fde%2Fapp%2Fsettings%3Ftab%3Dprofile%23section'
+		);
+		expect(carried(url)).toBe('/de/app/settings?tab=profile#section');
+	});
+
+	/**
+	 * Der Grund für das Wrapping: die Callback-Regel erlaubt kein `#`, ein Ziel mit
+	 * Fragment fällt also ganz weg. Im Query ist es `%23` und kommt durch.
+	 */
+	it('keeps a fragment the callback grammar would have cost', () => {
+		expect(callbackURLFor('/de/app/settings#section', '/de/app')).toBe('/de/app');
+
+		const url = authPageURL('/de/signin', '/de/app/settings#section');
+		expect(callbackURLFor(url, '/de/app')).toBe(url);
+		expect(carried(url)).toBe('/de/app/settings#section');
+	});
+
+	it.each(['en', 'de', 'es', 'fr'])('carries a %s destination', (lang) => {
+		const destination = `/${lang}/app/settings?tab=profile#section`;
+		const url = authPageURL(`/${lang}/forgot-password`, destination);
+
+		expect(url.startsWith(`/${lang}/forgot-password?redirectTo=`)).toBe(true);
+		expect(carried(url)).toBe(destination);
+	});
+
+	/**
+	 * Die sechs Zeichen, die `encodeURIComponent` roh lässt. Ungeschützt antwortet
+	 * Better Auth mit `403 INVALID_CALLBACK_URL` und reißt die Anfrage mit.
+	 */
+	it.each([
+		['!', '%21'],
+		["'", '%27'],
+		['(', '%28'],
+		[')', '%29'],
+		['*', '%2A'],
+		['~', '%7E']
+	])('escapes %s, which the callback grammar refuses', (character, escaped) => {
+		const destination = `/de/app/a${character}b`;
+		const url = authPageURL('/de/signin', destination);
+
+		expect(url).toBe(`/de/signin?redirectTo=%2Fde%2Fapp%2Fa${escaped}b`);
+		expect(url).not.toContain(character);
+		expect(callbackURLFor(url, '/de/app')).toBe(url);
+		expect(carried(url)).toBe(destination);
+	});
+
+	/**
+	 * Jede Seite der Kette baut den Link für die nächste aus dem gelesenen Wert.
+	 * Doppelt kodiert käme das Ziel als eigene Escape-Sequenz an.
+	 */
+	it('does not add a layer per page in the chain', () => {
+		const destination = '/de/app/settings?tab=profile#section';
+
+		const forgot = authPageURL('/de/forgot-password', destination);
+		const reset = authPageURL('/de/reset-password', carried(forgot)!);
+		const signin = authPageURL('/de/signin', carried(reset)!);
+
+		expect(carried(signin)).toBe(destination);
+		expect(signin).toBe(authPageURL('/de/signin', destination));
+	});
+
+	it('gives the bare page when there is nothing to carry', () => {
+		expect(authPageURL('/de/forgot-password', '')).toBe('/de/forgot-password');
+	});
+
+	// Dieselbe Whitelist wie eine echte Navigation: der Wert landet in einem Link
+	// und im Callback, auf den Better Auth weiterleitet.
+	it.each([
+		'//evil.com',
+		'/\\evil.com',
+		'http://evil.com',
+		'http:evil.com',
+		'javascript:alert(1)',
+		'/%2f%2fevil.com',
+		'//user:pass@redirect.invalid/x',
+		'/de/%zz',
+		'/de/app%0d%0aLocation:%20https://evil.test',
+		'/de/app\nLocation: https://evil.test',
+		'/app',
+		'/pricing',
+		'/favicon.ico',
+		'/zz/app'
+	])('drops %s rather than carry it', (hostile) => {
+		expect(authPageURL('/de/signin', hostile)).toBe('/de/signin');
 	});
 });

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -58,6 +58,42 @@ export function safeAuthDestination(url: string, fallback: string): string {
 	return isSupportedLanguage(path.match(/^\/([a-z]{2})(?:[/?#]|$)/)?.[1]) ? path : fallback;
 }
 
+/**
+ * Eine eigene Auth-Seite, die ein noch offenes Ziel im Query mitführt.
+ *
+ * Better Auths relative Callback-Regel erlaubt kein `#` (`matchesOriginPattern`
+ * in better-auth/dist/auth/trusted-origins.mjs), ein Ziel mit Fragment fällt als
+ * Callback also ganz weg. Im Query ist es `%23` und kommt durch.
+ *
+ * `pagePath` ist selbst gebaut und vertraut, `destination` nicht: ohne gültiges
+ * Ziel bleibt die nackte Seite.
+ */
+export function authPageURL(pagePath: string, destination: string): string {
+	const safeDestination = safeAuthDestination(destination, '');
+	if (!safeDestination) return pagePath;
+
+	// Der Guard gilt `pagePath`: die Kodierung liefert nur unreservierte Zeichen
+	// und Prozent-Escapes, die die Grammatik im Query zulässt.
+	return callbackURLFor(
+		`${pagePath}?redirectTo=${encodeCallbackComponent(safeDestination)}`,
+		pagePath
+	);
+}
+
+/**
+ * `encodeURIComponent` plus die sechs Zeichen, die es roh lässt.
+ *
+ * `!'()*~` stehen nicht in der Callback-Grammatik. Ein ungeschütztes davon
+ * beantwortet Better Auth mit `403 INVALID_CALLBACK_URL` und reißt die Anfrage
+ * selbst mit, statt nur den Deep Link zu verlieren.
+ */
+function encodeCallbackComponent(value: string): string {
+	return encodeURIComponent(value).replace(
+		/[!'()*~]/g,
+		(character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+	);
+}
+
 function hasUnsafeUrlCharacters(value: string): boolean {
 	return value.includes('\\') || hasControlCharacters(value);
 }

--- a/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/forgot-password/+page.svelte
@@ -10,6 +10,8 @@
 	import { authClient } from '$lib/auth-client.js';
 	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 	import { localizedHref } from '$lib/utils/i18n';
+	import { authPageURL } from '$lib/utils/url';
+	import { page } from '$app/state';
 	import { resolve } from '$app/paths';
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
@@ -30,6 +32,17 @@
 	let lastValidSubmission = $state<string | null>(null);
 
 	const id = $props.id();
+
+	/**
+	 * Ziel aus der Page-URL, damit der Zurück-Link es schon im ersten Render
+	 * trägt. Ungeprüft; `authPageURL` verengt es.
+	 *
+	 * Der Reset-Callback ist die Reset-SEITE, nicht das Ziel: Better Auth hängt
+	 * `?token=` daran, und das gehört ins Formular, nicht an den Deep Link.
+	 */
+	const rawDestination = $derived(page.url.searchParams.get('redirectTo') ?? '');
+	const resetCallbackURL = $derived(authPageURL(localizedHref('/reset-password'), rawDestination));
+	const signInHref = $derived(authPageURL(localizedHref('/signin'), rawDestination));
 
 	const authFlow = authFlowContext.get();
 	// Form data, initialized once from the shared auth-flow email
@@ -117,7 +130,7 @@
 		try {
 			const { error: err } = await authClient.requestPasswordReset({
 				email: formData.email,
-				redirectTo: localizedHref('/reset-password')
+				redirectTo: resetCallbackURL
 			});
 
 			if (err) {
@@ -245,7 +258,7 @@
 							</Field.Field>
 							<Field.Description class="text-center">
 								<a
-									href={resolve(localizedHref('/signin'))}
+									href={resolve(signInHref)}
 									data-testid="forgot-password-back-link"
 									class="underline underline-offset-4"
 								>

--- a/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/reset-password/+page.svelte
@@ -19,6 +19,7 @@
 	import { slide } from 'svelte/transition';
 	import { prefersReducedMotion } from 'svelte/motion';
 	import { getAuthErrorKey } from '$lib/utils/auth-messages';
+	import { authPageURL } from '$lib/utils/url';
 	import { translateValidationErrors } from '$lib/utils/validation-i18n.js';
 
 	const { t } = getTranslate();
@@ -34,6 +35,16 @@
 
 	// Get token directly from SvelteKit's page state
 	const token = $derived(page.url.searchParams.get('token'));
+
+	/**
+	 * Ziel neben dem Token, nicht hineingemischt. Ungeprüft; `authPageURL`
+	 * verengt es.
+	 *
+	 * Ein Href für Erfolgs- und Zurück-Link: beide führen zur selben Anmeldung.
+	 * Das Token bleibt draußen, es ist verbraucht und gehört in keinen Link.
+	 */
+	const rawDestination = $derived(page.url.searchParams.get('redirectTo') ?? '');
+	const signInHref = $derived(authPageURL(localizedHref('/signin'), rawDestination));
 
 	// Form data
 	let formData = $state({ password: '', confirmPassword: '' });
@@ -207,7 +218,11 @@
 									class="rounded-md bg-success/10 p-3 text-sm text-success"
 								>
 									<T keyName={message} />
-									<a href={resolve(localizedHref('/signin'))} class="underline">
+									<a
+										href={resolve(signInHref)}
+										data-testid="reset-password-signin-link"
+										class="underline"
+									>
 										<T keyName="auth.reset_password.sign_in_link" defaultValue="Sign in" />
 									</a>
 								</div>
@@ -281,7 +296,7 @@
 							</Field.Field>
 							<Field.Description class="text-center">
 								<a
-									href={resolve(localizedHref('/signin'))}
+									href={resolve(signInHref)}
 									data-testid="reset-password-back-link"
 									class="underline underline-offset-4"
 								>

--- a/src/routes/[[lang]]/(auth)/signin/+page.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/+page.svelte
@@ -30,7 +30,7 @@
 		getVerificationErrorKey
 	} from '$lib/utils/auth-messages';
 	import {
-		callbackURLFor,
+		authPageURL,
 		oauthErrorCallbackURL,
 		safeAuthDestination,
 		verificationErrorIn
@@ -55,6 +55,18 @@
 	const oauthProviders = useQuery(api.auth.getAvailableOAuthProviders, {}, () => ({
 		initialData: data.oauthProviders
 	}));
+
+	/**
+	 * Ziel aus der Page-URL, nicht aus `params`: die Links unten gehören zum
+	 * ersten Paint, und `params` ist beim SSR leer.
+	 *
+	 * `requestedDestination` bleibt leer, wenn nichts Brauchbares ankam, damit die
+	 * Links den Parameter weglassen. `finalDestination` ist, wohin diese Seite
+	 * tatsächlich navigiert.
+	 */
+	const rawDestination = $derived(page.url.searchParams.get('redirectTo') ?? '');
+	const requestedDestination = $derived(safeAuthDestination(rawDestination, ''));
+	const finalDestination = $derived(requestedDestination || localizedHref('/app'));
 
 	// Passkey always available on signin, so alternative auth is always shown
 	const hasAlternativeAuth = true;
@@ -142,7 +154,7 @@
 	function redirectAfterAuthentication() {
 		if (authRedirectStarted) return;
 		authRedirectStarted = true;
-		window.location.href = safeAuthDestination(params.redirectTo, localizedHref('/app'));
+		window.location.href = finalDestination;
 	}
 
 	// Redirect when authenticated, unless the server kept this visitor here to
@@ -197,10 +209,12 @@
 					// rejected right here, and Better Auth mints the recovery
 					// verification link from this same field, defaulting it to `/` and
 					// dropping both the locale and the continuation with it.
-					callbackURL: callbackURLFor(
-						safeAuthDestination(params.redirectTo, localizedHref('/app')),
-						localizedHref('/app')
-					)
+					//
+					// Trägt das Ziel, statt es zu sein: die Callback-Grammatik erlaubt
+					// kein Fragment. Der Umweg kostet einen Redirect, weil ein
+					// angemeldeter Besucher hier direkt an `redirectTo` weitergereicht
+					// wird.
+					callbackURL: authPageURL(localizedHref('/signin'), finalDestination)
 				},
 				{
 					onError: (ctx) => {
@@ -237,13 +251,13 @@
 		try {
 			await authClient.signIn.social({
 				provider,
-				callbackURL: callbackURLFor(
-					safeAuthDestination(params.redirectTo, localizedHref('/app')),
-					localizedHref('/app')
-				),
+				callbackURL: authPageURL(localizedHref('/signin'), finalDestination),
 				// Without this the callback reports a failure to Better Auth's default
 				// error URL, which is the marketing homepage in production.
-				errorCallbackURL: oauthErrorCallbackURL(localizedHref('/signin'), params.redirectTo)
+				//
+				// Bleibt beim rohen Wert: hier gilt absichtlich die weitere Prüfung,
+				// und die Seite verengt das Ziel beim Navigieren erneut.
+				errorCallbackURL: oauthErrorCallbackURL(localizedHref('/signin'), rawDestination)
 			});
 		} catch (error) {
 			clearPendingOAuthProvider();
@@ -334,7 +348,7 @@
 					{hasAlternativeAuth}
 					{enabledProviderCount}
 					oauthProviders={oauthProviders.data}
-					redirectTo={params.redirectTo}
+					redirectTo={requestedDestination}
 					{termsLink}
 					{isLastUsedAuthMethod}
 					onSubmit={handleSignIn}

--- a/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
+++ b/src/routes/[[lang]]/(auth)/signin/SignInForm.svelte
@@ -3,6 +3,7 @@
 	import { T, getTranslate } from '@tolgee/svelte';
 	import { resolve } from '$app/paths';
 	import { localizedHref } from '$lib/utils/i18n';
+	import { authPageURL } from '$lib/utils/url';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Field from '$lib/components/ui/field/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
@@ -30,7 +31,8 @@
 					github?: boolean;
 			  }
 			| undefined;
-		redirectTo: string | undefined;
+		/** Von der Seite bereits verengt; leer, wenn nichts Brauchbares ankam. */
+		redirectTo: string;
 		termsLink: HTMLAnchorElement | null;
 		isLastUsedAuthMethod: (method: LastAuthMethod) => boolean;
 		onSubmit: (event: SubmitEvent) => void | Promise<void>;
@@ -60,6 +62,10 @@
 
 	const hasEmailError = $derived((signInErrors.email?.length ?? 0) > 0);
 	const hasPasswordError = $derived((signInErrors.password?.length ?? 0) > 0);
+
+	// Beide Links reichen das Ziel weiter. Am Forgot-Link ging es bisher verloren.
+	const forgotPasswordHref = $derived(authPageURL(localizedHref('/forgot-password'), redirectTo));
+	const signUpHref = $derived(authPageURL(localizedHref('/signup'), redirectTo));
 
 	let hydrated = $state(false);
 	let forgotPasswordLink = $state<HTMLAnchorElement | null>(null);
@@ -138,7 +144,8 @@
 					</Field.Label>
 					<a
 						bind:this={forgotPasswordLink}
-						href={resolve(localizedHref('/forgot-password'))}
+						href={resolve(forgotPasswordHref)}
+						data-testid="signin-forgot-password-link"
 						tabindex="-1"
 						onkeydown={handleForgotPasswordKeydown}
 						class="ms-auto text-sm text-muted-foreground underline-offset-2 hover:underline active:translate-y-px"
@@ -196,10 +203,7 @@
 				<T keyName="auth.signin.no_account" defaultValue="Don't have an account?" />
 				<a
 					bind:this={signUpLink}
-					href={resolve(
-						localizedHref('/signup') +
-							(redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : '')
-					)}
+					href={resolve(signUpHref)}
 					onkeydown={handleSignUpLinkKeydown}
 					class="underline underline-offset-4"
 				>

--- a/src/routes/[[lang]]/(auth)/signin/signin-callback-url.test.ts
+++ b/src/routes/[[lang]]/(auth)/signin/signin-callback-url.test.ts
@@ -12,13 +12,14 @@
  * route every successful password sign-in through a page announcing an email
  * verification that did not happen.
  *
- * The one value that satisfies both is the final destination the page already
- * navigates to itself, so the guard is that the two expressions stay the same
- * expression. Structural because the failure is a plausible edit to one line,
- * not a state the sign-in flow can be driven into: the redirect it produces is
- * a full page load in the browser, and the link it produces is asserted
- * against a real Better Auth instance in
- * src/lib/convex/__tests__/verificationRecovery.test.ts.
+ * The value that satisfies both is this page carrying the destination, so the
+ * guard is that both readings and the page's own navigation stay pinned to one
+ * destination expression. Structural because the failure is a plausible edit to
+ * one line, not a state the sign-in flow can be driven into: the redirect it
+ * produces is a full page load in the browser, and the link it produces is
+ * asserted against a real Better Auth instance in
+ * src/lib/convex/__tests__/verificationRecovery.test.ts and
+ * src/lib/utils/__tests__/callback-url.contract.test.ts.
  *
  * Comments are dropped first, because the cheapest way to make a text search
  * lie is to leave the old line behind as prose while the real call moves on.
@@ -66,14 +67,15 @@ const source = normalized(
 	)
 );
 
-const DESTINATION = "safeAuthDestination(params.redirectTo, localizedHref('/app'))";
+const DESTINATION = 'finalDestination';
 
 /**
  * Better Auth applies its own, stricter relative-path rule to `callbackURL`,
- * so the destination is narrowed again before it is sent. The navigation below
- * is ours and keeps the full value.
+ * and it takes no fragment, so the destination travels inside the query of a
+ * page path that does satisfy the rule. The navigation below is ours and keeps
+ * the full value.
  */
-const CALLBACK = `callbackURLFor(${DESTINATION}, localizedHref('/app'))`;
+const CALLBACK = `authPageURL(localizedHref('/signin'), ${DESTINATION})`;
 
 describe('password sign-in callback URL', () => {
 	it('sends the destination Better Auth needs for the recovery link', () => {
@@ -86,8 +88,63 @@ describe('password sign-in callback URL', () => {
 		expect(source.slice(callStart, callEnd)).toContain(normalized(`callbackURL: ${CALLBACK}`));
 	});
 
+	/**
+	 * Social-Sign-in kehrt zum Callback zurück, nicht zu dieser Seite, hat also
+	 * keine zweite Chance zu navigieren. Der E2E-Lauf meldet ein verifiziertes
+	 * Konto per Passwort an und erreicht diesen Pfad nie.
+	 */
+	it('brings a social sign-in back through the same wrapper', () => {
+		const callStart = source.indexOf(normalized('authClient.signIn.social('));
+		expect(callStart, 'the social sign-in call moved or was renamed').toBeGreaterThan(-1);
+
+		const callEnd = source.indexOf(normalized('} catch (error) {'), callStart);
+		expect(callEnd, 'the catch moved; the slice below is unbounded').toBeGreaterThan(-1);
+
+		expect(source.slice(callStart, callEnd)).toContain(normalized(`callbackURL: ${CALLBACK}`));
+	});
+
+	/**
+	 * Für die Fehler-URL gilt absichtlich die weitere Prüfung: der Wert ist
+	 * Beifahrer in einer selbst gewählten Seite, und die Seite verengt ihn beim
+	 * Navigieren erneut. Doppelt verengt verlöre man nur funktionierende Links.
+	 */
+	it('keeps the OAuth failure URL on the unnarrowed value', () => {
+		expect(source).toContain(
+			normalized(
+				"errorCallbackURL: oauthErrorCallbackURL(localizedHref('/signin'), rawDestination)"
+			)
+		);
+	});
+
 	it('agrees with the redirect the page performs itself', () => {
 		expect(source).toContain(normalized(`window.location.href = ${DESTINATION};`));
+	});
+
+	/**
+	 * Woran der Name hängt. Aus `params` gelesen sähe die Zeile gleich aus, aber
+	 * dessen Cache füllt sich nur im Browser: die Links dieser Seite gingen dann
+	 * ohne Ziel raus und blieben so, wo Hydration nie ankommt.
+	 */
+	it('reads the destination from the page URL, not from the params cache', () => {
+		expect(source).toContain(
+			normalized("const rawDestination = $derived(page.url.searchParams.get('redirectTo') ?? '');")
+		);
+		expect(source).toContain(
+			normalized("const requestedDestination = $derived(safeAuthDestination(rawDestination, ''));")
+		);
+		expect(source).toContain(
+			normalized(
+				"const finalDestination = $derived(requestedDestination || localizedHref('/app'));"
+			)
+		);
+	});
+
+	/**
+	 * Das Formular rendert die Links und bekommt den verengten Wert: ein Ziel, das
+	 * diese Seite nicht anfahren würde, gehört auch in keinen Link.
+	 */
+	it('gives the form the destination it validated', () => {
+		expect(source).toContain(normalized('redirectTo={requestedDestination}'));
 	});
 
 	/**


### PR DESCRIPTION
Closes #822

Regression guard: added password-recovery destination contract

Password recovery lost the original sign-in destination. The recommended return path after a rejected OAuth sign-in therefore landed on the default page.

The recovery pages now preserve a validated internal destination, including its query and fragment, through the subsequent sign-in. The reset callback stays separate from the final destination. Invalid links retain the error state without forwarding the reset token.

Verified with real Better Auth HTTP contracts, focused tests, complete static and type checks, and the full local E2E suite. The final base passed 1,938 unit tests, independent review, and all CI checks. The production deployment and public recovery links were verified.

![Sign-in after returning from password recovery](https://github.com/user-attachments/assets/bebbdea4-ac57-4d01-a3f0-1bb0b212783b)
