### PR TITLE
fix(deploy): Treat empty platform values as unset

### DIFF
--- a/scripts/deploy/platform.test.ts
+++ b/scripts/deploy/platform.test.ts
@@ -53,7 +53,7 @@ describe('sanitizeBranchAlias', () => {
 	});
 });
 
-describe('detectPlatform (Vercel)', () => {
+describe.each([undefined, ''])('detectPlatform (Vercel, unset=%s)', (unset) => {
 	// detectPlatform reads process.env, so isolate the vars it touches
 	const vars = [
 		'VERCEL',
@@ -67,7 +67,8 @@ describe('detectPlatform (Vercel)', () => {
 	beforeEach(() => {
 		for (const key of vars) {
 			saved[key] = process.env[key];
-			delete process.env[key];
+			if (unset === undefined) delete process.env[key];
+			else process.env[key] = unset;
 		}
 		process.env.VERCEL = '1';
 		process.env.VERCEL_URL = 'myapp-abc123xyz.vercel.app';
@@ -110,7 +111,7 @@ describe('detectPlatform (Vercel)', () => {
 	});
 });
 
-describe('detectPlatform (Cloudflare)', () => {
+describe.each([undefined, ''])('detectPlatform (Cloudflare, unset=%s)', (unset) => {
 	const vars = [
 		'VERCEL',
 		'WORKERS_CI',
@@ -129,7 +130,8 @@ describe('detectPlatform (Cloudflare)', () => {
 	beforeEach(() => {
 		for (const key of vars) {
 			saved[key] = process.env[key];
-			delete process.env[key];
+			if (unset === undefined) delete process.env[key];
+			else process.env[key] = unset;
 		}
 		process.env.PRODUCTION_BRANCH = 'main';
 	});
@@ -150,6 +152,9 @@ describe('detectPlatform (Cloudflare)', () => {
 		const platform = detectPlatform();
 		expect(platform.siteUrl).toBe('https://app.example.com');
 		expect(platform.deployUrl).toBe('https://generated.pages.dev');
+		expect(platform.environment).toBe('production');
+		expect(platform.isPreview).toBe(false);
+		expect(platform.gitRef).toBe('main');
 	});
 
 	it('uses the Pages deployment URL for a preview despite inherited production values', () => {

--- a/scripts/deploy/platform.ts
+++ b/scripts/deploy/platform.ts
@@ -39,21 +39,21 @@ export function detectPlatform(): PlatformContext {
 	// Vercel: VERCEL is set to "1" by the platform
 	if (process.env.VERCEL) {
 		const env = process.env.VERCEL_ENV as 'production' | 'preview' | 'development' | undefined;
-		const environment = env ?? 'development';
-		const vercelUrl = process.env.VERCEL_URL ?? null;
+		const environment = env || 'development';
+		const vercelUrl = process.env.VERCEL_URL || null;
 		// VERCEL_URL is the per-deployment generated host (changes every deploy).
 		// For production builds prefer VERCEL_PROJECT_PRODUCTION_URL, the stable
 		// production domain, so baked canonical/og URLs don't point at an
 		// ephemeral deployment host.
 		const productionUrl =
-			environment === 'production' ? (process.env.VERCEL_PROJECT_PRODUCTION_URL ?? null) : null;
-		const siteHost = productionUrl ?? vercelUrl;
+			environment === 'production' ? process.env.VERCEL_PROJECT_PRODUCTION_URL || null : null;
+		const siteHost = productionUrl || vercelUrl;
 
 		return {
 			platform: 'vercel',
 			environment,
 			deployUrl: vercelUrl,
-			gitRef: process.env.VERCEL_GIT_COMMIT_REF ?? null,
+			gitRef: process.env.VERCEL_GIT_COMMIT_REF || null,
 			isPreview: environment === 'preview',
 			// Vercel provides hostnames only (no protocol)
 			siteUrl: siteHost ? `https://${siteHost}` : null
@@ -62,14 +62,14 @@ export function detectPlatform(): PlatformContext {
 
 	// Cloudflare Workers (WORKERS_CI) or Pages (CF_PAGES)
 	if (process.env.WORKERS_CI || process.env.CF_PAGES) {
-		const branch = process.env.WORKERS_CI_BRANCH ?? process.env.CF_PAGES_BRANCH ?? null;
+		const branch = process.env.WORKERS_CI_BRANCH || process.env.CF_PAGES_BRANCH || null;
 		const productionBranch = process.env.PRODUCTION_BRANCH || 'main';
 		const isPreview = branch !== null && branch !== productionBranch;
 		const environment = isPreview ? 'preview' : 'production';
 
 		// CF_PAGES_URL is a full URL with https:// (Pages only)
-		const deployUrl = process.env.CF_PAGES_URL ?? null;
-		const productionSiteUrl = process.env.PUBLIC_SITE_URL ?? process.env.SITE_URL ?? null;
+		const deployUrl = process.env.CF_PAGES_URL || null;
+		const productionSiteUrl = process.env.PUBLIC_SITE_URL || process.env.SITE_URL || null;
 
 		let siteUrl: string | null = null;
 		if (isPreview) {
@@ -105,6 +105,6 @@ export function detectPlatform(): PlatformContext {
 		deployUrl: null,
 		gitRef: null,
 		isPreview: false,
-		siteUrl: process.env.PUBLIC_SITE_URL ?? process.env.SITE_URL ?? null
+		siteUrl: process.env.PUBLIC_SITE_URL || process.env.SITE_URL || null
 	};
 }


### PR DESCRIPTION
Regression guard: added empty-environment platform cases

Varlock can inject unset optional variables as empty strings. This caused a Cloudflare Pages production build to be classified as a preview and could prevent URL fallbacks from reaching a configured value. The behavior was reproduced with Varlock 1.16 and 1.18.

Platform detection now treats empty values as absent. The Vercel and Cloudflare tests cover both missing and empty variables.

Verified with a regression test that failed before the fix, the real Varlock loading path, static checks, the full type check, CI, E2E, and the Workers build.
