### PR TITLE
refactor(usage): Share the feature declaration

### DIFF
--- a/src/lib/convex/aiUsage/feature.ts
+++ b/src/lib/convex/aiUsage/feature.ts
@@ -1,0 +1,13 @@
+import { v } from 'convex/values';
+
+/**
+ * Canonical declaration of the LLM operations we meter.
+ *
+ * Used by both schema.ts (the `aiUsage.feature` column) and the `insert`
+ * mutation's argument validator, so adding a feature here updates both.
+ */
+export const aiUsageFeatureValidator = v.union(
+	v.literal('ai_chat'),
+	v.literal('ai_chat_title'),
+	v.literal('support_chat')
+);

--- a/src/lib/convex/aiUsage/record.ts
+++ b/src/lib/convex/aiUsage/record.ts
@@ -1,20 +1,15 @@
-import { v } from 'convex/values';
+import { v, type Infer } from 'convex/values';
 import { internalMutation } from '../_generated/server';
 import type { ActionCtx } from '../_generated/server';
 import { internal } from '../_generated/api';
 import { costOf } from '../pricing/prices';
 import { sumOptional, type CapturedModelUsage } from './capture';
+import { aiUsageFeatureValidator } from './feature';
 
 export type { CapturedModelUsage } from './capture';
 
-/** The LLM operations we meter. Keep in sync with the schema `aiUsage.feature` union. */
-export type Feature = 'ai_chat' | 'ai_chat_title' | 'support_chat';
-
-const vFeature = v.union(
-	v.literal('ai_chat'),
-	v.literal('ai_chat_title'),
-	v.literal('support_chat')
-);
+/** The LLM operations we meter. */
+export type Feature = Infer<typeof aiUsageFeatureValidator>;
 
 // Raw per-model usage as captured at the call site (cost not yet resolved).
 // totalTokens is required: captureDirect normalizes a provider-omitted value
@@ -40,7 +35,7 @@ const vCapturedModel = v.object({
 export const insert = internalMutation({
 	args: {
 		userId: v.optional(v.string()),
-		feature: vFeature,
+		feature: aiUsageFeatureValidator,
 		threadId: v.optional(v.string()),
 		status: v.optional(v.union(v.literal('ok'), v.literal('partial'), v.literal('error'))),
 		models: v.array(vCapturedModel)

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -3,6 +3,7 @@ import { v } from 'convex/values';
 import { vEmailEvent } from '@convex-dev/resend';
 import { supportThreadFields } from './support/supportThreadFields';
 import { founderIncidentEmailFields } from './emails/founderIncidentTypes';
+import { aiUsageFeatureValidator } from './aiUsage/feature';
 
 export default defineSchema({
 	// Note: Better Auth component manages its own tables (users, sessions, accounts, verifications)
@@ -221,7 +222,7 @@ export default defineSchema({
 	// billing/admin query is added on by_user_at.
 	aiUsage: defineTable({
 		userId: v.optional(v.string()), // Better Auth _id, anon_* id, or absent
-		feature: v.union(v.literal('ai_chat'), v.literal('ai_chat_title'), v.literal('support_chat')),
+		feature: aiUsageFeatureValidator,
 		threadId: v.optional(v.string()),
 		status: v.union(v.literal('ok'), v.literal('partial'), v.literal('error')),
 		models: v.array(


### PR DESCRIPTION
The AI usage feature values were declared in three places. A new value could reach the TypeScript type while still failing the storage validator.

The schema and mutation now use the same validator, and the type is derived from it. The published validator contracts remain byte-for-byte identical.

Verified with static checks, the Convex type check, 27 focused tests, and an independent review.
