### PR TITLE
ci(main): Guard the checked integration tree

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -23,12 +23,37 @@ jobs:
           # convex-consumer-compat compares against a baseline commit, which a
           # shallow checkout cannot resolve.
           fetch-depth: 0
+      - name: Record checkout identity
+        run: |
+          {
+            echo "### Checkout identity"
+            echo
+            echo "- expected: \`$GITHUB_SHA\`"
+            echo "- commit: \`$(git rev-parse HEAD)\`"
+            echo "- tree: \`$(git rev-parse 'HEAD^{tree}')\`"
+            echo "- parents: \`$(git rev-parse 'HEAD^@' | tr '\n' ' ')\`"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: 'stable'
       - run: go install github.com/client9/misspell/cmd/misspell@latest
       - run: bun install
+      - name: Assert source identity after install
+        run: |
+          head="$(git rev-parse HEAD)"
+          if [ "$head" != "$GITHUB_SHA" ]; then
+            echo "Source identity lost: HEAD is $head, the event commit is $GITHUB_SHA." >&2
+            exit 1
+          fi
+          status="$(git status --porcelain=v1 --untracked-files=all)"
+          if [ -n "$status" ]; then
+            echo "Source identity lost: the working tree no longer matches $GITHUB_SHA." >&2
+            printf '%s\n' "$status" >&2
+            echo "Commit the regenerated file, or ignore it when it is build output." >&2
+            exit 1
+          fi
       - run: bun scripts/static-checks.ts --ci --scope lint
       # Refuses to remove a Convex function that deployed app code still calls
       # (see https://github.com/stickerdaniel/saas-starter/issues/789). The PR run
@@ -41,6 +66,20 @@ jobs:
       - run: bun run check:convex-compat
         env:
           CONVEX_COMPAT_BASE: ${{ github.event_name == 'push' && github.event.before || '' }}
+      - name: Assert source identity after checks
+        run: |
+          head="$(git rev-parse HEAD)"
+          if [ "$head" != "$GITHUB_SHA" ]; then
+            echo "Source identity lost: HEAD is $head, the event commit is $GITHUB_SHA." >&2
+            exit 1
+          fi
+          status="$(git status --porcelain=v1 --untracked-files=all)"
+          if [ -n "$status" ]; then
+            echo "Source identity lost: the working tree no longer matches $GITHUB_SHA." >&2
+            printf '%s\n' "$status" >&2
+            echo "Commit the regenerated file, or ignore it when it is build output." >&2
+            exit 1
+          fi
 
   typecheck:
     name: Type Check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ For reviews and audits, fetch and inspect `origin/main` rather than the shared m
 
 Open PRs as drafts because ready PRs can auto-merge. Mark a PR ready only after all follow-up work is done, then run `gh pr merge <n> --squash --auto` without `--delete-branch`: the repository deletes merged branches itself, which lets GitHub retarget the next stacked PR onto the merged base. An explicit `--delete-branch` deletes the branch outside the merge flow and force-closes dependent stacked PRs instead. After each merge in a stack, rebase the retargeted PR onto the new base before merging it.
 
+That squash-and-auto flow is the only way the production branch moves, and only from a PR whose required checks pass on its current head. Update an out-of-date branch first and then wait for every required check again, because the passing ones ran against a different tree. Never merge with `--admin` and never push to the production branch directly. What the pre-merge checks certify is the tree the server ran them against rather than the squash commit the merge then creates; checks that run after the push see that squash commit themselves. The branch protection behind this is a GitHub setting rather than anything this repository can enforce.
+
 Except for truly small UI-only or docs-only changes, monitor the branch through green required CI, merge it, and verify a green production deployment. If a required check fails, read its provider logs and guide it to green; never override an unexplained failure.
 
 ### Commit messages

--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ Set the required platform and Convex production variables listed in the [environ
 
 ### Deploy
 
-Push to your production branch (default: `main`) and the connected platform deploys automatically, or trigger a manual deploy:
+Merge a reviewed pull request into your production branch (default: `main`) and the connected platform deploys the resulting push. Deployment is push-driven, so whatever the merge puts on that branch becomes the production build. Keeping review in that path is a maintainer procedure; what branch protection enforces is the narrower technical half described under [Preview Deployments](#preview-deployments), that a pull request's required checks passed against an up-to-date branch. Verify or configure those settings separately for each fork, since they live in GitHub rather than in this repository and an organization rule may already supply some of them.
+
+Each supported platform also has a manual deploy:
 
 **Cloudflare Workers:**
 

--- a/btca.config.jsonc
+++ b/btca.config.jsonc
@@ -502,6 +502,13 @@
 		},
 		{
 			"type": "git",
+			"name": "yaml",
+			"url": "https://github.com/eemeli/yaml",
+			"branch": "main",
+			"specialNotes": "yaml package. Parser behind the workflow guards in scripts/workflow-artifacts.test.ts, which read GitHub Actions definitions as YAML instead of approximating them with regexes."
+		},
+		{
+			"type": "git",
 			"name": "autumnTypescript",
 			"url": "https://github.com/useautumn/typescript",
 			"branch": "main",

--- a/bun.lock
+++ b/bun.lock
@@ -108,6 +108,7 @@
         "vite": "8.1.4",
         "vite-plugin-devtools-json": "1.0.0",
         "vitest": "4.1.10",
+        "yaml": "^2.9.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -160,7 +160,8 @@
 		"vaul-svelte": "1.0.0-next.7",
 		"vite": "8.1.4",
 		"vite-plugin-devtools-json": "1.0.0",
-		"vitest": "4.1.10"
+		"vitest": "4.1.10",
+		"yaml": "^2.9.0"
 	},
 	"patchedDependencies": {
 		"oxlint-plugin-convex@0.1.1": "patches/oxlint-plugin-convex@0.1.1.patch",

--- a/scripts/workflow-artifacts.test.ts
+++ b/scripts/workflow-artifacts.test.ts
@@ -1,6 +1,10 @@
+import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+import { sanitizedGitEnv } from './git-context';
 
 /**
  * Actions artifacts and caches share one account-wide storage quota. When it
@@ -140,5 +144,178 @@ describe('docker build records', () => {
 			// registry tags are the authoritative build evidence.
 			expect(source, workflow).toContain('DOCKER_BUILD_RECORD_UPLOAD: false');
 		}
+	});
+});
+
+describe.skipIf(process.platform === 'win32')('lint job source identity', () => {
+	const lintSteps = (() => {
+		const workflow = parseYaml(
+			fs.readFileSync(path.join(WORKFLOWS_DIR, 'static-checks.yml'), 'utf-8')
+		) as { jobs?: Record<string, { steps?: unknown }> };
+		const steps = workflow.jobs?.lint?.steps;
+		if (!Array.isArray(steps)) throw new TypeError('the lint job carried no step list');
+		return steps as Array<{ name?: string; run?: string }>;
+	})();
+
+	const guards = lintSteps.filter((step) => step.name?.startsWith('Assert source identity'));
+
+	function git(cwd: string, args: string[]): string {
+		const result = spawnSync('git', args, {
+			cwd,
+			encoding: 'utf-8',
+			env: sanitizedGitEnv()
+		});
+		if (result.status !== 0) throw new Error(result.stderr);
+		return result.stdout.trim();
+	}
+
+	function fixture(): string {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'source-identity-'));
+		git(dir, ['init', '-q', '-b', 'main']);
+		git(dir, ['config', 'user.email', 'guard@example.test']);
+		git(dir, ['config', 'user.name', 'Guard Fixture']);
+		git(dir, ['config', 'commit.gpgsign', 'false']);
+		fs.writeFileSync(path.join(dir, '.gitignore'), 'generated/\nsrc/env.d.ts\n');
+		fs.mkdirSync(path.join(dir, 'src'));
+		fs.writeFileSync(path.join(dir, 'src', 'env.d.ts'), 'export {};\n');
+		fs.writeFileSync(path.join(dir, 'app.ts'), 'export const version = 1;\n');
+		git(dir, ['add', '-A', '-f']);
+		git(dir, ['commit', '-q', '-m', 'base']);
+		return dir;
+	}
+
+	function exec(script: string, dir: string, sha: string): number {
+		const result = spawnSync('bash', ['-e', '-o', 'pipefail', '-c', script], {
+			cwd: dir,
+			env: { ...sanitizedGitEnv(), GITHUB_SHA: sha },
+			encoding: 'utf-8'
+		});
+		return result.status ?? 1;
+	}
+
+	function withoutGuard(script: string, marker: string): string {
+		const lines = script.split('\n');
+		const start = lines.findIndex(
+			(line) => line.trimStart().startsWith('if ') && line.includes(marker)
+		);
+		const end = lines.findIndex((line, index) => index > start && line.trim() === 'fi');
+		if (start < 0 || end <= start) throw new Error(`no guard block around ${marker}`);
+		return [...lines.slice(0, start), ...lines.slice(end + 1)].join('\n');
+	}
+
+	function withInlinedStatus(script: string): string {
+		return script
+			.replace(/^\t*status="[^\n]*\n/m, '')
+			.replace(
+				'if [ -n "$status" ]',
+				'if [ -n "$(git status --porcelain=v1 --untracked-files=all)" ]'
+			);
+	}
+
+	function onEachGuard(dir: string, sha: string, expected: number): void {
+		expect(guards, 'the lint job carries both guard steps').toHaveLength(2);
+		for (const guard of guards) {
+			expect(exec(String(guard.run), dir, sha), String(guard.name)).toBe(expected);
+		}
+	}
+
+	function inFixture(body: (dir: string, head: string) => void): void {
+		const dir = fixture();
+		try {
+			body(dir, git(dir, ['rev-parse', 'HEAD']));
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	}
+
+	it('reasserts the source identity after install and after the checks', () => {
+		expect(guards.map((step) => step.name)).toEqual([
+			'Assert source identity after install',
+			'Assert source identity after checks'
+		]);
+		const installIndex = lintSteps.findIndex((step) => step.run === 'bun install');
+		expect(installIndex).toBeGreaterThanOrEqual(0);
+		expect(lintSteps[installIndex + 1]?.name).toBe('Assert source identity after install');
+		expect(lintSteps.at(-1)?.name).toBe('Assert source identity after checks');
+		expect(String(guards[0]?.run)).toBe(String(guards[1]?.run));
+	});
+
+	it('accepts the tree the event commit describes', () => {
+		inFixture((dir, head) => onEachGuard(dir, head, 0));
+	});
+
+	it('rejects a tracked file that a generator rewrote, ignored or not', () => {
+		inFixture((dir, head) => {
+			fs.writeFileSync(path.join(dir, 'src', 'env.d.ts'), 'export const generated = true;\n');
+			onEachGuard(dir, head, 1);
+		});
+	});
+
+	it('rejects a staged change', () => {
+		inFixture((dir, head) => {
+			fs.writeFileSync(path.join(dir, 'app.ts'), 'export const version = 2;\n');
+			git(dir, ['add', 'app.ts']);
+			onEachGuard(dir, head, 1);
+		});
+	});
+
+	it('rejects a new file no ignore rule covers', () => {
+		inFixture((dir, head) => {
+			fs.writeFileSync(path.join(dir, 'report.txt'), 'left behind\n');
+			onEachGuard(dir, head, 1);
+		});
+	});
+
+	it('accepts ignored generator output', () => {
+		inFixture((dir, head) => {
+			fs.mkdirSync(path.join(dir, 'generated'));
+			fs.writeFileSync(path.join(dir, 'generated', 'out.js'), 'export const built = true;\n');
+			onEachGuard(dir, head, 0);
+		});
+	});
+
+	it('rejects a clean tree once HEAD left the event commit', () => {
+		inFixture((dir, head) => {
+			fs.writeFileSync(path.join(dir, 'app.ts'), 'export const version = 2;\n');
+			git(dir, ['add', '-A']);
+			git(dir, ['commit', '-q', '-m', 'second']);
+			onEachGuard(dir, head, 1);
+		});
+	});
+
+	it('fails the job when the index cannot be read at all', () => {
+		inFixture((dir, head) => {
+			fs.writeFileSync(path.join(dir, '.git', 'index'), 'DIRC');
+			expect(git(dir, ['rev-parse', 'HEAD'])).toBe(head);
+			expect(guards, 'the lint job carries both guard steps').toHaveLength(2);
+			for (const guard of guards) {
+				expect(exec(String(guard.run), dir, head), String(guard.name)).not.toBe(0);
+			}
+		});
+	});
+
+	it('owes the unreadable index to the separate status capture', () => {
+		const script = String(guards[0]?.run);
+		inFixture((dir, head) => {
+			fs.writeFileSync(path.join(dir, '.git', 'index'), 'DIRC');
+			expect(exec(script, dir, head)).not.toBe(0);
+			expect(exec(withInlinedStatus(script), dir, head)).toBe(0);
+		});
+	});
+
+	it('owes each rejection to its own guard', () => {
+		const script = String(guards[0]?.run);
+		inFixture((dir, head) => {
+			fs.writeFileSync(path.join(dir, 'src', 'env.d.ts'), 'export const generated = true;\n');
+			expect(exec(script, dir, head)).toBe(1);
+			expect(exec(withoutGuard(script, '-n "$status"'), dir, head)).toBe(0);
+		});
+		inFixture((dir, head) => {
+			fs.writeFileSync(path.join(dir, 'app.ts'), 'export const version = 2;\n');
+			git(dir, ['add', '-A']);
+			git(dir, ['commit', '-q', '-m', 'second']);
+			expect(exec(script, dir, head)).toBe(1);
+			expect(exec(withoutGuard(script, '"$head" != "$GITHUB_SHA"'), dir, head)).toBe(0);
+		});
 	});
 });


### PR DESCRIPTION
Regression guard: added lint job source identity

Install and verification steps can modify source files without changing HEAD. A green check alone would then leave the tested Git tree unknown.

The existing lint job records the commit, tree, and parents. After installation and verification it rejects modified source files and an unreadable Git status. The repository guidance separates the required PR squash-merge flow from GitHub's branch-protection guarantee and requires each fork to configure that protection independently.

Verified with static checks, actionlint, 15 workflow tests using real Git fixtures and rollback checks, plus the complete suite with 1,906 passing tests and 8 skips before the unchanged rebase diff.
