### PR TITLE
fix(setup): Make replacements crash-safe

### DIFF
--- a/.github/workflows/template-setup-windows.yml
+++ b/.github/workflows/template-setup-windows.yml
@@ -1,0 +1,36 @@
+name: Template Setup Windows
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/template-setup.ts'
+      - 'scripts/template-setup.test.ts'
+      - 'scripts/template-setup.integration.test.ts'
+      - '.github/workflows/template-setup-windows.yml'
+  pull_request:
+    paths:
+      - 'scripts/template-setup.ts'
+      - 'scripts/template-setup.test.ts'
+      - 'scripts/template-setup.integration.test.ts'
+      - '.github/workflows/template-setup-windows.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: template-setup-windows-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Template Setup Windows
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.9
+      - run: bun install --frozen-lockfile
+      - run: bun vitest --run scripts/template-setup.test.ts scripts/template-setup.integration.test.ts

--- a/.github/workflows/template-setup-windows.yml
+++ b/.github/workflows/template-setup-windows.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.9
-      - run: bun install --frozen-lockfile
+      - run: bun install --frozen-lockfile --ignore-scripts
       - run: bun vitest --run scripts/template-setup.test.ts scripts/template-setup.integration.test.ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "saas-starter",
 	"version": "0.1.0",
+	"templateSetupVersion": 1,
 	"license": "MIT",
 	"type": "module",
 	"scripts": {

--- a/scripts/template-setup.integration.test.ts
+++ b/scripts/template-setup.integration.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Führt das echte Setup als eigenen Prozess gegen private Fixture-Kopien aus.
+ * Nur der vollständige Lauf zeigt, dass gequotete Branding-Werte importierbaren
+ * Code ergeben und dass abgelehnte Eingaben vor dem ersten Write scheitern.
+ *
+ * Die Fixtures kopieren die tatsächlichen Repository-Dateien und benötigen keine
+ * installierten Dependencies, weil das Setup nur Builtins und reine lokale
+ * Module importiert.
+ */
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { testExecutable } from './test-executable';
+
+const ROOT = join(import.meta.dirname, '..');
+/** Vorab aufgelöstes reales Bun; der Testrunner selbst läuft unter Node. */
+const BUN = testExecutable('bun');
+
+const FIXTURE_FILES = [
+	'package.json',
+	'bun.lock',
+	'README.md',
+	'wrangler.toml',
+	'scripts/template-setup.ts',
+	'src/lib/config/legal.ts',
+	'src/lib/config/site.ts',
+	'src/lib/content/legal-metadata.ts'
+] as const;
+
+const fixtures: string[] = [];
+
+afterAll(() => {
+	for (const dir of fixtures) rmSync(dir, { recursive: true, force: true });
+});
+
+function createFixture(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'template-setup-'));
+	fixtures.push(dir);
+	for (const rel of FIXTURE_FILES) {
+		const dest = join(dir, rel);
+		mkdirSync(dirname(dest), { recursive: true });
+		cpSync(join(ROOT, rel), dest);
+	}
+	return dir;
+}
+
+function snapshot(dir: string): Record<string, string> {
+	return Object.fromEntries(
+		FIXTURE_FILES.map((rel) => [rel, readFileSync(join(dir, rel), 'utf-8')])
+	);
+}
+
+function runSetup(dir: string, args: string[]) {
+	const result = spawnSync(BUN, [join(dir, 'scripts/template-setup.ts'), ...args], {
+		cwd: dir,
+		encoding: 'utf-8',
+		// stdin bleibt ohne TTY: das Setup läuft nicht-interaktiv, wie unter CI und in der CLI.
+		stdio: ['ignore', 'pipe', 'pipe'],
+		timeout: 60_000,
+		killSignal: 'SIGKILL'
+	});
+	return { code: result.status ?? -1, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+}
+
+/** Importiert die erzeugte legal.ts in einem frischen Prozess. */
+function importLegalConfig(dir: string) {
+	const importer = join(dir, 'import-legal.ts');
+	writeFileSync(
+		importer,
+		"import { LEGAL_CONFIG, getLegalEmailAddress } from './src/lib/config/legal';\n" +
+			'console.log(JSON.stringify({ config: LEGAL_CONFIG, mailto: getLegalEmailAddress() }));\n',
+		'utf-8'
+	);
+	const result = spawnSync(BUN, [importer], {
+		cwd: dir,
+		encoding: 'utf-8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+		timeout: 60_000,
+		killSignal: 'SIGKILL'
+	});
+	return {
+		code: result.status ?? -1,
+		stderr: result.stderr ?? '',
+		value:
+			result.status === 0
+				? (JSON.parse(result.stdout) as { config: Record<string, unknown>; mailto: string })
+				: undefined
+	};
+}
+
+const IDENTITY = [
+	'--brand',
+	'Northwind Labs',
+	'--company',
+	'Northwind Labs GmbH',
+	'--operator',
+	'Anne Weber',
+	'--address',
+	'Hauptstrasse 5, 12345 Berlin',
+	'--email',
+	'kontakt@northwind-labs.de'
+];
+
+const REQUIRED = ['--slug', 'northwind-labs', '--repo', 'northwind/northwind-labs'];
+
+describe('template setup writes importable branding values', () => {
+	// Gewöhnliche Namen genügen: ein Apostroph reicht, um den erzeugten Code zu brechen.
+	it.each([
+		{ label: 'apostrophe', flag: '--brand', key: 'brandName', value: "O'Connor Software" },
+		{
+			label: 'double quotes',
+			flag: '--company',
+			key: 'companyName',
+			value: 'The "Blue Door" GmbH'
+		},
+		{ label: 'backslash', flag: '--operator', key: 'operatorName', value: 'Anne\\Marie Weber' },
+		{
+			label: 'multiline address',
+			flag: '--address',
+			key: 'address',
+			value: 'Hauptstrasse 5\n12345 Berlin\nDeutschland'
+		},
+		{
+			// $&, $1 und $` dürfen nicht als Ersetzungsmuster interpretiert werden.
+			label: 'replacement metacharacters',
+			flag: '--brand',
+			key: 'brandName',
+			value: "Ampersand $& Backref $1 Tick $` Quote $' Co"
+		}
+	])('keeps a $label intact', ({ flag, key, value }) => {
+		const dir = createFixture();
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY, flag, value]);
+		expect(run.code, run.stderr).toBe(0);
+
+		const imported = importLegalConfig(dir);
+		expect(imported.code, imported.stderr).toBe(0);
+		expect(imported.value?.config[key]).toBe(value);
+	});
+
+	it('derives the contact email helpers from the supplied address', () => {
+		const dir = createFixture();
+		expect(runSetup(dir, [...REQUIRED, ...IDENTITY]).code).toBe(0);
+
+		const imported = importLegalConfig(dir);
+		expect(imported.code, imported.stderr).toBe(0);
+		expect(imported.value?.mailto).toBe('kontakt@northwind-labs.de');
+		expect(imported.value?.config.email).toEqual({
+			user: 'kontakt',
+			domain: 'northwind-labs',
+			tld: 'de'
+		});
+	});
+});
+
+describe('template setup re-runs', () => {
+	it('preserves the configured identity without identity flags', () => {
+		const dir = createFixture();
+		expect(runSetup(dir, [...REQUIRED, ...IDENTITY]).code).toBe(0);
+		const afterFirst = snapshot(dir);
+
+		const rerun = runSetup(dir, REQUIRED);
+		expect(rerun.code, rerun.stderr).toBe(0);
+		expect(snapshot(dir)).toEqual(afterFirst);
+	});
+
+	it('keeps a brand that was deliberately set to the template name', () => {
+		const dir = createFixture();
+		expect(runSetup(dir, [...REQUIRED, ...IDENTITY.slice(2), '--brand', 'SaaS Starter']).code).toBe(
+			0
+		);
+		const afterFirst = snapshot(dir);
+
+		// titleCase('northwind-labs') wäre 'Northwind Labs'; der gewählte Name gewinnt.
+		const rerun = runSetup(dir, REQUIRED);
+		expect(rerun.code, rerun.stderr).toBe(0);
+		expect(snapshot(dir)).toEqual(afterFirst);
+		expect(readFileSync(join(dir, 'src/lib/config/legal.ts'), 'utf-8')).toContain(
+			"brandName: 'SaaS Starter'"
+		);
+	});
+
+	it('rewrites the quick start again after the repository is renamed', () => {
+		const dir = createFixture();
+		expect(runSetup(dir, [...REQUIRED, ...IDENTITY]).code).toBe(0);
+		const renamed = runSetup(dir, [
+			'--slug',
+			'northwind-cloud',
+			'--repo',
+			'northwind/northwind-cloud'
+		]);
+		expect(renamed.code, renamed.stderr).toBe(0);
+
+		const readme = readFileSync(join(dir, 'README.md'), 'utf-8');
+		expect(readme).toContain('git clone https://github.com/northwind/northwind-cloud.git');
+		expect(readme).toContain('cd northwind-cloud');
+		expect(readme).not.toContain('northwind-labs');
+	});
+});
+
+describe('template setup quick start', () => {
+	it('replaces the template instructions with the generated project setup', () => {
+		const dir = createFixture();
+		expect(runSetup(dir, [...REQUIRED, ...IDENTITY]).code).toBe(0);
+
+		const readme = readFileSync(join(dir, 'README.md'), 'utf-8');
+		expect(readme.split('\n')[0]).toBe('# Northwind Labs');
+		expect(readme).toContain(
+			'```bash\ngit clone https://github.com/northwind/northwind-labs.git\ncd northwind-labs\nbun install\nbun run dev\n```'
+		);
+		expect(readme).not.toContain('gh repo create');
+		expect(readme).not.toContain('my-saas-product');
+		expect(readme).not.toContain('Live demo!');
+		// Unverwandte Prosa bleibt erhalten.
+		expect(readme).toContain('## Why This Exists');
+	});
+
+	it('keeps the root name in manifest and lockfile in sync', () => {
+		const dir = createFixture();
+		expect(runSetup(dir, [...REQUIRED, ...IDENTITY]).code).toBe(0);
+
+		const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'));
+		const lock = readFileSync(join(dir, 'bun.lock'), 'utf-8');
+		expect(pkg.name).toBe('northwind-labs');
+		expect(/"workspaces"\s*:\s*\{\s*""\s*:\s*\{\s*"name"\s*:\s*"([^"]*)"/.exec(lock)?.[1]).toBe(
+			'northwind-labs'
+		);
+		// Nur der Root-Name ändert sich; der Abhängigkeitsgraph bleibt bytegleich.
+		expect(lock).toBe(
+			readFileSync(join(ROOT, 'bun.lock'), 'utf-8').replace(
+				'"name": "saas-starter"',
+				'"name": "northwind-labs"'
+			)
+		);
+	});
+});
+
+describe('template setup rejects input before writing', () => {
+	it.each([
+		{
+			label: 'an unknown flag',
+			args: [...REQUIRED, ...IDENTITY, '--barnd', 'typo'],
+			expected: /Unknown option '--barnd'/
+		},
+		{
+			label: 'an unknown boolean flag',
+			args: [...REQUIRED, ...IDENTITY, '--verbose'],
+			expected: /Unknown option '--verbose'/
+		},
+		{
+			label: 'an invalid slug',
+			args: ['--slug', 'Northwind Labs', '--repo', 'northwind/northwind-labs', ...IDENTITY],
+			expected: /slug must match/
+		},
+		{
+			label: 'an unsafe repository',
+			args: ['--slug', 'northwind-labs', '--repo', 'northwind/repo.git', ...IDENTITY],
+			expected: /repo must use a safe GitHub owner\/name format/
+		},
+		{
+			label: 'an invalid email',
+			args: [...REQUIRED, ...IDENTITY.slice(0, -1), 'kaputt'],
+			expected: /email must match user@domain\.tld pattern/
+		},
+		{
+			label: 'missing required values without a TTY',
+			args: [],
+			expected: /needs --slug, --repo, --brand in non-interactive mode/
+		}
+	])('leaves every file untouched given $label', ({ args, expected }) => {
+		const dir = createFixture();
+		const before = snapshot(dir);
+
+		const run = runSetup(dir, args);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(expected);
+		expect(snapshot(dir)).toEqual(before);
+	});
+
+	it.each([
+		{
+			label: 'the site config lost its githubSlug',
+			file: 'src/lib/config/site.ts',
+			mutate: (source: string) => source.replace(/\tgithubSlug: '[^']*',\n/, ''),
+			expected: /Could not find githubSlug/
+		},
+		{
+			// Gültige Datei mit einem zweiten Treffer: der erste steht im Doc-Kommentar und
+			// steuert die Laufzeit nicht. Stilles Ersetzen träfe den falschen Wert.
+			label: 'the site config carries a second githubSlug example',
+			file: 'src/lib/config/site.ts',
+			mutate: (source: string) =>
+				source.replace(
+					'export interface SiteConfig {',
+					"export interface SiteConfig {\n\t/** Example: githubSlug: 'octocat/hello-world' */"
+				),
+			expected: /Expected exactly one githubSlug in src\/lib\/config\/site\.ts, found 2/
+		},
+		{
+			label: 'the legal config lost its export block',
+			file: 'src/lib/config/legal.ts',
+			mutate: (source: string) =>
+				source.replace(
+					/^export const LEGAL_CONFIG[\s\S]*?^\} as const;$/m,
+					"export const LEGAL_CONFIG = { brandName: 'X' };"
+				),
+			expected: /Expected exactly one LEGAL_CONFIG block/
+		},
+		{
+			label: 'the README lost its quick start',
+			file: 'README.md',
+			mutate: () => '# Custom Title\n\nUnrelated prose.\n',
+			expected: /Expected exactly one quick start clone block/
+		},
+		{
+			label: 'wrangler.toml lost its name assignment',
+			file: 'wrangler.toml',
+			mutate: (source: string) => source.replace(/^name = "[^"]*".*\n/m, ''),
+			expected: /Expected exactly one name assignment/
+		}
+	])('leaves every file untouched when $label', ({ file, mutate, expected }) => {
+		const dir = createFixture();
+		writeFileSync(join(dir, file), mutate(readFileSync(join(dir, file), 'utf-8')), 'utf-8');
+		const before = snapshot(dir);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(expected);
+		expect(snapshot(dir)).toEqual(before);
+	});
+});
+
+describe('template setup help', () => {
+	it('prints the supported flags and writes nothing', () => {
+		const dir = createFixture();
+		const before = snapshot(dir);
+
+		const run = runSetup(dir, ['--help']);
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain('--slug');
+		expect(run.stdout).toContain('Unknown flags are rejected before any file is written.');
+		expect(snapshot(dir)).toEqual(before);
+	});
+});

--- a/scripts/template-setup.integration.test.ts
+++ b/scripts/template-setup.integration.test.ts
@@ -8,7 +8,7 @@
  * Module importiert.
  */
 import { spawnSync } from 'node:child_process';
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { afterAll, describe, expect, it } from 'vitest';
@@ -53,7 +53,9 @@ function snapshot(dir: string): Record<string, string> {
 }
 
 function runSetup(dir: string, args: string[]) {
-	const result = spawnSync(BUN, [join(dir, 'scripts/template-setup.ts'), ...args], {
+	// Der öffentliche Einstieg, damit auch das Skript-Dispatch aus dem Manifest geprüft
+	// wird. Die Fixture bringt das reale package.json mit und braucht keine Dependencies.
+	const result = spawnSync(BUN, ['run', 'setup', ...args], {
 		cwd: dir,
 		encoding: 'utf-8',
 		// stdin bleibt ohne TTY: das Setup läuft nicht-interaktiv, wie unter CI und in der CLI.
@@ -104,6 +106,16 @@ const IDENTITY = [
 ];
 
 const REQUIRED = ['--slug', 'northwind-labs', '--repo', 'northwind/northwind-labs'];
+
+/** Wie IDENTITY, aber ohne --brand und --company, damit deren Defaults greifen. */
+const IDENTITY_WITHOUT_COMPANY = [
+	'--operator',
+	'Anne Weber',
+	'--address',
+	'Hauptstrasse 5, 12345 Berlin',
+	'--email',
+	'kontakt@northwind-labs.de'
+];
 
 describe('template setup writes importable branding values', () => {
 	// Gewöhnliche Namen genügen: ein Apostroph reicht, um den erzeugten Code zu brechen.
@@ -328,6 +340,224 @@ describe('template setup rejects input before writing', () => {
 		expect(run.code).toBe(1);
 		expect(run.stderr).toMatch(expected);
 		expect(snapshot(dir)).toEqual(before);
+	});
+});
+
+describe('template setup recognizes a genuinely set up project', () => {
+	// Ein von Hand geänderter Package-Name oder githubSlug beweist keine Einrichtung:
+	// solange der Quick Start die gh-repo-create-Form trägt, bleibt --brand Pflicht.
+	it.each([
+		{
+			label: 'only the package name was renamed by hand',
+			mutate: (dir: string) => {
+				const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'));
+				pkg.name = 'renamed-by-hand';
+				writeFileSync(join(dir, 'package.json'), JSON.stringify(pkg, null, '\t') + '\n', 'utf-8');
+			}
+		},
+		{
+			label: 'the package name and the githubSlug were edited by hand',
+			mutate: (dir: string) => {
+				const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'));
+				pkg.name = 'renamed-by-hand';
+				writeFileSync(join(dir, 'package.json'), JSON.stringify(pkg, null, '\t') + '\n', 'utf-8');
+				const site = join(dir, 'src/lib/config/site.ts');
+				writeFileSync(
+					site,
+					readFileSync(site, 'utf-8').replace(
+						"githubSlug: 'stickerdaniel/saas-starter'",
+						"githubSlug: 'someone/edited-by-hand'"
+					),
+					'utf-8'
+				);
+			}
+		}
+	])('still demands --brand when $label', ({ mutate }) => {
+		const dir = createFixture();
+		mutate(dir);
+		const before = snapshot(dir);
+
+		const run = runSetup(dir, ['--slug', 'renamed-by-hand', '--repo', 'northwind/northwind-labs']);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(/Missing: --brand/);
+		expect(snapshot(dir)).toEqual(before);
+	});
+
+	it('stops demanding flags once the quick start names this repository', () => {
+		const dir = createFixture();
+		// Der Slug bleibt bewusst auf dem Template-Wert.
+		expect(
+			runSetup(dir, [
+				'--slug',
+				'saas-starter',
+				'--repo',
+				'northwind/northwind-labs',
+				'--brand',
+				'Northwind Labs',
+				...IDENTITY
+			]).code
+		).toBe(0);
+		const afterFirst = snapshot(dir);
+
+		const rerun = runSetup(dir, []);
+		expect(rerun.code, rerun.stderr).toBe(0);
+		expect(rerun.stderr).not.toMatch(/Missing:/);
+		expect(snapshot(dir)).toEqual(afterFirst);
+	});
+
+	it('leaves a CRLF README byte-identical on a re-run', () => {
+		const dir = createFixture();
+		expect(runSetup(dir, [...REQUIRED, ...IDENTITY]).code).toBe(0);
+		const readme = join(dir, 'README.md');
+		writeFileSync(readme, readFileSync(readme, 'utf-8').replace(/\n/g, '\r\n'), 'utf-8');
+		const afterFirst = snapshot(dir);
+
+		const rerun = runSetup(dir, []);
+		expect(rerun.code, rerun.stderr).toBe(0);
+		expect(snapshot(dir)).toEqual(afterFirst);
+		expect(readFileSync(readme, 'utf-8')).toContain('\r\n');
+	});
+
+	it('keeps an existing empty company name instead of deriving one', () => {
+		const dir = createFixture();
+		const legal = join(dir, 'src/lib/config/legal.ts');
+		writeFileSync(
+			legal,
+			readFileSync(legal, 'utf-8').replace(/companyName: '[^']*'/, "companyName: ''"),
+			'utf-8'
+		);
+
+		expect(
+			runSetup(dir, [...REQUIRED, '--brand', 'Northwind', ...IDENTITY_WITHOUT_COMPANY]).code
+		).toBe(0);
+		const imported = importLegalConfig(dir);
+		expect(imported.code, imported.stderr).toBe(0);
+		expect(imported.value?.config.companyName).toBe('');
+		const afterFirst = snapshot(dir);
+
+		const rerun = runSetup(dir, []);
+		expect(rerun.code, rerun.stderr).toBe(0);
+		expect(snapshot(dir)).toEqual(afterFirst);
+	});
+
+	it('derives a company name only when the key is truly absent', () => {
+		const dir = createFixture();
+		const legal = join(dir, 'src/lib/config/legal.ts');
+		writeFileSync(
+			legal,
+			readFileSync(legal, 'utf-8').replace(/\tcompanyName: '[^']*',\n/, ''),
+			'utf-8'
+		);
+
+		expect(
+			runSetup(dir, [...REQUIRED, '--brand', 'Northwind', ...IDENTITY_WITHOUT_COMPANY]).code
+		).toBe(0);
+		const imported = importLegalConfig(dir);
+		expect(imported.code, imported.stderr).toBe(0);
+		expect(imported.value?.config.companyName).toBe('Northwind Inc.');
+	});
+});
+
+describe('template setup keeps prose values on one line', () => {
+	const multiline = 'Northwind Labs\n\n## Injected Heading\n\nmore text';
+
+	// Brand und Operator werden roh in die Absätze von Privacy und Terms eingesetzt.
+	it.each([
+		{ flag: '--brand', expected: /brand must be a single line/ },
+		{ flag: '--operator', expected: /operator must be a single line/ }
+	])('rejects a multi-line $flag before writing', ({ flag, expected }) => {
+		const dir = createFixture();
+		const before = snapshot(dir);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY, flag, multiline]);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(expected);
+		expect(snapshot(dir)).toEqual(before);
+	});
+
+	it('still accepts a multi-line address', () => {
+		const dir = createFixture();
+		const run = runSetup(dir, [
+			...REQUIRED,
+			...IDENTITY,
+			'--address',
+			'Hauptstrasse 5\n12345 Berlin\nDeutschland'
+		]);
+
+		expect(run.code, run.stderr).toBe(0);
+		const imported = importLegalConfig(dir);
+		expect(imported.code, imported.stderr).toBe(0);
+		expect(imported.value?.config.address).toBe('Hauptstrasse 5\n12345 Berlin\nDeutschland');
+	});
+});
+
+describe('template setup contact email end to end', () => {
+	it.each(['a@b@c.de', 'erste person@example.de', 'a@ex ample.de', 'a@example..de'])(
+		'rejects %s before writing',
+		(value) => {
+			const dir = createFixture();
+			const before = snapshot(dir);
+
+			const run = runSetup(dir, [...REQUIRED, ...IDENTITY.slice(0, 6), '--email', value]);
+			expect(run.code).toBe(1);
+			expect(run.stderr).toMatch(/email must match user@domain\.tld pattern/);
+			expect(snapshot(dir)).toEqual(before);
+		}
+	);
+
+	it('keeps a subdomain address split into three parts', () => {
+		const dir = createFixture();
+		expect(
+			runSetup(dir, [...REQUIRED, ...IDENTITY.slice(0, 6), '--email', 'a@mail.example.com']).code
+		).toBe(0);
+
+		const imported = importLegalConfig(dir);
+		expect(imported.code, imported.stderr).toBe(0);
+		expect(imported.value?.config.email).toEqual({
+			user: 'a',
+			domain: 'mail',
+			tld: 'example.com'
+		});
+		expect(imported.value?.mailto).toBe('a@mail.example.com');
+	});
+});
+
+/**
+ * Gemessen, nicht angenommen: nur wenn ein echter Schreibversuch auf eine 0444-Datei
+ * scheitert, prüft der folgende Test überhaupt eine Schreibverweigerung. Als root
+ * bleibt der Fall unbeobachtbar und der Test meldet das, statt Erfolg zu behaupten.
+ */
+const writeDenialEnforced = (() => {
+	const dir = mkdtempSync(join(tmpdir(), 'template-setup-wperm-'));
+	fixtures.push(dir);
+	const probe = join(dir, 'probe.txt');
+	writeFileSync(probe, 'x', 'utf-8');
+	chmodSync(probe, 0o444);
+	try {
+		writeFileSync(probe, 'y', 'utf-8');
+		return false;
+	} catch {
+		return true;
+	} finally {
+		chmodSync(probe, 0o644);
+	}
+})();
+
+describe('template setup checks write access before the first write', () => {
+	it.skipIf(!writeDenialEnforced)('writes nothing when a planned output file is read-only', () => {
+		const dir = createFixture();
+		const readme = join(dir, 'README.md');
+		chmodSync(readme, 0o444);
+		const before = snapshot(dir);
+
+		try {
+			const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+			expect(run.code).toBe(1);
+			expect(run.stderr).toMatch(/Cannot write README\.md; check file permissions/);
+			expect(snapshot(dir)).toEqual(before);
+		} finally {
+			chmodSync(readme, 0o644);
+		}
 	});
 });
 

--- a/scripts/template-setup.integration.test.ts
+++ b/scripts/template-setup.integration.test.ts
@@ -165,7 +165,7 @@ describe('template setup writes importable branding values', () => {
 			key: 'operatorName',
 			value: 'Research / Development @ Northwind'
 		},
-		{ label: 'backslash', flag: '--company', key: 'companyName', value: 'Anne\\Marie Weber' },
+		{ label: 'backslash', flag: '--operator', key: 'operatorName', value: 'Anne\\Marie Weber' },
 		{
 			label: 'multiline address',
 			flag: '--address',
@@ -211,6 +211,20 @@ describe('template setup re-runs', () => {
 		const afterFirst = snapshot(dir);
 
 		const rerun = runSetup(dir, REQUIRED);
+		expect(rerun.code, rerun.stderr).toBe(0);
+		expect(snapshot(dir)).toEqual(afterFirst);
+	});
+
+	it('preserves a literal single delimiter across a flagless re-run', () => {
+		const dir = createFixture();
+		const first = runSetup(dir, [...REQUIRED, ...IDENTITY, '--brand', 'A*STAR']);
+		expect(first.code, first.stderr).toBe(0);
+		const imported = importLegalConfig(dir);
+		expect(imported.code, imported.stderr).toBe(0);
+		expect(imported.value?.config.brandName).toBe('A*STAR');
+		const afterFirst = snapshot(dir);
+
+		const rerun = runSetup(dir, []);
 		expect(rerun.code, rerun.stderr).toBe(0);
 		expect(snapshot(dir)).toEqual(afterFirst);
 	});
@@ -750,37 +764,6 @@ describe('template setup keeps prose values on one line', () => {
 		const before = snapshot(dir);
 
 		const run = runSetup(dir, [...REQUIRED, ...IDENTITY, flag, multiline]);
-		expect(run.code).toBe(1);
-		expect(run.stderr).toMatch(expected);
-		expect(snapshot(dir)).toEqual(before);
-	});
-
-	it.each([
-		{
-			flag: '--brand',
-			value: '*Star* Co',
-			expected: /brand must not contain active Markdown inline syntax/
-		},
-		{
-			flag: '--brand',
-			value: '[Northwind](https://example.com)',
-			expected: /brand must not contain active Markdown inline syntax/
-		},
-		{
-			flag: '--operator',
-			value: '*Star* Co',
-			expected: /operator must not contain active Markdown inline syntax/
-		},
-		{
-			flag: '--operator',
-			value: '[Northwind](https://example.com)',
-			expected: /operator must not contain active Markdown inline syntax/
-		}
-	])('rejects active inline Markdown in $flag before writing', ({ flag, value, expected }) => {
-		const dir = createFixture();
-		const before = snapshot(dir);
-
-		const run = runSetup(dir, [...REQUIRED, ...IDENTITY, flag, value]);
 		expect(run.code).toBe(1);
 		expect(run.stderr).toMatch(expected);
 		expect(snapshot(dir)).toEqual(before);

--- a/scripts/template-setup.integration.test.ts
+++ b/scripts/template-setup.integration.test.ts
@@ -303,6 +303,49 @@ mock.module('fs', () => ({
 	});
 });
 
+describe('template setup legal metadata anchors', () => {
+	it('updates the three exported dates without matching a comment', () => {
+		const dir = createFixture();
+		const metadata = join(dir, 'src/lib/content/legal-metadata.ts');
+		writeFileSync(
+			metadata,
+			readFileSync(metadata, 'utf-8').replace(
+				"\timpressum: '2026-03-21'",
+				'\t// impressum: \'2000-01-01\'\n\timpressum: "2026-03-21"'
+			),
+			'utf-8'
+		);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code, run.stderr).toBe(0);
+		const updated = readFileSync(metadata, 'utf-8');
+		expect(updated).toContain("// impressum: '2000-01-01'");
+		const dates = [...updated.matchAll(/^\s*(privacy|terms|impressum): ['"]([^'"]+)['"]/gm)].map(
+			([, , date]) => date
+		);
+		expect(dates).toHaveLength(3);
+		expect(new Set(dates).size).toBe(1);
+		expect(dates[0]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+	});
+
+	it('rejects a flagless re-run with a missing exported date before writes', () => {
+		const dir = createFixture();
+		expect(runSetup(dir, [...REQUIRED, ...IDENTITY]).code).toBe(0);
+		const metadata = join(dir, 'src/lib/content/legal-metadata.ts');
+		writeFileSync(
+			metadata,
+			readFileSync(metadata, 'utf-8').replace(/^\s*impressum: ['"][^'"]+['"]\r?\n/m, ''),
+			'utf-8'
+		);
+		const before = snapshot(dir);
+
+		const rerun = runSetup(dir, []);
+		expect(rerun.code).toBe(1);
+		expect(rerun.stderr).toMatch(/Could not update every date/);
+		expect(snapshot(dir)).toEqual(before);
+	});
+});
+
 describe('template setup quick start', () => {
 	it('replaces the template instructions with the generated project setup', () => {
 		const dir = createFixture();
@@ -318,6 +361,31 @@ describe('template setup quick start', () => {
 		expect(readme).not.toContain('Live demo!');
 		// Unverwandte Prosa bleibt erhalten.
 		expect(readme).toContain('## Why This Exists');
+	});
+
+	it('keeps links to prefix-related repositories byte-identical', () => {
+		const dir = createFixture();
+		const readme = join(dir, 'README.md');
+		const relatedLink = 'https://github.com/stickerdaniel/saas-starter-tools/issues/1';
+		writeFileSync(readme, `${readFileSync(readme, 'utf-8')}\n${relatedLink}\n`, 'utf-8');
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code, run.stderr).toBe(0);
+		const updated = readFileSync(readme, 'utf-8');
+		expect(updated).toContain(relatedLink);
+		expect(updated).toContain('https://github.com/northwind/northwind-labs/actions');
+	});
+
+	it('writes a literal strikethrough-looking brand and recognizes the end state', () => {
+		const dir = createFixture();
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY, '--brand', '~~Northwind~~']);
+		expect(run.code, run.stderr).toBe(0);
+		const afterFirst = snapshot(dir);
+		expect(afterFirst['README.md'].split('\n')[0]).toBe('# \\~\\~Northwind\\~\\~');
+
+		const rerun = runSetup(dir, []);
+		expect(rerun.code, rerun.stderr).toBe(0);
+		expect(snapshot(dir)).toEqual(afterFirst);
 	});
 
 	it('uses an option-safe directory for a repository basename starting with a hyphen', () => {
@@ -377,6 +445,27 @@ describe('template setup quick start', () => {
 		const updated = readFileSync(wrangler, 'utf-8');
 		expect(updated).toMatch(/^name = "northwind-labs"/m);
 		expect(updated.endsWith(environment)).toBe(true);
+	});
+
+	it('ignores root-looking syntax inside multiline TOML strings', () => {
+		const dir = createFixture();
+		const wrangler = join(dir, 'wrangler.toml');
+		const stringValues = `description = """
+name = "basic-string"
+[example.basic]
+"""
+literal = '''
+name = "literal-string"
+[example.literal]
+'''
+`;
+		writeFileSync(wrangler, stringValues + readFileSync(wrangler, 'utf-8'), 'utf-8');
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code, run.stderr).toBe(0);
+		const updated = readFileSync(wrangler, 'utf-8');
+		expect(updated).toContain(stringValues);
+		expect(updated).toMatch(/^name = "northwind-labs" # TEMPLATE:/m);
 	});
 });
 
@@ -447,6 +536,11 @@ describe('template setup rejects input before writing', () => {
 		{
 			label: 'a 101-character repository name',
 			args: ['--slug', 'northwind-labs', '--repo', `northwind/${'r'.repeat(101)}`, ...IDENTITY],
+			expected: /repo must use a safe GitHub owner\/name format/
+		},
+		{
+			label: 'a repository basename ending in a period',
+			args: ['--slug', 'northwind-labs', '--repo', 'northwind/project.', ...IDENTITY],
 			expected: /repo must use a safe GitHub owner\/name format/
 		},
 		{
@@ -542,6 +636,18 @@ describe('template setup rejects input before writing', () => {
 			label: 'wrangler.toml lost its name assignment',
 			file: 'wrangler.toml',
 			mutate: (source: string) => source.replace(/^name = "[^"]*".*\n/m, ''),
+			expected: /Expected exactly one name assignment/
+		},
+		{
+			label: 'wrangler.toml uses a multiline basic string for the root name',
+			file: 'wrangler.toml',
+			mutate: (source: string) => source.replace(/^name = "[^"]*".*$/m, 'name = """base-worker"""'),
+			expected: /Expected exactly one name assignment/
+		},
+		{
+			label: 'wrangler.toml uses a multiline literal string for the root name',
+			file: 'wrangler.toml',
+			mutate: (source: string) => source.replace(/^name = "[^"]*".*$/m, "name = '''base-worker'''"),
 			expected: /Expected exactly one name assignment/
 		}
 	])('leaves every file untouched when $label', ({ file, mutate, expected }) => {

--- a/scripts/template-setup.integration.test.ts
+++ b/scripts/template-setup.integration.test.ts
@@ -6,7 +6,9 @@
  */
 import { spawnSync } from 'node:child_process';
 import {
+	accessSync,
 	chmodSync,
+	constants,
 	cpSync,
 	existsSync,
 	linkSync,
@@ -591,6 +593,25 @@ describe('template setup quick start', () => {
 		expect(readFileSync(join(dir, 'README.md'), 'utf-8')).toContain(
 			'git clone https://github.com/northwind/-project.git\ncd ./-project\n'
 		);
+	});
+
+	it('keeps a foreign fenced demo while removing the template paragraph', () => {
+		const dir = createFixture();
+		const readme = join(dir, 'README.md');
+		const foreignFence =
+			'```markdown\n> [Live demo!](https://vendor.example) Keep this example byte-identical.\n\n```\n\n';
+		writeFileSync(
+			readme,
+			readFileSync(readme, 'utf-8').replace('> [Live demo!]', foreignFence + '> [Live demo!]'),
+			'utf-8'
+		);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code, run.stderr).toBe(0);
+		const updated = readFileSync(readme, 'utf-8');
+		expect(updated).toContain(foreignFence);
+		expect(updated.match(/Live demo!/g)).toHaveLength(1);
+		expect(updated).not.toContain('https://saas.daniel.sticker.name');
 	});
 
 	it('removes the live demo from a fully CRLF-encoded README', () => {
@@ -1414,23 +1435,63 @@ describe('template setup structural process guards', () => {
 		expect(stagingArtifacts(dir)).toEqual([]);
 	});
 
-	it('rewrites an exact repository URL before sentence punctuation in the public process', () => {
+	it('rejects multiple real live demo paragraphs before writes', () => {
 		const dir = createFixture();
 		const readme = join(dir, 'README.md');
 		writeFileSync(
 			readme,
 			readFileSync(readme, 'utf-8').replace(
 				'## Why This Exists',
-				'Exact prose URL: https://github.com/stickerdaniel/saas-starter. \n\n## Why This Exists'
+				'> [Live demo!](https://another.example) Another template demo.\n\n## Why This Exists'
+			),
+			'utf-8'
+		);
+		const before = snapshot(dir);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(/live demo.*found 2/i);
+		expect(run.stdout).not.toContain('Applying:');
+		expect(snapshot(dir)).toEqual(before);
+		expect(stagingArtifacts(dir)).toEqual([]);
+	});
+
+	it('rewrites repository URLs before closing punctuation in the public process', () => {
+		const dir = createFixture();
+		const readme = join(dir, 'README.md');
+		const oldUrl = 'https://github.com/stickerdaniel/saas-starter';
+		const newUrl = 'https://github.com/northwind/northwind-labs';
+		const sentenceUrls = [
+			`${oldUrl}.)`,
+			`${oldUrl}."`,
+			`${oldUrl}.']`,
+			`${oldUrl}.git.)`,
+			`${oldUrl}.git."`,
+			`${oldUrl}.git.']`
+		].join('\n');
+		writeFileSync(
+			readme,
+			readFileSync(readme, 'utf-8').replace(
+				'## Why This Exists',
+				`${sentenceUrls}\n\n## Why This Exists`
 			),
 			'utf-8'
 		);
 
 		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
 		expect(run.code, run.stderr).toBe(0);
-		expect(readFileSync(readme, 'utf-8')).toContain(
-			'Exact prose URL: https://github.com/northwind/northwind-labs. '
-		);
+		const afterFirst = readFileSync(readme, 'utf-8');
+		expect(afterFirst).not.toContain(oldUrl);
+		expect(afterFirst).toContain(`${newUrl}.)`);
+		expect(afterFirst).toContain(`${newUrl}."`);
+		expect(afterFirst).toContain(`${newUrl}.']`);
+		expect(afterFirst).toContain(`${newUrl}.git.)`);
+		expect(afterFirst).toContain(`${newUrl}.git."`);
+		expect(afterFirst).toContain(`${newUrl}.git.']`);
+
+		const rerun = runSetup(dir, []);
+		expect(rerun.code, rerun.stderr).toBe(0);
+		expect(readFileSync(readme, 'utf-8')).not.toContain(oldUrl);
 	});
 });
 
@@ -1454,6 +1515,21 @@ const writeDenialEnforced = (() => {
 	}
 })();
 
+const parentWriteDenialEnforced = (() => {
+	const dir = mkdtempSync(join(tmpdir(), 'template-setup-dperm-'));
+	fixtures.push(dir);
+	chmodSync(dir, 0o555);
+	try {
+		const probe = mkdtempSync(join(dir, 'probe-'));
+		rmSync(probe, { recursive: true, force: true });
+		return false;
+	} catch {
+		return true;
+	} finally {
+		chmodSync(dir, 0o755);
+	}
+})();
+
 describe('template setup checks write access before the first write', () => {
 	it.skipIf(!writeDenialEnforced)('writes nothing when a planned output file is read-only', () => {
 		const dir = createFixture();
@@ -1470,6 +1546,34 @@ describe('template setup checks write access before the first write', () => {
 			chmodSync(readme, 0o644);
 		}
 	});
+
+	it.skipIf(!parentWriteDenialEnforced)(
+		'writes nothing when a canonical parent directory is read-only',
+		() => {
+			const dir = createFixture();
+			const rootFiles = ['package.json', 'bun.lock', 'README.md', 'wrangler.toml'] as const;
+			const before = snapshot(dir);
+			chmodSync(dir, 0o555);
+
+			try {
+				expect(() => mkdtempSync(join(dir, '.write-probe-'))).toThrow();
+				for (const rel of rootFiles) accessSync(join(dir, rel), constants.W_OK);
+				accessSync(join(dir, 'src/lib/config'), constants.W_OK);
+				accessSync(join(dir, 'src/lib/content'), constants.W_OK);
+
+				const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+				expect(run.code).toBe(1);
+				expect(run.stderr).toMatch(
+					/Cannot write parent directory for package\.json; check directory permissions/
+				);
+				expect(run.stdout).not.toContain('Applying:');
+				expect(snapshot(dir)).toEqual(before);
+				expect(stagingArtifacts(dir)).toEqual([]);
+			} finally {
+				chmodSync(dir, 0o755);
+			}
+		}
+	);
 });
 
 describe('template setup help', () => {

--- a/scripts/template-setup.integration.test.ts
+++ b/scripts/template-setup.integration.test.ts
@@ -1,22 +1,46 @@
 /**
- * Führt das echte Setup als eigenen Prozess gegen private Fixture-Kopien aus.
- * Nur der vollständige Lauf zeigt, dass gequotete Branding-Werte importierbaren
- * Code ergeben und dass abgelehnte Eingaben vor dem ersten Write scheitern.
- *
- * Die Fixtures kopieren die tatsächlichen Repository-Dateien und benötigen keine
- * installierten Dependencies, weil das Setup nur Builtins und reine lokale
- * Module importiert.
+ * Runs the real setup process against private fixture copies. Full processes prove
+ * generated branding remains importable and rejected inputs fail before mutation.
+ * Fixtures need no installed dependencies because setup imports only built-ins and
+ * dependency-free local modules.
  */
 import { spawnSync } from 'node:child_process';
-import { chmodSync, cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import {
+	chmodSync,
+	cpSync,
+	existsSync,
+	linkSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync
+} from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { afterAll, describe, expect, it } from 'vitest';
 import { testExecutable } from './test-executable';
 
 const ROOT = join(import.meta.dirname, '..');
-/** Vorab aufgelöstes reales Bun; der Testrunner selbst läuft unter Node. */
+/** Real Bun executable resolved before tests; the test runner itself uses Node. */
 const BUN = testExecutable('bun');
+const CHILD_ENV: NodeJS.ProcessEnv = Object.fromEntries(
+	[
+		'PATH',
+		'HOME',
+		'TMPDIR',
+		'TEMP',
+		'TMP',
+		'SystemRoot',
+		'ComSpec',
+		'PATHEXT',
+		'USERPROFILE'
+	].flatMap((key) => (process.env[key] === undefined ? [] : [[key, process.env[key]]]))
+);
 
 const FIXTURE_FILES = [
 	'package.json',
@@ -53,15 +77,18 @@ function snapshot(dir: string): Record<string, string> {
 }
 
 function runSetup(dir: string, args: string[], preload?: string) {
-	// Normalerweise der öffentliche Einstieg, damit auch das Skript-Dispatch aus dem
-	// Manifest geprüft wird. Die Fehler-Injektion lädt sich direkt vor das echte Skript.
+	// Use the public manifest dispatch so preload faults exercise the same process path as users.
 	const command = preload
-		? ['--preload', preload, 'scripts/template-setup.ts', ...args]
+		? [`--preload=${preload}`, 'run', 'setup', ...args]
 		: ['run', 'setup', ...args];
 	const result = spawnSync(BUN, command, {
 		cwd: dir,
 		encoding: 'utf-8',
-		// stdin bleibt ohne TTY: das Setup läuft nicht-interaktiv, wie unter CI und in der CLI.
+		// The manifest script starts a nested Bun runtime; propagate the same CLI preload to it.
+		env: preload
+			? { ...CHILD_ENV, BUN_OPTIONS: `--preload=${preload.replaceAll('\\', '/')}` }
+			: CHILD_ENV,
+		// Keep stdin detached from a TTY, matching CI and non-interactive CLI use.
 		stdio: ['ignore', 'pipe', 'pipe'],
 		timeout: 60_000,
 		killSignal: 'SIGKILL'
@@ -69,7 +96,172 @@ function runSetup(dir: string, args: string[], preload?: string) {
 	return { code: result.status ?? -1, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
 }
 
-/** Importiert die erzeugte legal.ts in einem frischen Prozess. */
+type FaultPhase =
+	| 'write'
+	| 'partial-write'
+	| 'chmod'
+	| 'single-install'
+	| 'single-cleanup-rmdir'
+	| 'legal-backup'
+	| 'legal-config-install'
+	| 'legal-metadata-install'
+	| 'legal-metadata-and-restore'
+	| 'legal-cleanup-unlink'
+	| 'legal-cleanup-rmdir';
+
+let faultSequence = 0;
+
+function createFaultPreload(
+	dir: string,
+	spec: { phase: FaultPhase; target: (typeof FIXTURE_FILES)[number] }
+): { id: string; path: string } {
+	faultSequence += 1;
+	const id = `SETUP_FAULT_${faultSequence}_${spec.phase.replaceAll('-', '_').toUpperCase()}`;
+	const preload = join(dir, `fault-${faultSequence}.mjs`);
+	const source = `import { mock } from 'bun:test';
+import defaultFs, * as fs from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+
+const id = ${JSON.stringify(id)};
+const phase = ${JSON.stringify(spec.phase)};
+const target = ${JSON.stringify(spec.target)};
+const targetSuffix = '/' + target;
+const targetBasename = target.slice(target.lastIndexOf('/') + 1);
+const targetParent = target.slice(0, target.lastIndexOf('/'));
+const prefix = Buffer.from('SETUP_PARTIAL_PREFIX');
+const normalize = (value) => String(value).replaceAll('\\\\', '/');
+const isStage = (value) => normalize(value).includes('/.template-setup-');
+const realWriteFileSync = fs.writeFileSync;
+const realReadFileSync = fs.readFileSync;
+const realChmodSync = fs.chmodSync;
+const realRenameSync = fs.renameSync;
+const realUnlinkSync = fs.unlinkSync;
+const realRmdirSync = fs.rmdirSync;
+let metadataFaulted = false;
+
+function fail(operation, detail) {
+	console.error('FAULT_HIT ' + id + ' operation=' + operation + ' ' + detail);
+	const error = new Error(id + ' injected ' + operation);
+	error.code = 'EIO';
+	throw error;
+}
+
+const replacements = {
+	writeFileSync(path, data, options) {
+		const normalized = normalize(path);
+		if ((phase === 'write' || phase === 'partial-write') && normalized.endsWith('/' + targetBasename)) {
+			const flag = typeof options === 'object' && options ? options.flag : undefined;
+			if (phase === 'partial-write') {
+				realWriteFileSync(path, prefix, options);
+				const observed = realReadFileSync(path);
+				fail('writeFileSync', 'path=' + normalized + ' stage=' + isStage(path) + ' flag=' + flag + ' prefix=' + observed.equals(prefix));
+			}
+			fail('writeFileSync', 'path=' + normalized + ' stage=' + isStage(path) + ' flag=' + flag);
+		}
+		return realWriteFileSync(path, data, options);
+	},
+	chmodSync(path, mode) {
+		const normalized = normalize(path);
+		if (phase === 'chmod' && normalized.endsWith('/' + targetBasename)) {
+			fail('chmodSync', 'path=' + normalized + ' stage=' + isStage(path) + ' mode=' + mode.toString(8));
+		}
+		return realChmodSync(path, mode);
+	},
+	renameSync(from, to) {
+		const source = normalize(from);
+		const destination = normalize(to);
+		const singleInstall =
+			phase === 'single-install' &&
+			isStage(source) &&
+			source.endsWith('/' + targetBasename) &&
+			destination.endsWith(targetSuffix);
+		const legalBackup =
+			phase === 'legal-backup' &&
+			source.endsWith('/src/lib/config/legal.ts') &&
+			isStage(destination) &&
+			destination.endsWith('/legal.ts.backup');
+		const legalConfigInstall =
+			phase === 'legal-config-install' &&
+			isStage(source) &&
+			source.endsWith('/legal.ts') &&
+			destination.endsWith('/src/lib/config/legal.ts');
+		const legalMetadataInstall =
+			(phase === 'legal-metadata-install' || phase === 'legal-metadata-and-restore') &&
+			isStage(source) &&
+			source.endsWith('/legal-metadata.ts') &&
+			destination.endsWith('/src/lib/content/legal-metadata.ts');
+		const legalRestore =
+			phase === 'legal-metadata-and-restore' &&
+			metadataFaulted &&
+			source.endsWith('/legal.ts.backup') &&
+			destination.endsWith('/src/lib/config/legal.ts');
+		if (singleInstall || legalBackup || legalConfigInstall) {
+			fail('renameSync', 'from=' + source + ' to=' + destination);
+		}
+		if (legalMetadataInstall) {
+			metadataFaulted = true;
+			fail('renameSync', 'from=' + source + ' to=' + destination);
+		}
+		if (legalRestore) {
+			fail('renameSync-restore', 'from=' + source + ' to=' + destination);
+		}
+		return realRenameSync(from, to);
+	},
+	unlinkSync(path) {
+		const normalized = normalize(path);
+		if (phase === 'legal-cleanup-unlink' && normalized.endsWith('/legal.ts.backup')) {
+			fail('unlinkSync', 'path=' + normalized + ' stage=' + isStage(path));
+		}
+		return realUnlinkSync(path);
+	},
+	rmdirSync(path) {
+		const normalized = normalize(path);
+		if (
+			(phase === 'legal-cleanup-rmdir' || phase === 'single-cleanup-rmdir') &&
+			isStage(path) &&
+			normalized.includes('/' + targetParent + '/.template-setup-' + targetBasename + '-')
+		) {
+			fail('rmdirSync', 'path=' + normalized + ' stage=true');
+		}
+		return realRmdirSync(path);
+	}
+};
+Object.assign(defaultFs, replacements);
+syncBuiltinESMExports();
+mock.module('fs', () => ({ ...fs, ...replacements }));
+`;
+	writeFileSync(preload, source, 'utf-8');
+	return { id, path: preload };
+}
+
+function expectFault(
+	run: ReturnType<typeof runSetup>,
+	fault: { id: string },
+	operation: string
+): void {
+	expect(run.code).toBe(1);
+	expect(run.stderr).toContain(`FAULT_HIT ${fault.id} operation=${operation}`);
+	expect(run.stderr).toContain('template-setup.ts');
+}
+
+function stagingArtifacts(dir: string): string[] {
+	const found: string[] = [];
+	function visit(current: string): void {
+		for (const entry of readdirSync(current, { withFileTypes: true })) {
+			const path = join(current, entry.name);
+			if (entry.name.startsWith('.template-setup-')) found.push(path);
+			if (entry.isDirectory()) visit(path);
+		}
+	}
+	visit(dir);
+	return found;
+}
+
+function mode(dir: string, rel: (typeof FIXTURE_FILES)[number]): number {
+	return lstatSync(join(dir, rel)).mode & 0o7777;
+}
+
+/** Imports the generated legal.ts in a fresh process. */
 function importLegalConfig(dir: string) {
 	const importer = join(dir, 'import-legal.ts');
 	writeFileSync(
@@ -121,7 +313,7 @@ function asciiDomainOfLength(length: number): string {
 	return labels.join('.');
 }
 
-/** Wie IDENTITY, aber ohne --brand und --company, damit deren Defaults greifen. */
+/** IDENTITY without brand and company so their defaults apply. */
 const IDENTITY_WITHOUT_COMPANY = [
 	'--operator',
 	'Anne Weber',
@@ -132,7 +324,7 @@ const IDENTITY_WITHOUT_COMPANY = [
 ];
 
 describe('template setup writes importable branding values', () => {
-	// Gewöhnliche Namen genügen: ein Apostroph reicht, um den erzeugten Code zu brechen.
+	// Ordinary names are sufficient: an apostrophe used to break generated code.
 	it.each([
 		{ label: 'apostrophe', flag: '--brand', key: 'brandName', value: "O'Connor Software" },
 		{
@@ -173,7 +365,7 @@ describe('template setup writes importable branding values', () => {
 			value: 'Hauptstrasse 5\n12345 Berlin\nDeutschland'
 		},
 		{
-			// $&, $1 und $` dürfen nicht als Ersetzungsmuster interpretiert werden.
+			// Replacement metacharacters must remain literal data.
 			label: 'replacement metacharacters',
 			flag: '--company',
 			key: 'companyName',
@@ -241,7 +433,8 @@ const realWriteFileSync = fs.writeFileSync;
 mock.module('fs', () => ({
 	...fs,
 	writeFileSync(path, ...args) {
-		if (String(path).replaceAll('\\\\', '/').endsWith('/src/lib/config/legal.ts')) {
+		const normalized = String(path).replaceAll('\\\\', '/');
+		if (normalized.includes('/.template-setup-') && normalized.endsWith('/legal.ts')) {
 			const error = new Error('Injected EIO for legal.ts');
 			error.code = 'EIO';
 			throw error;
@@ -258,14 +451,11 @@ mock.module('fs', () => ({
 		expect(failed.code).toBe(1);
 		expect(failed.stderr).toMatch(/Injected EIO for legal\.ts/);
 		const partial = snapshot(dir);
-		expect(partial['package.json']).not.toBe(before['package.json']);
-		expect(partial['src/lib/config/legal.ts']).toBe(before['src/lib/config/legal.ts']);
-		expect(partial['README.md']).toBe(before['README.md']);
-		expect(partial['src/lib/config/site.ts']).toBe(before['src/lib/config/site.ts']);
+		expect(partial).toEqual(before);
 
 		const rerun = runSetup(dir, []);
 		expect(rerun.code).toBe(1);
-		expect(rerun.stderr).toMatch(/Missing: --repo, --brand/);
+		expect(rerun.stderr).toMatch(/Missing: --slug, --repo, --brand/);
 		expect(snapshot(dir)).toEqual(partial);
 	});
 
@@ -276,7 +466,7 @@ mock.module('fs', () => ({
 		);
 		const afterFirst = snapshot(dir);
 
-		// titleCase('northwind-labs') wäre 'Northwind Labs'; der gewählte Name gewinnt.
+		// The explicitly chosen name takes precedence over titleCase('northwind-labs').
 		const rerun = runSetup(dir, REQUIRED);
 		expect(rerun.code, rerun.stderr).toBe(0);
 		expect(snapshot(dir)).toEqual(afterFirst);
@@ -359,7 +549,7 @@ describe('template setup quick start', () => {
 		expect(readme).not.toContain('gh repo create');
 		expect(readme).not.toContain('my-saas-product');
 		expect(readme).not.toContain('Live demo!');
-		// Unverwandte Prosa bleibt erhalten.
+		// Unrelated prose remains unchanged.
 		expect(readme).toContain('## Why This Exists');
 	});
 
@@ -425,7 +615,7 @@ describe('template setup quick start', () => {
 		expect(/"workspaces"\s*:\s*\{\s*""\s*:\s*\{\s*"name"\s*:\s*"([^"]*)"/.exec(lock)?.[1]).toBe(
 			'northwind-labs'
 		);
-		// Nur der Root-Name ändert sich; der Abhängigkeitsgraph bleibt bytegleich.
+		// Only the root name changes; the dependency graph remains byte-identical.
 		expect(lock).toBe(
 			readFileSync(join(ROOT, 'bun.lock'), 'utf-8').replace(
 				'"name": "saas-starter"',
@@ -624,13 +814,13 @@ describe('template setup rejects input before writing', () => {
 					/^export const LEGAL_CONFIG[\s\S]*?^\} as const;$/m,
 					"export const LEGAL_CONFIG = { brandName: 'X' };"
 				),
-			expected: /Expected exactly one LEGAL_CONFIG block/
+			expected: /LEGAL_CONFIG must use a direct object initializer/
 		},
 		{
 			label: 'the README lost its quick start',
 			file: 'README.md',
 			mutate: () => '# Custom Title\n\nUnrelated prose.\n',
-			expected: /Expected exactly one quick start clone block/
+			expected: /Expected exactly one Quick Start H2/
 		},
 		{
 			label: 'wrangler.toml lost its name assignment',
@@ -700,8 +890,7 @@ describe('template setup rejects input before writing', () => {
 });
 
 describe('template setup recognizes a genuinely set up project', () => {
-	// Ein von Hand geänderter Package-Name oder githubSlug beweist keine Einrichtung:
-	// solange der Quick Start die gh-repo-create-Form trägt, bleibt --brand Pflicht.
+	// A hand-edited package name or githubSlug does not prove setup while Quick Start is bootstrap.
 	it.each([
 		{
 			label: 'only the package name was renamed by hand',
@@ -769,7 +958,7 @@ describe('template setup recognizes a genuinely set up project', () => {
 
 	it('stops demanding flags once the full generated README state is consistent', () => {
 		const dir = createFixture();
-		// Der Slug bleibt bewusst auf dem Template-Wert.
+		// Deliberately retain the template slug.
 		expect(
 			runSetup(dir, [
 				'--slug',
@@ -861,7 +1050,7 @@ describe('template setup recognizes a genuinely set up project', () => {
 describe('template setup keeps prose values on one line', () => {
 	const multiline = 'Northwind Labs\n\n## Injected Heading\n\nmore text';
 
-	// Brand und Operator werden roh in die Absätze von Privacy und Terms eingesetzt.
+	// Brand and operator enter Privacy and Terms paragraphs as raw text.
 	it.each([
 		{ flag: '--brand', expected: /brand must be a single line/ },
 		{ flag: '--operator', expected: /operator must be a single line/ }
@@ -946,10 +1135,308 @@ describe('template setup contact email end to end', () => {
 	});
 });
 
+const SINGLE_REPLACE_OUTPUTS = [
+	'package.json',
+	'bun.lock',
+	'wrangler.toml',
+	'README.md',
+	'src/lib/config/site.ts'
+] as const;
+
+const SINGLE_REPLACE_FAULTS = ['write', 'partial-write', 'single-install'] as const;
+
+describe('template setup atomic single-file replacements', () => {
+	it.each(
+		SINGLE_REPLACE_OUTPUTS.flatMap((target) =>
+			SINGLE_REPLACE_FAULTS.map((phase) => ({ target, phase }))
+		)
+	)('keeps $target whole after a $phase fault and converges on retry', ({ target, phase }) => {
+		const expectedDir = createFixture();
+		const expectedRun = runSetup(expectedDir, [...REQUIRED, ...IDENTITY]);
+		expect(expectedRun.code, expectedRun.stderr).toBe(0);
+		const expected = snapshot(expectedDir);
+
+		const dir = createFixture();
+		const before = snapshot(dir);
+		const fault = createFaultPreload(dir, { phase, target });
+		const failed = runSetup(dir, [...REQUIRED, ...IDENTITY], fault.path);
+		expectFault(failed, fault, phase === 'single-install' ? 'renameSync' : 'writeFileSync');
+		if (phase !== 'single-install') {
+			expect(failed.stderr).toContain('stage=true');
+			expect(failed.stderr).toContain('flag=wx');
+		}
+		if (phase === 'partial-write') expect(failed.stderr).toContain('prefix=true');
+
+		const partial = snapshot(dir);
+		expect(partial[target]).toBe(before[target]);
+		for (const rel of FIXTURE_FILES) {
+			expect([before[rel], expected[rel]]).toContain(partial[rel]);
+		}
+
+		const retry = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(retry.code, retry.stderr).toBe(0);
+		expect(snapshot(dir)).toEqual(expected);
+	});
+
+	it('accepts a flagless retry after the final site replacement committed before cleanup failed', () => {
+		const dir = createFixture();
+		const fault = createFaultPreload(dir, {
+			phase: 'single-cleanup-rmdir',
+			target: 'src/lib/config/site.ts'
+		});
+		const failed = runSetup(dir, [...REQUIRED, ...IDENTITY], fault.path);
+		expectFault(failed, fault, 'rmdirSync');
+		expect(readFileSync(join(dir, 'README.md'), 'utf-8')).toContain(
+			'git clone https://github.com/northwind/northwind-labs.git'
+		);
+		expect(readFileSync(join(dir, 'src/lib/config/site.ts'), 'utf-8')).toContain(
+			"githubSlug: 'northwind/northwind-labs'"
+		);
+
+		const retry = runSetup(dir, []);
+		expect(retry.code, retry.stderr).toBe(0);
+	});
+});
+
+const LEGAL_OUTPUTS = ['src/lib/config/legal.ts', 'src/lib/content/legal-metadata.ts'] as const;
+
+function setLegalModes(dir: string): { config: number; metadata: number } {
+	chmodSync(join(dir, LEGAL_OUTPUTS[0]), 0o640);
+	chmodSync(join(dir, LEGAL_OUTPUTS[1]), 0o604);
+	const modes = { config: mode(dir, LEGAL_OUTPUTS[0]), metadata: mode(dir, LEGAL_OUTPUTS[1]) };
+	if (process.platform !== 'win32') expect(modes.config).not.toBe(modes.metadata);
+	return modes;
+}
+
+const LEGAL_PREPARE_FAULTS = ['write', 'partial-write', 'chmod'] as const;
+
+describe('template setup legal pair commit protocol', () => {
+	it.each(
+		LEGAL_OUTPUTS.flatMap((target) => LEGAL_PREPARE_FAULTS.map((phase) => ({ target, phase })))
+	)('leaves the original pair after a $phase fault for $target', ({ target, phase }) => {
+		const expectedDir = createFixture();
+		setLegalModes(expectedDir);
+		const expectedRun = runSetup(expectedDir, [...REQUIRED, ...IDENTITY]);
+		expect(expectedRun.code, expectedRun.stderr).toBe(0);
+		const expected = snapshot(expectedDir);
+
+		const dir = createFixture();
+		const originalModes = setLegalModes(dir);
+		const before = snapshot(dir);
+		const fault = createFaultPreload(dir, { phase, target });
+		const failed = runSetup(dir, [...REQUIRED, ...IDENTITY], fault.path);
+		expectFault(failed, fault, phase === 'chmod' ? 'chmodSync' : 'writeFileSync');
+		expect(failed.stderr).toContain('stage=true');
+		if (phase !== 'chmod') expect(failed.stderr).toContain('flag=wx');
+		if (phase === 'partial-write') expect(failed.stderr).toContain('prefix=true');
+		expect(snapshot(dir)).toEqual(before);
+		expect(mode(dir, LEGAL_OUTPUTS[0])).toBe(originalModes.config);
+		expect(mode(dir, LEGAL_OUTPUTS[1])).toBe(originalModes.metadata);
+
+		const retry = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(retry.code, retry.stderr).toBe(0);
+		expect(snapshot(dir)).toEqual(expected);
+		expect(mode(dir, LEGAL_OUTPUTS[0])).toBe(originalModes.config);
+		expect(mode(dir, LEGAL_OUTPUTS[1])).toBe(originalModes.metadata);
+	});
+
+	it.each([
+		{ phase: 'legal-backup' as const, operation: 'renameSync' },
+		{ phase: 'legal-config-install' as const, operation: 'renameSync' },
+		{ phase: 'legal-metadata-install' as const, operation: 'renameSync' }
+	])('restores the original pair after $phase fails before commit', ({ phase, operation }) => {
+		const dir = createFixture();
+		const originalModes = setLegalModes(dir);
+		const before = snapshot(dir);
+		const fault = createFaultPreload(dir, { phase, target: LEGAL_OUTPUTS[0] });
+		const failed = runSetup(dir, [...REQUIRED, ...IDENTITY], fault.path);
+		expectFault(failed, fault, operation);
+		expect(snapshot(dir)).toEqual(before);
+		expect(mode(dir, LEGAL_OUTPUTS[0])).toBe(originalModes.config);
+		expect(mode(dir, LEGAL_OUTPUTS[1])).toBe(originalModes.metadata);
+
+		const retry = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(retry.code, retry.stderr).toBe(0);
+	});
+
+	it('preserves the backup and recovery file when restoring the config fails', () => {
+		const dir = createFixture();
+		const beforeConfig = readFileSync(join(dir, LEGAL_OUTPUTS[0]));
+		const beforeMetadata = readFileSync(join(dir, LEGAL_OUTPUTS[1]));
+		const fault = createFaultPreload(dir, {
+			phase: 'legal-metadata-and-restore',
+			target: LEGAL_OUTPUTS[0]
+		});
+		const failed = runSetup(dir, [...REQUIRED, ...IDENTITY], fault.path);
+
+		expect(failed.code).toBe(1);
+		expect(failed.stderr).toContain(`FAULT_HIT ${fault.id} operation=renameSync`);
+		expect(failed.stderr).toContain(`FAULT_HIT ${fault.id} operation=renameSync-restore`);
+		expect(failed.stderr).toContain('template-setup.ts');
+		expect(failed.stderr).toMatch(/Recovery required/);
+		expect(failed.stderr).toMatch(/legal\.ts\.backup/);
+		expect(failed.stderr).toMatch(/canonical config=.*canonical metadata=/);
+		expect(existsSync(join(dir, LEGAL_OUTPUTS[0]))).toBe(false);
+		expect(readFileSync(join(dir, LEGAL_OUTPUTS[1]))).toEqual(beforeMetadata);
+
+		const stages = stagingArtifacts(dir);
+		expect(stages.length).toBeGreaterThan(0);
+		const retained = stages.flatMap((stage) =>
+			readdirSync(stage).map((entry) => ({
+				path: join(stage, entry),
+				bytes: readFileSync(join(stage, entry))
+			}))
+		);
+		expect(retained.some(({ path }) => path.endsWith('legal.ts.backup'))).toBe(true);
+		expect(retained.some(({ bytes }) => bytes.equals(beforeConfig))).toBe(true);
+		expect(retained.some(({ path }) => path.endsWith('legal.ts.recovery'))).toBe(true);
+	});
+
+	it.each([
+		{ phase: 'legal-cleanup-unlink' as const, operation: 'unlinkSync' },
+		{ phase: 'legal-cleanup-rmdir' as const, operation: 'rmdirSync' }
+	])('keeps the committed pair after $phase fails', ({ phase, operation }) => {
+		const expectedDir = createFixture();
+		setLegalModes(expectedDir);
+		expect(runSetup(expectedDir, [...REQUIRED, ...IDENTITY]).code).toBe(0);
+		const expectedConfig = readFileSync(join(expectedDir, LEGAL_OUTPUTS[0]));
+		const expectedMetadata = readFileSync(join(expectedDir, LEGAL_OUTPUTS[1]));
+
+		const dir = createFixture();
+		const originalModes = setLegalModes(dir);
+		const fault = createFaultPreload(dir, { phase, target: LEGAL_OUTPUTS[0] });
+		const failed = runSetup(dir, [...REQUIRED, ...IDENTITY], fault.path);
+		expectFault(failed, fault, operation);
+		expect(readFileSync(join(dir, LEGAL_OUTPUTS[0]))).toEqual(expectedConfig);
+		expect(readFileSync(join(dir, LEGAL_OUTPUTS[1]))).toEqual(expectedMetadata);
+		expect(mode(dir, LEGAL_OUTPUTS[0])).toBe(originalModes.config);
+		expect(mode(dir, LEGAL_OUTPUTS[1])).toBe(originalModes.metadata);
+		expect(stagingArtifacts(dir).length).toBeGreaterThan(0);
+
+		const retry = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(retry.code, retry.stderr).toBe(0);
+		expect(readFileSync(join(dir, LEGAL_OUTPUTS[0]))).toEqual(expectedConfig);
+		expect(readFileSync(join(dir, LEGAL_OUTPUTS[1]))).toEqual(expectedMetadata);
+	});
+});
+
+describe('template setup path preflight', () => {
+	it('rejects a symlink target before creating staging directories', () => {
+		const dir = createFixture();
+		const readme = join(dir, 'README.md');
+		const realReadme = join(dir, 'README.real.md');
+		renameSync(readme, realReadme);
+		symlinkSync('README.real.md', readme, 'file');
+		const before = readFileSync(realReadme);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(/regular file|symbolic link|symlink/i);
+		expect(readFileSync(realReadme)).toEqual(before);
+		expect(stagingArtifacts(dir)).toEqual([]);
+	});
+
+	it('rejects a hardlink target before creating staging directories', () => {
+		const dir = createFixture();
+		const readme = join(dir, 'README.md');
+		const peer = join(dir, 'README.peer.md');
+		renameSync(readme, peer);
+		linkSync(peer, readme);
+		const before = readFileSync(peer);
+		expect(lstatSync(readme).nlink).toBeGreaterThan(1);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(/hardlink|link count|nlink/i);
+		expect(readFileSync(peer)).toEqual(before);
+		expect(stagingArtifacts(dir)).toEqual([]);
+	});
+
+	it('rejects a real parent outside the repository root before staging', () => {
+		const dir = createFixture();
+		const config = join(dir, 'src/lib/config');
+		const outside = mkdtempSync(join(tmpdir(), 'template-setup-outside-'));
+		fixtures.push(outside);
+		cpSync(config, outside, { recursive: true });
+		rmSync(config, { recursive: true });
+		symlinkSync(outside, config, process.platform === 'win32' ? 'junction' : 'dir');
+		const beforeLegal = readFileSync(join(outside, 'legal.ts'));
+		const beforeSite = readFileSync(join(outside, 'site.ts'));
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(/outside.*repository|repository root/i);
+		expect(readFileSync(join(outside, 'legal.ts'))).toEqual(beforeLegal);
+		expect(readFileSync(join(outside, 'site.ts'))).toEqual(beforeSite);
+		expect(stagingArtifacts(dir)).toEqual([]);
+	});
+});
+
+describe('template setup structural process guards', () => {
+	it('rejects a template decoy with an indirect real LEGAL_CONFIG before writes', () => {
+		const dir = createFixture();
+		const legal = join(dir, 'src/lib/config/legal.ts');
+		const direct = readFileSync(legal, 'utf-8');
+		const block = /^export const LEGAL_CONFIG = \{[\s\S]*?^\} as const;$/m.exec(direct)?.[0];
+		expect(block).toBeDefined();
+		const indirect = direct.replace(
+			block!,
+			`const currentConfig = ${block!.replace('export const LEGAL_CONFIG = ', '')}\nconst decoy = \`export const LEGAL_CONFIG = { brandName: 'Decoy' } as const;\`;\nexport const LEGAL_CONFIG = currentConfig;`
+		);
+		writeFileSync(legal, indirect, 'utf-8');
+		const before = snapshot(dir);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(/LEGAL_CONFIG/);
+		expect(snapshot(dir)).toEqual(before);
+		expect(stagingArtifacts(dir)).toEqual([]);
+	});
+
+	it('rejects a foreign clone example when the real Quick Start candidate is missing', () => {
+		const dir = createFixture();
+		const readme = join(dir, 'README.md');
+		const source = readFileSync(readme, 'utf-8')
+			.replace(
+				'gh repo create my-saas-product --template stickerdaniel/saas-starter --clone\ncd my-saas-product\nbun install\nbun run dev',
+				'mkdir my-saas-product\nbun install\nbun run dev'
+			)
+			.concat(
+				'\n## Unrelated Vendor Checkout\n\n```bash\ngit clone https://github.com/example/vendor-tool.git\ncd vendor-tool\nbun install\nbun run dev\n```\n'
+			);
+		writeFileSync(readme, source, 'utf-8');
+		const before = snapshot(dir);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(/candidate/);
+		expect(snapshot(dir)).toEqual(before);
+		expect(stagingArtifacts(dir)).toEqual([]);
+	});
+
+	it('rewrites an exact repository URL before sentence punctuation in the public process', () => {
+		const dir = createFixture();
+		const readme = join(dir, 'README.md');
+		writeFileSync(
+			readme,
+			readFileSync(readme, 'utf-8').replace(
+				'## Why This Exists',
+				'Exact prose URL: https://github.com/stickerdaniel/saas-starter. \n\n## Why This Exists'
+			),
+			'utf-8'
+		);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code, run.stderr).toBe(0);
+		expect(readFileSync(readme, 'utf-8')).toContain(
+			'Exact prose URL: https://github.com/northwind/northwind-labs. '
+		);
+	});
+});
+
 /**
- * Gemessen, nicht angenommen: nur wenn ein echter Schreibversuch auf eine 0444-Datei
- * scheitert, prüft der folgende Test überhaupt eine Schreibverweigerung. Als root
- * bleibt der Fall unbeobachtbar und der Test meldet das, statt Erfolg zu behaupten.
+ * This test measures a real denied write. Root can bypass 0444 permissions, so the
+ * case reports itself as unobservable there instead of claiming coverage.
  */
 const writeDenialEnforced = (() => {
 	const dir = mkdtempSync(join(tmpdir(), 'template-setup-wperm-'));

--- a/scripts/template-setup.integration.test.ts
+++ b/scripts/template-setup.integration.test.ts
@@ -110,6 +110,17 @@ const IDENTITY = [
 
 const REQUIRED = ['--slug', 'northwind-labs', '--repo', 'northwind/northwind-labs'];
 
+function asciiDomainOfLength(length: number): string {
+	const labels: string[] = [];
+	let remaining = length;
+	while (remaining > 63) {
+		labels.push('a'.repeat(63));
+		remaining -= 64;
+	}
+	labels.push('a'.repeat(remaining));
+	return labels.join('.');
+}
+
 /** Wie IDENTITY, aber ohne --brand und --company, damit deren Defaults greifen. */
 const IDENTITY_WITHOUT_COMPANY = [
 	'--operator',
@@ -130,7 +141,31 @@ describe('template setup writes importable branding values', () => {
 			key: 'companyName',
 			value: 'The "Blue Door" GmbH'
 		},
-		{ label: 'backslash', flag: '--operator', key: 'operatorName', value: 'Anne\\Marie Weber' },
+		{
+			label: 'ampersand, apostrophe, and hyphen',
+			flag: '--operator',
+			key: 'operatorName',
+			value: "Anne-Marie & O'Connor"
+		},
+		{
+			label: 'literal entity text',
+			flag: '--brand',
+			key: 'brandName',
+			value: 'Research &copy; Labs'
+		},
+		{
+			label: 'parentheses and Unicode symbols',
+			flag: '--brand',
+			key: 'brandName',
+			value: 'Northwind (Europe)™ 🚀'
+		},
+		{
+			label: 'slash and at sign',
+			flag: '--operator',
+			key: 'operatorName',
+			value: 'Research / Development @ Northwind'
+		},
+		{ label: 'backslash', flag: '--company', key: 'companyName', value: 'Anne\\Marie Weber' },
 		{
 			label: 'multiline address',
 			flag: '--address',
@@ -140,8 +175,8 @@ describe('template setup writes importable branding values', () => {
 		{
 			// $&, $1 und $` dürfen nicht als Ersetzungsmuster interpretiert werden.
 			label: 'replacement metacharacters',
-			flag: '--brand',
-			key: 'brandName',
+			flag: '--company',
+			key: 'companyName',
 			value: "Ampersand $& Backref $1 Tick $` Quote $' Co"
 		}
 	])('keeps a $label intact', ({ flag, key, value }) => {
@@ -401,6 +436,16 @@ describe('template setup rejects input before writing', () => {
 			expected: /repo must use a safe GitHub owner\/name format/
 		},
 		{
+			label: 'a reserved clone directory basename',
+			args: ['--slug', 'northwind-labs', '--repo', 'northwind/con', ...IDENTITY],
+			expected: /repo basename must be safe for the generated cross-platform clone directory/
+		},
+		{
+			label: 'a reserved clone directory basename before an extension',
+			args: ['--slug', 'northwind-labs', '--repo', 'northwind/COM1.project', ...IDENTITY],
+			expected: /repo basename must be safe for the generated cross-platform clone directory/
+		},
+		{
 			label: 'an invalid email',
 			args: [...REQUIRED, ...IDENTITY.slice(0, -1), 'kaputt'],
 			expected: /email must use the consumer-compatible user@domain\.tld subset/
@@ -408,6 +453,20 @@ describe('template setup rejects input before writing', () => {
 		{
 			label: 'a Unicode email localpart longer than 64 UTF-8 bytes',
 			args: [...REQUIRED, ...IDENTITY.slice(0, -1), `${'é'.repeat(33)}@example.de`],
+			expected: /email must use the consumer-compatible user@domain\.tld subset/
+		},
+		{
+			label: 'a 64-byte localpart with a 190-byte ASCII domain',
+			args: [
+				...REQUIRED,
+				...IDENTITY.slice(0, -1),
+				`${'a'.repeat(64)}@${asciiDomainOfLength(190)}`
+			],
+			expected: /email must use the consumer-compatible user@domain\.tld subset/
+		},
+		{
+			label: 'a one-byte localpart with a 253-byte ASCII domain',
+			args: [...REQUIRED, ...IDENTITY.slice(0, -1), `a@${asciiDomainOfLength(253)}`],
 			expected: /email must use the consumer-compatible user@domain\.tld subset/
 		},
 		{
@@ -560,7 +619,35 @@ describe('template setup recognizes a genuinely set up project', () => {
 		expect(snapshot(dir)).toEqual(before);
 	});
 
-	it('stops demanding flags once the quick start names this repository', () => {
+	it('rejects a flagless run when only githubSlug and the clone block were edited', () => {
+		const dir = createFixture();
+		const site = join(dir, 'src/lib/config/site.ts');
+		writeFileSync(
+			site,
+			readFileSync(site, 'utf-8').replace(
+				"githubSlug: 'stickerdaniel/saas-starter'",
+				"githubSlug: 'northwind/northwind-labs'"
+			),
+			'utf-8'
+		);
+		const readme = join(dir, 'README.md');
+		writeFileSync(
+			readme,
+			readFileSync(readme, 'utf-8').replace(
+				'gh repo create my-saas-product --template stickerdaniel/saas-starter --clone\ncd my-saas-product',
+				'git clone https://github.com/northwind/northwind-labs.git\ncd ./northwind-labs'
+			),
+			'utf-8'
+		);
+		const before = snapshot(dir);
+
+		const run = runSetup(dir, []);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(/needs --slug, --repo, --brand in non-interactive mode/);
+		expect(snapshot(dir)).toEqual(before);
+	});
+
+	it('stops demanding flags once the full generated README state is consistent', () => {
 		const dir = createFixture();
 		// Der Slug bleibt bewusst auf dem Template-Wert.
 		expect(
@@ -663,6 +750,37 @@ describe('template setup keeps prose values on one line', () => {
 		const before = snapshot(dir);
 
 		const run = runSetup(dir, [...REQUIRED, ...IDENTITY, flag, multiline]);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(expected);
+		expect(snapshot(dir)).toEqual(before);
+	});
+
+	it.each([
+		{
+			flag: '--brand',
+			value: '*Star* Co',
+			expected: /brand must not contain active Markdown inline syntax/
+		},
+		{
+			flag: '--brand',
+			value: '[Northwind](https://example.com)',
+			expected: /brand must not contain active Markdown inline syntax/
+		},
+		{
+			flag: '--operator',
+			value: '*Star* Co',
+			expected: /operator must not contain active Markdown inline syntax/
+		},
+		{
+			flag: '--operator',
+			value: '[Northwind](https://example.com)',
+			expected: /operator must not contain active Markdown inline syntax/
+		}
+	])('rejects active inline Markdown in $flag before writing', ({ flag, value, expected }) => {
+		const dir = createFixture();
+		const before = snapshot(dir);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY, flag, value]);
 		expect(run.code).toBe(1);
 		expect(run.stderr).toMatch(expected);
 		expect(snapshot(dir)).toEqual(before);

--- a/scripts/template-setup.integration.test.ts
+++ b/scripts/template-setup.integration.test.ts
@@ -206,7 +206,7 @@ describe('template setup re-runs', () => {
 
 		const readme = readFileSync(join(dir, 'README.md'), 'utf-8');
 		expect(readme).toContain('git clone https://github.com/northwind/northwind-cloud.git');
-		expect(readme).toContain('cd northwind-cloud');
+		expect(readme).toContain('cd ./northwind-cloud');
 		expect(readme).not.toContain('northwind-labs');
 	});
 });
@@ -219,13 +219,40 @@ describe('template setup quick start', () => {
 		const readme = readFileSync(join(dir, 'README.md'), 'utf-8');
 		expect(readme.split('\n')[0]).toBe('# Northwind Labs');
 		expect(readme).toContain(
-			'```bash\ngit clone https://github.com/northwind/northwind-labs.git\ncd northwind-labs\nbun install\nbun run dev\n```'
+			'```bash\ngit clone https://github.com/northwind/northwind-labs.git\ncd ./northwind-labs\nbun install\nbun run dev\n```'
 		);
 		expect(readme).not.toContain('gh repo create');
 		expect(readme).not.toContain('my-saas-product');
 		expect(readme).not.toContain('Live demo!');
 		// Unverwandte Prosa bleibt erhalten.
 		expect(readme).toContain('## Why This Exists');
+	});
+
+	it('uses an option-safe directory for a repository basename starting with a hyphen', () => {
+		const dir = createFixture();
+		const run = runSetup(dir, [
+			'--slug',
+			'northwind-project',
+			'--repo',
+			'northwind/-project',
+			...IDENTITY
+		]);
+		expect(run.code, run.stderr).toBe(0);
+		expect(readFileSync(join(dir, 'README.md'), 'utf-8')).toContain(
+			'git clone https://github.com/northwind/-project.git\ncd ./-project\n'
+		);
+	});
+
+	it('removes the live demo from a fully CRLF-encoded README', () => {
+		const dir = createFixture();
+		const readme = join(dir, 'README.md');
+		writeFileSync(readme, readFileSync(readme, 'utf-8').replace(/\n/g, '\r\n'), 'utf-8');
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code, run.stderr).toBe(0);
+		const updated = readFileSync(readme, 'utf-8');
+		expect(updated).not.toContain('Live demo!');
+		expect(updated).not.toMatch(/[^\r]\n/);
 	});
 
 	it('keeps the root name in manifest and lockfile in sync', () => {
@@ -248,6 +275,33 @@ describe('template setup quick start', () => {
 	});
 });
 
+describe('template setup finds the runtime repository property', () => {
+	it('ignores comments, strings, and interface signatures around SITE_CONFIG', () => {
+		const dir = createFixture();
+		const site = join(dir, 'src/lib/config/site.ts');
+		writeFileSync(
+			site,
+			readFileSync(site, 'utf-8')
+				.replace(
+					'export interface SiteConfig {',
+					"// githubSlug: 'comment/line'\nconst example = \"githubSlug: 'string/example'\";\n\nexport interface SiteConfig {\n\t/** githubSlug: 'comment/doc' */"
+				)
+				.replace(
+					"\tgithubSlug: 'stickerdaniel/saas-starter',",
+					"\t/*\n\t * githubSlug: 'comment/block'\n\t */\n\tgithubSlug: 'stickerdaniel/saas-starter',"
+				),
+			'utf-8'
+		);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code, run.stderr).toBe(0);
+		const updated = readFileSync(site, 'utf-8');
+		expect(updated).toContain("githubSlug: 'northwind/northwind-labs'");
+		expect(updated).toContain("githubSlug: 'comment/block'");
+		expect(updated).toContain("githubSlug: 'string/example'");
+	});
+});
+
 describe('template setup rejects input before writing', () => {
 	it.each([
 		{
@@ -266,14 +320,34 @@ describe('template setup rejects input before writing', () => {
 			expected: /slug must match/
 		},
 		{
+			label: 'a leading slug hyphen in attached flag form',
+			args: ['--slug=-northwind', '--repo', 'northwind/northwind-labs', ...IDENTITY],
+			expected: /slug must match/
+		},
+		{
+			label: 'a trailing slug hyphen',
+			args: ['--slug', 'northwind-', '--repo', 'northwind/northwind-labs', ...IDENTITY],
+			expected: /slug must match/
+		},
+		{
+			label: 'a 64-character worker slug',
+			args: ['--slug', 'n'.repeat(64), '--repo', 'northwind/northwind-labs', ...IDENTITY],
+			expected: /slug must match/
+		},
+		{
 			label: 'an unsafe repository',
 			args: ['--slug', 'northwind-labs', '--repo', 'northwind/repo.git', ...IDENTITY],
 			expected: /repo must use a safe GitHub owner\/name format/
 		},
 		{
+			label: 'a 101-character repository name',
+			args: ['--slug', 'northwind-labs', '--repo', `northwind/${'r'.repeat(101)}`, ...IDENTITY],
+			expected: /repo must use a safe GitHub owner\/name format/
+		},
+		{
 			label: 'an invalid email',
 			args: [...REQUIRED, ...IDENTITY.slice(0, -1), 'kaputt'],
-			expected: /email must match user@domain\.tld pattern/
+			expected: /email must use the consumer-compatible user@domain\.tld subset/
 		},
 		{
 			label: 'missing required values without a TTY',
@@ -298,16 +372,21 @@ describe('template setup rejects input before writing', () => {
 			expected: /Could not find githubSlug/
 		},
 		{
-			// Gültige Datei mit einem zweiten Treffer: der erste steht im Doc-Kommentar und
-			// steuert die Laufzeit nicht. Stilles Ersetzen träfe den falschen Wert.
-			label: 'the site config carries a second githubSlug example',
+			label: 'the site config carries duplicate direct githubSlug properties',
 			file: 'src/lib/config/site.ts',
 			mutate: (source: string) =>
 				source.replace(
-					'export interface SiteConfig {',
-					"export interface SiteConfig {\n\t/** Example: githubSlug: 'octocat/hello-world' */"
+					"\tgithubSlug: 'stickerdaniel/saas-starter',",
+					"\tgithubSlug: 'stickerdaniel/saas-starter',\n\tgithubSlug: 'other/repository',"
 				),
-			expected: /Expected exactly one githubSlug in src\/lib\/config\/site\.ts, found 2/
+			expected: /Expected exactly one direct githubSlug property/
+		},
+		{
+			label: 'the site config uses a non-literal githubSlug value',
+			file: 'src/lib/config/site.ts',
+			mutate: (source: string) =>
+				source.replace("githubSlug: 'stickerdaniel/saas-starter'", 'githubSlug: repository'),
+			expected: /direct string literal/
 		},
 		{
 			label: 'the legal config lost its export block',
@@ -339,6 +418,43 @@ describe('template setup rejects input before writing', () => {
 		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
 		expect(run.code).toBe(1);
 		expect(run.stderr).toMatch(expected);
+		expect(snapshot(dir)).toEqual(before);
+	});
+
+	it.each([
+		['Date', (source: string) => source.replace('{\n', '{\n\tunsupported: new Date(0),\n')],
+		['Map', (source: string) => source.replace('{\n', '{\n\tunsupported: new Map(),\n')],
+		['Set', (source: string) => source.replace('{\n', '{\n\tunsupported: new Set(),\n')],
+		['RegExp', (source: string) => source.replace('{\n', '{\n\tunsupported: /value/,\n')],
+		[
+			'class instance',
+			(source: string) =>
+				`class UnsupportedConfigValue {}\n${source.replace(
+					'{\n',
+					'{\n\tunsupported: new UnsupportedConfigValue(),\n'
+				)}`
+		],
+		[
+			'null-prototype object',
+			(source: string) =>
+				source.replace(
+					'{\n',
+					"{\n\tunsupported: Object.assign(Object.create(null), { value: 'kept' }),\n"
+				)
+		],
+		[
+			'own __proto__ data property',
+			(source: string) => source.replace('{\n', "{\n\t['__proto__']: 'kept',\n")
+		]
+	])('rejects an imported %s before normalization or writes', (_label, mutate) => {
+		const dir = createFixture();
+		const legal = join(dir, 'src/lib/config/legal.ts');
+		writeFileSync(legal, mutate(readFileSync(legal, 'utf-8')), 'utf-8');
+		const before = snapshot(dir);
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(/Unsupported LEGAL_CONFIG/);
 		expect(snapshot(dir)).toEqual(before);
 	});
 });
@@ -403,6 +519,22 @@ describe('template setup recognizes a genuinely set up project', () => {
 		expect(rerun.code, rerun.stderr).toBe(0);
 		expect(rerun.stderr).not.toMatch(/Missing:/);
 		expect(snapshot(dir)).toEqual(afterFirst);
+	});
+
+	it('recognizes the previous bare cd form on a re-run', () => {
+		const dir = createFixture();
+		expect(runSetup(dir, [...REQUIRED, ...IDENTITY]).code).toBe(0);
+		const readme = join(dir, 'README.md');
+		writeFileSync(
+			readme,
+			readFileSync(readme, 'utf-8').replace('cd ./northwind-labs', 'cd northwind-labs'),
+			'utf-8'
+		);
+
+		const rerun = runSetup(dir, []);
+		expect(rerun.code, rerun.stderr).toBe(0);
+		expect(rerun.stderr).not.toMatch(/Missing:/);
+		expect(readFileSync(readme, 'utf-8')).toContain('cd ./northwind-labs');
 	});
 
 	it('leaves a CRLF README byte-identical on a re-run', () => {
@@ -492,18 +624,42 @@ describe('template setup keeps prose values on one line', () => {
 });
 
 describe('template setup contact email end to end', () => {
-	it.each(['a@b@c.de', 'erste person@example.de', 'a@ex ample.de', 'a@example..de'])(
-		'rejects %s before writing',
-		(value) => {
-			const dir = createFixture();
-			const before = snapshot(dir);
+	it.each([
+		'a@b@c.de',
+		'erste person@example.de',
+		'a@ex ample.de',
+		'a@example..de',
+		'a?subject=changed@example.de',
+		'a#fragment@example.de',
+		'a/path@example.de',
+		'a%20name@example.de',
+		'a@-example.de',
+		'a@example-.de',
+		`a@${'d'.repeat(64)}.de`
+	])('rejects %s before writing', (value) => {
+		const dir = createFixture();
+		const before = snapshot(dir);
 
-			const run = runSetup(dir, [...REQUIRED, ...IDENTITY.slice(0, 6), '--email', value]);
-			expect(run.code).toBe(1);
-			expect(run.stderr).toMatch(/email must match user@domain\.tld pattern/);
-			expect(snapshot(dir)).toEqual(before);
-		}
-	);
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY.slice(0, 6), '--email', value]);
+		expect(run.code).toBe(1);
+		expect(run.stderr).toMatch(/email must use the consumer-compatible user@domain\.tld subset/);
+		expect(snapshot(dir)).toEqual(before);
+	});
+
+	it('keeps plus, apostrophe, and Unicode in the supported subset', () => {
+		const dir = createFixture();
+		const email = "jörg+o'connor@münchen.example";
+		expect(runSetup(dir, [...REQUIRED, ...IDENTITY.slice(0, 6), '--email', email]).code).toBe(0);
+
+		const imported = importLegalConfig(dir);
+		expect(imported.code, imported.stderr).toBe(0);
+		expect(imported.value?.config.email).toEqual({
+			user: "jörg+o'connor",
+			domain: 'münchen',
+			tld: 'example'
+		});
+		expect(imported.value?.mailto).toBe(email);
+	});
 
 	it('keeps a subdomain address split into three parts', () => {
 		const dir = createFixture();

--- a/scripts/template-setup.integration.test.ts
+++ b/scripts/template-setup.integration.test.ts
@@ -52,10 +52,13 @@ function snapshot(dir: string): Record<string, string> {
 	);
 }
 
-function runSetup(dir: string, args: string[]) {
-	// Der öffentliche Einstieg, damit auch das Skript-Dispatch aus dem Manifest geprüft
-	// wird. Die Fixture bringt das reale package.json mit und braucht keine Dependencies.
-	const result = spawnSync(BUN, ['run', 'setup', ...args], {
+function runSetup(dir: string, args: string[], preload?: string) {
+	// Normalerweise der öffentliche Einstieg, damit auch das Skript-Dispatch aus dem
+	// Manifest geprüft wird. Die Fehler-Injektion lädt sich direkt vor das echte Skript.
+	const command = preload
+		? ['--preload', preload, 'scripts/template-setup.ts', ...args]
+		: ['run', 'setup', ...args];
+	const result = spawnSync(BUN, command, {
 		cwd: dir,
 		encoding: 'utf-8',
 		// stdin bleibt ohne TTY: das Setup läuft nicht-interaktiv, wie unter CI und in der CLI.
@@ -177,6 +180,46 @@ describe('template setup re-runs', () => {
 		expect(snapshot(dir)).toEqual(afterFirst);
 	});
 
+	it('keeps completion signals unset when legal.ts fails and rejects a flagless re-run', () => {
+		const dir = createFixture();
+		const preload = join(dir, 'fail-legal-write.mjs');
+		writeFileSync(
+			preload,
+			`import { mock } from 'bun:test';
+import * as fs from 'node:fs';
+
+const realWriteFileSync = fs.writeFileSync;
+mock.module('fs', () => ({
+	...fs,
+	writeFileSync(path, ...args) {
+		if (String(path).replaceAll('\\\\', '/').endsWith('/src/lib/config/legal.ts')) {
+			const error = new Error('Injected EIO for legal.ts');
+			error.code = 'EIO';
+			throw error;
+		}
+		return realWriteFileSync(path, ...args);
+	}
+}));
+`,
+			'utf-8'
+		);
+		const before = snapshot(dir);
+
+		const failed = runSetup(dir, [...REQUIRED, ...IDENTITY], preload);
+		expect(failed.code).toBe(1);
+		expect(failed.stderr).toMatch(/Injected EIO for legal\.ts/);
+		const partial = snapshot(dir);
+		expect(partial['package.json']).not.toBe(before['package.json']);
+		expect(partial['src/lib/config/legal.ts']).toBe(before['src/lib/config/legal.ts']);
+		expect(partial['README.md']).toBe(before['README.md']);
+		expect(partial['src/lib/config/site.ts']).toBe(before['src/lib/config/site.ts']);
+
+		const rerun = runSetup(dir, []);
+		expect(rerun.code).toBe(1);
+		expect(rerun.stderr).toMatch(/Missing: --repo, --brand/);
+		expect(snapshot(dir)).toEqual(partial);
+	});
+
 	it('keeps a brand that was deliberately set to the template name', () => {
 		const dir = createFixture();
 		expect(runSetup(dir, [...REQUIRED, ...IDENTITY.slice(2), '--brand', 'SaaS Starter']).code).toBe(
@@ -273,6 +316,19 @@ describe('template setup quick start', () => {
 			)
 		);
 	});
+
+	it('keeps environment worker names byte-identical', () => {
+		const dir = createFixture();
+		const wrangler = join(dir, 'wrangler.toml');
+		const environment = '\n[env.staging]\nname = "staging-worker" # keep me\n';
+		writeFileSync(wrangler, readFileSync(wrangler, 'utf-8') + environment, 'utf-8');
+
+		const run = runSetup(dir, [...REQUIRED, ...IDENTITY]);
+		expect(run.code, run.stderr).toBe(0);
+		const updated = readFileSync(wrangler, 'utf-8');
+		expect(updated).toMatch(/^name = "northwind-labs"/m);
+		expect(updated.endsWith(environment)).toBe(true);
+	});
 });
 
 describe('template setup finds the runtime repository property', () => {
@@ -347,6 +403,11 @@ describe('template setup rejects input before writing', () => {
 		{
 			label: 'an invalid email',
 			args: [...REQUIRED, ...IDENTITY.slice(0, -1), 'kaputt'],
+			expected: /email must use the consumer-compatible user@domain\.tld subset/
+		},
+		{
+			label: 'a Unicode email localpart longer than 64 UTF-8 bytes',
+			args: [...REQUIRED, ...IDENTITY.slice(0, -1), `${'é'.repeat(33)}@example.de`],
 			expected: /email must use the consumer-compatible user@domain\.tld subset/
 		},
 		{

--- a/scripts/template-setup.test.ts
+++ b/scripts/template-setup.test.ts
@@ -4,6 +4,8 @@ import {
 	escapeMarkdownInline,
 	githubSlugProperty,
 	isValidGithubRepository,
+	parseContactEmail,
+	readmeShowsConvertedQuickStart,
 	replaceGithubSlugSource,
 	replaceLegalConfigSource,
 	replaceLegalContentDatesSource,
@@ -222,6 +224,16 @@ Unrelated prose stays.
 		expect(replaceReadmeSource(source, { ...options, brand }).split('\n')[0]).toBe(heading);
 	});
 
+	it('keeps CRLF line endings in the rewritten clone block', () => {
+		const crlf = source.replace(/\n/g, '\r\n');
+		const updated = replaceReadmeSource(crlf, options);
+
+		expect(updated).toContain(
+			'git clone https://github.com/northwind/northwind-labs.git\r\ncd northwind-labs\r\n'
+		);
+		expect(updated).not.toMatch(/[^\r]\n/);
+	});
+
 	it('fails before writes when an anchor is missing or ambiguous', () => {
 		expect(() => replaceReadmeSource('no heading here\n', options)).toThrow(
 			/Could not find the top-level heading/
@@ -232,6 +244,69 @@ Unrelated prose stays.
 		expect(() => replaceReadmeSource(source + source, options)).toThrow(
 			/quick start clone block in README.md, found 2/
 		);
+	});
+});
+
+describe('template setup detects the converted quick start', () => {
+	const bootstrap =
+		'# Title\n\n```bash\ngh repo create my-saas-product --template stickerdaniel/saas-starter --clone\ncd my-saas-product\nbun install\n```\n';
+	const converted =
+		'# Title\n\n```bash\ngit clone https://github.com/northwind/northwind-labs.git\ncd northwind-labs\nbun install\n```\n';
+
+	it('treats the template bootstrap form as not set up', () => {
+		expect(readmeShowsConvertedQuickStart(bootstrap, 'stickerdaniel/saas-starter')).toBe(false);
+		expect(readmeShowsConvertedQuickStart(bootstrap, 'northwind/northwind-labs')).toBe(false);
+	});
+
+	it('accepts the converted block only for the repository it names', () => {
+		expect(readmeShowsConvertedQuickStart(converted, 'northwind/northwind-labs')).toBe(true);
+		expect(readmeShowsConvertedQuickStart(converted, 'someone/other-repo')).toBe(false);
+	});
+
+	it('reads the converted block with CRLF line endings', () => {
+		expect(
+			readmeShowsConvertedQuickStart(converted.replace(/\n/g, '\r\n'), 'northwind/northwind-labs')
+		).toBe(true);
+	});
+
+	it('reports not set up when the block is missing or ambiguous', () => {
+		expect(readmeShowsConvertedQuickStart('# Title\n\nprose\n', 'northwind/northwind-labs')).toBe(
+			false
+		);
+		expect(readmeShowsConvertedQuickStart(converted + converted, 'northwind/northwind-labs')).toBe(
+			false
+		);
+	});
+});
+
+describe('template setup contact email', () => {
+	it.each([
+		{
+			value: 'kontakt@northwind-labs.de',
+			parts: { user: 'kontakt', domain: 'northwind-labs', tld: 'de' }
+		},
+		{ value: 'a@mail.example.com', parts: { user: 'a', domain: 'mail', tld: 'example.com' } },
+		{
+			value: 'first.last@example.co.uk',
+			parts: { user: 'first.last', domain: 'example', tld: 'co.uk' }
+		}
+	])('splits $value into three parts', ({ value, parts }) => {
+		expect(parseContactEmail(value)).toEqual(parts);
+	});
+
+	// Zusätzliche @, Leerzeichen in den Segmenten und leere Domainlabels müssen durchfallen.
+	it.each([
+		'a@b@c.de',
+		'erste person@example.de',
+		'a@ex ample.de',
+		'a@example .de',
+		'a@.de',
+		'a@example..de',
+		'a@example.',
+		'@example.de',
+		'plain-text'
+	])('rejects %s', (value) => {
+		expect(parseContactEmail(value)).toBeUndefined();
 	});
 });
 

--- a/scripts/template-setup.test.ts
+++ b/scripts/template-setup.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import {
+	askUntilValid,
+	escapeMarkdownInline,
 	githubSlugProperty,
 	isValidGithubRepository,
 	replaceGithubSlugSource,
+	replaceLegalConfigSource,
 	replaceLegalContentDatesSource,
+	replaceLockRootNameSource,
+	replaceReadmeSource,
+	replaceWranglerNameSource,
+	serializeConfigValue,
+	tsStringLiteral,
 	updateLegalContentDatesSource
 } from './template-setup';
 
@@ -43,6 +51,17 @@ describe('template setup repository configuration', () => {
 			/Could not find githubSlug/
 		);
 	});
+
+	it('fails instead of replacing the wrong one of two occurrences', () => {
+		// Ein Beispiel im Doc-Kommentar steht vor dem echten Feld: der erste Treffer ist
+		// nicht der, der die Laufzeit steuert.
+		const source =
+			"export interface SiteConfig {\n\t/** Example: githubSlug: 'octocat/hello-world' */\n\tgithubSlug: `${string}/${string}`;\n}\n\nexport const SITE_CONFIG = {\n\tgithubSlug: 'old-owner/old-repo'\n};\n";
+
+		expect(() => replaceGithubSlugSource(source, 'new-owner/new-repo')).toThrow(
+			/Expected exactly one githubSlug in src\/lib\/config\/site\.ts, found 2/
+		);
+	});
 });
 
 describe('template setup legal dates', () => {
@@ -65,5 +84,211 @@ describe('template setup legal dates', () => {
 		expect(() =>
 			replaceLegalContentDatesSource(source.replace("impressum: '2026-03-21'", ''), '2026-08-24')
 		).toThrow(/Could not update every date/);
+	});
+});
+
+describe('template setup string literals', () => {
+	// Erwartet wird der Literaltext Zeichen für Zeichen. Dass er beim Einlesen wieder
+	// denselben Wert ergibt, prüft template-setup.integration.test.ts mit echtem Import.
+	it.each([
+		{ value: 'Plain Name', literal: "'Plain Name'" },
+		// Prettier bevorzugt einfache Quotes und weicht nur aus, wenn das Escapes spart.
+		{ value: "O'Connor Software", literal: '"O\'Connor Software"' },
+		{ value: 'The "Blue Door" GmbH', literal: '\'The "Blue Door" GmbH\'' },
+		{ value: 'Anne\\Marie Weber', literal: "'Anne\\\\Marie Weber'" },
+		{ value: 'Hauptstrasse 5\n12345 Berlin', literal: "'Hauptstrasse 5\\n12345 Berlin'" },
+		{ value: 'Tab\there', literal: "'Tab\\there'" },
+		{
+			value: "Ampersand $& Backref $1 Tick $` Quote $' Co",
+			literal: '"Ampersand $& Backref $1 Tick $` Quote $\' Co"'
+		},
+		{ value: 'Mixed \\ and " and \'', literal: "'Mixed \\\\ and \" and \\''" }
+	])('emits $literal for $value', ({ value, literal }) => {
+		expect(tsStringLiteral(value)).toBe(literal);
+	});
+});
+
+describe('template setup config serialization', () => {
+	it('emits tab-indented TypeScript and keeps additional keys', () => {
+		expect(
+			serializeConfigValue({ brandName: 'Acme', email: { user: 'a' }, forkKey: 'kept' }, '')
+		).toBe("{\n\tbrandName: 'Acme',\n\temail: {\n\t\tuser: 'a'\n\t},\n\tforkKey: 'kept'\n}");
+	});
+
+	it('rejects values it cannot represent instead of writing broken code', () => {
+		expect(() => serializeConfigValue({ list: [1, 2] }, '')).toThrow(/Unsupported LEGAL_CONFIG/);
+	});
+
+	const source = `export const LEGAL_CONFIG = {
+	brandName: 'SaaS Starter',
+	email: {
+		user: 'daniel'
+	}
+} as const;
+
+export function helper(): string {
+	return LEGAL_CONFIG.brandName;
+}
+`;
+
+	it('replaces only the export block and preserves the helpers', () => {
+		const updated = replaceLegalConfigSource(source, {
+			brandName: "O'Connor & Co",
+			email: { user: 'kontakt' }
+		});
+
+		expect(updated).toContain('brandName: "O\'Connor & Co"');
+		expect(updated).toContain('export function helper(): string {');
+		expect(updated).not.toContain("brandName: 'SaaS Starter'");
+	});
+
+	it('fails before writes when the export block is missing or ambiguous', () => {
+		expect(() => replaceLegalConfigSource('export const OTHER = {};', { a: 'b' })).toThrow(
+			/found 0/
+		);
+		expect(() => replaceLegalConfigSource(source + source, { a: 'b' })).toThrow(/found 2/);
+	});
+});
+
+describe('template setup README', () => {
+	const source = `# Ship SaaS faster
+
+[![Badge](https://github.com/old-owner/old-repo/actions/badge.svg)](https://github.com/old-owner/old-repo/actions)
+
+> [Live demo!](https://demo.example) The public demo covers the user-facing features.
+
+## Quick Start
+
+\`\`\`bash
+gh repo create my-saas-product --template old-owner/old-repo --clone
+cd my-saas-product
+bun install
+bun run dev
+\`\`\`
+
+Unrelated prose stays.
+`;
+
+	const options = {
+		brand: 'Northwind Labs',
+		repository: 'northwind/northwind-labs',
+		oldGithubUrl: 'https://github.com/old-owner/old-repo',
+		githubUrl: 'https://github.com/northwind/northwind-labs'
+	};
+
+	it('brands the heading, drops the demo, and explains the generated project', () => {
+		const updated = replaceReadmeSource(source, options);
+
+		expect(updated.split('\n')[0]).toBe('# Northwind Labs');
+		expect(updated).not.toContain('Live demo!');
+		expect(updated).toContain(
+			'git clone https://github.com/northwind/northwind-labs.git\ncd northwind-labs\nbun install'
+		);
+		expect(updated).not.toContain('gh repo create');
+		expect(updated).toContain('Unrelated prose stays.');
+		expect(updated).toContain('https://github.com/northwind/northwind-labs/actions');
+	});
+
+	it('is idempotent and follows a later repository rename', () => {
+		const once = replaceReadmeSource(source, options);
+		expect(replaceReadmeSource(once, options)).toBe(once);
+
+		const renamed = replaceReadmeSource(once, {
+			brand: 'Northwind Labs',
+			repository: 'northwind/northwind-cloud',
+			oldGithubUrl: options.githubUrl,
+			githubUrl: 'https://github.com/northwind/northwind-cloud'
+		});
+		expect(renamed).toContain(
+			'git clone https://github.com/northwind/northwind-cloud.git\ncd northwind-cloud'
+		);
+		expect(renamed).not.toContain('northwind-labs');
+	});
+
+	it('escapes a brand that would otherwise render as Markdown', () => {
+		expect(escapeMarkdownInline('A *bold* [link]')).toBe('A \\*bold\\* \\[link\\]');
+		expect(replaceReadmeSource(source, { ...options, brand: '*Star* Co' }).split('\n')[0]).toBe(
+			'# \\*Star\\* Co'
+		);
+	});
+
+	// Ohne Maskierung rendert marked "Research &copy; Labs" als "Research © Labs" und
+	// "Project ###" als "Project", weil ### die schließende Zeichenfolge der Überschrift ist.
+	it.each([
+		{ brand: 'Research &copy; Labs', heading: '# Research \\&copy; Labs' },
+		{ brand: 'Project ###', heading: '# Project \\#\\#\\#' },
+		{ brand: 'A & B GmbH', heading: '# A \\& B GmbH' }
+	])('keeps $brand literal in the heading', ({ brand, heading }) => {
+		expect(replaceReadmeSource(source, { ...options, brand }).split('\n')[0]).toBe(heading);
+	});
+
+	it('fails before writes when an anchor is missing or ambiguous', () => {
+		expect(() => replaceReadmeSource('no heading here\n', options)).toThrow(
+			/Could not find the top-level heading/
+		);
+		expect(() => replaceReadmeSource('# Title\n\nprose\n', options)).toThrow(
+			/quick start clone block in README.md, found 0/
+		);
+		expect(() => replaceReadmeSource(source + source, options)).toThrow(
+			/quick start clone block in README.md, found 2/
+		);
+	});
+});
+
+describe('template setup manifest metadata', () => {
+	it('renames the worker without touching the trailing comment', () => {
+		expect(replaceWranglerNameSource('name = "old" # keep me\nmain = "x"\n', 'new-name')).toBe(
+			'name = "new-name" # keep me\nmain = "x"\n'
+		);
+	});
+
+	it('fails before writes when the worker name is missing or ambiguous', () => {
+		expect(() => replaceWranglerNameSource('main = "x"\n', 'new')).toThrow(/found 0/);
+		expect(() => replaceWranglerNameSource('name = "a"\nname = "b"\n', 'new')).toThrow(/found 2/);
+	});
+
+	it('syncs only the lockfile root name', () => {
+		const lock =
+			'{\n  "lockfileVersion": 1,\n  "workspaces": {\n    "": {\n      "name": "saas-starter",\n      "dependencies": {\n        "zod": "4.4.2"\n      }\n    }\n  }\n}\n';
+		const updated = replaceLockRootNameSource(lock, 'northwind-labs');
+
+		expect(updated).toBe(lock.replace('"name": "saas-starter"', '"name": "northwind-labs"'));
+		expect(updated).toContain('"zod": "4.4.2"');
+	});
+
+	it('fails before writes when the lockfile root name is missing', () => {
+		expect(() => replaceLockRootNameSource('{"lockfileVersion": 1}', 'new')).toThrow(/found 0/);
+	});
+});
+
+describe('template setup interactive answers', () => {
+	const isPositive: (value: string) => string | undefined = (value) =>
+		/^[a-z]+$/.test(value) ? undefined : 'must be lowercase letters';
+
+	it('asks again until the answer validates', async () => {
+		const answers = ['Nope!', '123', 'valid'];
+		const problems: string[] = [];
+		const result = await askUntilValid(
+			async () => answers.shift(),
+			'Value',
+			'fallback',
+			isPositive,
+			(problem) => problems.push(problem)
+		);
+
+		expect(result).toBe('valid');
+		expect(problems).toEqual(['must be lowercase letters', 'must be lowercase letters']);
+	});
+
+	it('gives up when the input ends', async () => {
+		expect(
+			await askUntilValid(
+				async () => undefined,
+				'Value',
+				'fallback',
+				isPositive,
+				() => {}
+			)
+		).toBeUndefined();
 	});
 });

--- a/scripts/template-setup.test.ts
+++ b/scripts/template-setup.test.ts
@@ -1,3 +1,4 @@
+import { lex } from 'svelte-streamdown';
 import { describe, expect, it } from 'vitest';
 import {
 	askUntilValid,
@@ -52,6 +53,7 @@ describe('template setup repository configuration', () => {
 		'owner-/repo',
 		'owner--name/repo',
 		'owner/repository.git',
+		'owner/project.',
 		`${'a'.repeat(40)}/repo`,
 		`owner/${'r'.repeat(101)}`,
 		'/repo',
@@ -148,8 +150,34 @@ describe('template setup legal dates', () => {
 		expect(updated.match(/2026-08-24/g)).toHaveLength(3);
 	});
 
+	it('updates only direct properties in the exported initializer', () => {
+		const misleadingSource = `// impressum: '1999-01-01'
+export const LEGAL_CONTENT_DATES = {
+	privacy: '2026-03-18',
+	terms: '2026-03-18',
+	// impressum: '2000-01-01'
+	impressum: "2026-03-21"
+} as const;
+
+const example = { impressum: '2001-01-01' };`;
+		const updated = replaceLegalContentDatesSource(misleadingSource, '2026-08-24');
+
+		expect(updated).toContain("// impressum: '1999-01-01'");
+		expect(updated).toContain("// impressum: '2000-01-01'");
+		expect(updated).toContain("const example = { impressum: '2001-01-01' };");
+		expect(updated).toContain('impressum: "2026-08-24"');
+		expect(updated.match(/2026-08-24/g)).toHaveLength(3);
+	});
+
 	it('preserves legal dates when the legal identity is unchanged', () => {
 		expect(updateLegalContentDatesSource(source, '2026-08-24', false)).toBe(source);
+	});
+
+	it('validates every direct property even when no date changes are needed', () => {
+		const missing = source.replace("impressum: '2026-03-21'", '');
+		expect(() => updateLegalContentDatesSource(missing, '2026-08-24', false)).toThrow(
+			/Could not update every date/
+		);
 	});
 
 	it('fails before writes when the metadata shape has drifted', () => {
@@ -292,11 +320,71 @@ Unrelated prose stays.
 		expect(renamed).not.toContain('northwind-labs');
 	});
 
+	it.each([
+		{
+			oldRepository: 'owner/app',
+			repository: 'owner/app-cloud',
+			relatedRepository: 'owner/app-tools'
+		},
+		{
+			oldRepository: 'owner/app-tools',
+			repository: 'owner/app',
+			relatedRepository: 'owner/app-tools-extra'
+		}
+	])(
+		'rewrites exact $oldRepository links without changing $relatedRepository',
+		({ oldRepository, repository, relatedRepository }) => {
+			const oldGithubUrl = `https://github.com/${oldRepository}`;
+			const githubUrl = `https://github.com/${repository}`;
+			const linkedSource = source
+				.replaceAll(options.oldGithubUrl, oldGithubUrl)
+				.replace(
+					'Unrelated prose stays.',
+					`${oldGithubUrl}\n${oldGithubUrl}/actions\n${oldGithubUrl}?tab=readme\n${oldGithubUrl}#readme\n${oldGithubUrl}.git\nhttps://github.com/${relatedRepository}`
+				);
+			const updated = replaceReadmeSource(linkedSource, {
+				brand: 'Northwind Labs',
+				repository,
+				oldGithubUrl,
+				githubUrl
+			});
+
+			expect(updated).toContain(`${githubUrl}\n`);
+			expect(updated).toContain(`${githubUrl}/actions`);
+			expect(updated).toContain(`${githubUrl}?tab=readme`);
+			expect(updated).toContain(`${githubUrl}#readme`);
+			expect(updated).toContain(`${githubUrl}.git`);
+			expect(updated).toContain(`https://github.com/${relatedRepository}`);
+		}
+	);
+
 	it('escapes a brand that would otherwise render as Markdown', () => {
 		expect(escapeMarkdownInline('A *bold* [link]')).toBe('A \\*bold\\* \\[link\\]');
 		expect(replaceReadmeSource(source, { ...options, brand: '*Star* Co' }).split('\n')[0]).toBe(
 			'# \\*Star\\* Co'
 		);
+	});
+
+	it('keeps a strikethrough-looking brand literal in the rendered heading', () => {
+		const heading = replaceReadmeSource(source, { ...options, brand: '~~Northwind~~' }).split(
+			'\n'
+		)[0]!;
+		const [token] = lex(heading);
+
+		expect(heading).toBe('# \\~\\~Northwind\\~\\~');
+		expect(token).toMatchObject({
+			type: 'heading',
+			tokens: [
+				{ type: 'escape', text: '~' },
+				{ type: 'escape', text: '~' },
+				{ type: 'text', text: 'Northwind' },
+				{ type: 'escape', text: '~' },
+				{ type: 'escape', text: '~' }
+			]
+		});
+		expect(token).not.toMatchObject({
+			tokens: expect.arrayContaining([expect.objectContaining({ type: 'del' })])
+		});
 	});
 
 	// Ohne Maskierung rendert marked "Research &copy; Labs" als "Research © Labs" und
@@ -497,6 +585,36 @@ describe('template setup manifest metadata', () => {
 		expect(replaceWranglerNameSource(source, 'new-name')).toBe(
 			'name = "new-name"\nmain = "x"\n\n[env.staging]\nname = "staging-worker" # keep me\n'
 		);
+	});
+
+	it('ignores table and name syntax inside multiline TOML strings', () => {
+		const source = `description = """
+name = "basic-string"
+[example.basic]
+"""
+literal = '''
+name = "literal-string"
+[example.literal]
+'''
+name = "base-worker"
+main = "x"
+
+[env.staging]
+name = "staging-worker"
+`;
+		const updated = replaceWranglerNameSource(source, 'new-name');
+
+		expect(updated).toBe(source.replace('name = "base-worker"', 'name = "new-name"'));
+		expect(updated).toContain('name = "basic-string"\n[example.basic]');
+		expect(updated).toContain('name = "literal-string"\n[example.literal]');
+		expect(updated).toContain('[env.staging]\nname = "staging-worker"');
+	});
+
+	it.each([
+		'name = """base-worker"""\n\n[env.staging]\nname = "staging-worker"\n',
+		"name = '''base-worker'''\n\n[env.staging]\nname = \"staging-worker\"\n"
+	])('fails closed when the root name uses a multiline string', (source) => {
+		expect(() => replaceWranglerNameSource(source, 'new-name')).toThrow(/name assignment/);
 	});
 
 	it('fails before writes when the root worker name is missing or ambiguous', () => {

--- a/scripts/template-setup.test.ts
+++ b/scripts/template-setup.test.ts
@@ -364,6 +364,30 @@ Unrelated prose stays.
 		expect(updated).toContain('https://github.com/northwind/northwind-labs/actions');
 	});
 
+	it('removes only the live demo paragraph outside foreign fences', () => {
+		const foreignFence =
+			'```markdown\n> [Live demo!](https://vendor.example) Keep this example byte-identical.\n\n```\n\n';
+		const withForeignFence = source.replace(
+			'> [Live demo!](https://demo.example) The public demo covers the user-facing features.\n\n',
+			foreignFence +
+				'> [Live demo!](https://demo.example) The public demo covers the user-facing features.\n\n'
+		);
+		const updated = replaceReadmeSource(withForeignFence, options);
+
+		expect(updated).toContain(foreignFence);
+		expect(updated.match(/Live demo!/g)).toHaveLength(1);
+		expect(updated).not.toContain('https://demo.example');
+	});
+
+	it('fails closed when multiple live demo paragraphs exist outside fences', () => {
+		const duplicate = source.replace(
+			'## Quick Start',
+			'> [Live demo!](https://another.example) Another template demo.\n\n## Quick Start'
+		);
+
+		expect(() => replaceReadmeSource(duplicate, options)).toThrow(/live demo.*found 2/i);
+	});
+
 	it('is idempotent and follows a later repository rename', () => {
 		const once = replaceReadmeSource(source, options);
 		expect(replaceReadmeSource(once, options)).toBe(once);
@@ -617,7 +641,13 @@ bun run dev
 		{ suffix: '.\n', changed: true },
 		{ suffix: '.\r\n', changed: true },
 		{ suffix: '.', changed: true },
+		{ suffix: '.)', changed: true },
+		{ suffix: '."', changed: true },
+		{ suffix: ".']", changed: true },
 		{ suffix: '.git. ', changed: true },
+		{ suffix: '.git.)', changed: true },
+		{ suffix: '.git."', changed: true },
+		{ suffix: ".git.']", changed: true },
 		{ suffix: '-tools ', changed: false },
 		{ suffix: '_tools ', changed: false },
 		{ suffix: '.tools ', changed: false },

--- a/scripts/template-setup.test.ts
+++ b/scripts/template-setup.test.ts
@@ -344,6 +344,15 @@ describe('template setup detects the converted quick start', () => {
 });
 
 describe('template setup contact email', () => {
+	it('enforces the 64-byte UTF-8 localpart boundary', () => {
+		const astralLetter = '𐐀';
+		expect(parseContactEmail(`${astralLetter.repeat(16)}@example.de`)?.user).toBe(
+			astralLetter.repeat(16)
+		);
+		expect(parseContactEmail(`${astralLetter.repeat(17)}@example.de`)).toBeUndefined();
+		expect(parseContactEmail(`${'é'.repeat(33)}@example.de`)).toBeUndefined();
+	});
+
 	it.each([
 		{
 			value: 'kontakt@northwind-labs.de',
@@ -396,8 +405,18 @@ describe('template setup manifest metadata', () => {
 		);
 	});
 
-	it('fails before writes when the worker name is missing or ambiguous', () => {
-		expect(() => replaceWranglerNameSource('main = "x"\n', 'new')).toThrow(/found 0/);
+	it('renames only the root worker when environments have their own names', () => {
+		const source =
+			'name = "base-worker"\nmain = "x"\n\n[env.staging]\nname = "staging-worker" # keep me\n';
+		expect(replaceWranglerNameSource(source, 'new-name')).toBe(
+			'name = "new-name"\nmain = "x"\n\n[env.staging]\nname = "staging-worker" # keep me\n'
+		);
+	});
+
+	it('fails before writes when the root worker name is missing or ambiguous', () => {
+		expect(() =>
+			replaceWranglerNameSource('[env.staging]\nname = "staging-worker"\n', 'new')
+		).toThrow(/found 0/);
 		expect(() => replaceWranglerNameSource('name = "a"\nname = "b"\n', 'new')).toThrow(/found 2/);
 	});
 

--- a/scripts/template-setup.test.ts
+++ b/scripts/template-setup.test.ts
@@ -4,6 +4,7 @@ import {
 	escapeMarkdownInline,
 	githubSlugProperty,
 	isValidGithubRepository,
+	isValidWorkerSlug,
 	parseContactEmail,
 	readmeShowsConvertedQuickStart,
 	replaceGithubSlugSource,
@@ -18,9 +19,12 @@ import {
 } from './template-setup';
 
 describe('template setup repository configuration', () => {
-	it.each(['owner/repo', 'owner-name/repo.name', 'Owner123/repo_name'])('accepts %s', (value) => {
-		expect(isValidGithubRepository(value)).toBe(true);
-	});
+	it.each(['owner/repo', 'owner-name/repo.name', 'Owner123/repo_name', `owner/${'r'.repeat(100)}`])(
+		'accepts %s',
+		(value) => {
+			expect(isValidGithubRepository(value)).toBe(true);
+		}
+	);
 
 	it.each([
 		'owner',
@@ -31,6 +35,7 @@ describe('template setup repository configuration', () => {
 		'owner--name/repo',
 		'owner/repository.git',
 		`${'a'.repeat(40)}/repo`,
+		`owner/${'r'.repeat(101)}`,
 		'/repo',
 		'owner/.',
 		'owner/..'
@@ -54,15 +59,54 @@ describe('template setup repository configuration', () => {
 		);
 	});
 
-	it('fails instead of replacing the wrong one of two occurrences', () => {
-		// Ein Beispiel im Doc-Kommentar steht vor dem echten Feld: der erste Treffer ist
-		// nicht der, der die Laufzeit steuert.
-		const source =
-			"export interface SiteConfig {\n\t/** Example: githubSlug: 'octocat/hello-world' */\n\tgithubSlug: `${string}/${string}`;\n}\n\nexport const SITE_CONFIG = {\n\tgithubSlug: 'old-owner/old-repo'\n};\n";
+	it('replaces only the direct property in the SITE_CONFIG initializer', () => {
+		const source = `// githubSlug: 'comment/line'
+export interface SiteConfig {
+	/** Example: githubSlug: 'comment/doc' */
+	githubSlug: \`${'${string}/${string}'}\`;
+}
 
-		expect(() => replaceGithubSlugSource(source, 'new-owner/new-repo')).toThrow(
-			/Expected exactly one githubSlug in src\/lib\/config\/site\.ts, found 2/
+const example = "githubSlug: 'string/example'";
+export const SITE_CONFIG = {
+	/*
+	 * githubSlug: 'comment/block'
+	 */
+	githubSlug: 'old-owner/old-repo', // githubSlug: 'comment/trailing'
+	structuredData: {}
+};
+`;
+
+		const updated = replaceGithubSlugSource(source, 'new-owner/new-repo');
+		expect(updated).toContain(
+			"githubSlug: 'new-owner/new-repo', // githubSlug: 'comment/trailing'"
 		);
+		expect(updated).toContain("githubSlug: 'comment/block'");
+		expect(updated).toContain("githubSlug: 'string/example'");
+	});
+
+	it('fails for duplicate or unsupported direct githubSlug properties', () => {
+		expect(() =>
+			replaceGithubSlugSource(
+				"export const SITE_CONFIG = { githubSlug: 'owner/one', githubSlug: 'owner/two' };",
+				'new-owner/new-repo'
+			)
+		).toThrow(/Expected exactly one direct githubSlug property/);
+		expect(() =>
+			replaceGithubSlugSource(
+				'export const SITE_CONFIG = { githubSlug: repository };',
+				'new-owner/new-repo'
+			)
+		).toThrow(/direct string literal/);
+	});
+});
+
+describe('template setup worker slug', () => {
+	it('accepts the 63-character boundary', () => {
+		expect(isValidWorkerSlug('n'.repeat(63))).toBe(true);
+	});
+
+	it.each(['-northwind', 'northwind-', 'n'.repeat(64)])('rejects %s', (value) => {
+		expect(isValidWorkerSlug(value)).toBe(false);
 	});
 });
 
@@ -117,8 +161,23 @@ describe('template setup config serialization', () => {
 		).toBe("{\n\tbrandName: 'Acme',\n\temail: {\n\t\tuser: 'a'\n\t},\n\tforkKey: 'kept'\n}");
 	});
 
-	it('rejects values it cannot represent instead of writing broken code', () => {
-		expect(() => serializeConfigValue({ list: [1, 2] }, '')).toThrow(/Unsupported LEGAL_CONFIG/);
+	it.each([
+		['array', [1, 2]],
+		['date', new Date('2026-09-06T00:00:00Z')],
+		['map', new Map([['key', 'value']])],
+		['set', new Set(['value'])],
+		['regular expression', /value/],
+		['class instance', new (class UnsupportedConfigValue {})()],
+		['null-prototype object', Object.assign(Object.create(null), { key: 'value' })],
+		['own __proto__ property', JSON.parse('{"__proto__":"value"}')]
+	])('rejects an unsupported %s instead of losing data', (_label, value) => {
+		expect(() => serializeConfigValue({ value }, '')).toThrow(/Unsupported LEGAL_CONFIG/);
+	});
+
+	it('keeps supported primitive values in ordinary data objects', () => {
+		expect(serializeConfigValue({ text: 'value', count: 2, enabled: false }, '')).toBe(
+			"{\n\ttext: 'value',\n\tcount: 2,\n\tenabled: false\n}"
+		);
 	});
 
 	const source = `export const LEGAL_CONFIG = {
@@ -184,7 +243,7 @@ Unrelated prose stays.
 		expect(updated.split('\n')[0]).toBe('# Northwind Labs');
 		expect(updated).not.toContain('Live demo!');
 		expect(updated).toContain(
-			'git clone https://github.com/northwind/northwind-labs.git\ncd northwind-labs\nbun install'
+			'git clone https://github.com/northwind/northwind-labs.git\ncd ./northwind-labs\nbun install'
 		);
 		expect(updated).not.toContain('gh repo create');
 		expect(updated).toContain('Unrelated prose stays.');
@@ -202,7 +261,7 @@ Unrelated prose stays.
 			githubUrl: 'https://github.com/northwind/northwind-cloud'
 		});
 		expect(renamed).toContain(
-			'git clone https://github.com/northwind/northwind-cloud.git\ncd northwind-cloud'
+			'git clone https://github.com/northwind/northwind-cloud.git\ncd ./northwind-cloud'
 		);
 		expect(renamed).not.toContain('northwind-labs');
 	});
@@ -229,8 +288,9 @@ Unrelated prose stays.
 		const updated = replaceReadmeSource(crlf, options);
 
 		expect(updated).toContain(
-			'git clone https://github.com/northwind/northwind-labs.git\r\ncd northwind-labs\r\n'
+			'git clone https://github.com/northwind/northwind-labs.git\r\ncd ./northwind-labs\r\n'
 		);
+		expect(updated).not.toContain('Live demo!');
 		expect(updated).not.toMatch(/[^\r]\n/);
 	});
 
@@ -251,15 +311,19 @@ describe('template setup detects the converted quick start', () => {
 	const bootstrap =
 		'# Title\n\n```bash\ngh repo create my-saas-product --template stickerdaniel/saas-starter --clone\ncd my-saas-product\nbun install\n```\n';
 	const converted =
-		'# Title\n\n```bash\ngit clone https://github.com/northwind/northwind-labs.git\ncd northwind-labs\nbun install\n```\n';
+		'# Title\n\n```bash\ngit clone https://github.com/northwind/northwind-labs.git\ncd ./northwind-labs\nbun install\n```\n';
+	const previouslyConverted = converted.replace('cd ./northwind-labs', 'cd northwind-labs');
 
 	it('treats the template bootstrap form as not set up', () => {
 		expect(readmeShowsConvertedQuickStart(bootstrap, 'stickerdaniel/saas-starter')).toBe(false);
 		expect(readmeShowsConvertedQuickStart(bootstrap, 'northwind/northwind-labs')).toBe(false);
 	});
 
-	it('accepts the converted block only for the repository it names', () => {
+	it('accepts both converted directory forms only for the repository they name', () => {
 		expect(readmeShowsConvertedQuickStart(converted, 'northwind/northwind-labs')).toBe(true);
+		expect(readmeShowsConvertedQuickStart(previouslyConverted, 'northwind/northwind-labs')).toBe(
+			true
+		);
 		expect(readmeShowsConvertedQuickStart(converted, 'someone/other-repo')).toBe(false);
 	});
 
@@ -289,6 +353,10 @@ describe('template setup contact email', () => {
 		{
 			value: 'first.last@example.co.uk',
 			parts: { user: 'first.last', domain: 'example', tld: 'co.uk' }
+		},
+		{
+			value: "jörg+o'connor@münchen.example",
+			parts: { user: "jörg+o'connor", domain: 'münchen', tld: 'example' }
 		}
 	])('splits $value into three parts', ({ value, parts }) => {
 		expect(parseContactEmail(value)).toEqual(parts);
@@ -303,6 +371,17 @@ describe('template setup contact email', () => {
 		'a@.de',
 		'a@example..de',
 		'a@example.',
+		'a@-example.de',
+		'a@example-.de',
+		`a@${'d'.repeat(64)}.de`,
+		`a@${['a'.repeat(63), 'b'.repeat(63), 'c'.repeat(63), 'd'.repeat(63)].join('.')}`,
+		'a?subject=changed@example.de',
+		'a#fragment@example.de',
+		'a/path@example.de',
+		'a%20name@example.de',
+		'a..b@example.de',
+		'.a@example.de',
+		'a.@example.de',
 		'@example.de',
 		'plain-text'
 	])('rejects %s', (value) => {

--- a/scripts/template-setup.test.ts
+++ b/scripts/template-setup.test.ts
@@ -6,7 +6,7 @@ import {
 	isValidGithubRepository,
 	isValidWorkerSlug,
 	parseContactEmail,
-	readmeShowsConvertedQuickStart,
+	readmeShowsCompletedSetup,
 	replaceGithubSlugSource,
 	replaceLegalConfigSource,
 	replaceLegalContentDatesSource,
@@ -18,13 +18,31 @@ import {
 	updateLegalContentDatesSource
 } from './template-setup';
 
+function asciiDomainOfLength(length: number): string {
+	const labels: string[] = [];
+	let remaining = length;
+	while (remaining > 63) {
+		labels.push('a'.repeat(63));
+		remaining -= 64;
+	}
+	labels.push('a'.repeat(remaining));
+	return labels.join('.');
+}
+
 describe('template setup repository configuration', () => {
-	it.each(['owner/repo', 'owner-name/repo.name', 'Owner123/repo_name', `owner/${'r'.repeat(100)}`])(
-		'accepts %s',
-		(value) => {
-			expect(isValidGithubRepository(value)).toBe(true);
-		}
-	);
+	it.each([
+		'owner/repo',
+		'owner-name/repo.name',
+		'Owner123/repo_name',
+		`owner/${'r'.repeat(100)}`,
+		'owner/com0',
+		'owner/com10',
+		'owner/lpt0',
+		'owner/lpt10',
+		'owner/console'
+	])('accepts %s', (value) => {
+		expect(isValidGithubRepository(value)).toBe(true);
+	});
 
 	it.each([
 		'owner',
@@ -38,7 +56,15 @@ describe('template setup repository configuration', () => {
 		`owner/${'r'.repeat(101)}`,
 		'/repo',
 		'owner/.',
-		'owner/..'
+		'owner/..',
+		...[
+			'con',
+			'prn',
+			'aux',
+			'nul',
+			...Array.from({ length: 9 }, (_, index) => `com${index + 1}`),
+			...Array.from({ length: 9 }, (_, index) => `lpt${index + 1}`)
+		].flatMap((basename) => [`owner/${basename}`, `owner/${basename.toUpperCase()}.project`])
 	])('rejects unsafe repository value %s', (value) => {
 		expect(isValidGithubRepository(value)).toBe(false);
 		expect(() => githubSlugProperty(value)).toThrow(/Invalid GitHub repository/);
@@ -307,39 +333,81 @@ Unrelated prose stays.
 	});
 });
 
-describe('template setup detects the converted quick start', () => {
+describe('template setup detects a consistent generated README', () => {
+	const liveDemo =
+		'> [Live demo!](https://demo.example) The public demo covers the user-facing features.\n\n';
 	const bootstrap =
-		'# Title\n\n```bash\ngh repo create my-saas-product --template stickerdaniel/saas-starter --clone\ncd my-saas-product\nbun install\n```\n';
+		'# Northwind Labs\n\n```bash\ngh repo create my-saas-product --template stickerdaniel/saas-starter --clone\ncd my-saas-product\nbun install\n```\n';
 	const converted =
-		'# Title\n\n```bash\ngit clone https://github.com/northwind/northwind-labs.git\ncd ./northwind-labs\nbun install\n```\n';
+		'# Northwind Labs\n\n```bash\ngit clone https://github.com/northwind/northwind-labs.git\ncd ./northwind-labs\nbun install\n```\n';
 	const previouslyConverted = converted.replace('cd ./northwind-labs', 'cd northwind-labs');
 
 	it('treats the template bootstrap form as not set up', () => {
-		expect(readmeShowsConvertedQuickStart(bootstrap, 'stickerdaniel/saas-starter')).toBe(false);
-		expect(readmeShowsConvertedQuickStart(bootstrap, 'northwind/northwind-labs')).toBe(false);
+		expect(
+			readmeShowsCompletedSetup(bootstrap, 'stickerdaniel/saas-starter', 'Northwind Labs')
+		).toBe(false);
+		expect(readmeShowsCompletedSetup(bootstrap, 'northwind/northwind-labs', 'Northwind Labs')).toBe(
+			false
+		);
 	});
 
-	it('accepts both converted directory forms only for the repository they name', () => {
-		expect(readmeShowsConvertedQuickStart(converted, 'northwind/northwind-labs')).toBe(true);
-		expect(readmeShowsConvertedQuickStart(previouslyConverted, 'northwind/northwind-labs')).toBe(
+	it('accepts both converted directory forms only for the current repository and brand', () => {
+		expect(readmeShowsCompletedSetup(converted, 'northwind/northwind-labs', 'Northwind Labs')).toBe(
 			true
 		);
-		expect(readmeShowsConvertedQuickStart(converted, 'someone/other-repo')).toBe(false);
+		expect(
+			readmeShowsCompletedSetup(previouslyConverted, 'northwind/northwind-labs', 'Northwind Labs')
+		).toBe(true);
+		expect(readmeShowsCompletedSetup(converted, 'someone/other-repo', 'Northwind Labs')).toBe(
+			false
+		);
+		expect(readmeShowsCompletedSetup(converted, 'northwind/northwind-labs', 'Other Brand')).toBe(
+			false
+		);
 	});
 
-	it('reads the converted block with CRLF line endings', () => {
+	it('requires the escaped generated heading and no template live demo paragraph', () => {
+		const escapedHeading = converted.replace('# Northwind Labs', '# Research \\&copy; Labs');
 		expect(
-			readmeShowsConvertedQuickStart(converted.replace(/\n/g, '\r\n'), 'northwind/northwind-labs')
+			readmeShowsCompletedSetup(escapedHeading, 'northwind/northwind-labs', 'Research &copy; Labs')
+		).toBe(true);
+		expect(
+			readmeShowsCompletedSetup(
+				converted.replace('# Northwind Labs', '# Other Brand'),
+				'northwind/northwind-labs',
+				'Northwind Labs'
+			)
+		).toBe(false);
+		expect(
+			readmeShowsCompletedSetup(
+				converted.replace('\n\n```bash', `\n\n${liveDemo}\`\`\`bash`),
+				'northwind/northwind-labs',
+				'Northwind Labs'
+			)
+		).toBe(false);
+	});
+
+	it('reads the consistent state with CRLF line endings', () => {
+		expect(
+			readmeShowsCompletedSetup(
+				converted.replace(/\n/g, '\r\n'),
+				'northwind/northwind-labs',
+				'Northwind Labs'
+			)
 		).toBe(true);
 	});
 
-	it('reports not set up when the block is missing or ambiguous', () => {
-		expect(readmeShowsConvertedQuickStart('# Title\n\nprose\n', 'northwind/northwind-labs')).toBe(
-			false
-		);
-		expect(readmeShowsConvertedQuickStart(converted + converted, 'northwind/northwind-labs')).toBe(
-			false
-		);
+	it('reports not set up when the clone block is missing or ambiguous', () => {
+		expect(
+			readmeShowsCompletedSetup(
+				'# Northwind Labs\n\nprose\n',
+				'northwind/northwind-labs',
+				'Northwind Labs'
+			)
+		).toBe(false);
+		expect(
+			readmeShowsCompletedSetup(converted + converted, 'northwind/northwind-labs', 'Northwind Labs')
+		).toBe(false);
 	});
 });
 
@@ -351,6 +419,24 @@ describe('template setup contact email', () => {
 		);
 		expect(parseContactEmail(`${astralLetter.repeat(17)}@example.de`)).toBeUndefined();
 		expect(parseContactEmail(`${'é'.repeat(33)}@example.de`)).toBeUndefined();
+	});
+
+	it('enforces the combined 254-byte SMTP path boundary', () => {
+		expect(parseContactEmail(`${'a'.repeat(64)}@${asciiDomainOfLength(189)}`)).toBeDefined();
+		expect(parseContactEmail(`${'a'.repeat(64)}@${asciiDomainOfLength(190)}`)).toBeUndefined();
+		expect(parseContactEmail(`a@${asciiDomainOfLength(252)}`)).toBeDefined();
+		expect(parseContactEmail(`a@${asciiDomainOfLength(253)}`)).toBeUndefined();
+	});
+
+	it('measures Unicode localparts as UTF-8 and Unicode domains after IDNA conversion', () => {
+		const unicodeLocal = 'é'.repeat(32);
+		expect(parseContactEmail(`${unicodeLocal}@${asciiDomainOfLength(189)}`)).toBeDefined();
+		expect(parseContactEmail(`${unicodeLocal}@${asciiDomainOfLength(190)}`)).toBeUndefined();
+
+		const unicodeDomainAtLimit = `münchen.${asciiDomainOfLength(174)}`;
+		const unicodeDomainOverLimit = `münchen.${asciiDomainOfLength(175)}`;
+		expect(parseContactEmail(`${'a'.repeat(64)}@${unicodeDomainAtLimit}`)).toBeDefined();
+		expect(parseContactEmail(`${'a'.repeat(64)}@${unicodeDomainOverLimit}`)).toBeUndefined();
 	});
 
 	it.each([

--- a/scripts/template-setup.test.ts
+++ b/scripts/template-setup.test.ts
@@ -188,11 +188,10 @@ const example = { impressum: '2001-01-01' };`;
 });
 
 describe('template setup string literals', () => {
-	// Erwartet wird der Literaltext Zeichen für Zeichen. Dass er beim Einlesen wieder
-	// denselben Wert ergibt, prüft template-setup.integration.test.ts mit echtem Import.
+	// These expectations compare source text. The integration test imports it to verify semantics.
 	it.each([
 		{ value: 'Plain Name', literal: "'Plain Name'" },
-		// Prettier bevorzugt einfache Quotes und weicht nur aus, wenn das Escapes spart.
+		// Prettier prefers single quotes unless another choice avoids escapes.
 		{ value: "O'Connor Software", literal: '"O\'Connor Software"' },
 		{ value: 'The "Blue Door" GmbH', literal: '\'The "Blue Door" GmbH\'' },
 		{ value: 'Anne\\Marie Weber', literal: "'Anne\\\\Marie Weber'" },
@@ -262,6 +261,67 @@ export function helper(): string {
 			/found 0/
 		);
 		expect(() => replaceLegalConfigSource(source + source, { a: 'b' })).toThrow(/found 2/);
+	});
+
+	it.each([
+		{
+			label: 'plain template text',
+			decoy: "const decoy = `export const LEGAL_CONFIG = { brandName: 'Decoy' } as const;`;\n"
+		},
+		{
+			label: 'template interpolation',
+			decoy:
+				'const decoy = `before ${"export const LEGAL_CONFIG = { brandName: \'Decoy\' } as const;"} after`;\n'
+		},
+		{
+			label: 'nested template interpolation',
+			decoy:
+				"const decoy = `before ${`nested export const LEGAL_CONFIG = { brandName: 'Decoy' } as const;`} after`;\n"
+		},
+		{
+			label: 'escaped template delimiter',
+			decoy:
+				"const decoy = `before \\` export const LEGAL_CONFIG = { brandName: 'Decoy' } as const; after`;\n"
+		},
+		{
+			label: 'comments and braces in interpolation',
+			decoy:
+				"const decoy = `before ${{ value: '} /* export const LEGAL_CONFIG = { */' /* } */ }} after`;\n"
+		},
+		{
+			label: 'block comment',
+			decoy: "/*\nexport const LEGAL_CONFIG = { brandName: 'Decoy' } as const;\n*/\n"
+		}
+	])('ignores a LEGAL_CONFIG decoy in $label', ({ decoy }) => {
+		const updated = replaceLegalConfigSource(decoy + source, { brandName: 'Updated' });
+
+		expect(updated.startsWith(decoy)).toBe(true);
+		expect(updated).toContain("brandName: 'Updated'");
+	});
+
+	it('fails closed for an unterminated template', () => {
+		expect(() =>
+			replaceLegalConfigSource("const decoy = `unterminated ${'${'}{ value: 1 }}\\n" + source, {
+				brandName: 'Updated'
+			})
+		).toThrow(/unterminated|unsupported/i);
+	});
+
+	it.each([
+		"const currentConfig = { brandName: 'Old' } as const;\nexport const LEGAL_CONFIG = currentConfig;\n",
+		"const LEGAL_CONFIG = { brandName: 'Old' } as const;\nexport { LEGAL_CONFIG };\n",
+		"export const LEGAL_CONFIG = { brandName: 'Old' } satisfies Record<string, unknown>;\n"
+	])('rejects an indirect, aliased, or unsupported initializer', (unsupported) => {
+		expect(() => replaceLegalConfigSource(unsupported, { brandName: 'Updated' })).toThrow(
+			/LEGAL_CONFIG/
+		);
+	});
+
+	it('rejects two real top-level exports despite template decoys', () => {
+		const decoy = 'const text = `export const LEGAL_CONFIG = { decoy: true } as const;`;\n';
+		expect(() =>
+			replaceLegalConfigSource(decoy + source + source, { brandName: 'Updated' })
+		).toThrow(/found 2/);
 	});
 });
 
@@ -387,8 +447,7 @@ Unrelated prose stays.
 		});
 	});
 
-	// Ohne Maskierung rendert marked "Research &copy; Labs" als "Research © Labs" und
-	// "Project ###" als "Project", weil ### die schließende Zeichenfolge der Überschrift ist.
+	// Without escaping, entities decode and closing ATX markers disappear from rendered text.
 	it.each([
 		{ brand: 'Research &copy; Labs', heading: '# Research \\&copy; Labs' },
 		{ brand: 'Project ###', heading: '# Project \\#\\#\\#' },
@@ -409,15 +468,180 @@ Unrelated prose stays.
 	});
 
 	it('fails before writes when an anchor is missing or ambiguous', () => {
-		expect(() => replaceReadmeSource('no heading here\n', options)).toThrow(
-			/Could not find the top-level heading/
-		);
+		expect(() => replaceReadmeSource('no heading here\n', options)).toThrow(/Quick Start|heading/);
 		expect(() => replaceReadmeSource('# Title\n\nprose\n', options)).toThrow(
-			/quick start clone block in README.md, found 0/
+			/Quick Start|candidate/
 		);
-		expect(() => replaceReadmeSource(source + source, options)).toThrow(
-			/quick start clone block in README.md, found 2/
+		expect(() => replaceReadmeSource(source + source, options)).toThrow(/Quick Start|candidate/);
+	});
+
+	it('rewrites only the installation candidate in the real Quick Start section', () => {
+		const foreign = `## Vendor Example
+
+\`\`\`bash
+git clone https://github.com/old-owner/old-repo.git
+cd old-repo
+bun install
+bun run dev
+\`\`\`
+`;
+		const updated = replaceReadmeSource(`${source}\n${foreign}`, options);
+
+		expect(updated.endsWith(foreign)).toBe(true);
+		expect(updated).toContain(
+			'git clone https://github.com/northwind/northwind-labs.git\ncd ./northwind-labs'
 		);
+	});
+
+	it('does not substitute a foreign clone block for a missing Quick Start candidate', () => {
+		const missingCandidate = source.replace(
+			'gh repo create my-saas-product --template old-owner/old-repo --clone\ncd my-saas-product\nbun install\nbun run dev',
+			'mkdir my-saas-product\nbun install\nbun run dev'
+		);
+		const foreign = `
+## Vendor Example
+
+\`\`\`bash
+git clone https://github.com/example/vendor.git
+cd vendor
+bun install
+bun run dev
+\`\`\`
+`;
+
+		expect(() => replaceReadmeSource(missingCandidate + foreign, options)).toThrow(/candidate/);
+	});
+
+	it.each([
+		['no Quick Start H2', source.replace('## Quick Start', '## Getting Started')],
+		['two Quick Start H2s', `${source}\n## Quick Start\n\nText only.\n`],
+		[
+			'a Quick Start heading only inside a fence',
+			source.replace('## Quick Start', '## Getting Started') + '\n```text\n## Quick Start\n```\n'
+		]
+	])('fails closed with $0', (_label, invalid) => {
+		expect(() => replaceReadmeSource(invalid, options)).toThrow(/Quick Start/);
+	});
+
+	it('ignores apparent headings inside fences when finding the section end', () => {
+		const fencedHeading = source.replace(
+			'bun run dev\n```',
+			'bun run dev\n```\n\n```text\n## Not A Real Section\n```'
+		);
+		expect(replaceReadmeSource(fencedHeading, options)).toContain(
+			'git clone https://github.com/northwind/northwind-labs.git'
+		);
+	});
+
+	it('rejects multiple installation candidates in Quick Start', () => {
+		const duplicate = source.replace(
+			'```bash\ngh repo create',
+			'```bash\ngit clone https://github.com/another/example.git\ncd example\nbun install\nbun run dev\n```\n\n```bash\ngh repo create'
+		);
+		expect(() => replaceReadmeSource(duplicate, options)).toThrow(/candidate/);
+	});
+
+	it.each([
+		[
+			'an unclosed fence',
+			source.replace(/```\n\nUnrelated prose stays\./, '\n\nUnrelated prose stays.')
+		],
+		[
+			'a closing fence with the wrong marker',
+			source.replace('bun run dev\n```', 'bun run dev\n~~~')
+		],
+		[
+			'a closing fence shorter than its opener',
+			source.replace('```bash', '````bash').replace('bun run dev\n```', 'bun run dev\n```')
+		]
+	])('fails closed for $0', (_label, invalid) => {
+		expect(() => replaceReadmeSource(invalid, options)).toThrow(/fence|unterminated/i);
+	});
+
+	it.each([
+		{
+			label: 'tilde fences with indentation',
+			opening: '   ~~~~bash',
+			closing: '  ~~~~',
+			lineBreak: '\n'
+		},
+		{ label: 'CRLF backtick fences', opening: '```bash', closing: '```', lineBreak: '\r\n' }
+	])('supports $label', ({ opening, closing, lineBreak }) => {
+		const candidate = [
+			'# Old',
+			'',
+			'## Quick Start',
+			'',
+			opening,
+			'git clone https://github.com/old-owner/old-repo.git',
+			'cd old-repo',
+			'bun install',
+			'bun run dev',
+			closing,
+			'',
+			'## Next'
+		].join(lineBreak);
+		const updated = replaceReadmeSource(candidate, options);
+
+		expect(updated).toContain(
+			`git clone https://github.com/northwind/northwind-labs.git${lineBreak}cd ./northwind-labs`
+		);
+	});
+
+	it('rejects mixed line endings inside the Quick Start block', () => {
+		const mixed = source.replace(
+			'cd my-saas-product\nbun install',
+			'cd my-saas-product\r\nbun install'
+		);
+		expect(() => replaceReadmeSource(mixed, options)).toThrow(/mixed line endings/i);
+	});
+
+	it('recognizes bootstrap, generated, and historical directory forms', () => {
+		const safeBootstrap = source.replace('cd my-saas-product', 'cd ./my-saas-product');
+		const generated = replaceReadmeSource(source, options);
+		const historical = generated.replace('cd ./northwind-labs', 'cd northwind-labs');
+
+		expect(replaceReadmeSource(safeBootstrap, options)).toBe(generated);
+		expect(readmeShowsCompletedSetup(source, 'old-owner/old-repo', 'Ship SaaS faster')).toBe(false);
+		expect(readmeShowsCompletedSetup(generated, 'northwind/northwind-labs', 'Northwind Labs')).toBe(
+			true
+		);
+		expect(
+			readmeShowsCompletedSetup(historical, 'northwind/northwind-labs', 'Northwind Labs')
+		).toBe(true);
+	});
+
+	it.each([
+		{ suffix: '. ', changed: true },
+		{ suffix: '.\t', changed: true },
+		{ suffix: '.\n', changed: true },
+		{ suffix: '.\r\n', changed: true },
+		{ suffix: '.', changed: true },
+		{ suffix: '.git. ', changed: true },
+		{ suffix: '-tools ', changed: false },
+		{ suffix: '_tools ', changed: false },
+		{ suffix: '.tools ', changed: false },
+		{ suffix: '.git-tools ', changed: false }
+	])('uses the exact repository URL boundary before $suffix', ({ suffix, changed }) => {
+		const marker = `${options.oldGithubUrl}${suffix}`;
+		const linked = source.replace('## Quick Start', `${marker}\n## Quick Start`);
+		const updated = replaceReadmeSource(linked, options);
+		const expected = `${changed ? options.githubUrl : options.oldGithubUrl}${suffix}`;
+
+		expect(updated).toContain(expected);
+	});
+
+	it('handles an old repository name that already contains a period', () => {
+		const dottedOptions = {
+			...options,
+			oldGithubUrl: 'https://github.com/old-owner/old.repo'
+		};
+		const linked = source
+			.replaceAll(options.oldGithubUrl, dottedOptions.oldGithubUrl)
+			.replace('Unrelated prose stays.', `${dottedOptions.oldGithubUrl}. `);
+		const updated = replaceReadmeSource(linked, dottedOptions);
+
+		expect(updated).toContain(`${options.githubUrl}. `);
 	});
 });
 
@@ -425,9 +649,9 @@ describe('template setup detects a consistent generated README', () => {
 	const liveDemo =
 		'> [Live demo!](https://demo.example) The public demo covers the user-facing features.\n\n';
 	const bootstrap =
-		'# Northwind Labs\n\n```bash\ngh repo create my-saas-product --template stickerdaniel/saas-starter --clone\ncd my-saas-product\nbun install\n```\n';
+		'# Northwind Labs\n\n## Quick Start\n\n```bash\ngh repo create my-saas-product --template stickerdaniel/saas-starter --clone\ncd my-saas-product\nbun install\nbun run dev\n```\n';
 	const converted =
-		'# Northwind Labs\n\n```bash\ngit clone https://github.com/northwind/northwind-labs.git\ncd ./northwind-labs\nbun install\n```\n';
+		'# Northwind Labs\n\n## Quick Start\n\n```bash\ngit clone https://github.com/northwind/northwind-labs.git\ncd ./northwind-labs\nbun install\nbun run dev\n```\n';
 	const previouslyConverted = converted.replace('cd ./northwind-labs', 'cd northwind-labs');
 
 	it('treats the template bootstrap form as not set up', () => {
@@ -545,7 +769,7 @@ describe('template setup contact email', () => {
 		expect(parseContactEmail(value)).toEqual(parts);
 	});
 
-	// Zusätzliche @, Leerzeichen in den Segmenten und leere Domainlabels müssen durchfallen.
+	// Extra at signs, whitespace, and empty domain labels must be rejected.
 	it.each([
 		'a@b@c.de',
 		'erste person@example.de',

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -17,7 +17,7 @@
  * lokale Module importiert.
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { accessSync, constants, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { createInterface, type Interface } from 'readline';
 import { pathToFileURL } from 'url';
@@ -217,6 +217,35 @@ function titleCase(slug: string): string {
 		.join(' ');
 }
 
+/**
+ * Eine gemeinsame enge Definition für Prüfung und Zerlegung: Nutzerteil, erste
+ * Domainkomponente und restlicher Domainname. Zusätzliche @, Leerzeichen innerhalb
+ * der Segmente und leere Domainlabels fallen damit durch. Kein RFC-Anspruch und
+ * keine Zustellbarkeitsprüfung.
+ */
+const EMAIL_PATTERN = /^([^\s@]+)@([^\s@.]+)\.([^\s@.]+(?:\.[^\s@.]+)*)$/;
+
+/**
+ * Zerlegt die Adresse in Nutzerteil, erste Domainkomponente und restlichen
+ * Domainnamen. Prüfung und Zerlegung teilen sich damit eine Definition.
+ */
+export function parseContactEmail(
+	value: string
+): { user: string; domain: string; tld: string } | undefined {
+	const match = EMAIL_PATTERN.exec(value);
+	if (!match) return undefined;
+	return { user: match[1]!, domain: match[2]!, tld: match[3]! };
+}
+
+/**
+ * Brand und Operator landen als Rohtext in den Absätzen von Privacy und Terms.
+ * Ein Zeilenumbruch zerlegt dort den Absatz und kann eine zusätzliche Überschrift
+ * erzeugen. Die Adresse bleibt bewusst mehrzeilig.
+ */
+function singleLineValidator(label: string): Validator {
+	return (value) => (/[\r\n]/.test(value) ? `${label} must be a single line` : undefined);
+}
+
 // ---------------------------------------------------------------------------
 // Sichere Serialisierung
 // ---------------------------------------------------------------------------
@@ -247,7 +276,7 @@ function tsKey(key: string): string {
 }
 
 /**
- * Serialisiert die Konfiguration als TypeScript-Objektliteral. Zusätzliche
+ * Serialisiert die Einstellungen als TypeScript-Objektliteral. Zusätzliche
  * Schlüssel eines Forks bleiben erhalten, weil über die tatsächlichen Einträge
  * iteriert wird.
  */
@@ -323,6 +352,12 @@ function readString(source: Record<string, unknown>, key: string): string {
 	return typeof value === 'string' ? value : '';
 }
 
+/** Unterscheidet einen vorhandenen (auch leeren) String von einem fehlenden Schlüssel. */
+function readOptionalString(source: Record<string, unknown>, key: string): string | undefined {
+	const value = source[key];
+	return typeof value === 'string' ? value : undefined;
+}
+
 export function isValidGithubRepository(value: string): boolean {
 	const match = /^([A-Za-z0-9-]+)\/([A-Za-z0-9._-]+)$/.exec(value);
 	if (!match) return false;
@@ -352,7 +387,7 @@ export function replaceGithubSlugSource(source: string, value: string): string {
 		throw new Error('Could not find githubSlug in src/lib/config/site.ts');
 	}
 	// Ein zweites Vorkommen, etwa ein Beispiel im Doc-Kommentar, würde sonst still den
-	// falschen Treffer ersetzen und die echte Konfiguration unverändert lassen.
+	// falschen Treffer ersetzen und den echten Eintrag unverändert lassen.
 	if (matches.length > 1) {
 		throw new Error(
 			`Expected exactly one githubSlug in src/lib/config/site.ts, found ${matches.length}`
@@ -420,20 +455,45 @@ export function replaceReadmeSource(
 	// Der Demo-Absatz gehört zum Template und fehlt nach dem ersten Lauf.
 	updated = updated.replace(/^> \[Live demo!\][^\n]*\n\n/m, () => '');
 
-	const clonePattern =
-		/^(?:gh repo create [^\n]*|git clone https:\/\/github\.com\/[^\n]*)\ncd [^\n]*$/gm;
-	const cloneMatches = updated.match(clonePattern);
+	const cloneMatches = updated.match(cloneBlockPattern());
 	if (cloneMatches?.length !== 1) {
 		throw new Error(
 			`Expected exactly one quick start clone block in README.md, found ${cloneMatches?.length ?? 0}`
 		);
 	}
 	updated = updated.replace(
-		clonePattern,
-		() => `git clone ${githubUrl}.git\ncd ${repositoryBasename}`
+		cloneBlockPattern(),
+		// Das gelesene Zeilenende zurückschreiben, damit eine CRLF-Datei CRLF bleibt.
+		(_match, lineBreak: string) => `git clone ${githubUrl}.git${lineBreak}cd ${repositoryBasename}`
 	);
 
 	return updated;
+}
+
+/**
+ * Der Quick-Start-Klonblock. Das Zeilenende wird mitgelesen, damit eine Datei mit
+ * CRLF unverändert bleibt.
+ */
+function cloneBlockPattern(): RegExp {
+	return /^(?:gh repo create [^\r\n]*|git clone https:\/\/github\.com\/[^\r\n]*)(\r?\n)cd [^\r\n]*$/gm;
+}
+
+/**
+ * Sagt, ob der Quick Start bereits auf genau dieses Repository umgeschrieben wurde.
+ * Nur der konvertierte git-clone-Block zählt als eingerichtet, die gh-repo-create-Form
+ * des Templates ausdrücklich nicht. Das ist eine Aussage über den vorliegenden
+ * Endzustand, kein Nachweis darüber, wie er entstanden ist.
+ */
+export function readmeShowsConvertedQuickStart(source: string, repository: string): boolean {
+	const matches = source.match(cloneBlockPattern());
+	if (matches?.length !== 1) return false;
+	const repositoryBasename = repository.split('/')[1];
+	if (!repositoryBasename) return false;
+	const [cloneLine, directoryLine] = matches[0]!.split(/\r?\n/);
+	return (
+		cloneLine === `git clone https://github.com/${repository}.git` &&
+		directoryLine === `cd ${repositoryBasename}`
+	);
 }
 
 export function replaceWranglerNameSource(source: string, slug: string): string {
@@ -487,7 +547,9 @@ async function main() {
 	const oldSlug = currentSlug();
 	const oldRepo = currentRepo();
 	const oldBrand = readString(legalConfig, 'brandName');
-	const oldCompany = readString(legalConfig, 'companyName');
+	// Ein vorhandener Wert bleibt erhalten, auch der leere String; nur ein wirklich
+	// fehlender Schlüssel bekommt den abgeleiteten Vorschlag.
+	const oldCompany = readOptionalString(legalConfig, 'companyName');
 	const oldOperator = readString(legalConfig, 'operatorName');
 	const oldAddress = readString(legalConfig, 'address');
 	const oldUser = readString(legalEmail, 'user');
@@ -495,17 +557,25 @@ async function main() {
 	const oldTld = readString(legalEmail, 'tld');
 	const oldEmail = oldUser && oldDomain && oldTld ? `${oldUser}@${oldDomain}.${oldTld}` : '';
 
-	// Der Markenname darf legitim 'SaaS Starter' lauten. Ob er gesetzt wurde, verrät erst
-	// Slug oder Repository: solange beide auf dem Template stehen, ist noch nichts gewählt.
-	const alreadySetUp = oldSlug !== TEMPLATE_SLUG || oldRepo !== TEMPLATE_REPOSITORY;
+	let readmeSource: string;
+	try {
+		readmeSource = read('README.md');
+	} catch (error) {
+		fail(error instanceof Error ? error.message : String(error));
+	}
 
-	if (!interactive) {
-		// Nur noch nicht gebrandete Werte sind Pflicht, damit ein erneuter Lauf ohne
-		// Identitätsflags die gesetzte Identität erhält.
+	// Der Markenname darf legitim 'SaaS Starter' lauten, und ein von Hand geänderter
+	// Package-Name beweist keine Einrichtung. Maßgeblich ist der Endzustand des Quick
+	// Starts für dieses Repository, nicht ein Nachweis über frühere Läufe.
+	const alreadySetUp = readmeShowsConvertedQuickStart(readmeSource, oldRepo);
+
+	if (!interactive && !alreadySetUp) {
+		// Solange der Quick Start die Bootstrapform trägt, sind die drei Kernwerte Pflicht.
+		// Danach ist nichts mehr Pflicht, auch ein bewusst beibehaltener Template-Slug nicht.
 		const missing: string[] = [];
 		if (!slugFlag && oldSlug === TEMPLATE_SLUG) missing.push('--slug');
 		if (!repoFlag && oldRepo === TEMPLATE_REPOSITORY) missing.push('--repo');
-		if (!brandFlag && !alreadySetUp) missing.push('--brand');
+		if (!brandFlag) missing.push('--brand');
 		if (missing.length > 0) {
 			console.error(
 				`Error: bun run setup needs --slug, --repo, --brand in non-interactive mode.\nMissing: ${missing.join(', ')}\nExample: bun run setup --slug my-app --repo owner/my-app --brand "My App"`
@@ -534,19 +604,21 @@ async function main() {
 		// titleCase nur als Vorschlag für das unberührte Template, nie als Ersatz für
 		// einen bereits gewählten Namen.
 		!alreadySetUp && (oldBrand === '' || oldBrand === TEMPLATE_BRAND) ? titleCase(slug) : oldBrand,
-		(value) => (value.trim() === '' ? 'brand must not be empty' : undefined)
+		(value) =>
+			value.trim() === '' ? 'brand must not be empty' : singleLineValidator('brand')(value)
 	);
 
 	const company = await resolveValue(
 		companyFlag,
 		'Company name (legal entity)',
-		oldCompany || `${brand} Inc.`
+		oldCompany ?? `${brand} Inc.`
 	);
 
 	const operator = await resolveValue(
 		operatorFlag,
 		'Operator name (person or org running the service)',
-		oldOperator
+		oldOperator,
+		singleLineValidator('operator')
 	);
 
 	const address = await resolveValue(
@@ -560,11 +632,11 @@ async function main() {
 		'Contact email (user@domain.tld)',
 		oldEmail,
 		(value) =>
-			/^([^@]+)@([^.]+)\.(.+)$/.test(value)
+			parseContactEmail(value)
 				? undefined
 				: `email must match user@domain.tld pattern, got: ${value}`
 	);
-	const [, emailUser, emailDomain, emailTld] = /^([^@]+)@([^.]+)\.(.+)$/.exec(email)!;
+	const { user: emailUser, domain: emailDomain, tld: emailTld } = parseContactEmail(email)!;
 
 	const githubUrl = `https://github.com/${repo}`;
 	const oldGithubUrl = `https://github.com/${oldRepo}`;
@@ -601,7 +673,7 @@ async function main() {
 		pkg.author = operator;
 		nextPackageJson = JSON.stringify(pkg, null, '\t') + '\n';
 		nextWrangler = replaceWranglerNameSource(read('wrangler.toml'), slug);
-		nextReadme = replaceReadmeSource(read('README.md'), {
+		nextReadme = replaceReadmeSource(readmeSource, {
 			brand,
 			repository: repo,
 			oldGithubUrl,
@@ -615,6 +687,25 @@ async function main() {
 		);
 		nextLegalSource = replaceLegalConfigSource(read('src/lib/config/legal.ts'), nextLegalConfig);
 		nextLock = hasLock ? replaceLockRootNameSource(read('bun.lock'), slug) : undefined;
+		// Erst wenn alle Inhalte stehen, prüfen, ob jede vorgesehene Datei beschreibbar
+		// ist. Sonst schreibt der Lauf die ersten Dateien und scheitert an einer späteren.
+		// Das deckt die schreibgeschützte Datei ab; eine Rechteänderung nach dieser
+		// Prüfung, ein voller Datenträger und ein Prozessabbruch bleiben außerhalb.
+		for (const rel of [
+			'package.json',
+			...(hasLock ? ['bun.lock'] : []),
+			'wrangler.toml',
+			'README.md',
+			'src/lib/config/site.ts',
+			'src/lib/content/legal-metadata.ts',
+			'src/lib/config/legal.ts'
+		]) {
+			try {
+				accessSync(join(ROOT, rel), constants.W_OK);
+			} catch {
+				throw new Error(`Cannot write ${rel}; check file permissions`);
+			}
+		}
 	} catch (error) {
 		fail(error instanceof Error ? error.message : String(error));
 	}

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -8,18 +8,28 @@
  *   bun run setup
  *   bun run setup --slug my-app --repo owner/my-app --brand "My App"
  *
- * Non-interactive mode (piped stdin, CI, agents) requires --slug, --repo, --brand.
- * Identity fields (company, operator, address, email) preserve current legal.ts
- * values when no flag is given; pass --company/--operator/--address/--email to override.
+ * Non-interactive mode (piped stdin, CI, agents) requires --slug, --repo, --brand
+ * while those still hold their template values. Identity fields (brand, company,
+ * operator, address, email) preserve the current legal.ts values when no flag is
+ * given, so a re-run without flags keeps the configured identity.
+ *
+ * Läuft ohne installierte Dependencies: es werden nur Node-Builtins und reine
+ * lokale Module importiert.
  */
 
-import { readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { createInterface, type Interface } from 'readline';
+import { pathToFileURL } from 'url';
 import { parseArgs } from 'util';
 import { isIsoCalendarDate } from '../src/lib/content/legal-metadata';
 
 const ROOT = join(import.meta.dirname, '..');
+
+/** Werte, die noch auf dem Template-Stand stehen und daher gesetzt werden müssen. */
+const TEMPLATE_SLUG = 'saas-starter';
+const TEMPLATE_REPOSITORY = 'stickerdaniel/saas-starter';
+const TEMPLATE_BRAND = 'SaaS Starter';
 
 function normalizeFlag(v: unknown): string | undefined {
 	if (typeof v !== 'string') return undefined;
@@ -42,21 +52,30 @@ interface SetupFlags {
  * below (see template-setup.test.ts) neither reads argv nor exits the process.
  */
 function readFlags(): SetupFlags {
-	const { values } = parseArgs({
-		args: process.argv.slice(2),
-		options: {
-			slug: { type: 'string' },
-			repo: { type: 'string' },
-			brand: { type: 'string' },
-			company: { type: 'string' },
-			operator: { type: 'string' },
-			address: { type: 'string' },
-			email: { type: 'string' },
-			help: { type: 'boolean', short: 'h', default: false }
-		},
-		strict: false,
-		allowPositionals: false
-	});
+	let values: Record<string, unknown>;
+	try {
+		// strict: unbekannte Flags sind Tippfehler und dürfen nicht stillschweigend
+		// verworfen werden, bevor irgendetwas geschrieben wird.
+		({ values } = parseArgs({
+			args: process.argv.slice(2),
+			options: {
+				slug: { type: 'string' },
+				repo: { type: 'string' },
+				brand: { type: 'string' },
+				company: { type: 'string' },
+				operator: { type: 'string' },
+				address: { type: 'string' },
+				email: { type: 'string' },
+				help: { type: 'boolean', short: 'h', default: false }
+			},
+			strict: true,
+			allowPositionals: false
+		}));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`Error: ${message}\nRun bun run setup --help to see the supported flags.`);
+		process.exit(1);
+	}
 
 	if (values.help) {
 		console.log(`Template Setup
@@ -75,9 +94,11 @@ Flags:
   --email     Contact email in user@domain.tld form
   -h, --help  Show this help
 
-In non-interactive mode (piped stdin, CI), --slug, --repo, --brand are required.
+In non-interactive mode (piped stdin, CI), --slug, --repo, --brand are required
+while they still hold their template values.
 Identity fields without flags preserve current legal.ts values.
-In interactive mode, missing flags are prompted with current values as defaults.`);
+In interactive mode, missing flags are prompted with current values as defaults.
+Unknown flags are rejected before any file is written.`);
 		process.exit(0);
 	}
 
@@ -95,8 +116,20 @@ In interactive mode, missing flags are prompted with current values as defaults.
 const interactive = !!process.stdin.isTTY;
 let rl: Interface | undefined;
 function ensureReadline(): Interface {
-	if (!rl) rl = createInterface({ input: process.stdin, output: process.stdout });
+	if (!rl) {
+		rl = createInterface({ input: process.stdin, output: process.stdout });
+		// Ctrl-C beendet die Eingabe wie ein EOF, statt den Prozess mit offener
+		// Schnittstelle hängen zu lassen.
+		rl.on('SIGINT', () => rl?.close());
+	}
 	return rl;
+}
+
+/** Bricht kontrolliert ab: immer vor dem ersten Write und mit geschlossener Eingabe. */
+function fail(message: string): never {
+	console.error(`Error: ${message}`);
+	rl?.close();
+	process.exit(1);
 }
 
 // ---------------------------------------------------------------------------
@@ -111,35 +144,70 @@ function write(rel: string, content: string): void {
 	writeFileSync(join(ROOT, rel), content, 'utf-8');
 }
 
-function replace(rel: string, pairs: Array<[string | RegExp, string]>): void {
-	let content = read(rel);
-	for (const [search, replacement] of pairs) {
-		if (typeof search === 'string') {
-			content = content.split(search).join(replacement);
-		} else {
-			content = content.replace(search, replacement);
-		}
-	}
-	write(rel, content);
-}
-
-function prompt(question: string, fallback: string): Promise<string> {
+/**
+ * Fragt eine Eingabe ab. Liefert undefined, wenn stdin schließt (EOF, Ctrl-D,
+ * Ctrl-C), damit der Aufrufer sauber abbrechen kann.
+ */
+function prompt(question: string, fallback: string): Promise<string | undefined> {
 	const iface = ensureReadline();
 	return new Promise((resolve) => {
+		let answered = false;
+		const onClose = () => {
+			if (!answered) resolve(undefined);
+		};
+		iface.once('close', onClose);
 		iface.question(`${question} [${fallback}]: `, (answer) => {
+			answered = true;
+			iface.off('close', onClose);
 			resolve(answer.trim() || fallback);
 		});
 	});
 }
 
+/** Gibt eine Fehlermeldung zurück, wenn der Wert unbrauchbar ist, sonst undefined. */
+export type Validator = (value: string) => string | undefined;
+
+/**
+ * Fragt so lange erneut, bis eine gültige Antwort vorliegt. Liefert undefined,
+ * wenn die Eingabe endet (EOF, Ctrl-D, Ctrl-C), damit der Aufrufer abbrechen kann.
+ */
+export async function askUntilValid(
+	ask: (question: string, fallback: string) => Promise<string | undefined>,
+	question: string,
+	fallback: string,
+	validate: Validator | undefined,
+	report: (problem: string) => void
+): Promise<string | undefined> {
+	for (;;) {
+		const answer = await ask(question, fallback);
+		if (answer === undefined) return undefined;
+		const problem = validate?.(answer);
+		if (!problem) return answer;
+		report(problem);
+	}
+}
+
 async function resolveValue(
 	flag: string | undefined,
 	question: string,
-	fallback: string
+	fallback: string,
+	validate?: Validator
 ): Promise<string> {
-	if (flag) return flag;
-	if (!interactive) return fallback;
-	return prompt(question, fallback);
+	if (flag !== undefined) {
+		const problem = validate?.(flag);
+		if (problem) fail(problem);
+		return flag;
+	}
+	if (!interactive) {
+		const problem = validate?.(fallback);
+		if (problem) fail(problem);
+		return fallback;
+	}
+	const answer = await askUntilValid(prompt, question, fallback, validate, (problem) =>
+		console.error(`  ${problem}`)
+	);
+	if (answer === undefined) fail('setup aborted, no input available on stdin');
+	return answer;
 }
 
 function titleCase(slug: string): string {
@@ -150,18 +218,109 @@ function titleCase(slug: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Sichere Serialisierung
+// ---------------------------------------------------------------------------
+
+const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * Erzeugt ein TypeScript-Stringliteral. JSON.stringify maskiert Backslashes,
+ * Steuerzeichen und Zeilenumbrüche korrekt; anschließend wird auf die Quote-Wahl
+ * umgestellt, die Prettier für diese Datei träfe (einfache Quotes, außer der Wert
+ * enthält davon mehr als doppelte).
+ */
+export function tsStringLiteral(value: string): string {
+	const singleQuotes = value.split("'").length - 1;
+	const doubleQuotes = value.split('"').length - 1;
+	const quote = singleQuotes > doubleQuotes ? '"' : "'";
+	const escaped = JSON.stringify(value)
+		.slice(1, -1)
+		.split('\\"')
+		.join('"')
+		.split(quote)
+		.join(`\\${quote}`);
+	return `${quote}${escaped}${quote}`;
+}
+
+function tsKey(key: string): string {
+	return IDENTIFIER.test(key) ? key : tsStringLiteral(key);
+}
+
+/**
+ * Serialisiert die Konfiguration als TypeScript-Objektliteral. Zusätzliche
+ * Schlüssel eines Forks bleiben erhalten, weil über die tatsächlichen Einträge
+ * iteriert wird.
+ */
+export function serializeConfigValue(value: unknown, indent: string): string {
+	if (typeof value === 'string') return tsStringLiteral(value);
+	if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+	if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+		const entries = Object.entries(value as Record<string, unknown>);
+		if (entries.length === 0) return '{}';
+		const inner = `${indent}\t`;
+		const body = entries
+			.map(([key, item]) => `${inner}${tsKey(key)}: ${serializeConfigValue(item, inner)}`)
+			.join(',\n');
+		return `{\n${body}\n${indent}}`;
+	}
+	throw new Error(`Unsupported LEGAL_CONFIG value of type ${typeof value}`);
+}
+
+function legalConfigBlockPattern(): RegExp {
+	return /^export const LEGAL_CONFIG = \{[\s\S]*?^\} as const;$/gm;
+}
+
+/**
+ * Ersetzt den eindeutigen LEGAL_CONFIG-Exportblock. Die Hilfsfunktionen und alle
+ * übrigen Dateiinhalte bleiben unberührt.
+ */
+export function replaceLegalConfigSource(source: string, config: Record<string, unknown>): string {
+	const matches = source.match(legalConfigBlockPattern());
+	if (matches?.length !== 1) {
+		throw new Error(
+			`Expected exactly one LEGAL_CONFIG block in src/lib/config/legal.ts, found ${matches?.length ?? 0}`
+		);
+	}
+	const block = `export const LEGAL_CONFIG = ${serializeConfigValue(config, '')} as const;`;
+	// Replacement-Callback: $&, $1 und $` in Branding-Werten dürfen nicht als
+	// Ersetzungsmuster interpretiert werden.
+	return source.replace(legalConfigBlockPattern(), () => block);
+}
+
+// ---------------------------------------------------------------------------
 // Detect current values (for re-run defaults)
 // ---------------------------------------------------------------------------
 
 function currentSlug(): string {
 	const pkg = JSON.parse(read('package.json'));
-	return pkg.name ?? 'saas-starter';
+	return pkg.name ?? TEMPLATE_SLUG;
 }
 
 function currentRepo(): string {
 	const siteConfig = read('src/lib/config/site.ts');
 	const match = siteConfig.match(/githubSlug:\s*['"]([^'"]+)['"]/);
 	return match?.[1] ?? 'user/my-saas';
+}
+
+/**
+ * Liest die rechtlichen Defaults aus dem reinen Modul statt per Regex. Ist die
+ * Datei beschädigt, scheitert der Import hier — vor jedem Write.
+ */
+async function readLegalConfig(): Promise<Record<string, unknown>> {
+	const modulePath = join(ROOT, 'src/lib/config/legal.ts');
+	const imported = (await import(pathToFileURL(modulePath).href)) as {
+		LEGAL_CONFIG?: unknown;
+	};
+	const config = imported.LEGAL_CONFIG;
+	if (config === null || typeof config !== 'object' || Array.isArray(config)) {
+		throw new Error('Could not read LEGAL_CONFIG from src/lib/config/legal.ts');
+	}
+	return structuredClone(config) as Record<string, unknown>;
+}
+
+function readString(source: Record<string, unknown>, key: string): string {
+	const value = source[key];
+	return typeof value === 'string' ? value : '';
 }
 
 export function isValidGithubRepository(value: string): boolean {
@@ -187,11 +346,19 @@ export function githubSlugProperty(value: string): string {
 }
 
 export function replaceGithubSlugSource(source: string, value: string): string {
-	const pattern = /githubSlug:\s*['"][^'"]+['"]/;
-	if (!pattern.test(source)) {
+	const pattern = /githubSlug:\s*['"][^'"]+['"]/g;
+	const matches = source.match(pattern);
+	if (!matches) {
 		throw new Error('Could not find githubSlug in src/lib/config/site.ts');
 	}
-	return source.replace(pattern, githubSlugProperty(value));
+	// Ein zweites Vorkommen, etwa ein Beispiel im Doc-Kommentar, würde sonst still den
+	// falschen Treffer ersetzen und die echte Konfiguration unverändert lassen.
+	if (matches.length > 1) {
+		throw new Error(
+			`Expected exactly one githubSlug in src/lib/config/site.ts, found ${matches.length}`
+		);
+	}
+	return source.replace(pattern, () => githubSlugProperty(value));
 }
 
 export function replaceLegalContentDatesSource(source: string, value: string): string {
@@ -215,40 +382,84 @@ export function updateLegalContentDatesSource(
 	return legalIdentityChanged ? replaceLegalContentDatesSource(source, value) : source;
 }
 
-function readLegalField(field: 'brandName' | 'companyName' | 'operatorName' | 'address'): string {
-	const src = read('src/lib/config/legal.ts');
-	const m = src.match(new RegExp(`${field}:\\s*'([^']*)'`));
-	return m?.[1] ?? '';
+// ---------------------------------------------------------------------------
+// README, wrangler, lockfile
+// ---------------------------------------------------------------------------
+
+/**
+ * Maskiert Zeichen, die den Markennamen in einer Markdown-Überschrift anders rendern
+ * würden. `&` gehört dazu, weil `&copy;` sonst als Entity ankommt, `#` wegen der
+ * schließenden Zeichenfolge einer ATX-Überschrift.
+ */
+export function escapeMarkdownInline(value: string): string {
+	return value.replace(/[\\`*_[\]<>&#]/g, (char) => `\\${char}`);
 }
 
-function readLegalEmailParts(): { user: string; domain: string; tld: string } {
-	const src = read('src/lib/config/legal.ts');
-	const user = src.match(/user:\s*'([^']*)'/)?.[1] ?? '';
-	const domain = src.match(/domain:\s*'([^']*)'/)?.[1] ?? '';
-	const tld = src.match(/tld:\s*'([^']*)'/)?.[1] ?? '';
-	return { user, domain, tld };
+/**
+ * Repariert Überschrift, Demo-Absatz und Quick Start. Der Quick Start erklärt danach
+ * die Einrichtung des erzeugten Projekts statt der Template-Erzeugung. Der Aufruf ist
+ * idempotent: die bereits erzeugte Form wird erneut erkannt.
+ */
+export function replaceReadmeSource(
+	source: string,
+	options: { brand: string; repository: string; oldGithubUrl: string; githubUrl: string }
+): string {
+	const { brand, repository, oldGithubUrl, githubUrl } = options;
+	const repositoryBasename = repository.split('/')[1]!;
+
+	// Zuerst die Repository-Links, damit der danach erzeugte Quick-Start-Block nicht
+	// noch einmal umgeschrieben wird.
+	let updated = oldGithubUrl === githubUrl ? source : source.split(oldGithubUrl).join(githubUrl);
+
+	const heading = /^# .+$/m;
+	if (!heading.test(updated)) {
+		throw new Error('Could not find the top-level heading in README.md');
+	}
+	updated = updated.replace(heading, () => `# ${escapeMarkdownInline(brand)}`);
+
+	// Der Demo-Absatz gehört zum Template und fehlt nach dem ersten Lauf.
+	updated = updated.replace(/^> \[Live demo!\][^\n]*\n\n/m, () => '');
+
+	const clonePattern =
+		/^(?:gh repo create [^\n]*|git clone https:\/\/github\.com\/[^\n]*)\ncd [^\n]*$/gm;
+	const cloneMatches = updated.match(clonePattern);
+	if (cloneMatches?.length !== 1) {
+		throw new Error(
+			`Expected exactly one quick start clone block in README.md, found ${cloneMatches?.length ?? 0}`
+		);
+	}
+	updated = updated.replace(
+		clonePattern,
+		() => `git clone ${githubUrl}.git\ncd ${repositoryBasename}`
+	);
+
+	return updated;
 }
 
-function currentBrand(): string {
-	return readLegalField('brandName') || 'SaaS Starter';
+export function replaceWranglerNameSource(source: string, slug: string): string {
+	const pattern = /^name = "[^"]*"/gm;
+	const matches = source.match(pattern);
+	if (matches?.length !== 1) {
+		throw new Error(
+			`Expected exactly one name assignment in wrangler.toml, found ${matches?.length ?? 0}`
+		);
+	}
+	return source.replace(pattern, () => `name = ${JSON.stringify(slug)}`);
 }
 
-function currentCompany(): string {
-	return readLegalField('companyName') || `${currentBrand()} Inc.`;
-}
-
-function currentOperator(): string {
-	return readLegalField('operatorName');
-}
-
-function currentAddress(): string {
-	return readLegalField('address');
-}
-
-function currentEmail(): string {
-	const { user, domain, tld } = readLegalEmailParts();
-	if (!user || !domain || !tld) return '';
-	return `${user}@${domain}.${tld}`;
+/**
+ * Synchronisiert allein den Root-Namen im Lockfile. Dependency-Einträge und
+ * Versionen bleiben bytegleich; der Abhängigkeitsgraph wird nicht neu berechnet.
+ */
+export function replaceLockRootNameSource(source: string, slug: string): string {
+	const pattern = /("workspaces"\s*:\s*\{\s*""\s*:\s*\{\s*"name"\s*:\s*)"(?:[^"\\]|\\.)*"/g;
+	const matches = source.match(pattern);
+	if (matches?.length !== 1) {
+		throw new Error(
+			`Expected exactly one workspace root name in bun.lock, found ${matches?.length ?? 0}`
+		);
+	}
+	return source.replace(pattern, (_match, prefix: string) => `${prefix}${JSON.stringify(slug)}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -268,11 +479,33 @@ async function main() {
 		email: emailFlag
 	} = readFlags();
 
+	const legalConfig = await readLegalConfig().catch((error: unknown) =>
+		fail(error instanceof Error ? error.message : String(error))
+	);
+	const legalEmail = (legalConfig.email ?? {}) as Record<string, unknown>;
+
+	const oldSlug = currentSlug();
+	const oldRepo = currentRepo();
+	const oldBrand = readString(legalConfig, 'brandName');
+	const oldCompany = readString(legalConfig, 'companyName');
+	const oldOperator = readString(legalConfig, 'operatorName');
+	const oldAddress = readString(legalConfig, 'address');
+	const oldUser = readString(legalEmail, 'user');
+	const oldDomain = readString(legalEmail, 'domain');
+	const oldTld = readString(legalEmail, 'tld');
+	const oldEmail = oldUser && oldDomain && oldTld ? `${oldUser}@${oldDomain}.${oldTld}` : '';
+
+	// Der Markenname darf legitim 'SaaS Starter' lauten. Ob er gesetzt wurde, verrät erst
+	// Slug oder Repository: solange beide auf dem Template stehen, ist noch nichts gewählt.
+	const alreadySetUp = oldSlug !== TEMPLATE_SLUG || oldRepo !== TEMPLATE_REPOSITORY;
+
 	if (!interactive) {
+		// Nur noch nicht gebrandete Werte sind Pflicht, damit ein erneuter Lauf ohne
+		// Identitätsflags die gesetzte Identität erhält.
 		const missing: string[] = [];
-		if (!slugFlag) missing.push('--slug');
-		if (!repoFlag) missing.push('--repo');
-		if (!brandFlag) missing.push('--brand');
+		if (!slugFlag && oldSlug === TEMPLATE_SLUG) missing.push('--slug');
+		if (!repoFlag && oldRepo === TEMPLATE_REPOSITORY) missing.push('--repo');
+		if (!brandFlag && !alreadySetUp) missing.push('--brand');
 		if (missing.length > 0) {
 			console.error(
 				`Error: bun run setup needs --slug, --repo, --brand in non-interactive mode.\nMissing: ${missing.join(', ')}\nExample: bun run setup --slug my-app --repo owner/my-app --brand "My App"`
@@ -281,62 +514,60 @@ async function main() {
 		}
 	}
 
-	const slug = await resolveValue(slugFlag, 'Project slug (lowercase, no spaces)', currentSlug());
-	if (!/^[a-z0-9-]+$/.test(slug)) {
-		console.error('Error: slug must match ^[a-z0-9-]+$ (lowercase letters, numbers, hyphens)');
-		process.exit(1);
-	}
+	const slug = await resolveValue(
+		slugFlag,
+		'Project slug (lowercase, no spaces)',
+		oldSlug,
+		(value) =>
+			/^[a-z0-9-]+$/.test(value)
+				? undefined
+				: 'slug must match ^[a-z0-9-]+$ (lowercase letters, numbers, hyphens)'
+	);
 
-	const repo = await resolveValue(repoFlag, 'GitHub repo (owner/name)', currentRepo());
-	if (!isValidGithubRepository(repo)) {
-		console.error('Error: repo must use a safe GitHub owner/name format');
-		process.exit(1);
-	}
-	const repoBasename = repo.split('/')[1];
+	const repo = await resolveValue(repoFlag, 'GitHub repo (owner/name)', oldRepo, (value) =>
+		isValidGithubRepository(value) ? undefined : 'repo must use a safe GitHub owner/name format'
+	);
 
-	const oldBrand = currentBrand();
 	const brand = await resolveValue(
 		brandFlag,
 		'Brand name (display name)',
-		oldBrand === 'SaaS Starter' ? titleCase(slug) : oldBrand
+		// titleCase nur als Vorschlag für das unberührte Template, nie als Ersatz für
+		// einen bereits gewählten Namen.
+		!alreadySetUp && (oldBrand === '' || oldBrand === TEMPLATE_BRAND) ? titleCase(slug) : oldBrand,
+		(value) => (value.trim() === '' ? 'brand must not be empty' : undefined)
 	);
 
-	const oldCompany = currentCompany();
 	const company = await resolveValue(
 		companyFlag,
 		'Company name (legal entity)',
 		oldCompany || `${brand} Inc.`
 	);
 
-	const oldOperator = currentOperator();
 	const operator = await resolveValue(
 		operatorFlag,
 		'Operator name (person or org running the service)',
 		oldOperator
 	);
 
-	const oldAddress = currentAddress();
 	const address = await resolveValue(
 		addressFlag,
 		'Address (for Impressum and email footer)',
 		oldAddress
 	);
 
-	const oldEmail = currentEmail();
-	const email = await resolveValue(emailFlag, 'Contact email (user@domain.tld)', oldEmail);
-	const emailMatch = email.match(/^([^@]+)@([^.]+)\.(.+)$/);
-	if (!emailMatch) {
-		console.error(`Error: email must match user@domain.tld pattern, got: ${email}`);
-		process.exit(1);
-	}
-	const [, emailUser, emailDomain, emailTld] = emailMatch;
+	const email = await resolveValue(
+		emailFlag,
+		'Contact email (user@domain.tld)',
+		oldEmail,
+		(value) =>
+			/^([^@]+)@([^.]+)\.(.+)$/.test(value)
+				? undefined
+				: `email must match user@domain.tld pattern, got: ${value}`
+	);
+	const [, emailUser, emailDomain, emailTld] = /^([^@]+)@([^.]+)\.(.+)$/.exec(email)!;
 
-	const oldSlug = currentSlug();
-	const oldRepo = currentRepo();
 	const githubUrl = `https://github.com/${repo}`;
 	const oldGithubUrl = `https://github.com/${oldRepo}`;
-	// Validate the central repository-slug shape before changing unrelated files.
-	const nextSiteConfig = replaceGithubSlugSource(read('src/lib/config/site.ts'), repo);
 	const setupDate = new Date().toISOString().slice(0, 10);
 	const legalIdentityChanged =
 		brand !== oldBrand ||
@@ -344,34 +575,64 @@ async function main() {
 		operator !== oldOperator ||
 		address !== oldAddress ||
 		email !== oldEmail;
-	const currentLegalMetadata = read('src/lib/content/legal-metadata.ts');
-	const nextLegalMetadata = updateLegalContentDatesSource(
-		currentLegalMetadata,
-		setupDate,
-		legalIdentityChanged
-	);
+
+	// Alle nächsten Dateiinhalte vor dem ersten Write berechnen. Ein fehlender oder
+	// mehrdeutiger Anker scheitert damit, bevor irgendetwas auf der Platte steht.
+	const nextLegalConfig = { ...legalConfig };
+	nextLegalConfig.brandName = brand;
+	nextLegalConfig.companyName = company;
+	nextLegalConfig.operatorName = operator;
+	nextLegalConfig.address = address;
+	nextLegalConfig.email = { ...legalEmail, user: emailUser, domain: emailDomain, tld: emailTld };
+
+	const lockPath = join(ROOT, 'bun.lock');
+	const hasLock = existsSync(lockPath);
+
+	let nextPackageJson: string;
+	let nextWrangler: string;
+	let nextReadme: string;
+	let nextSiteConfig: string;
+	let nextLegalMetadata: string;
+	let nextLegalSource: string;
+	let nextLock: string | undefined;
+	try {
+		const pkg = JSON.parse(read('package.json'));
+		pkg.name = slug;
+		pkg.author = operator;
+		nextPackageJson = JSON.stringify(pkg, null, '\t') + '\n';
+		nextWrangler = replaceWranglerNameSource(read('wrangler.toml'), slug);
+		nextReadme = replaceReadmeSource(read('README.md'), {
+			brand,
+			repository: repo,
+			oldGithubUrl,
+			githubUrl
+		});
+		nextSiteConfig = replaceGithubSlugSource(read('src/lib/config/site.ts'), repo);
+		nextLegalMetadata = updateLegalContentDatesSource(
+			read('src/lib/content/legal-metadata.ts'),
+			setupDate,
+			legalIdentityChanged
+		);
+		nextLegalSource = replaceLegalConfigSource(read('src/lib/config/legal.ts'), nextLegalConfig);
+		nextLock = hasLock ? replaceLockRootNameSource(read('bun.lock'), slug) : undefined;
+	} catch (error) {
+		fail(error instanceof Error ? error.message : String(error));
+	}
 
 	console.log(`\nApplying: slug=${slug}, repo=${repo}, brand="${brand}"\n`);
 
-	// package.json — name and author
-	const pkg = JSON.parse(read('package.json'));
-	pkg.name = slug;
-	pkg.author = operator;
-	write('package.json', JSON.stringify(pkg, null, '\t') + '\n');
+	write('package.json', nextPackageJson);
 	console.log('  ✓ package.json');
 
-	// wrangler.toml
-	replace('wrangler.toml', [[`name = "${oldSlug}"`, `name = "${slug}"`]]);
+	if (nextLock !== undefined) {
+		write('bun.lock', nextLock);
+		console.log('  ✓ bun.lock (root name)');
+	}
+
+	write('wrangler.toml', nextWrangler);
 	console.log('  ✓ wrangler.toml');
 
-	// README.md
-	replace('README.md', [
-		[`# ${oldBrand}`, `# ${brand}`],
-		[oldGithubUrl, githubUrl],
-		[`cd ${oldSlug === 'saas-starter' ? 'saas-starter' : repoBasename}`, `cd ${repoBasename}`],
-		// Remove demo link line (matches the > See a live demo... line)
-		[/^> See a live demo.*\n\n/m, '']
-	]);
+	write('README.md', nextReadme);
 	console.log('  ✓ README.md');
 
 	// Site config — single source for runtime repository links
@@ -386,18 +647,7 @@ async function main() {
 	);
 
 	// Legal config — single source of truth for brand identity
-	const oldUser = readLegalEmailParts().user;
-	const oldDomain = readLegalEmailParts().domain;
-	const oldTld = readLegalEmailParts().tld;
-	const oldEmailBlock = `user: '${oldUser}',\n\t\tdomain: '${oldDomain}',\n\t\ttld: '${oldTld}'`;
-	const newEmailBlock = `user: '${emailUser}',\n\t\tdomain: '${emailDomain}',\n\t\ttld: '${emailTld}'`;
-	replace('src/lib/config/legal.ts', [
-		[`brandName: '${oldBrand}'`, `brandName: '${brand}'`],
-		[`companyName: '${oldCompany}'`, `companyName: '${company}'`],
-		[`operatorName: '${oldOperator}'`, `operatorName: '${operator}'`],
-		[`address: '${oldAddress}'`, `address: '${address}'`],
-		[oldEmailBlock, newEmailBlock]
-	]);
+	write('src/lib/config/legal.ts', nextLegalSource);
 	console.log('  ✓ legal.ts');
 
 	console.log('\n✅ Done! Next steps:');

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -1,5 +1,5 @@
 /**
- * Template setup script — replaces project-specific placeholders after
+ * Template setup script: replaces project-specific placeholders after
  * generating a new repo from the GitHub template.
  *
  * Safe to re-run: prompts with current values as defaults.
@@ -13,12 +13,24 @@
  * operator, address, email) preserve the current legal.ts values when no flag is
  * given, so a re-run without flags keeps the configured identity.
  *
- * Läuft ohne installierte Dependencies: es werden nur Node-Builtins und reine
- * lokale Module importiert.
+ * Runs before dependencies are installed: imports are limited to Node built-ins
+ * and dependency-free local modules.
  */
 
-import { accessSync, constants, existsSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import {
+	accessSync,
+	chmodSync,
+	constants,
+	lstatSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	renameSync,
+	rmdirSync,
+	unlinkSync,
+	writeFileSync
+} from 'fs';
+import { basename, dirname, isAbsolute, join, relative, sep } from 'path';
 import { createInterface, type Interface } from 'readline';
 import { domainToASCII, pathToFileURL } from 'url';
 import { parseArgs } from 'util';
@@ -26,7 +38,7 @@ import { isIsoCalendarDate } from '../src/lib/content/legal-metadata';
 
 const ROOT = join(import.meta.dirname, '..');
 
-/** Werte, die noch auf dem Template-Stand stehen und daher gesetzt werden müssen. */
+/** Values that still carry the template identity and must be configured. */
 const TEMPLATE_SLUG = 'saas-starter';
 const TEMPLATE_REPOSITORY = 'stickerdaniel/saas-starter';
 const TEMPLATE_BRAND = 'SaaS Starter';
@@ -54,8 +66,7 @@ interface SetupFlags {
 function readFlags(): SetupFlags {
 	let values: Record<string, unknown>;
 	try {
-		// strict: unbekannte Flags sind Tippfehler und dürfen nicht stillschweigend
-		// verworfen werden, bevor irgendetwas geschrieben wird.
+		// Unknown flags are likely typos and must fail before any file is written.
 		({ values } = parseArgs({
 			args: process.argv.slice(2),
 			options: {
@@ -118,14 +129,13 @@ let rl: Interface | undefined;
 function ensureReadline(): Interface {
 	if (!rl) {
 		rl = createInterface({ input: process.stdin, output: process.stdout });
-		// Ctrl-C beendet die Eingabe wie ein EOF, statt den Prozess mit offener
-		// Schnittstelle hängen zu lassen.
+		// Treat Ctrl-C like EOF so the process does not retain an open interface.
 		rl.on('SIGINT', () => rl?.close());
 	}
 	return rl;
 }
 
-/** Bricht kontrolliert ab: immer vor dem ersten Write und mit geschlossener Eingabe. */
+/** Exits cleanly before mutation and closes any interactive input. */
 function fail(message: string): never {
 	console.error(`Error: ${message}`);
 	rl?.close();
@@ -136,18 +146,250 @@ function fail(message: string): never {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function read(rel: string): string {
-	return readFileSync(join(ROOT, rel), 'utf-8');
+interface CanonicalFile {
+	rel: string;
+	path: string;
+	parent: string;
+	bytes: Buffer;
+	source: string;
+	mode: number;
 }
 
-function write(rel: string, content: string): void {
-	writeFileSync(join(ROOT, rel), content, 'utf-8');
+interface StagedFile {
+	file: CanonicalFile;
+	directory: string;
+	path: string;
+}
+
+const REAL_ROOT = realpathSync(ROOT);
+
+function isWithinRepository(path: string): boolean {
+	const fromRoot = relative(REAL_ROOT, path);
+	return (
+		fromRoot === '' ||
+		(!isAbsolute(fromRoot) && fromRoot !== '..' && !fromRoot.startsWith(`..${sep}`))
+	);
+}
+
+function inspectCanonicalFile(rel: string): CanonicalFile {
+	const path = join(ROOT, rel);
+	const parent = realpathSync(dirname(path));
+	if (!isWithinRepository(parent)) {
+		throw new Error(`Refusing ${rel}: real parent is outside the repository root`);
+	}
+
+	const stat = lstatSync(path);
+	if (!stat.isFile()) throw new Error(`Refusing ${rel}: canonical target must be a regular file`);
+	if (stat.nlink !== 1) {
+		throw new Error(`Refusing ${rel}: canonical target must have link count 1, got ${stat.nlink}`);
+	}
+	try {
+		accessSync(path, constants.W_OK);
+	} catch {
+		throw new Error(`Cannot write ${rel}; check file permissions`);
+	}
+	const bytes = readFileSync(path);
+	return { rel, path, parent, bytes, source: bytes.toString('utf-8'), mode: stat.mode & 0o7777 };
+}
+
+function inspectOptionalCanonicalFile(rel: string): CanonicalFile | undefined {
+	try {
+		return inspectCanonicalFile(rel);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+		throw error;
+	}
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function removeOwnedFile(path: string, errors: string[]): void {
+	try {
+		unlinkSync(path);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+			errors.push(`${path}: ${errorMessage(error)}`);
+		}
+	}
+}
+
+function removeOwnedDirectory(path: string, errors: string[]): void {
+	try {
+		rmdirSync(path);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+			errors.push(`${path}: ${errorMessage(error)}`);
+		}
+	}
 }
 
 /**
- * Fragt eine Eingabe ab. Liefert undefined, wenn stdin schließt (EOF, Ctrl-D,
- * Ctrl-C), damit der Aufrufer sauber abbrechen kann.
+ * Canonical files stay wholly old or new for handled synchronous failures. Process
+ * termination, ENOSPC, permission races, concurrent writers, network filesystems, and
+ * preservation of owners, ACLs, xattrs, or birthtime remain outside this contract.
  */
+function stageFile(file: CanonicalFile, content: string): StagedFile {
+	const directory = mkdtempSync(join(file.parent, `.template-setup-${basename(file.path)}-`));
+	const path = join(directory, basename(file.path));
+	try {
+		writeFileSync(path, content, { encoding: 'utf-8', flag: 'wx' });
+		chmodSync(path, file.mode);
+		return { file, directory, path };
+	} catch (error) {
+		const cleanupErrors: string[] = [];
+		removeOwnedFile(path, cleanupErrors);
+		removeOwnedDirectory(directory, cleanupErrors);
+		if (cleanupErrors.length > 0) {
+			throw new Error(
+				`${errorMessage(error)}; staging cleanup failed: ${cleanupErrors.join('; ')}`,
+				{ cause: error }
+			);
+		}
+		throw error;
+	}
+}
+
+function replaceAtomically(file: CanonicalFile, content: string): void {
+	const staged = stageFile(file, content);
+	try {
+		renameSync(staged.path, file.path);
+	} catch (error) {
+		const cleanupErrors: string[] = [];
+		removeOwnedFile(staged.path, cleanupErrors);
+		removeOwnedDirectory(staged.directory, cleanupErrors);
+		if (cleanupErrors.length > 0) {
+			throw new Error(
+				`${errorMessage(error)}; staging cleanup failed: ${cleanupErrors.join('; ')}`,
+				{ cause: error }
+			);
+		}
+		throw error;
+	}
+
+	const cleanupErrors: string[] = [];
+	removeOwnedDirectory(staged.directory, cleanupErrors);
+	if (cleanupErrors.length > 0) {
+		throw new Error(
+			`Replacement committed for ${file.rel}, but cleanup failed: ${cleanupErrors.join('; ')}`
+		);
+	}
+}
+
+function canonicalState(file: CanonicalFile): string {
+	try {
+		const bytes = readFileSync(file.path);
+		return bytes.equals(file.bytes) ? 'original' : 'changed';
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === 'ENOENT' ? 'missing' : 'unreadable';
+	}
+}
+
+function assertOriginalBytes(file: CanonicalFile): void {
+	const current = readFileSync(file.path);
+	if (!current.equals(file.bytes)) {
+		throw new Error(`Refusing to replace ${file.rel}: canonical bytes changed after preflight`);
+	}
+}
+
+type LegalPairState =
+	'PREPARED' | 'CONFIG_BACKED_UP' | 'CONFIG_INSTALLED' | 'COMMITTED' | 'RESTORED';
+
+function replaceLegalPair(
+	config: CanonicalFile,
+	configContent: string,
+	metadata: CanonicalFile,
+	metadataContent: string
+): void {
+	const stagedConfig = stageFile(config, configContent);
+	let stagedMetadata: StagedFile;
+	try {
+		stagedMetadata = stageFile(metadata, metadataContent);
+	} catch (error) {
+		const cleanupErrors: string[] = [];
+		removeOwnedFile(stagedConfig.path, cleanupErrors);
+		removeOwnedDirectory(stagedConfig.directory, cleanupErrors);
+		if (cleanupErrors.length > 0) {
+			throw new Error(
+				`${errorMessage(error)}; legal staging cleanup failed: ${cleanupErrors.join('; ')}`,
+				{ cause: error }
+			);
+		}
+		throw error;
+	}
+
+	const backupPath = join(stagedConfig.directory, `${basename(config.path)}.backup`);
+	const recoveryPath = join(stagedConfig.directory, `${basename(config.path)}.recovery`);
+	let state: LegalPairState = 'PREPARED';
+	try {
+		assertOriginalBytes(config);
+		assertOriginalBytes(metadata);
+		renameSync(config.path, backupPath);
+		state = 'CONFIG_BACKED_UP';
+		renameSync(stagedConfig.path, config.path);
+		state = 'CONFIG_INSTALLED';
+		renameSync(stagedMetadata.path, metadata.path);
+		state = 'COMMITTED';
+	} catch (error) {
+		if (state === 'CONFIG_BACKED_UP') {
+			try {
+				renameSync(backupPath, config.path);
+				state = 'RESTORED';
+			} catch (restoreError) {
+				throw new Error(
+					`Recovery required after legal pair failure: state=${state}; backup=${backupPath}; ` +
+						`recovery=${recoveryPath}; canonical config=${canonicalState(config)}; ` +
+						`canonical metadata=${canonicalState(metadata)}; operation failed: ${errorMessage(error)}; ` +
+						`restore failed: ${errorMessage(restoreError)}`,
+					{ cause: restoreError }
+				);
+			}
+		} else if (state === 'CONFIG_INSTALLED') {
+			try {
+				renameSync(config.path, recoveryPath);
+				renameSync(backupPath, config.path);
+				state = 'RESTORED';
+			} catch (restoreError) {
+				throw new Error(
+					`Recovery required after legal pair failure: state=${state}; backup=${backupPath}; ` +
+						`recovery=${recoveryPath}; canonical config=${canonicalState(config)}; ` +
+						`canonical metadata=${canonicalState(metadata)}; operation failed: ${errorMessage(error)}; ` +
+						`restore failed: ${errorMessage(restoreError)}`,
+					{ cause: restoreError }
+				);
+			}
+		}
+
+		const cleanupErrors: string[] = [];
+		removeOwnedFile(stagedConfig.path, cleanupErrors);
+		removeOwnedFile(recoveryPath, cleanupErrors);
+		removeOwnedFile(stagedMetadata.path, cleanupErrors);
+		removeOwnedDirectory(stagedConfig.directory, cleanupErrors);
+		removeOwnedDirectory(stagedMetadata.directory, cleanupErrors);
+		if (cleanupErrors.length > 0) {
+			throw new Error(
+				`${errorMessage(error)}; legal pair state=${state}; cleanup failed: ${cleanupErrors.join('; ')}`,
+				{ cause: error }
+			);
+		}
+		throw error;
+	}
+
+	const cleanupErrors: string[] = [];
+	removeOwnedFile(backupPath, cleanupErrors);
+	removeOwnedFile(stagedConfig.path, cleanupErrors);
+	removeOwnedFile(stagedMetadata.path, cleanupErrors);
+	removeOwnedDirectory(stagedConfig.directory, cleanupErrors);
+	removeOwnedDirectory(stagedMetadata.directory, cleanupErrors);
+	if (cleanupErrors.length > 0) {
+		throw new Error(
+			`Legal pair state=${state}; commit completed, but cleanup failed: ${cleanupErrors.join('; ')}`
+		);
+	}
+}
+
+/** Prompts once and returns undefined when stdin closes through EOF, Ctrl-D, or Ctrl-C. */
 function prompt(question: string, fallback: string): Promise<string | undefined> {
 	const iface = ensureReadline();
 	return new Promise((resolve) => {
@@ -164,13 +406,10 @@ function prompt(question: string, fallback: string): Promise<string | undefined>
 	});
 }
 
-/** Gibt eine Fehlermeldung zurück, wenn der Wert unbrauchbar ist, sonst undefined. */
+/** Returns a validation message for an unusable value. */
 export type Validator = (value: string) => string | undefined;
 
-/**
- * Fragt so lange erneut, bis eine gültige Antwort vorliegt. Liefert undefined,
- * wenn die Eingabe endet (EOF, Ctrl-D, Ctrl-C), damit der Aufrufer abbrechen kann.
- */
+/** Repeats a prompt until it validates, or returns undefined when input closes. */
 export async function askUntilValid(
 	ask: (question: string, fallback: string) => Promise<string | undefined>,
 	question: string,
@@ -218,14 +457,13 @@ function titleCase(slug: string): string {
 }
 
 /**
- * Bewusst enges Subset für die vorhandenen unkodierten mailto-Consumer. Plus,
- * Apostroph und Unicode-Buchstaben bleiben erlaubt; URI-Strukturzeichen und
- * kodierungspflichtige Localparts werden abgelehnt. Kein vollständiger RFC- oder
- * Zustellbarkeitsvalidator.
+ * Deliberately narrow subset for existing unencoded mailto consumers. Plus signs,
+ * apostrophes, and Unicode letters remain valid; URI separators and local parts that
+ * require encoding are rejected. This is not full RFC or deliverability validation.
  */
 const EMAIL_LOCAL_PART = /^[\p{L}\p{N}\p{M}._+'-]+$/u;
 
-/** Zerlegt und prüft die Adresse, ohne gültige Originalteile zu normalisieren. */
+/** Splits and validates the address without normalizing accepted source parts. */
 export function parseContactEmail(
 	value: string
 ): { user: string; domain: string; tld: string } | undefined {
@@ -268,25 +506,22 @@ export function parseContactEmail(
 }
 
 /**
- * Brand und Operator landen als Rohtext in den Absätzen von Privacy und Terms.
- * Ein Zeilenumbruch zerlegt dort den Absatz und kann eine zusätzliche Überschrift
- * erzeugen. Die Adresse bleibt bewusst mehrzeilig.
+ * Brand and operator values enter Privacy and Terms paragraphs as raw text. A line
+ * break would split the paragraph and can create another heading. Address stays multiline.
  */
 function singleLineValidator(label: string): Validator {
 	return (value) => (/[\r\n]/.test(value) ? `${label} must be a single line` : undefined);
 }
 
 // ---------------------------------------------------------------------------
-// Sichere Serialisierung
+// Safe serialization
 // ---------------------------------------------------------------------------
 
 const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
 /**
- * Erzeugt ein TypeScript-Stringliteral. JSON.stringify maskiert Backslashes,
- * Steuerzeichen und Zeilenumbrüche korrekt; anschließend wird auf die Quote-Wahl
- * umgestellt, die Prettier für diese Datei träfe (einfache Quotes, außer der Wert
- * enthält davon mehr als doppelte).
+ * Emits a TypeScript string literal. JSON.stringify escapes backslashes, control
+ * characters, and line breaks before matching Prettier's quote preference for this file.
  */
 export function tsStringLiteral(value: string): string {
 	const singleQuotes = value.split("'").length - 1;
@@ -305,11 +540,7 @@ function tsKey(key: string): string {
 	return IDENTIFIER.test(key) ? key : tsStringLiteral(key);
 }
 
-/**
- * Serialisiert die Einstellungen als TypeScript-Objektliteral. Zusätzliche
- * Schlüssel eines Forks bleiben erhalten, weil über die tatsächlichen Einträge
- * iteriert wird.
- */
+/** Serializes supported values as a TypeScript object while preserving fork-owned keys. */
 export function serializeConfigValue(value: unknown, indent: string): string {
 	if (typeof value === 'string') return tsStringLiteral(value);
 	if (typeof value === 'number' || typeof value === 'boolean') return String(value);
@@ -328,55 +559,240 @@ export function serializeConfigValue(value: unknown, indent: string): string {
 	throw new Error(`Unsupported LEGAL_CONFIG value of type ${typeof value}`);
 }
 
-function legalConfigBlockPattern(): RegExp {
-	return /^export const LEGAL_CONFIG = \{[\s\S]*?^\} as const;$/gm;
+function maskTypeScriptTopLevelCode(source: string): string {
+	const masked = source.split('');
+	const mask = (index: number): void => {
+		if (source[index] !== '\n' && source[index] !== '\r') masked[index] = ' ';
+	};
+
+	function consumeQuoted(index: number, quote: "'" | '"'): number {
+		mask(index++);
+		while (index < source.length) {
+			if (source[index] === '\\') {
+				mask(index++);
+				if (index >= source.length) break;
+				mask(index++);
+				continue;
+			}
+			if (source[index] === quote) {
+				mask(index++);
+				return index;
+			}
+			if (source[index] === '\n' || source[index] === '\r') {
+				throw new Error('Unsupported unterminated string in src/lib/config/legal.ts');
+			}
+			mask(index++);
+		}
+		throw new Error('Unsupported unterminated string in src/lib/config/legal.ts');
+	}
+
+	function consumeLineComment(index: number): number {
+		mask(index++);
+		mask(index++);
+		while (index < source.length && source[index] !== '\n' && source[index] !== '\r') {
+			mask(index++);
+		}
+		return index;
+	}
+
+	function consumeBlockComment(index: number): number {
+		mask(index++);
+		mask(index++);
+		while (index < source.length) {
+			if (source[index] === '*' && source[index + 1] === '/') {
+				mask(index++);
+				mask(index++);
+				return index;
+			}
+			mask(index++);
+		}
+		throw new Error('Unsupported unterminated block comment in src/lib/config/legal.ts');
+	}
+
+	function consumeTemplateInterpolation(index: number): number {
+		let depth = 1;
+		while (index < source.length) {
+			const char = source[index];
+			const next = source[index + 1];
+			if (char === "'" || char === '"') {
+				index = consumeQuoted(index, char);
+				continue;
+			}
+			if (char === '`') {
+				index = consumeTemplate(index);
+				continue;
+			}
+			if (char === '/' && next === '/') {
+				index = consumeLineComment(index);
+				continue;
+			}
+			if (char === '/' && next === '*') {
+				index = consumeBlockComment(index);
+				continue;
+			}
+			if (char === '/') {
+				throw new Error('Unsupported slash syntax in template interpolation in legal.ts');
+			}
+			if (char === '{') depth += 1;
+			if (char === '}') {
+				depth -= 1;
+				mask(index++);
+				if (depth === 0) return index;
+				continue;
+			}
+			mask(index++);
+		}
+		throw new Error('Unsupported unterminated template interpolation in legal.ts');
+	}
+
+	function consumeTemplate(index: number): number {
+		mask(index++);
+		while (index < source.length) {
+			if (source[index] === '\\') {
+				mask(index++);
+				if (index >= source.length) break;
+				mask(index++);
+				continue;
+			}
+			if (source[index] === '`') {
+				mask(index++);
+				return index;
+			}
+			if (source[index] === '$' && source[index + 1] === '{') {
+				mask(index++);
+				mask(index++);
+				index = consumeTemplateInterpolation(index);
+				continue;
+			}
+			mask(index++);
+		}
+		throw new Error('Unsupported unterminated template in src/lib/config/legal.ts');
+	}
+
+	let index = 0;
+	while (index < source.length) {
+		const char = source[index];
+		const next = source[index + 1];
+		if (char === "'" || char === '"') {
+			index = consumeQuoted(index, char);
+			continue;
+		}
+		if (char === '`') {
+			index = consumeTemplate(index);
+			continue;
+		}
+		if (char === '/' && next === '/') {
+			index = consumeLineComment(index);
+			continue;
+		}
+		if (char === '/' && next === '*') {
+			index = consumeBlockComment(index);
+			continue;
+		}
+		if (char === '/') {
+			throw new Error('Unsupported slash syntax in src/lib/config/legal.ts');
+		}
+		index += 1;
+	}
+	return masked.join('');
 }
 
-/**
- * Ersetzt den eindeutigen LEGAL_CONFIG-Exportblock. Die Hilfsfunktionen und alle
- * übrigen Dateiinhalte bleiben unberührt.
- */
-export function replaceLegalConfigSource(source: string, config: Record<string, unknown>): string {
-	const matches = source.match(legalConfigBlockPattern());
-	if (matches?.length !== 1) {
+interface LegalConfigSourceMatch {
+	start: number;
+	end: number;
+}
+
+function findLegalConfigSource(source: string): LegalConfigSourceMatch {
+	const masked = maskTypeScriptTopLevelCode(source);
+	const topLevel = new Set<number>();
+	let braceDepth = 0;
+	let bracketDepth = 0;
+	let parenthesisDepth = 0;
+	for (let index = 0; index < masked.length; index += 1) {
+		if (braceDepth === 0 && bracketDepth === 0 && parenthesisDepth === 0) topLevel.add(index);
+		if (masked[index] === '{') braceDepth += 1;
+		else if (masked[index] === '}') braceDepth -= 1;
+		else if (masked[index] === '[') bracketDepth += 1;
+		else if (masked[index] === ']') bracketDepth -= 1;
+		else if (masked[index] === '(') parenthesisDepth += 1;
+		else if (masked[index] === ')') parenthesisDepth -= 1;
+		if (braceDepth < 0 || bracketDepth < 0 || parenthesisDepth < 0) {
+			throw new Error('Unsupported unbalanced syntax in src/lib/config/legal.ts');
+		}
+	}
+	if (braceDepth !== 0 || bracketDepth !== 0 || parenthesisDepth !== 0) {
+		throw new Error('Unsupported unbalanced syntax in src/lib/config/legal.ts');
+	}
+
+	const declarations = [...masked.matchAll(/\bexport\s+const\s+LEGAL_CONFIG\b/g)].filter(
+		(match) => match.index !== undefined && topLevel.has(match.index)
+	);
+	if (declarations.length !== 1) {
 		throw new Error(
-			`Expected exactly one LEGAL_CONFIG block in src/lib/config/legal.ts, found ${matches?.length ?? 0}`
+			`Expected exactly one LEGAL_CONFIG export in src/lib/config/legal.ts, found ${declarations.length}`
 		);
 	}
+
+	const declaration = declarations[0]!;
+	let cursor = declaration.index + declaration[0].length;
+	while (/\s/.test(masked[cursor] ?? '')) cursor += 1;
+	if (masked[cursor++] !== '=') {
+		throw new Error('LEGAL_CONFIG must use a direct object initializer followed by as const;');
+	}
+	while (/\s/.test(masked[cursor] ?? '')) cursor += 1;
+	if (masked[cursor] !== '{') {
+		throw new Error('LEGAL_CONFIG must use a direct object initializer followed by as const;');
+	}
+
+	let objectDepth = 1;
+	let close = cursor + 1;
+	for (; close < masked.length; close += 1) {
+		if (masked[close] === '{') objectDepth += 1;
+		if (masked[close] === '}') {
+			objectDepth -= 1;
+			if (objectDepth === 0) break;
+		}
+	}
+	if (objectDepth !== 0) throw new Error('Could not find the end of LEGAL_CONFIG');
+
+	const suffix = /^\s+as\s+const\s*;/.exec(masked.slice(close + 1));
+	if (!suffix) {
+		throw new Error('LEGAL_CONFIG must use a direct object initializer followed by as const;');
+	}
+	return { start: declaration.index, end: close + 1 + suffix[0].length };
+}
+
+/** Replaces the one supported top-level LEGAL_CONFIG initializer. */
+export function replaceLegalConfigSource(source: string, config: Record<string, unknown>): string {
+	const match = findLegalConfigSource(source);
 	const block = `export const LEGAL_CONFIG = ${serializeConfigValue(config, '')} as const;`;
-	// Replacement-Callback: $&, $1 und $` in Branding-Werten dürfen nicht als
-	// Ersetzungsmuster interpretiert werden.
-	return source.replace(legalConfigBlockPattern(), () => block);
+	return source.slice(0, match.start) + block + source.slice(match.end);
 }
 
 // ---------------------------------------------------------------------------
 // Detect current values (for re-run defaults)
 // ---------------------------------------------------------------------------
 
-function currentSlug(): string {
-	const pkg = JSON.parse(read('package.json'));
+function currentSlug(source: string): string {
+	const pkg = JSON.parse(source);
 	return pkg.name ?? TEMPLATE_SLUG;
 }
 
-function currentRepo(): string {
-	return findGithubSlugProperty(read('src/lib/config/site.ts')).value;
+function currentRepo(source: string): string {
+	return findGithubSlugProperty(source).value;
 }
 
-/**
- * Liest die rechtlichen Defaults aus dem reinen Modul statt per Regex. Ist die
- * Datei beschädigt, scheitert der Import hier — vor jedem Write.
- */
-async function readLegalConfig(): Promise<Record<string, unknown>> {
-	const modulePath = join(ROOT, 'src/lib/config/legal.ts');
-	const imported = (await import(pathToFileURL(modulePath).href)) as {
+/** Reads legal defaults from the real module and validates the supported data shape. */
+async function readLegalConfig(file: CanonicalFile): Promise<Record<string, unknown>> {
+	const imported = (await import(pathToFileURL(file.path).href)) as {
 		LEGAL_CONFIG?: unknown;
 	};
+	assertOriginalBytes(file);
 	const config = imported.LEGAL_CONFIG;
 	if (config === null || typeof config !== 'object' || Array.isArray(config)) {
 		throw new Error('Could not read LEGAL_CONFIG from src/lib/config/legal.ts');
 	}
-	// Vor structuredClone prüfen: Klasseninstanzen und Null-Prototyp-Objekte würden
-	// dort zu gewöhnlichen Objekten und könnten anschließend unbemerkt Daten verlieren.
+	// Validate before structuredClone can normalize class instances or null-prototype objects.
 	serializeConfigValue(config, '');
 	return structuredClone(config) as Record<string, unknown>;
 }
@@ -386,7 +802,7 @@ function readString(source: Record<string, unknown>, key: string): string {
 	return typeof value === 'string' ? value : '';
 }
 
-/** Unterscheidet einen vorhandenen (auch leeren) String von einem fehlenden Schlüssel. */
+/** Distinguishes an existing string, including empty, from a missing key. */
 function readOptionalString(source: Record<string, unknown>, key: string): string | undefined {
 	const value = source[key];
 	return typeof value === 'string' ? value : undefined;
@@ -434,9 +850,8 @@ interface GithubSlugMatch {
 }
 
 /**
- * Blendet Kommentare sowie String- und Template-Inhalte aus, behält aber Länge,
- * Zeilenumbrüche und Literalgrenzen. Damit lassen sich die wenigen benötigten
- * Strukturanker bestimmen, ohne beliebige TypeScript-Syntax zu interpretieren.
+ * Masks comments, strings, and template contents while retaining offsets and line
+ * breaks. The remaining code supports the few required anchors without parsing TypeScript.
  */
 function maskTypeScriptNonCode(source: string): string {
 	const masked = source.split('');
@@ -715,19 +1130,218 @@ export function updateLegalContentDatesSource(
 // README, wrangler, lockfile
 // ---------------------------------------------------------------------------
 
-/**
- * Maskiert Zeichen, die den Markennamen in einer Markdown-Überschrift anders rendern
- * würden. `&` gehört dazu, weil `&copy;` sonst als Entity ankommt, `#` wegen der
- * schließenden Zeichenfolge einer ATX-Überschrift.
- */
+/** Escapes characters that would change the literal rendering of a Markdown heading. */
 export function escapeMarkdownInline(value: string): string {
 	return value.replace(/[\\`*_[\]<>&#~]/g, (char) => `\\${char}`);
+}
+
+interface MarkdownLine {
+	start: number;
+	end: number;
+	fullEnd: number;
+	content: string;
+	lineBreak: '' | '\n' | '\r\n';
+}
+
+interface MarkdownFence {
+	openLine: number;
+	closeLine: number;
+	marker: '`' | '~';
+	length: number;
+	info: string;
+}
+
+interface MarkdownHeading {
+	line: number;
+	level: number;
+	text: string;
+}
+
+interface QuickStartCandidate {
+	cloneLine: MarkdownLine;
+	directoryLine: MarkdownLine;
+	clone: string;
+	directory: string;
+}
+
+interface ReadmeStructure {
+	lines: MarkdownLine[];
+	fences: MarkdownFence[];
+	headings: MarkdownHeading[];
+	candidate: QuickStartCandidate;
+}
+
+function markdownLines(source: string): MarkdownLine[] {
+	const lines: MarkdownLine[] = [];
+	let start = 0;
+	while (start < source.length) {
+		const lf = source.indexOf('\n', start);
+		if (lf === -1) {
+			lines.push({
+				start,
+				end: source.length,
+				fullEnd: source.length,
+				content: source.slice(start),
+				lineBreak: ''
+			});
+			return lines;
+		}
+		const crlf = lf > start && source[lf - 1] === '\r';
+		const end = crlf ? lf - 1 : lf;
+		lines.push({
+			start,
+			end,
+			fullEnd: lf + 1,
+			content: source.slice(start, end),
+			lineBreak: crlf ? '\r\n' : '\n'
+		});
+		start = lf + 1;
+	}
+	if (source === '' || source.endsWith('\n')) {
+		lines.push({ start, end: start, fullEnd: start, content: '', lineBreak: '' });
+	}
+	return lines;
+}
+
+function openingFence(
+	line: string
+): { marker: '`' | '~'; length: number; info: string } | undefined {
+	const match = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+	if (!match) return undefined;
+	const marker = match[1]![0] as '`' | '~';
+	const info = match[2]!.trim();
+	if (marker === '`' && info.includes('`')) return undefined;
+	return { marker, length: match[1]!.length, info };
+}
+
+function closesFence(line: string, fence: { marker: '`' | '~'; length: number }): boolean {
+	const match = /^ {0,3}(`+|~+)[ \t]*$/.exec(line);
+	return !!match && match[1]![0] === fence.marker && match[1]!.length >= fence.length;
+}
+
+function markdownHeading(line: string): { level: number; text: string } | undefined {
+	const match = /^ {0,3}(#{1,6})(?:[ \t]+(.*)|[ \t]*)$/.exec(line);
+	if (!match) return undefined;
+	const text = (match[2] ?? '').replace(/[ \t]+#+[ \t]*$/, '').trim();
+	return { level: match[1]!.length, text };
+}
+
+function installationCandidate(lines: MarkdownLine[]): QuickStartCandidate | undefined {
+	if (
+		lines.length !== 4 ||
+		lines[2]!.content !== 'bun install' ||
+		lines[3]!.content !== 'bun run dev'
+	) {
+		return undefined;
+	}
+	const clone = lines[0]!.content;
+	const directory = lines[1]!.content;
+	const git = /^git clone https:\/\/github\.com\/[A-Za-z0-9-]+\/([A-Za-z0-9._-]+)\.git$/.exec(
+		clone
+	);
+	if (git) {
+		const expected = git[1]!;
+		if (directory !== `cd ${expected}` && directory !== `cd ./${expected}`) return undefined;
+		return { cloneLine: lines[0]!, directoryLine: lines[1]!, clone, directory };
+	}
+	const bootstrap =
+		/^gh repo create ([A-Za-z0-9._-]+) --template [A-Za-z0-9-]+\/[A-Za-z0-9._-]+ --clone$/.exec(
+			clone
+		);
+	if (!bootstrap || (directory !== `cd ${bootstrap[1]}` && directory !== `cd ./${bootstrap[1]}`)) {
+		return undefined;
+	}
+	return { cloneLine: lines[0]!, directoryLine: lines[1]!, clone, directory };
+}
+
+function findReadmeStructure(source: string): ReadmeStructure {
+	const lines = markdownLines(source);
+	const fences: MarkdownFence[] = [];
+	const headings: MarkdownHeading[] = [];
+	let open: { line: number; marker: '`' | '~'; length: number; info: string } | undefined;
+	for (let index = 0; index < lines.length; index += 1) {
+		const content = lines[index]!.content;
+		if (open) {
+			if (closesFence(content, open)) {
+				fences.push({
+					openLine: open.line,
+					closeLine: index,
+					marker: open.marker,
+					length: open.length,
+					info: open.info
+				});
+				open = undefined;
+			}
+			continue;
+		}
+		const fence = openingFence(content);
+		if (fence) {
+			open = { line: index, ...fence };
+			continue;
+		}
+		const heading = markdownHeading(content);
+		if (heading) headings.push({ line: index, ...heading });
+	}
+	if (open) throw new Error('README.md contains an unterminated fenced code block');
+
+	const quickStarts = headings.filter(({ level, text }) => level === 2 && text === 'Quick Start');
+	if (quickStarts.length !== 1) {
+		throw new Error(
+			`Expected exactly one Quick Start H2 in README.md, found ${quickStarts.length}`
+		);
+	}
+	const quickStart = quickStarts[0]!;
+	const nextSection = headings.find(
+		({ line, level }) => line > quickStart.line && (level === 1 || level === 2)
+	);
+	const sectionEnd = nextSection?.line ?? lines.length;
+	const candidates = fences
+		.filter(
+			({ openLine, closeLine, info }) =>
+				openLine > quickStart.line && closeLine < sectionEnd && info.toLowerCase() === 'bash'
+		)
+		.map(({ openLine, closeLine }) => installationCandidate(lines.slice(openLine + 1, closeLine)))
+		.filter((candidate): candidate is QuickStartCandidate => candidate !== undefined);
+	if (candidates.length !== 1) {
+		throw new Error(
+			`Expected exactly one Quick Start installation candidate in README.md, found ${candidates.length}`
+		);
+	}
+	const candidate = candidates[0]!;
+	const cloneLine = lines.indexOf(candidate.cloneLine);
+	const candidateLineBreaks = new Set(
+		lines
+			.slice(cloneLine - 1, cloneLine + 5)
+			.map(({ lineBreak }) => lineBreak)
+			.filter((lineBreak) => lineBreak !== '')
+	);
+	if (candidateLineBreaks.size > 1) throw new Error('Quick Start contains mixed line endings');
+	return { lines, fences, headings, candidate };
+}
+
+function repositoryUrlBoundary(source: string, end: number): boolean {
+	const next = source[end];
+	if (next === undefined) return true;
+	if (source.startsWith('.git', end)) {
+		const afterGit = source[end + 4];
+		if (afterGit === '.') {
+			const afterPeriod = source[end + 5];
+			return afterPeriod === undefined || /\s/.test(afterPeriod);
+		}
+		return afterGit === undefined || !/[A-Za-z0-9._-]/.test(afterGit);
+	}
+	if (next === '.') {
+		const afterPeriod = source[end + 1];
+		return afterPeriod === undefined || /\s/.test(afterPeriod);
+	}
+	return !/[A-Za-z0-9._-]/.test(next);
 }
 
 function replaceGithubRepositoryUrls(
 	source: string,
 	oldGithubUrl: string,
-	githubUrl: string
+	githubUrl: string,
+	excluded: Array<{ start: number; end: number }>
 ): string {
 	let updated = '';
 	let cursor = 0;
@@ -735,99 +1349,75 @@ function replaceGithubRepositoryUrls(
 		const start = source.indexOf(oldGithubUrl, cursor);
 		if (start === -1) return updated + source.slice(cursor);
 		const end = start + oldGithubUrl.length;
-		const next = source[end];
-		const gitSuffix = source.startsWith('.git', end);
-		const afterGit = gitSuffix ? source[end + '.git'.length] : undefined;
-		const isBoundary =
-			next === undefined ||
-			!/[A-Za-z0-9._-]/.test(next) ||
-			(gitSuffix && (afterGit === undefined || !/[A-Za-z0-9._-]/.test(afterGit)));
-
+		const protectedRange = excluded.some((range) => start >= range.start && start < range.end);
 		updated += source.slice(cursor, start);
-		updated += isBoundary ? githubUrl : oldGithubUrl;
+		updated += !protectedRange && repositoryUrlBoundary(source, end) ? githubUrl : oldGithubUrl;
 		cursor = end;
 	}
 }
 
-/**
- * Repariert Überschrift, Demo-Absatz und Quick Start. Der Quick Start erklärt danach
- * die Einrichtung des erzeugten Projekts statt der Template-Erzeugung. Der Aufruf ist
- * idempotent: die bereits erzeugte Form wird erneut erkannt.
- */
+/** Updates the heading, template demo paragraph, repository URLs, and exact Quick Start candidate. */
 export function replaceReadmeSource(
 	source: string,
 	options: { brand: string; repository: string; oldGithubUrl: string; githubUrl: string }
 ): string {
 	const { brand, repository, oldGithubUrl, githubUrl } = options;
 	const repositoryBasename = repository.split('/')[1]!;
-
-	// Zuerst die Repository-Links, damit der danach erzeugte Quick-Start-Block nicht
-	// noch einmal umgeschrieben wird.
+	const structure = findReadmeStructure(source);
+	const { cloneLine, directoryLine } = structure.candidate;
 	let updated =
-		oldGithubUrl === githubUrl
-			? source
-			: replaceGithubRepositoryUrls(source, oldGithubUrl, githubUrl);
+		source.slice(0, cloneLine.start) +
+		`git clone ${githubUrl}.git${cloneLine.lineBreak}cd ./${repositoryBasename}` +
+		source.slice(directoryLine.end);
 
-	const heading = /^# .+$/m;
-	if (!heading.test(updated)) {
-		throw new Error('Could not find the top-level heading in README.md');
+	if (oldGithubUrl !== githubUrl) {
+		const updatedStructure = findReadmeStructure(updated);
+		const excluded = updatedStructure.fences.map(({ openLine, closeLine }) => ({
+			start: updatedStructure.lines[openLine]!.start,
+			end: updatedStructure.lines[closeLine]!.fullEnd
+		}));
+		updated = replaceGithubRepositoryUrls(updated, oldGithubUrl, githubUrl, excluded);
 	}
-	updated = updated.replace(heading, () => `# ${escapeMarkdownInline(brand)}`);
-
-	// Der Demo-Absatz gehört zum Template und fehlt nach dem ersten Lauf.
 	updated = updated.replace(liveDemoParagraphPattern(), () => '');
 
-	const cloneMatches = updated.match(cloneBlockPattern());
-	if (cloneMatches?.length !== 1) {
-		throw new Error(
-			`Expected exactly one quick start clone block in README.md, found ${cloneMatches?.length ?? 0}`
-		);
-	}
-	updated = updated.replace(
-		cloneBlockPattern(),
-		// Das gelesene Zeilenende zurückschreiben, damit eine CRLF-Datei CRLF bleibt.
-		(_match, lineBreak: string) =>
-			`git clone ${githubUrl}.git${lineBreak}cd ./${repositoryBasename}`
-	);
-
+	const finalStructure = findReadmeStructure(updated);
+	const heading = finalStructure.headings.find(({ level }) => level === 1);
+	if (!heading) throw new Error('Could not find the top-level heading in README.md');
+	const headingLine = finalStructure.lines[heading.line]!;
+	updated =
+		updated.slice(0, headingLine.start) +
+		`# ${escapeMarkdownInline(brand)}` +
+		updated.slice(headingLine.end);
 	return updated;
-}
-
-/**
- * Der Quick-Start-Klonblock. Das Zeilenende wird mitgelesen, damit eine Datei mit
- * CRLF unverändert bleibt.
- */
-function cloneBlockPattern(): RegExp {
-	return /^(?:gh repo create [^\r\n]*|git clone https:\/\/github\.com\/[^\r\n]*)(\r?\n)cd [^\r\n]*$/gm;
 }
 
 function liveDemoParagraphPattern(): RegExp {
 	return /^> \[Live demo!\][^\r\n]*(?:\r?\n){2}/m;
 }
 
-/**
- * Reports whether the README has the complete generated state for the current
- * repository and legal brand. Manually produced consistent states remain valid.
- */
+/** Reports whether the README carries the generated identity in the exact Quick Start section. */
 export function readmeShowsCompletedSetup(
 	source: string,
 	repository: string,
 	brand: string
 ): boolean {
-	const matches = source.match(cloneBlockPattern());
-	if (matches?.length !== 1) return false;
+	let structure: ReadmeStructure;
+	try {
+		structure = findReadmeStructure(source);
+	} catch {
+		return false;
+	}
 	const repositoryBasename = repository.split('/')[1];
 	if (!repositoryBasename) return false;
-	const [cloneLine, directoryLine] = matches[0]!.split(/\r?\n/);
+	const { clone, directory } = structure.candidate;
 	if (
-		cloneLine !== `git clone https://github.com/${repository}.git` ||
-		(directoryLine !== `cd ${repositoryBasename}` && directoryLine !== `cd ./${repositoryBasename}`)
+		clone !== `git clone https://github.com/${repository}.git` ||
+		(directory !== `cd ${repositoryBasename}` && directory !== `cd ./${repositoryBasename}`)
 	) {
 		return false;
 	}
-
-	const heading = /^# .+$/m.exec(source)?.[0];
-	return heading === `# ${escapeMarkdownInline(brand)}` && !liveDemoParagraphPattern().test(source);
+	const heading = structure.headings.find(({ level }) => level === 1);
+	return heading?.text === escapeMarkdownInline(brand) && !liveDemoParagraphPattern().test(source);
 }
 
 function maskTomlNonCode(source: string): string {
@@ -897,10 +1487,7 @@ export function replaceWranglerNameSource(source: string, slug: string): string 
 	return source.slice(0, literalStart) + JSON.stringify(slug) + source.slice(literalEnd);
 }
 
-/**
- * Synchronisiert allein den Root-Namen im Lockfile. Dependency-Einträge und
- * Versionen bleiben bytegleich; der Abhängigkeitsgraph wird nicht neu berechnet.
- */
+/** Synchronizes only the lockfile root name without recalculating dependencies. */
 export function replaceLockRootNameSource(source: string, slug: string): string {
 	const pattern = /("workspaces"\s*:\s*\{\s*""\s*:\s*\{\s*"name"\s*:\s*)"(?:[^"\\]|\\.)*"/g;
 	const matches = source.match(pattern);
@@ -929,16 +1516,33 @@ async function main() {
 		email: emailFlag
 	} = readFlags();
 
-	const legalConfig = await readLegalConfig().catch((error: unknown) =>
-		fail(error instanceof Error ? error.message : String(error))
+	let packageFile: CanonicalFile;
+	let lockFile: CanonicalFile | undefined;
+	let wranglerFile: CanonicalFile;
+	let readmeFile: CanonicalFile;
+	let siteFile: CanonicalFile;
+	let legalConfigFile: CanonicalFile;
+	let legalMetadataFile: CanonicalFile;
+	try {
+		packageFile = inspectCanonicalFile('package.json');
+		lockFile = inspectOptionalCanonicalFile('bun.lock');
+		wranglerFile = inspectCanonicalFile('wrangler.toml');
+		readmeFile = inspectCanonicalFile('README.md');
+		siteFile = inspectCanonicalFile('src/lib/config/site.ts');
+		legalConfigFile = inspectCanonicalFile('src/lib/config/legal.ts');
+		legalMetadataFile = inspectCanonicalFile('src/lib/content/legal-metadata.ts');
+	} catch (error) {
+		fail(errorMessage(error));
+	}
+
+	const legalConfig = await readLegalConfig(legalConfigFile).catch((error: unknown) =>
+		fail(errorMessage(error))
 	);
 	const legalEmail = (legalConfig.email ?? {}) as Record<string, unknown>;
-
-	const oldSlug = currentSlug();
-	const oldRepo = currentRepo();
+	const oldSlug = currentSlug(packageFile.source);
+	const oldRepo = currentRepo(siteFile.source);
 	const oldBrand = readString(legalConfig, 'brandName');
-	// Ein vorhandener Wert bleibt erhalten, auch der leere String; nur ein wirklich
-	// fehlender Schlüssel bekommt den abgeleiteten Vorschlag.
+	// Preserve an existing string, including an empty one. Only a missing key gets a suggestion.
 	const oldCompany = readOptionalString(legalConfig, 'companyName');
 	const oldOperator = readString(legalConfig, 'operatorName');
 	const oldAddress = readString(legalConfig, 'address');
@@ -947,21 +1551,11 @@ async function main() {
 	const oldTld = readString(legalEmail, 'tld');
 	const oldEmail = oldUser && oldDomain && oldTld ? `${oldUser}@${oldDomain}.${oldTld}` : '';
 
-	let readmeSource: string;
-	try {
-		readmeSource = read('README.md');
-	} catch (error) {
-		fail(error instanceof Error ? error.message : String(error));
-	}
-
-	// Der Markenname darf legitim 'SaaS Starter' lauten, und ein von Hand geänderter
-	// Package-Name beweist keine Einrichtung. Maßgeblich ist der konsistente README-
-	// Endzustand für dieses Repository und die aktuelle rechtliche Marke.
-	const alreadySetUp = readmeShowsCompletedSetup(readmeSource, oldRepo, oldBrand);
+	// A chosen template brand and hand-edited package name are valid only with a complete README state.
+	const alreadySetUp = readmeShowsCompletedSetup(readmeFile.source, oldRepo, oldBrand);
 
 	if (!interactive && !alreadySetUp) {
-		// Solange der Quick Start die Bootstrapform trägt, sind die drei Kernwerte Pflicht.
-		// Danach ist nichts mehr Pflicht, auch ein bewusst beibehaltener Template-Slug nicht.
+		// The three core values remain required until Quick Start carries the generated form.
 		const missing: string[] = [];
 		if (!slugFlag && oldSlug === TEMPLATE_SLUG) missing.push('--slug');
 		if (!repoFlag && oldRepo === TEMPLATE_REPOSITORY) missing.push('--repo');
@@ -996,8 +1590,7 @@ async function main() {
 	const brand = await resolveValue(
 		brandFlag,
 		'Brand name (display name)',
-		// titleCase nur als Vorschlag für das unberührte Template, nie als Ersatz für
-		// einen bereits gewählten Namen.
+		// Use titleCase only as a suggestion for the untouched template identity.
 		!alreadySetUp && (oldBrand === '' || oldBrand === TEMPLATE_BRAND) ? titleCase(slug) : oldBrand,
 		(value) =>
 			value.trim() === '' ? 'brand must not be empty' : singleLineValidator('brand')(value)
@@ -1043,17 +1636,13 @@ async function main() {
 		address !== oldAddress ||
 		email !== oldEmail;
 
-	// Alle nächsten Dateiinhalte vor dem ersten Write berechnen. Ein fehlender oder
-	// mehrdeutiger Anker scheitert damit, bevor irgendetwas auf der Platte steht.
+	// Compute every next canonical value before creating a staging directory.
 	const nextLegalConfig = { ...legalConfig };
 	nextLegalConfig.brandName = brand;
 	nextLegalConfig.companyName = company;
 	nextLegalConfig.operatorName = operator;
 	nextLegalConfig.address = address;
 	nextLegalConfig.email = { ...legalEmail, user: emailUser, domain: emailDomain, tld: emailTld };
-
-	const lockPath = join(ROOT, 'bun.lock');
-	const hasLock = existsSync(lockPath);
 
 	let nextPackageJson: string;
 	let nextWrangler: string;
@@ -1063,77 +1652,54 @@ async function main() {
 	let nextLegalSource: string;
 	let nextLock: string | undefined;
 	try {
-		const pkg = JSON.parse(read('package.json'));
+		const pkg = JSON.parse(packageFile.source);
 		pkg.name = slug;
 		pkg.author = operator;
 		nextPackageJson = JSON.stringify(pkg, null, '\t') + '\n';
-		nextWrangler = replaceWranglerNameSource(read('wrangler.toml'), slug);
-		nextReadme = replaceReadmeSource(readmeSource, {
+		nextWrangler = replaceWranglerNameSource(wranglerFile.source, slug);
+		nextReadme = replaceReadmeSource(readmeFile.source, {
 			brand,
 			repository: repo,
 			oldGithubUrl,
 			githubUrl
 		});
-		nextSiteConfig = replaceGithubSlugSource(read('src/lib/config/site.ts'), repo);
+		nextSiteConfig = replaceGithubSlugSource(siteFile.source, repo);
 		nextLegalMetadata = updateLegalContentDatesSource(
-			read('src/lib/content/legal-metadata.ts'),
+			legalMetadataFile.source,
 			setupDate,
 			legalIdentityChanged
 		);
-		nextLegalSource = replaceLegalConfigSource(read('src/lib/config/legal.ts'), nextLegalConfig);
-		nextLock = hasLock ? replaceLockRootNameSource(read('bun.lock'), slug) : undefined;
-		// Erst wenn alle Inhalte stehen, prüfen, ob jede vorgesehene Datei beschreibbar
-		// ist. Sonst schreibt der Lauf die ersten Dateien und scheitert an einer späteren.
-		// Das deckt die schreibgeschützte Datei ab; eine Rechteänderung nach dieser
-		// Prüfung, ein voller Datenträger und ein Prozessabbruch bleiben außerhalb.
-		for (const rel of [
-			'package.json',
-			...(hasLock ? ['bun.lock'] : []),
-			'wrangler.toml',
-			'README.md',
-			'src/lib/config/site.ts',
-			'src/lib/content/legal-metadata.ts',
-			'src/lib/config/legal.ts'
-		]) {
-			try {
-				accessSync(join(ROOT, rel), constants.W_OK);
-			} catch {
-				throw new Error(`Cannot write ${rel}; check file permissions`);
-			}
-		}
+		nextLegalSource = replaceLegalConfigSource(legalConfigFile.source, nextLegalConfig);
+		nextLock = lockFile ? replaceLockRootNameSource(lockFile.source, slug) : undefined;
 	} catch (error) {
-		fail(error instanceof Error ? error.message : String(error));
+		fail(errorMessage(error));
 	}
 
 	console.log(`\nApplying: slug=${slug}, repo=${repo}, brand="${brand}"\n`);
 
-	write('package.json', nextPackageJson);
-	console.log('  ✓ package.json');
-
-	if (nextLock !== undefined) {
-		write('bun.lock', nextLock);
-		console.log('  ✓ bun.lock (root name)');
-	}
-
-	write('wrangler.toml', nextWrangler);
-	console.log('  ✓ wrangler.toml');
-
-	write('src/lib/content/legal-metadata.ts', nextLegalMetadata);
+	replaceLegalPair(legalConfigFile, nextLegalSource, legalMetadataFile, nextLegalMetadata);
+	console.log('  ✓ legal.ts');
 	console.log(
 		legalIdentityChanged
 			? `  ✓ legal-metadata.ts (Last Updated: ${setupDate})`
 			: '  ✓ legal-metadata.ts (unchanged)'
 	);
 
-	// Legal config — single source of truth for brand identity
-	write('src/lib/config/legal.ts', nextLegalSource);
-	console.log('  ✓ legal.ts');
+	replaceAtomically(packageFile, nextPackageJson);
+	console.log('  ✓ package.json');
 
-	write('README.md', nextReadme);
+	if (lockFile && nextLock !== undefined) {
+		replaceAtomically(lockFile, nextLock);
+		console.log('  ✓ bun.lock (root name)');
+	}
+
+	replaceAtomically(wranglerFile, nextWrangler);
+	console.log('  ✓ wrangler.toml');
+
+	replaceAtomically(readmeFile, nextReadme);
 	console.log('  ✓ README.md');
 
-	// Site config — single source for runtime repository links
-	write('src/lib/config/site.ts', nextSiteConfig);
+	replaceAtomically(siteFile, nextSiteConfig);
 	console.log('  ✓ site.ts');
 
 	console.log('\n✅ Done! Next steps:');

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -413,6 +413,7 @@ export function isValidGithubRepository(value: string): boolean {
 		!owner.endsWith('-') &&
 		!owner.includes('--') &&
 		!['.', '..'].includes(repository) &&
+		!repository.endsWith('.') &&
 		!repository.toLowerCase().endsWith('.git') &&
 		// The generated clone directory must remain portable across ordinary Win32 filesystems.
 		!hasReservedWindowsDeviceBasename(value)
@@ -585,17 +586,119 @@ export function replaceGithubSlugSource(source: string, value: string): string {
 	return source.slice(0, match.start) + replacement + source.slice(match.end);
 }
 
-export function replaceLegalContentDatesSource(source: string, value: string): string {
-	if (!isIsoCalendarDate(value)) throw new Error(`Invalid legal content date: ${value}`);
-	let replacements = 0;
-	const updated = source.replace(/(privacy|terms|impressum): '[^']+'/g, (_match, key: string) => {
-		replacements += 1;
-		return `${key}: '${value}'`;
-	});
-	if (replacements !== 3) {
+interface LegalContentDateMatch {
+	start: number;
+	end: number;
+	quote: "'" | '"';
+}
+
+function findLegalContentDateProperties(source: string): LegalContentDateMatch[] {
+	const masked = maskTypeScriptNonCode(source);
+	const initializers = [
+		...masked.matchAll(/^export[ \t]+const[ \t]+LEGAL_CONTENT_DATES[ \t]*=[ \t]*\{/gm)
+	];
+	if (initializers.length !== 1) {
 		throw new Error('Could not update every date in src/lib/content/legal-metadata.ts');
 	}
-	return updated;
+
+	const initializer = initializers[0]!;
+	const open = initializer.index + initializer[0].lastIndexOf('{');
+	let close = -1;
+	let braceDepth = 1;
+	for (let index = open + 1; index < masked.length; index += 1) {
+		if (masked[index] === '{') braceDepth += 1;
+		if (masked[index] === '}') {
+			braceDepth -= 1;
+			if (braceDepth === 0) {
+				close = index;
+				break;
+			}
+		}
+	}
+	if (close === -1) {
+		throw new Error('Could not update every date in src/lib/content/legal-metadata.ts');
+	}
+
+	const expected = new Set(['privacy', 'terms', 'impressum']);
+	const matches = new Map<string, LegalContentDateMatch[]>();
+	let segmentStart = open + 1;
+	braceDepth = 1;
+	let bracketDepth = 0;
+	let parenthesisDepth = 0;
+	for (let index = open + 1; index <= close; index += 1) {
+		const char = masked[index];
+		const atBoundary =
+			index === close ||
+			(char === ',' && braceDepth === 1 && bracketDepth === 0 && parenthesisDepth === 0);
+		if (atBoundary) {
+			const segment = masked.slice(segmentStart, index);
+			const leading = /^\s*/.exec(segment)![0].length;
+			const propertyStart = segmentStart + leading;
+			const key = /^(privacy|terms|impressum)\b/.exec(masked.slice(propertyStart))?.[1];
+			if (key && expected.has(key)) {
+				const keyMatches = matches.get(key) ?? [];
+				matches.set(key, keyMatches);
+				let cursor = propertyStart + key.length;
+				while (/\s/.test(masked[cursor] ?? '')) cursor += 1;
+				if (masked[cursor] !== ':') {
+					keyMatches.push({ start: -1, end: -1, quote: "'" });
+				} else {
+					cursor += 1;
+					while (/\s/.test(masked[cursor] ?? '')) cursor += 1;
+					const quote = masked[cursor];
+					if (quote !== "'" && quote !== '"') {
+						keyMatches.push({ start: -1, end: -1, quote: "'" });
+					} else {
+						const literalEnd = masked.indexOf(quote, cursor + 1);
+						const literal = literalEnd === -1 ? '' : source.slice(cursor + 1, literalEnd);
+						const trailing = literalEnd === -1 ? '' : masked.slice(literalEnd + 1, index).trim();
+						keyMatches.push(
+							literalEnd !== -1 &&
+								trailing === '' &&
+								!literal.includes('\\') &&
+								isIsoCalendarDate(literal)
+								? { start: cursor, end: literalEnd + 1, quote }
+								: { start: -1, end: -1, quote: "'" }
+						);
+					}
+				}
+			}
+			segmentStart = index + 1;
+			continue;
+		}
+		if (char === '{') braceDepth += 1;
+		else if (char === '}') braceDepth -= 1;
+		else if (char === '[') bracketDepth += 1;
+		else if (char === ']') bracketDepth -= 1;
+		else if (char === '(') parenthesisDepth += 1;
+		else if (char === ')') parenthesisDepth -= 1;
+	}
+
+	const properties = [...expected].flatMap((key) => matches.get(key) ?? []);
+	if (
+		properties.length !== expected.size ||
+		[...expected].some((key) => matches.get(key)?.length !== 1) ||
+		properties.some(({ start }) => start === -1)
+	) {
+		throw new Error('Could not update every date in src/lib/content/legal-metadata.ts');
+	}
+	return properties;
+}
+
+export function replaceLegalContentDatesSource(source: string, value: string): string {
+	if (!isIsoCalendarDate(value)) throw new Error(`Invalid legal content date: ${value}`);
+	const properties = findLegalContentDateProperties(source).sort(
+		(left, right) => right.start - left.start
+	);
+	return properties.reduce(
+		(updated, property) =>
+			updated.slice(0, property.start) +
+			property.quote +
+			value +
+			property.quote +
+			updated.slice(property.end),
+		source
+	);
 }
 
 export function updateLegalContentDatesSource(
@@ -603,7 +706,9 @@ export function updateLegalContentDatesSource(
 	value: string,
 	legalIdentityChanged: boolean
 ): string {
-	return legalIdentityChanged ? replaceLegalContentDatesSource(source, value) : source;
+	if (legalIdentityChanged) return replaceLegalContentDatesSource(source, value);
+	findLegalContentDateProperties(source);
+	return source;
 }
 
 // ---------------------------------------------------------------------------
@@ -616,7 +721,32 @@ export function updateLegalContentDatesSource(
  * schließenden Zeichenfolge einer ATX-Überschrift.
  */
 export function escapeMarkdownInline(value: string): string {
-	return value.replace(/[\\`*_[\]<>&#]/g, (char) => `\\${char}`);
+	return value.replace(/[\\`*_[\]<>&#~]/g, (char) => `\\${char}`);
+}
+
+function replaceGithubRepositoryUrls(
+	source: string,
+	oldGithubUrl: string,
+	githubUrl: string
+): string {
+	let updated = '';
+	let cursor = 0;
+	for (;;) {
+		const start = source.indexOf(oldGithubUrl, cursor);
+		if (start === -1) return updated + source.slice(cursor);
+		const end = start + oldGithubUrl.length;
+		const next = source[end];
+		const gitSuffix = source.startsWith('.git', end);
+		const afterGit = gitSuffix ? source[end + '.git'.length] : undefined;
+		const isBoundary =
+			next === undefined ||
+			!/[A-Za-z0-9._-]/.test(next) ||
+			(gitSuffix && (afterGit === undefined || !/[A-Za-z0-9._-]/.test(afterGit)));
+
+		updated += source.slice(cursor, start);
+		updated += isBoundary ? githubUrl : oldGithubUrl;
+		cursor = end;
+	}
 }
 
 /**
@@ -633,7 +763,10 @@ export function replaceReadmeSource(
 
 	// Zuerst die Repository-Links, damit der danach erzeugte Quick-Start-Block nicht
 	// noch einmal umgeschrieben wird.
-	let updated = oldGithubUrl === githubUrl ? source : source.split(oldGithubUrl).join(githubUrl);
+	let updated =
+		oldGithubUrl === githubUrl
+			? source
+			: replaceGithubRepositoryUrls(source, oldGithubUrl, githubUrl);
 
 	const heading = /^# .+$/m;
 	if (!heading.test(updated)) {
@@ -697,18 +830,71 @@ export function readmeShowsCompletedSetup(
 	return heading === `# ${escapeMarkdownInline(brand)}` && !liveDemoParagraphPattern().test(source);
 }
 
+function maskTomlNonCode(source: string): string {
+	const masked = source.split('');
+	let index = 0;
+	while (index < source.length) {
+		if (source[index] === '#') {
+			while (index < source.length && source[index] !== '\n' && source[index] !== '\r') {
+				masked[index++] = ' ';
+			}
+			continue;
+		}
+
+		const quote = source[index];
+		if (quote !== "'" && quote !== '"') {
+			index += 1;
+			continue;
+		}
+		const multiline = source.startsWith(quote.repeat(3), index);
+		const delimiterLength = multiline ? 3 : 1;
+		index += delimiterLength;
+		let closed = false;
+		while (index < source.length) {
+			if (multiline && source.startsWith(quote.repeat(3), index)) {
+				index += 3;
+				closed = true;
+				break;
+			}
+			if (!multiline && source[index] === quote) {
+				index += 1;
+				closed = true;
+				break;
+			}
+			if (!multiline && (source[index] === '\n' || source[index] === '\r')) break;
+			if (quote === '"' && source[index] === '\\') {
+				masked[index++] = ' ';
+				if (index < source.length && source[index] !== '\n' && source[index] !== '\r') {
+					masked[index] = ' ';
+				}
+				index += 1;
+				continue;
+			}
+			if (source[index] !== '\n' && source[index] !== '\r') masked[index] = ' ';
+			index += 1;
+		}
+		if (!closed) throw new Error('Unsupported or unterminated string in wrangler.toml');
+	}
+	return masked.join('');
+}
+
 export function replaceWranglerNameSource(source: string, slug: string): string {
-	const firstTable = /^[ \t]*\[\[?[^\r\n\]]+\]\]?[ \t]*(?:#.*)?$/m.exec(source);
+	const masked = maskTomlNonCode(source);
+	const firstTable = /^[ \t]*\[\[?[^\r\n\]]+\]\]?[ \t]*$/m.exec(masked);
 	const rootEnd = firstTable?.index ?? source.length;
-	const root = source.slice(0, rootEnd);
-	const pattern = /^name = "[^"]*"/gm;
-	const matches = root.match(pattern);
-	if (matches?.length !== 1) {
+	const root = masked.slice(0, rootEnd);
+	const pattern = /^[ \t]*name[ \t]*=[ \t]*"[^"\r\n]*"[ \t]*(?=\r?$)/gm;
+	const matches = [...root.matchAll(pattern)];
+	if (matches.length !== 1) {
 		throw new Error(
-			`Expected exactly one name assignment in wrangler.toml, found ${matches?.length ?? 0}`
+			`Expected exactly one name assignment in wrangler.toml, found ${matches.length}`
 		);
 	}
-	return root.replace(pattern, () => `name = ${JSON.stringify(slug)}`) + source.slice(rootEnd);
+	const match = matches[0]!;
+	const assignmentStart = match.index;
+	const literalStart = masked.indexOf('"', assignmentStart);
+	const literalEnd = masked.indexOf('"', literalStart + 1) + 1;
+	return source.slice(0, literalStart) + JSON.stringify(slug) + source.slice(literalEnd);
 }
 
 /**

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -233,9 +233,10 @@ export function parseContactEmail(
 	if (at <= 0 || at !== value.lastIndexOf('@')) return undefined;
 
 	const user = value.slice(0, at);
+	const userBytes = new TextEncoder().encode(user).byteLength;
 	const domainName = value.slice(at + 1);
 	if (
-		new TextEncoder().encode(user).byteLength > 64 ||
+		userBytes > 64 ||
 		!EMAIL_LOCAL_PART.test(user) ||
 		user.startsWith('.') ||
 		user.endsWith('.') ||
@@ -260,7 +261,8 @@ export function parseContactEmail(
 		}
 		asciiLabels.push(ascii);
 	}
-	if (asciiLabels.join('.').length > 253) return undefined;
+	const asciiDomain = asciiLabels.join('.');
+	if (asciiDomain.length > 253 || userBytes + 1 + asciiDomain.length > 254) return undefined;
 
 	return { user, domain: labels[0]!, tld: labels.slice(1).join('.') };
 }
@@ -269,9 +271,23 @@ export function parseContactEmail(
  * Brand und Operator landen als Rohtext in den Absätzen von Privacy und Terms.
  * Ein Zeilenumbruch zerlegt dort den Absatz und kann eine zusätzliche Überschrift
  * erzeugen. Die Adresse bleibt bewusst mehrzeilig.
+ *
+ * Reject only delimiter combinations that create active inline Markdown in that
+ * paragraph context. Ordinary punctuation and Unicode symbols remain literal.
  */
-function singleLineValidator(label: string): Validator {
-	return (value) => (/[\r\n]/.test(value) ? `${label} must be a single line` : undefined);
+const MARKDOWN_INLINE_DELIMITER = /[\\`*_~]/u;
+const MARKDOWN_LINK = /!?\[[^\]\r\n]*\](?:\([^\r\n)]*\)|\[[^\]\r\n]*\])/u;
+const MARKDOWN_ANGLE_STRUCTURE = /<[^>\r\n]+>/u;
+
+function legalMarkdownTextValidator(label: string): Validator {
+	return (value) => {
+		if (/[\r\n]/.test(value)) return `${label} must be a single line`;
+		return MARKDOWN_INLINE_DELIMITER.test(value) ||
+			MARKDOWN_LINK.test(value) ||
+			MARKDOWN_ANGLE_STRUCTURE.test(value)
+			? `${label} must not contain active Markdown inline syntax such as emphasis, links, code, strikethrough, HTML or autolinks, or escapes`
+			: undefined;
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -394,6 +410,11 @@ export function isValidWorkerSlug(value: string): boolean {
 	return value.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(value);
 }
 
+function hasReservedWindowsDeviceBasename(value: string): boolean {
+	const repository = /^[A-Za-z0-9-]+\/([A-Za-z0-9._-]+)$/.exec(value)?.[1];
+	return repository ? /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i.test(repository) : false;
+}
+
 export function isValidGithubRepository(value: string): boolean {
 	const match = /^([A-Za-z0-9-]+)\/([A-Za-z0-9._-]+)$/.exec(value);
 	if (!match) return false;
@@ -406,7 +427,9 @@ export function isValidGithubRepository(value: string): boolean {
 		!owner.endsWith('-') &&
 		!owner.includes('--') &&
 		!['.', '..'].includes(repository) &&
-		!repository.toLowerCase().endsWith('.git')
+		!repository.toLowerCase().endsWith('.git') &&
+		// The generated clone directory must remain portable across ordinary Win32 filesystems.
+		!hasReservedWindowsDeviceBasename(value)
 	);
 }
 
@@ -633,7 +656,7 @@ export function replaceReadmeSource(
 	updated = updated.replace(heading, () => `# ${escapeMarkdownInline(brand)}`);
 
 	// Der Demo-Absatz gehört zum Template und fehlt nach dem ersten Lauf.
-	updated = updated.replace(/^> \[Live demo!\][^\r\n]*(?:\r?\n){2}/m, () => '');
+	updated = updated.replace(liveDemoParagraphPattern(), () => '');
 
 	const cloneMatches = updated.match(cloneBlockPattern());
 	if (cloneMatches?.length !== 1) {
@@ -659,22 +682,33 @@ function cloneBlockPattern(): RegExp {
 	return /^(?:gh repo create [^\r\n]*|git clone https:\/\/github\.com\/[^\r\n]*)(\r?\n)cd [^\r\n]*$/gm;
 }
 
+function liveDemoParagraphPattern(): RegExp {
+	return /^> \[Live demo!\][^\r\n]*(?:\r?\n){2}/m;
+}
+
 /**
- * Sagt, ob der Quick Start bereits auf genau dieses Repository umgeschrieben wurde.
- * Nur der konvertierte git-clone-Block zählt als eingerichtet, die gh-repo-create-Form
- * des Templates ausdrücklich nicht. Das ist eine Aussage über den vorliegenden
- * Endzustand, kein Nachweis darüber, wie er entstanden ist.
+ * Reports whether the README has the complete generated state for the current
+ * repository and legal brand. Manually produced consistent states remain valid.
  */
-export function readmeShowsConvertedQuickStart(source: string, repository: string): boolean {
+export function readmeShowsCompletedSetup(
+	source: string,
+	repository: string,
+	brand: string
+): boolean {
 	const matches = source.match(cloneBlockPattern());
 	if (matches?.length !== 1) return false;
 	const repositoryBasename = repository.split('/')[1];
 	if (!repositoryBasename) return false;
 	const [cloneLine, directoryLine] = matches[0]!.split(/\r?\n/);
-	return (
-		cloneLine === `git clone https://github.com/${repository}.git` &&
-		(directoryLine === `cd ${repositoryBasename}` || directoryLine === `cd ./${repositoryBasename}`)
-	);
+	if (
+		cloneLine !== `git clone https://github.com/${repository}.git` ||
+		(directoryLine !== `cd ${repositoryBasename}` && directoryLine !== `cd ./${repositoryBasename}`)
+	) {
+		return false;
+	}
+
+	const heading = /^# .+$/m.exec(source)?.[0];
+	return heading === `# ${escapeMarkdownInline(brand)}` && !liveDemoParagraphPattern().test(source);
 }
 
 export function replaceWranglerNameSource(source: string, slug: string): string {
@@ -749,9 +783,9 @@ async function main() {
 	}
 
 	// Der Markenname darf legitim 'SaaS Starter' lauten, und ein von Hand geänderter
-	// Package-Name beweist keine Einrichtung. Maßgeblich ist der Endzustand des Quick
-	// Starts für dieses Repository, nicht ein Nachweis über frühere Läufe.
-	const alreadySetUp = readmeShowsConvertedQuickStart(readmeSource, oldRepo);
+	// Package-Name beweist keine Einrichtung. Maßgeblich ist der konsistente README-
+	// Endzustand für dieses Repository und die aktuelle rechtliche Marke.
+	const alreadySetUp = readmeShowsCompletedSetup(readmeSource, oldRepo, oldBrand);
 
 	if (!interactive && !alreadySetUp) {
 		// Solange der Quick Start die Bootstrapform trägt, sind die drei Kernwerte Pflicht.
@@ -778,9 +812,14 @@ async function main() {
 				: 'slug must match the 1-63 character worker name format (lowercase letters, numbers, inner hyphens)'
 	);
 
-	const repo = await resolveValue(repoFlag, 'GitHub repo (owner/name)', oldRepo, (value) =>
-		isValidGithubRepository(value) ? undefined : 'repo must use a safe GitHub owner/name format'
-	);
+	const repo = await resolveValue(repoFlag, 'GitHub repo (owner/name)', oldRepo, (value) => {
+		if (hasReservedWindowsDeviceBasename(value)) {
+			return 'repo basename must be safe for the generated cross-platform clone directory; Windows device names remain reserved before an extension';
+		}
+		return isValidGithubRepository(value)
+			? undefined
+			: 'repo must use a safe GitHub owner/name format';
+	});
 
 	const brand = await resolveValue(
 		brandFlag,
@@ -789,7 +828,7 @@ async function main() {
 		// einen bereits gewählten Namen.
 		!alreadySetUp && (oldBrand === '' || oldBrand === TEMPLATE_BRAND) ? titleCase(slug) : oldBrand,
 		(value) =>
-			value.trim() === '' ? 'brand must not be empty' : singleLineValidator('brand')(value)
+			value.trim() === '' ? 'brand must not be empty' : legalMarkdownTextValidator('brand')(value)
 	);
 
 	const company = await resolveValue(
@@ -802,7 +841,7 @@ async function main() {
 		operatorFlag,
 		'Operator name (person or org running the service)',
 		oldOperator,
-		singleLineValidator('operator')
+		legalMarkdownTextValidator('operator')
 	);
 
 	const address = await resolveValue(

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -20,7 +20,7 @@
 import { accessSync, constants, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { createInterface, type Interface } from 'readline';
-import { pathToFileURL } from 'url';
+import { domainToASCII, pathToFileURL } from 'url';
 import { parseArgs } from 'util';
 import { isIsoCalendarDate } from '../src/lib/content/legal-metadata';
 
@@ -85,7 +85,7 @@ Usage:
   bun run setup --slug <s> --repo <owner/name> --brand <s> [--company <s>] [--operator <s>] [--address <s>] [--email <user@domain.tld>]
 
 Flags:
-  --slug      Project slug (lowercase, hyphens; matches ^[a-z0-9-]+$)
+  --slug      Worker slug (1-63 lowercase letters, numbers, or inner hyphens)
   --repo      GitHub repo in owner/name format
   --brand     Brand display name
   --company   Company name (legal entity)
@@ -218,23 +218,51 @@ function titleCase(slug: string): string {
 }
 
 /**
- * Eine gemeinsame enge Definition für Prüfung und Zerlegung: Nutzerteil, erste
- * Domainkomponente und restlicher Domainname. Zusätzliche @, Leerzeichen innerhalb
- * der Segmente und leere Domainlabels fallen damit durch. Kein RFC-Anspruch und
- * keine Zustellbarkeitsprüfung.
+ * Bewusst enges Subset für die vorhandenen unkodierten mailto-Consumer. Plus,
+ * Apostroph und Unicode-Buchstaben bleiben erlaubt; URI-Strukturzeichen und
+ * kodierungspflichtige Localparts werden abgelehnt. Kein vollständiger RFC- oder
+ * Zustellbarkeitsvalidator.
  */
-const EMAIL_PATTERN = /^([^\s@]+)@([^\s@.]+)\.([^\s@.]+(?:\.[^\s@.]+)*)$/;
+const EMAIL_LOCAL_PART = /^[\p{L}\p{N}\p{M}._+'-]+$/u;
 
-/**
- * Zerlegt die Adresse in Nutzerteil, erste Domainkomponente und restlichen
- * Domainnamen. Prüfung und Zerlegung teilen sich damit eine Definition.
- */
+/** Zerlegt und prüft die Adresse, ohne gültige Originalteile zu normalisieren. */
 export function parseContactEmail(
 	value: string
 ): { user: string; domain: string; tld: string } | undefined {
-	const match = EMAIL_PATTERN.exec(value);
-	if (!match) return undefined;
-	return { user: match[1]!, domain: match[2]!, tld: match[3]! };
+	const at = value.indexOf('@');
+	if (at <= 0 || at !== value.lastIndexOf('@')) return undefined;
+
+	const user = value.slice(0, at);
+	const domainName = value.slice(at + 1);
+	if (
+		user.length > 64 ||
+		!EMAIL_LOCAL_PART.test(user) ||
+		user.startsWith('.') ||
+		user.endsWith('.') ||
+		user.includes('..')
+	) {
+		return undefined;
+	}
+
+	const labels = domainName.split('.');
+	if (labels.length < 2 || labels.some((label) => label === '')) return undefined;
+	const asciiLabels: string[] = [];
+	for (const label of labels) {
+		const ascii = domainToASCII(label);
+		if (
+			ascii === '' ||
+			ascii.length > 63 ||
+			!/^[A-Za-z0-9-]+$/.test(ascii) ||
+			ascii.startsWith('-') ||
+			ascii.endsWith('-')
+		) {
+			return undefined;
+		}
+		asciiLabels.push(ascii);
+	}
+	if (asciiLabels.join('.').length > 253) return undefined;
+
+	return { user, domain: labels[0]!, tld: labels.slice(1).join('.') };
 }
 
 /**
@@ -284,6 +312,9 @@ export function serializeConfigValue(value: unknown, indent: string): string {
 	if (typeof value === 'string') return tsStringLiteral(value);
 	if (typeof value === 'number' || typeof value === 'boolean') return String(value);
 	if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+		if (Object.getPrototypeOf(value) !== Object.prototype || Object.hasOwn(value, '__proto__')) {
+			throw new Error('Unsupported LEGAL_CONFIG object type or __proto__ data property');
+		}
 		const entries = Object.entries(value as Record<string, unknown>);
 		if (entries.length === 0) return '{}';
 		const inner = `${indent}\t`;
@@ -326,9 +357,7 @@ function currentSlug(): string {
 }
 
 function currentRepo(): string {
-	const siteConfig = read('src/lib/config/site.ts');
-	const match = siteConfig.match(/githubSlug:\s*['"]([^'"]+)['"]/);
-	return match?.[1] ?? 'user/my-saas';
+	return findGithubSlugProperty(read('src/lib/config/site.ts')).value;
 }
 
 /**
@@ -344,6 +373,9 @@ async function readLegalConfig(): Promise<Record<string, unknown>> {
 	if (config === null || typeof config !== 'object' || Array.isArray(config)) {
 		throw new Error('Could not read LEGAL_CONFIG from src/lib/config/legal.ts');
 	}
+	// Vor structuredClone prüfen: Klasseninstanzen und Null-Prototyp-Objekte würden
+	// dort zu gewöhnlichen Objekten und könnten anschließend unbemerkt Daten verlieren.
+	serializeConfigValue(config, '');
 	return structuredClone(config) as Record<string, unknown>;
 }
 
@@ -358,6 +390,10 @@ function readOptionalString(source: Record<string, unknown>, key: string): strin
 	return typeof value === 'string' ? value : undefined;
 }
 
+export function isValidWorkerSlug(value: string): boolean {
+	return value.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(value);
+}
+
 export function isValidGithubRepository(value: string): boolean {
 	const match = /^([A-Za-z0-9-]+)\/([A-Za-z0-9._-]+)$/.exec(value);
 	if (!match) return false;
@@ -365,6 +401,7 @@ export function isValidGithubRepository(value: string): boolean {
 	const repository = match[2]!;
 	return (
 		owner.length <= 39 &&
+		repository.length <= 100 &&
 		!owner.startsWith('-') &&
 		!owner.endsWith('-') &&
 		!owner.includes('--') &&
@@ -380,20 +417,163 @@ export function githubSlugProperty(value: string): string {
 	return `githubSlug: '${value}'`;
 }
 
-export function replaceGithubSlugSource(source: string, value: string): string {
-	const pattern = /githubSlug:\s*['"][^'"]+['"]/g;
-	const matches = source.match(pattern);
-	if (!matches) {
-		throw new Error('Could not find githubSlug in src/lib/config/site.ts');
+interface GithubSlugMatch {
+	start: number;
+	end: number;
+	value: string;
+}
+
+/**
+ * Blendet Kommentare sowie String- und Template-Inhalte aus, behält aber Länge,
+ * Zeilenumbrüche und Literalgrenzen. Damit lassen sich die wenigen benötigten
+ * Strukturanker bestimmen, ohne beliebige TypeScript-Syntax zu interpretieren.
+ */
+function maskTypeScriptNonCode(source: string): string {
+	const masked = source.split('');
+	let index = 0;
+	while (index < source.length) {
+		const char = source[index];
+		const next = source[index + 1];
+		if (char === '/' && next === '/') {
+			masked[index++] = ' ';
+			masked[index++] = ' ';
+			while (index < source.length && source[index] !== '\n') masked[index++] = ' ';
+			continue;
+		}
+		if (char === '/' && next === '*') {
+			masked[index++] = ' ';
+			masked[index++] = ' ';
+			while (index < source.length) {
+				if (source[index] === '*' && source[index + 1] === '/') {
+					masked[index++] = ' ';
+					masked[index++] = ' ';
+					break;
+				}
+				if (source[index] !== '\n' && source[index] !== '\r') masked[index] = ' ';
+				index += 1;
+			}
+			continue;
+		}
+		if (char === "'" || char === '"' || char === '`') {
+			const quote = char;
+			index += 1;
+			while (index < source.length) {
+				if (source[index] === '\\') {
+					masked[index++] = ' ';
+					if (index < source.length && source[index] !== '\n' && source[index] !== '\r') {
+						masked[index] = ' ';
+					}
+					index += 1;
+					continue;
+				}
+				if (source[index] === quote) {
+					index += 1;
+					break;
+				}
+				if (source[index] !== '\n' && source[index] !== '\r') masked[index] = ' ';
+				index += 1;
+			}
+			continue;
+		}
+		index += 1;
 	}
-	// Ein zweites Vorkommen, etwa ein Beispiel im Doc-Kommentar, würde sonst still den
-	// falschen Treffer ersetzen und den echten Eintrag unverändert lassen.
-	if (matches.length > 1) {
+	return masked.join('');
+}
+
+function findGithubSlugProperty(source: string): GithubSlugMatch {
+	const masked = maskTypeScriptNonCode(source);
+	const initializers = [...masked.matchAll(/\bexport\s+const\s+SITE_CONFIG\s*=\s*\{/g)];
+	if (initializers.length !== 1) {
 		throw new Error(
-			`Expected exactly one githubSlug in src/lib/config/site.ts, found ${matches.length}`
+			`Expected exactly one direct SITE_CONFIG initializer in src/lib/config/site.ts, found ${initializers.length}`
 		);
 	}
-	return source.replace(pattern, () => githubSlugProperty(value));
+
+	const initializer = initializers[0]!;
+	const open = initializer.index + initializer[0].lastIndexOf('{');
+	let close = -1;
+	let braceDepth = 1;
+	for (let index = open + 1; index < masked.length; index += 1) {
+		if (masked[index] === '{') braceDepth += 1;
+		if (masked[index] === '}') {
+			braceDepth -= 1;
+			if (braceDepth === 0) {
+				close = index;
+				break;
+			}
+		}
+	}
+	if (close === -1) {
+		throw new Error('Could not find the end of SITE_CONFIG in src/lib/config/site.ts');
+	}
+
+	const candidates: Array<GithubSlugMatch | undefined> = [];
+	let segmentStart = open + 1;
+	braceDepth = 1;
+	let bracketDepth = 0;
+	let parenthesisDepth = 0;
+	for (let index = open + 1; index <= close; index += 1) {
+		const char = masked[index];
+		const atBoundary =
+			index === close ||
+			(char === ',' && braceDepth === 1 && bracketDepth === 0 && parenthesisDepth === 0);
+		if (atBoundary) {
+			const segment = masked.slice(segmentStart, index);
+			const leading = /^\s*/.exec(segment)![0].length;
+			const propertyStart = segmentStart + leading;
+			if (
+				masked.startsWith('githubSlug', propertyStart) &&
+				!/[A-Za-z0-9_$]/.test(masked[propertyStart + 'githubSlug'.length] ?? '')
+			) {
+				let cursor = propertyStart + 'githubSlug'.length;
+				while (/\s/.test(masked[cursor] ?? '')) cursor += 1;
+				if (masked[cursor] !== ':') {
+					candidates.push(undefined);
+				} else {
+					cursor += 1;
+					while (/\s/.test(masked[cursor] ?? '')) cursor += 1;
+					const quote = masked[cursor];
+					const literalEnd =
+						quote === "'" || quote === '"' ? masked.indexOf(quote, cursor + 1) : -1;
+					const trailing = literalEnd === -1 ? '' : masked.slice(literalEnd + 1, index).trim();
+					const value = literalEnd === -1 ? '' : source.slice(cursor + 1, literalEnd);
+					candidates.push(
+						literalEnd !== -1 && trailing === '' && !value.includes('\\')
+							? { start: propertyStart, end: literalEnd + 1, value }
+							: undefined
+					);
+				}
+			}
+			segmentStart = index + 1;
+			continue;
+		}
+		if (char === '{') braceDepth += 1;
+		else if (char === '}') braceDepth -= 1;
+		else if (char === '[') bracketDepth += 1;
+		else if (char === ']') bracketDepth -= 1;
+		else if (char === '(') parenthesisDepth += 1;
+		else if (char === ')') parenthesisDepth -= 1;
+	}
+
+	if (candidates.length === 0) {
+		throw new Error('Could not find githubSlug as a direct property in src/lib/config/site.ts');
+	}
+	if (candidates.length !== 1) {
+		throw new Error(
+			`Expected exactly one direct githubSlug property in src/lib/config/site.ts, found ${candidates.length}`
+		);
+	}
+	const match = candidates[0];
+	if (!match) {
+		throw new Error('githubSlug must use a direct string literal in src/lib/config/site.ts');
+	}
+	return match;
+}
+
+export function replaceGithubSlugSource(source: string, value: string): string {
+	const replacement = githubSlugProperty(value);
+	const match = findGithubSlugProperty(source);
+	return source.slice(0, match.start) + replacement + source.slice(match.end);
 }
 
 export function replaceLegalContentDatesSource(source: string, value: string): string {
@@ -453,7 +633,7 @@ export function replaceReadmeSource(
 	updated = updated.replace(heading, () => `# ${escapeMarkdownInline(brand)}`);
 
 	// Der Demo-Absatz gehört zum Template und fehlt nach dem ersten Lauf.
-	updated = updated.replace(/^> \[Live demo!\][^\n]*\n\n/m, () => '');
+	updated = updated.replace(/^> \[Live demo!\][^\r\n]*(?:\r?\n){2}/m, () => '');
 
 	const cloneMatches = updated.match(cloneBlockPattern());
 	if (cloneMatches?.length !== 1) {
@@ -464,7 +644,8 @@ export function replaceReadmeSource(
 	updated = updated.replace(
 		cloneBlockPattern(),
 		// Das gelesene Zeilenende zurückschreiben, damit eine CRLF-Datei CRLF bleibt.
-		(_match, lineBreak: string) => `git clone ${githubUrl}.git${lineBreak}cd ${repositoryBasename}`
+		(_match, lineBreak: string) =>
+			`git clone ${githubUrl}.git${lineBreak}cd ./${repositoryBasename}`
 	);
 
 	return updated;
@@ -492,7 +673,7 @@ export function readmeShowsConvertedQuickStart(source: string, repository: strin
 	const [cloneLine, directoryLine] = matches[0]!.split(/\r?\n/);
 	return (
 		cloneLine === `git clone https://github.com/${repository}.git` &&
-		directoryLine === `cd ${repositoryBasename}`
+		(directoryLine === `cd ${repositoryBasename}` || directoryLine === `cd ./${repositoryBasename}`)
 	);
 }
 
@@ -589,9 +770,9 @@ async function main() {
 		'Project slug (lowercase, no spaces)',
 		oldSlug,
 		(value) =>
-			/^[a-z0-9-]+$/.test(value)
+			isValidWorkerSlug(value)
 				? undefined
-				: 'slug must match ^[a-z0-9-]+$ (lowercase letters, numbers, hyphens)'
+				: 'slug must match the 1-63 character worker name format (lowercase letters, numbers, inner hyphens)'
 	);
 
 	const repo = await resolveValue(repoFlag, 'GitHub repo (owner/name)', oldRepo, (value) =>
@@ -634,7 +815,7 @@ async function main() {
 		(value) =>
 			parseContactEmail(value)
 				? undefined
-				: `email must match user@domain.tld pattern, got: ${value}`
+				: `email must use the consumer-compatible user@domain.tld subset without URI separators or encoded localparts, got: ${value}`
 	);
 	const { user: emailUser, domain: emailDomain, tld: emailTld } = parseContactEmail(email)!;
 

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -235,7 +235,7 @@ export function parseContactEmail(
 	const user = value.slice(0, at);
 	const domainName = value.slice(at + 1);
 	if (
-		user.length > 64 ||
+		new TextEncoder().encode(user).byteLength > 64 ||
 		!EMAIL_LOCAL_PART.test(user) ||
 		user.startsWith('.') ||
 		user.endsWith('.') ||
@@ -678,14 +678,17 @@ export function readmeShowsConvertedQuickStart(source: string, repository: strin
 }
 
 export function replaceWranglerNameSource(source: string, slug: string): string {
+	const firstTable = /^[ \t]*\[\[?[^\r\n\]]+\]\]?[ \t]*(?:#.*)?$/m.exec(source);
+	const rootEnd = firstTable?.index ?? source.length;
+	const root = source.slice(0, rootEnd);
 	const pattern = /^name = "[^"]*"/gm;
-	const matches = source.match(pattern);
+	const matches = root.match(pattern);
 	if (matches?.length !== 1) {
 		throw new Error(
 			`Expected exactly one name assignment in wrangler.toml, found ${matches?.length ?? 0}`
 		);
 	}
-	return source.replace(pattern, () => `name = ${JSON.stringify(slug)}`);
+	return root.replace(pattern, () => `name = ${JSON.stringify(slug)}`) + source.slice(rootEnd);
 }
 
 /**
@@ -904,13 +907,6 @@ async function main() {
 	write('wrangler.toml', nextWrangler);
 	console.log('  ✓ wrangler.toml');
 
-	write('README.md', nextReadme);
-	console.log('  ✓ README.md');
-
-	// Site config — single source for runtime repository links
-	write('src/lib/config/site.ts', nextSiteConfig);
-	console.log('  ✓ site.ts');
-
 	write('src/lib/content/legal-metadata.ts', nextLegalMetadata);
 	console.log(
 		legalIdentityChanged
@@ -921,6 +917,13 @@ async function main() {
 	// Legal config — single source of truth for brand identity
 	write('src/lib/config/legal.ts', nextLegalSource);
 	console.log('  ✓ legal.ts');
+
+	write('README.md', nextReadme);
+	console.log('  ✓ README.md');
+
+	// Site config — single source for runtime repository links
+	write('src/lib/config/site.ts', nextSiteConfig);
+	console.log('  ✓ site.ts');
 
 	console.log('\n✅ Done! Next steps:');
 	console.log('  1. Replace static/logo.svg with your logo, then run: bun run build:emails');

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -177,6 +177,11 @@ function inspectCanonicalFile(rel: string): CanonicalFile {
 	if (!isWithinRepository(parent)) {
 		throw new Error(`Refusing ${rel}: real parent is outside the repository root`);
 	}
+	try {
+		accessSync(parent, constants.W_OK);
+	} catch {
+		throw new Error(`Cannot write parent directory for ${rel}; check directory permissions`);
+	}
 
 	const stat = lstatSync(path);
 	if (!stat.isFile()) throw new Error(`Refusing ${rel}: canonical target must be a regular file`);
@@ -1319,21 +1324,27 @@ function findReadmeStructure(source: string): ReadmeStructure {
 	return { lines, fences, headings, candidate };
 }
 
+function repositorySentencePeriodBoundary(source: string, period: number): boolean {
+	let cursor = period + 1;
+	const afterPeriod = source[cursor];
+	if (afterPeriod === undefined || /\s/.test(afterPeriod)) return true;
+
+	const closing = /^[\])}"'’”]+/.exec(source.slice(cursor));
+	if (!closing) return false;
+	cursor += closing[0].length;
+	const afterClosing = source[cursor];
+	return afterClosing === undefined || /[\s,;:!?]/.test(afterClosing);
+}
+
 function repositoryUrlBoundary(source: string, end: number): boolean {
 	const next = source[end];
 	if (next === undefined) return true;
 	if (source.startsWith('.git', end)) {
 		const afterGit = source[end + 4];
-		if (afterGit === '.') {
-			const afterPeriod = source[end + 5];
-			return afterPeriod === undefined || /\s/.test(afterPeriod);
-		}
+		if (afterGit === '.') return repositorySentencePeriodBoundary(source, end + 4);
 		return afterGit === undefined || !/[A-Za-z0-9._-]/.test(afterGit);
 	}
-	if (next === '.') {
-		const afterPeriod = source[end + 1];
-		return afterPeriod === undefined || /\s/.test(afterPeriod);
-	}
+	if (next === '.') return repositorySentencePeriodBoundary(source, end);
 	return !/[A-Za-z0-9._-]/.test(next);
 }
 
@@ -1378,7 +1389,7 @@ export function replaceReadmeSource(
 		}));
 		updated = replaceGithubRepositoryUrls(updated, oldGithubUrl, githubUrl, excluded);
 	}
-	updated = updated.replace(liveDemoParagraphPattern(), () => '');
+	updated = removeTemplateLiveDemoParagraph(updated, findReadmeStructure(updated));
 
 	const finalStructure = findReadmeStructure(updated);
 	const heading = finalStructure.headings.find(({ level }) => level === 1);
@@ -1392,7 +1403,35 @@ export function replaceReadmeSource(
 }
 
 function liveDemoParagraphPattern(): RegExp {
-	return /^> \[Live demo!\][^\r\n]*(?:\r?\n){2}/m;
+	return /^> \[Live demo!\][^\r\n]*(?:\r?\n){2}/gm;
+}
+
+function liveDemoParagraphRanges(
+	source: string,
+	structure: ReadmeStructure
+): Array<{ start: number; end: number }> {
+	const fences = structure.fences.map(({ openLine, closeLine }) => ({
+		start: structure.lines[openLine]!.start,
+		end: structure.lines[closeLine]!.fullEnd
+	}));
+	return [...source.matchAll(liveDemoParagraphPattern())].flatMap((match) => {
+		const start = match.index;
+		if (start === undefined || fences.some((range) => start >= range.start && start < range.end)) {
+			return [];
+		}
+		return [{ start, end: start + match[0].length }];
+	});
+}
+
+function removeTemplateLiveDemoParagraph(source: string, structure: ReadmeStructure): string {
+	const matches = liveDemoParagraphRanges(source, structure);
+	if (matches.length > 1) {
+		throw new Error(
+			`Expected at most one live demo paragraph outside fences in README.md, found ${matches.length}`
+		);
+	}
+	const match = matches[0];
+	return match ? source.slice(0, match.start) + source.slice(match.end) : source;
 }
 
 /** Reports whether the README carries the generated identity in the exact Quick Start section. */
@@ -1417,7 +1456,10 @@ export function readmeShowsCompletedSetup(
 		return false;
 	}
 	const heading = structure.headings.find(({ level }) => level === 1);
-	return heading?.text === escapeMarkdownInline(brand) && !liveDemoParagraphPattern().test(source);
+	return (
+		heading?.text === escapeMarkdownInline(brand) &&
+		liveDemoParagraphRanges(source, structure).length === 0
+	);
 }
 
 function maskTomlNonCode(source: string): string {

--- a/scripts/template-setup.ts
+++ b/scripts/template-setup.ts
@@ -271,23 +271,9 @@ export function parseContactEmail(
  * Brand und Operator landen als Rohtext in den Absätzen von Privacy und Terms.
  * Ein Zeilenumbruch zerlegt dort den Absatz und kann eine zusätzliche Überschrift
  * erzeugen. Die Adresse bleibt bewusst mehrzeilig.
- *
- * Reject only delimiter combinations that create active inline Markdown in that
- * paragraph context. Ordinary punctuation and Unicode symbols remain literal.
  */
-const MARKDOWN_INLINE_DELIMITER = /[\\`*_~]/u;
-const MARKDOWN_LINK = /!?\[[^\]\r\n]*\](?:\([^\r\n)]*\)|\[[^\]\r\n]*\])/u;
-const MARKDOWN_ANGLE_STRUCTURE = /<[^>\r\n]+>/u;
-
-function legalMarkdownTextValidator(label: string): Validator {
-	return (value) => {
-		if (/[\r\n]/.test(value)) return `${label} must be a single line`;
-		return MARKDOWN_INLINE_DELIMITER.test(value) ||
-			MARKDOWN_LINK.test(value) ||
-			MARKDOWN_ANGLE_STRUCTURE.test(value)
-			? `${label} must not contain active Markdown inline syntax such as emphasis, links, code, strikethrough, HTML or autolinks, or escapes`
-			: undefined;
-	};
+function singleLineValidator(label: string): Validator {
+	return (value) => (/[\r\n]/.test(value) ? `${label} must be a single line` : undefined);
 }
 
 // ---------------------------------------------------------------------------
@@ -828,7 +814,7 @@ async function main() {
 		// einen bereits gewählten Namen.
 		!alreadySetUp && (oldBrand === '' || oldBrand === TEMPLATE_BRAND) ? titleCase(slug) : oldBrand,
 		(value) =>
-			value.trim() === '' ? 'brand must not be empty' : legalMarkdownTextValidator('brand')(value)
+			value.trim() === '' ? 'brand must not be empty' : singleLineValidator('brand')(value)
 	);
 
 	const company = await resolveValue(
@@ -841,7 +827,7 @@ async function main() {
 		operatorFlag,
 		'Operator name (person or org running the service)',
 		oldOperator,
-		legalMarkdownTextValidator('operator')
+		singleLineValidator('operator')
 	);
 
 	const address = await resolveValue(


### PR DESCRIPTION
Regression guard: added template setup safety contracts

Template setup could serialize invalid branding, overwrite the wrong source anchors, and leave generated projects partially updated after filesystem failures. This also blocked a safe scaffolding CLI for #604.

Setup now validates every source and destination before mutation, stages replacements in private directories, preserves file modes, commits the legal configuration pair with recovery state, and rejects unsafe links or ambiguous README structures. The focused Windows workflow exercises the same setup tests on Bun 1.3.9.

Verified with an independent review, 316 focused tests, changed-file Static Checks including Knip, full type checks, 2,469 unit tests, a production build, all required CI, and the native Windows setup workflow.