### PR TITLE
fix(deploy): Preserve Workers production branch

### DIFF
--- a/scripts/deploy/steps.test.ts
+++ b/scripts/deploy/steps.test.ts
@@ -2,7 +2,12 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { PlatformContext } from './platform';
-import { computeBuildEnv, resolveDeploymentSiteOrigin, type ConvexDeployment } from './steps';
+import {
+	computeBuildEnv,
+	convexDeployEnvironment,
+	resolveDeploymentSiteOrigin,
+	type ConvexDeployment
+} from './steps';
 
 const deployment: ConvexDeployment = {
 	urlSlug: 'curious-lark-703.eu-west-1',
@@ -120,5 +125,22 @@ describe('resolveDeploymentSiteOrigin', () => {
 				{ PUBLIC_SITE_URL: 'not a url', SITE_URL: 'https://production.example.com' }
 			)
 		).toBe('https://preview.example.com');
+	});
+});
+
+describe('convexDeployEnvironment', () => {
+	it('lets Convex read the Workers production branch after Varlock injection', () => {
+		const sourceEnv: NodeJS.ProcessEnv = {
+			CF_PAGES: '',
+			CF_PAGES_BRANCH: '',
+			WORKERS_CI: '1',
+			WORKERS_CI_BRANCH: 'main'
+		};
+
+		const deployEnv = convexDeployEnvironment(sourceEnv);
+
+		expect(deployEnv).not.toHaveProperty('CF_PAGES_BRANCH');
+		expect(deployEnv.WORKERS_CI_BRANCH).toBe('main');
+		expect(sourceEnv.CF_PAGES_BRANCH).toBe('');
 	});
 });

--- a/scripts/deploy/steps.ts
+++ b/scripts/deploy/steps.ts
@@ -18,6 +18,14 @@ export interface ConvexDeployment {
 	name: string | null;
 }
 
+export function convexDeployEnvironment(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+	const deployEnv = { ...env };
+	// Convex checks the Pages branch before the Workers branch. Varlock represents
+	// an unset schema entry as "", so remove it and preserve Convex's production guard.
+	if (deployEnv.CF_PAGES_BRANCH === '') delete deployEnv.CF_PAGES_BRANCH;
+	return deployEnv;
+}
+
 /**
  * Sync translations with Tolgee (optional, skipped without TOLGEE_API_KEY)
  */
@@ -116,7 +124,7 @@ export async function deployConvex(platform: PlatformContext): Promise<ConvexDep
 	}
 
 	console.log('Deploying Convex functions...');
-	let result = runCommandCapture('bunx', args);
+	let result = runCommandCapture('bunx', args, convexDeployEnvironment());
 
 	if (result.stdout) console.log(result.stdout);
 	if (result.stderr) console.error(result.stderr);


### PR DESCRIPTION
Regression guard: added Workers/Pages environment normalization test

Varlock 1.18 represents unset optional schema entries as empty strings. During Workers Builds, Convex read the empty CF_PAGES_BRANCH before WORKERS_CI_BRANCH=main, classified main as non-production, and refused the production deploy key. This has blocked production builds since #910.

The deploy wrapper removes only the empty Pages branch from the Convex child environment. The real Workers branch reaches Convex, its production guard stays enabled, and the parent environment remains unchanged.

Verified with 11 focused deploy tests, changed-file static checks, full type checks, required CI, the Workers preview deployment, and preview E2E.