### PR TITLE
fix(support): Stop logging handoff details

### DIFF
--- a/src/lib/convex/support/tools/handoff.test.ts
+++ b/src/lib/convex/support/tools/handoff.test.ts
@@ -1,0 +1,74 @@
+import type { ToolCtx } from '@convex-dev/agent';
+import type { ZodObject } from 'zod';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { internal } from '../../_generated/api';
+import { requestHandoff } from './handoff';
+
+const executeOptions = {
+	abortSignal: new AbortController().signal,
+	toolCallId: 'handoff-test',
+	messages: [],
+	context: {}
+};
+
+function executeRequestHandoff(
+	ctx: { threadId?: string; runMutation: ReturnType<typeof vi.fn> },
+	input: Record<string, unknown> = {}
+) {
+	const tool = { ...requestHandoff, ctx: ctx as unknown as ToolCtx };
+	const inputSchema = requestHandoff.inputSchema as unknown as ZodObject;
+	if (!tool.execute) {
+		throw new Error('requestHandoff must be executable');
+	}
+	return tool.execute(inputSchema.parse(input) as unknown as Record<string, never>, executeOptions);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('requestHandoff', () => {
+	it('requests the handoff transition without logging model input', async () => {
+		const marker = 'visitor-private-marker';
+		const runMutation = vi.fn().mockResolvedValue(null);
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+		const result = await executeRequestHandoff(
+			{ threadId: 'thread-1', runMutation },
+			{ reason: marker }
+		);
+
+		expect(runMutation).toHaveBeenCalledWith(internal.support.handoff.internalSetHandoff, {
+			threadId: 'thread-1'
+		});
+		expect(log).not.toHaveBeenCalled();
+		expect(result).toBe(
+			'The team has been brought in and will reply right here in this chat. Let the user know, and tell them they can leave their email in the field below the chat to get notified when the team replies.'
+		);
+	});
+
+	it('advertises an empty input object to the model', () => {
+		const inputSchema = requestHandoff.inputSchema as unknown as ZodObject;
+
+		expect(inputSchema.safeParse({}).success).toBe(true);
+		expect(Object.keys(inputSchema.shape)).toEqual([]);
+	});
+
+	it('returns the fallback without a thread id', async () => {
+		const runMutation = vi.fn();
+
+		const result = await executeRequestHandoff({ runMutation });
+
+		expect(runMutation).not.toHaveBeenCalled();
+		expect(result).toBe(
+			"I couldn't reach the team from here. Please send your message again and a human will pick it up."
+		);
+	});
+
+	it('propagates mutation failures', async () => {
+		const error = new Error('mutation failed');
+		const runMutation = vi.fn().mockRejectedValue(error);
+
+		await expect(executeRequestHandoff({ threadId: 'thread-1', runMutation })).rejects.toBe(error);
+	});
+});

--- a/src/lib/convex/support/tools/handoff.ts
+++ b/src/lib/convex/support/tools/handoff.ts
@@ -19,24 +19,13 @@ import { internal } from '../../_generated/api';
 export const requestHandoff = createTool({
 	description:
 		'Hand this conversation to a human on the team. Call it whenever something needs a human instead of guessing or only explaining: a bug or error the user reported (an explanation does not fix a bug), a question you cannot resolve yourself, or anything not covered by your instructions. It flags this same chat so the team takes over and replies right here. It does not ask the user for an email; the widget shows an email field below the chat where they can leave one to get notified.',
-	inputSchema: z.object({
-		reason: z
-			.string()
-			.optional()
-			.describe(
-				'One-line summary of what the user asked and why it needs a human; for a bug, what broke and how to reproduce it. Always fill this in. For team context and logging only; not shown to the user.'
-			)
-	}),
-	execute: async (ctx, { reason }) => {
+	inputSchema: z.object({}),
+	execute: async (ctx) => {
 		// threadId is injected by the agent into the tool ctx (streamText builds
 		// toolCtx = { ...ctx, threadId, userId } and wraps every tool with it).
 		// It is always present on the real streamText path; guard defensively.
 		if (!ctx.threadId) {
 			return "I couldn't reach the team from here. Please send your message again and a human will pick it up.";
-		}
-
-		if (reason) {
-			console.log(`[requestHandoff] thread=${ctx.threadId} reason=${reason}`);
 		}
 
 		await ctx.runMutation(internal.support.handoff.internalSetHandoff, {


### PR DESCRIPTION
Regression guard: added `handoff.test.ts`

The support handoff tool asked the model to summarize the user's request and logged that text. A handoff reason can include private user content even though the state transition only needs the injected thread ID.

The tool now accepts no model-authored fields. Existing calls that still send `reason` remain compatible because the real Zod object strips unknown keys. The transition, missing-thread fallback, and mutation-error behavior are unchanged.

Verified with a red test against the previous code, the real `createTool` wrapper, 1,965 passing unit tests, static checks, full type checks, the Convex check, and an independent review.
