### PR TITLE
fix(auth): Support Unicode password letters

### DIFF
--- a/src/lib/schemas/__tests__/password.test.ts
+++ b/src/lib/schemas/__tests__/password.test.ts
@@ -24,6 +24,61 @@ describe('passwordValidation', () => {
 		}
 	});
 
+	it.each(['Éléphant12', 'PASSWORD1é', 'Жжabcdef12', '𐐀𐐨123456'])(
+		'accepts Unicode letters without changing the value: %s',
+		(password) => {
+			const result = v.safeParse(passwordValidation, password);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.output).toBe(password);
+			}
+		}
+	);
+
+	it('rejects Unicode passwords without an uppercase letter', () => {
+		const result = v.safeParse(passwordValidation, 'éléphant12');
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.issues.some((i) => i.message === 'validation.password.uppercase')).toBe(true);
+		}
+	});
+
+	it('rejects Unicode passwords without a lowercase letter', () => {
+		const result = v.safeParse(passwordValidation, 'ÉLÉPHANT12');
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.issues.some((i) => i.message === 'validation.password.lowercase')).toBe(true);
+		}
+	});
+
+	it('rejects uncased letters as uppercase and lowercase letters', () => {
+		const result = v.safeParse(passwordValidation, '漢字漢字漢字漢字12');
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.issues.some((i) => i.message === 'validation.password.uppercase')).toBe(true);
+			expect(result.issues.some((i) => i.message === 'validation.password.lowercase')).toBe(true);
+		}
+	});
+
+	it.each(['Éléphantab', 'Éléphant١٢'])(
+		'rejects Unicode password without ASCII number: %s',
+		(password) => {
+			const result = v.safeParse(passwordValidation, password);
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.issues.some((i) => i.message === 'validation.password.number')).toBe(true);
+			}
+		}
+	);
+
+	it('rejects Unicode passwords shorter than minimum length', () => {
+		const result = v.safeParse(passwordValidation, 'Éléphant1');
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.issues.some((i) => i.message === 'validation.password.min_length')).toBe(true);
+		}
+	});
+
 	it('rejects passwords shorter than minimum length', () => {
 		const result = v.safeParse(passwordValidation, 'Pass123'); // 7 chars
 		expect(result.success).toBe(false);

--- a/src/lib/schemas/password.ts
+++ b/src/lib/schemas/password.ts
@@ -14,8 +14,8 @@ export const PASSWORD_MIN_LENGTH = 10;
 export const passwordValidation = v.pipe(
 	v.string(),
 	v.minLength(PASSWORD_MIN_LENGTH, 'validation.password.min_length'),
-	v.regex(/[A-Z]/, 'validation.password.uppercase'),
-	v.regex(/[a-z]/, 'validation.password.lowercase'),
+	v.regex(/\p{Lu}/u, 'validation.password.uppercase'),
+	v.regex(/\p{Ll}/u, 'validation.password.lowercase'),
 	v.regex(/[0-9]/, 'validation.password.number')
 );
 


### PR DESCRIPTION
Closes #814

Regression guard: added Unicode password category tests

The shared password policy asks for uppercase and lowercase letters but recognizes only ASCII. Valid passwords containing accented or non-Latin letters can therefore fail registration, password changes, or resets.

The letter checks now use Unicode categories while retaining the existing minimum length, ASCII digit requirement, and exact password value.

Verified with 23 password tests, regressions that fail before the fix, changed-file static checks, full type checks, and the Convex check.
