### PR TITLE
style(e2e): Translate readiness comments

### DIFF
--- a/e2e/utils/backend-readiness.ts
+++ b/e2e/utils/backend-readiness.ts
@@ -6,9 +6,9 @@ const DEFAULT_TIMEOUT_MS = 90_000;
 const DEFAULT_POLL_INTERVAL_MS = 1000;
 
 export interface BackendReadinessOptions {
-	/** Gesamtbudget für alle Versuche. Nur Tests weichen vom Default ab. */
+	/** Total budget for all attempts. Only tests override the default. */
 	timeoutMs?: number;
-	/** Pause zwischen zwei Health-Abfragen. Nur Tests weichen vom Default ab. */
+	/** Pause between two health checks. Only tests override the default. */
 	pollIntervalMs?: number;
 }
 
@@ -26,11 +26,11 @@ export interface BackendReadinessOptions {
  * reach the backend (vite.config.ts envVars wiring), the call returns
  * Unauthorized and we fail fast with a clear error.
  *
- * Das Zeitbudget ist verbindlich: ConvexHttpClient.query kennt selbst keine
- * Frist, also hängt hier alles an einem AbortController, den ein Gesamttimer
- * auslöst. Ein Backend, das die Verbindung annimmt und dann schweigt, ließ den
- * Aufruf sonst über die Frist hinaus warten, weil sie erst nach der Abfrage
- * geprüft wurde.
+ * The time budget is binding: ConvexHttpClient.query has no deadline of its
+ * own, so everything here relies on an AbortController triggered by a single
+ * overall timer. A backend that accepts the connection and then stays silent
+ * would otherwise let the call wait past the deadline because it was only
+ * checked after the query.
  */
 export async function waitForBackendReady(
 	convexUrl: string,
@@ -43,17 +43,16 @@ export async function waitForBackendReady(
 	const controller = new AbortController();
 	const deadlineTimer = setTimeout(() => controller.abort(), timeoutMs);
 
-	// Eigener Client nur für die Readiness-Schleife: sein Transport hängt am
-	// Signal, der reguläre Setup-Client des Aufrufers bleibt davon unberührt und
-	// überlebt den Abbruch.
+	// Dedicated client for the readiness loop: its transport uses the signal,
+	// while the caller's regular setup client remains unaffected and survives
+	// the abort.
 	const client = new ConvexHttpClient(convexUrl, {
 		fetch: (input, init) => fetch(input, { ...init, signal: controller.signal })
 	});
 
 	const start = Date.now();
-	// Der Timer allein genügt nicht: läuft das Budget zwischen zwei Ticks ab,
-	// dürfen weder eine weitere Abfrage starten noch eine späte Antwort als
-	// Erfolg zählen.
+	// The timer alone is not enough: if the budget expires between two ticks,
+	// neither another query may start nor may a late response count as success.
 	const pastDeadline = () => controller.signal.aborted || Date.now() - start >= timeoutMs;
 
 	let lastError: unknown;
@@ -69,7 +68,7 @@ export async function waitForBackendReady(
 					return;
 				}
 			} catch (err) {
-				// Ein Abbruch ist die abgelaufene Frist, kein Backend-Fehler.
+				// An abort means the deadline expired, not that the backend failed.
 				if (pastDeadline()) break;
 
 				// Distinguish auth failure (config bug, fail fast) from cold-boot/network errors (retry).
@@ -87,8 +86,8 @@ export async function waitForBackendReady(
 			}
 
 			try {
-				// Die Pause hängt am selben Signal, damit der Timer sie beendet, statt
-				// einen unbeobachteten Verlierer eines Promise-Rennens zu hinterlassen.
+				// The pause uses the same signal so the timer ends it instead of leaving
+				// behind an unobserved loser in a promise race.
 				await sleep(pollIntervalMs, undefined, { signal: controller.signal });
 			} catch {
 				break;
@@ -99,8 +98,8 @@ export async function waitForBackendReady(
 		throw new Error(`Test backend never reported ready (api.tests.health) within ${timeoutMs}ms`);
 	} finally {
 		clearTimeout(deadlineTimer);
-		// Beendet einen noch laufenden Request samt offenem Antwortbody, auch wenn
-		// die Schleife über den Auth-Fehlerpfad verlassen wird.
+		// End any request still in flight along with its open response body, even
+		// when the loop exits through the authentication error path.
 		controller.abort();
 	}
 }

--- a/scripts/e2e-backend-readiness.test.ts
+++ b/scripts/e2e-backend-readiness.test.ts
@@ -5,9 +5,9 @@ import type { Socket } from 'node:net';
 import { afterEach, describe, expect, it } from 'vitest';
 import { waitForBackendReady } from '../e2e/utils/backend-readiness';
 
-// Aufgenommen von einem echten lokalen Convex-1.42.1-Backend über
-// POST /api/query für tests:health. Beide Envelopes kamen mit HTTP 200; die
-// Fehlerform ist damit die reale UDF-Form, keine nachgebaute Annahme.
+// Captured from a real local Convex 1.42.1 backend via POST /api/query for
+// tests:health. Both envelopes arrived with HTTP 200, so the error shape is the
+// actual UDF shape rather than a reconstructed assumption.
 const HEALTH_READY_ENVELOPE = { status: 'success', value: { ok: true } };
 const UNAUTHORIZED_ENVELOPE = {
 	status: 'error',
@@ -44,8 +44,8 @@ async function startBackend(
 
 	const server = createServer((request, response) => {
 		requestCount += 1;
-		// 'close' feuert auch nach einer vollständigen Antwort, deshalb zählt nur
-		// der Fall, in dem die Verbindung vor dem Ende der Antwort wegbricht.
+		// 'close' also fires after a complete response, so only count the case
+		// where the connection drops before the response ends.
 		response.on('close', () => {
 			if (!response.writableFinished) markDisconnected();
 		});
@@ -89,7 +89,8 @@ afterEach(async () => {
 
 describe('waitForBackendReady deadline', { timeout: 20_000 }, () => {
 	it('ends the wait when the backend accepts the connection and never answers', async () => {
-		// Absichtlich keine Antwort: der Client wartet ohne Frist ewig auf sie.
+		// Deliberately leave the request unanswered: without a deadline, the client
+		// waits forever.
 		const backend = await startBackend(() => {});
 
 		const started = Date.now();
@@ -98,15 +99,15 @@ describe('waitForBackendReady deadline', { timeout: 20_000 }, () => {
 		).rejects.toThrow('Test backend never reported ready (api.tests.health) within 300ms');
 		expect(Date.now() - started).toBeLessThan(300 + RUNTIME_BUDGET_MS);
 
-		// Vor dem eigenen Cleanup: der Abbruch muss vom Client kommen.
+		// Before our own cleanup, the client must initiate the abort.
 		await backend.clientDisconnected;
 	});
 
 	it('ends the wait when headers are flushed and the response body stays open', async () => {
 		const backend = await startBackend((_request, response) => {
 			response.writeHead(200, { 'content-type': 'application/json' });
-			// Unvollständiges JSON: die Antwort ist angefangen und wird nie beendet,
-			// der Client hängt also im Lesen des Bodys statt im Request.
+			// Incomplete JSON: the response has started and never finishes, so the
+			// hang occurs while the client reads the body after sending the request.
 			response.write('{"status":"suc');
 		});
 
@@ -120,8 +121,8 @@ describe('waitForBackendReady deadline', { timeout: 20_000 }, () => {
 	});
 
 	it('ends the polling pause instead of waiting out the interval', async () => {
-		// Erste Abfrage scheitert transient, danach würde die Pause weit über die
-		// Frist hinaus laufen.
+		// The first query fails transiently; the subsequent pause would run far
+		// past the deadline.
 		const backend = await startBackend((request) => request.socket.destroy());
 
 		const started = Date.now();


### PR DESCRIPTION
The backend-readiness gate still contained German developer comments in public source. The implementation and tests were already correct, but the mixed-language commentary made the reference path harder to reuse.

The comments now explain the deadline, abort, response-body, polling, and real Convex fixture contracts in English. A comment-stripped TypeScript AST comparison confirms that executable syntax is unchanged.

Verified with 6 focused unit tests, changed-file static checks, full type checks, the complete E2E suite with 110 passing and 1 skipped, and an independent review.