### PR TITLE
test(git-context): Renormalize the filtered fixture

### DIFF
--- a/scripts/git-context.test.ts
+++ b/scripts/git-context.test.ts
@@ -6,6 +6,7 @@ import {
 	realpathSync,
 	rmSync,
 	symlinkSync,
+	utimesSync,
 	writeFileSync
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -390,6 +391,12 @@ describe('staged Git context', () => {
 	});
 
 	it.skipIf(process.platform === 'win32')('accepts a clean-filtered staged blob', () => {
+		// The setup staged a.ts before this filter existed. Age the file and refresh the still
+		// unfiltered index so its stat data is trusted rather than racily clean, which is the
+		// state a real commit reaches: from there `git add` skips the path and stages nothing.
+		const stale = new Date(Date.now() - 60_000);
+		utimesSync(path.join(repository, 'a.ts'), stale, stale);
+		git(repository, ['update-index', '--refresh']);
 		const filter = path.join(directory, 'filter');
 		writeFileSync(
 			filter,
@@ -399,7 +406,8 @@ describe('staged Git context', () => {
 		git(repository, ['config', 'filter.corrupt.clean', filter]);
 		git(repository, ['config', 'filter.corrupt.required', 'true']);
 		writeFileSync(path.join(repository, '.gitattributes'), 'a.ts filter=corrupt\n');
-		git(repository, ['add', '.gitattributes', 'a.ts']);
+		git(repository, ['add', '.gitattributes']);
+		git(repository, ['add', '--renormalize', 'a.ts']);
 
 		expect(stagedFilesMatchWorktree(['a.ts'], repository)).toBe(true);
 		expect(stagedFilesWithCleanFilters(['a.ts'], repository)).toEqual(['a.ts']);


### PR DESCRIPTION
Closes #904

Regression guard: added trusted stat-cache clean-filter fixture

The clean-filter test could fail depending on Git's stat cache. The file had been staged before the filter was configured, and a normal `git add` did not always read it again.

The fixture establishes the trusted cache state without a delay and explicitly renormalizes the file after the attribute change. Production behavior is unchanged.

Verified with 1,896 passing unit tests and 8 skips, the type scope, static checks, and an independent review. A separate counterexample reproduces the failure without renormalization and passes with it.
