### PR TITLE
fix(legal): Render configured values literally

### DIFF
--- a/src/lib/components/legal-markdown.svelte
+++ b/src/lib/components/legal-markdown.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-	import { Streamdown } from 'svelte-streamdown';
+	import { Streamdown, type StreamdownProps } from 'svelte-streamdown';
 	import { page } from '$app/state';
 	import type { Snippet } from 'svelte';
 	import LegalMarkdownLink from './legal-markdown-link.svelte';
 	import { LEGAL_LINK_PREFIXES } from './legal-markdown-link';
 	import { localizedHref } from '$lib/utils/i18n';
+	import {
+		legalLiteralExtensions,
+		resolveLegalLiteral,
+		type LegalMarkdownContent
+	} from '$lib/content/legal-template';
 
 	interface LinkToken {
 		href: string;
@@ -17,7 +22,9 @@
 		href?: string | null;
 	}
 
-	let { content }: { content: string } = $props();
+	type ChildrenSnippetProps = Parameters<NonNullable<StreamdownProps['children']>>[0];
+
+	let { content }: { content: LegalMarkdownContent } = $props();
 </script>
 
 {#snippet link({ children, token, href }: LinkSnippetProps)}
@@ -30,9 +37,21 @@
 	/>
 {/snippet}
 
+{#snippet children({ token, children: fallbackChildren }: ChildrenSnippetProps)}
+	{#if token.type === 'legalLiteral'}
+		<span class="legal-literal" style="white-space: pre-wrap"
+			>{resolveLegalLiteral(token, content.literals)}</span
+		>
+	{:else}
+		{@render fallbackChildren()}
+	{/if}
+{/snippet}
+
 <Streamdown
-	{content}
+	content={content.markdown}
 	{link}
+	{children}
+	extensions={legalLiteralExtensions}
 	defaultOrigin={page.url.origin}
 	allowedLinkPrefixes={LEGAL_LINK_PREFIXES}
 	baseTheme="shadcn"

--- a/src/lib/components/legal-markdown.test.ts
+++ b/src/lib/components/legal-markdown.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+
+import { createRequire } from 'node:module';
+import { render } from 'svelte/server';
+import { describe, expect, it, vi } from 'vitest';
+import { createLegalMarkdown, type LegalMarkdownContent } from '$lib/content/legal-template';
+import LegalMarkdown from './legal-markdown.svelte';
+
+vi.mock('$app/state', () => ({
+	page: {
+		params: { lang: 'en' },
+		url: new URL('https://example.com/en/terms')
+	}
+}));
+
+const { JSDOM } = createRequire(import.meta.url)('jsdom') as {
+	JSDOM: new (html?: string) => { window: { document: Document } };
+};
+
+function renderDocument(content: LegalMarkdownContent): Document {
+	const { body } = render(LegalMarkdown, { props: { content } });
+	return new JSDOM(body).window.document;
+}
+
+describe('LegalMarkdown', () => {
+	it('renders configured values as exact literal text', () => {
+		const operator = [
+			'# Northwind GmbH',
+			'> Quote',
+			'- List Operator',
+			'1. Numbered Operator',
+			'```ts',
+			'alert(1)',
+			'```',
+			'    indented operator'
+		].join('\n');
+		const brand = String.raw`*Star* **Bold** ~~Deleted~~ [Name](https://evil.example) ![Image](https://evil.example/image.png) <https://evil.example> <script>alert(1)</script> &amp; $x^2$ Anne\Marie`;
+		const address = [
+			'  Example Street 1',
+			'\tSecond floor',
+			'',
+			'- Suite 2',
+			'# Hidden heading',
+			'<img src="https://evil.example/image.png">',
+			'```html',
+			'<script>alert(2)</script>',
+			'```'
+		].join('\r\n');
+		const content = createLegalMarkdown(
+			'sample',
+			'# Authored heading\n\nAuthored *emphasis* and [Privacy](privacy).\n\nOperator:\n\n{{OPERATOR}}\n\nBrand: {{BRAND}}\n\nAddress:\n\n{{ADDRESS}}',
+			{ OPERATOR: operator, BRAND: brand, ADDRESS: address }
+		);
+		const document = renderDocument(content);
+		const literals = [...document.querySelectorAll<HTMLElement>('.legal-literal')];
+
+		expect(literals.map((element) => element.textContent)).toEqual([
+			operator,
+			brand,
+			address.replace(/\r\n?/g, '\n')
+		]);
+		for (const literal of literals) {
+			expect(literal.style.whiteSpace).toBe('pre-wrap');
+			expect(literal.children).toHaveLength(0);
+		}
+
+		expect(document.querySelectorAll('h1')).toHaveLength(1);
+		expect(document.querySelector('h1')?.textContent).toBe('Authored heading');
+		expect(document.querySelectorAll('em')).toHaveLength(1);
+		expect(document.querySelector('em')?.textContent).toBe('emphasis');
+		expect(document.querySelectorAll('a')).toHaveLength(1);
+		expect(document.querySelector('a')?.getAttribute('href')).toBe('/en/privacy');
+		expect(document.querySelector('a')?.hasAttribute('data-streamdown-link')).toBe(true);
+		expect(
+			document.querySelector(
+				'blockquote, ul, ol, pre, code, img, script, strong, del, [data-streamdown-math]'
+			)
+		).toBeNull();
+	});
+
+	it('keeps same-named literals isolated between documents', () => {
+		const first = renderDocument(createLegalMarkdown('first', '{{NAME}}', { NAME: 'First value' }));
+		const second = renderDocument(
+			createLegalMarkdown('second', '{{NAME}}', { NAME: 'Second value' })
+		);
+
+		expect(first.querySelector('.legal-literal')?.textContent).toBe('First value');
+		expect(second.querySelector('.legal-literal')?.textContent).toBe('Second value');
+	});
+});

--- a/src/lib/components/legal-markdown.test.ts
+++ b/src/lib/components/legal-markdown.test.ts
@@ -78,6 +78,20 @@ describe('LegalMarkdown', () => {
 		).toBeNull();
 	});
 
+	it('renders table-cell values as literal text', () => {
+		const value = '**Bold** <script>alert(1)</script> [Link](https://evil.example)';
+		const document = renderDocument(
+			createLegalMarkdown('sample', '| Header |\n| --- |\n| {{VALUE}} |', { VALUE: value })
+		);
+		const literal = document.querySelector<HTMLElement>('td .legal-literal');
+
+		expect(document.querySelector('th')?.textContent).toBe('Header');
+		expect(document.querySelectorAll('table, thead, tbody')).toHaveLength(3);
+		expect(literal?.textContent).toBe(value);
+		expect(literal?.children).toHaveLength(0);
+		expect(document.querySelector('strong, script, a')).toBeNull();
+	});
+
 	it('keeps same-named literals isolated between documents', () => {
 		const first = renderDocument(createLegalMarkdown('first', '{{NAME}}', { NAME: 'First value' }));
 		const second = renderDocument(

--- a/src/lib/content/authored-content.test.ts
+++ b/src/lib/content/authored-content.test.ts
@@ -19,21 +19,34 @@ function markdownDestinations(document: string): string[] {
 }
 
 describe('authored legal content', () => {
-	it('renders configured identity and authored dates', () => {
-		expect(privacyMarkdown).toContain(`# Privacy Policy`);
-		expect(privacyMarkdown).toContain(LEGAL_CONFIG.brandName);
-		expect(privacyMarkdown).toContain(LEGAL_CONFIG.operatorName);
-		expect(privacyMarkdown).toContain(formatLegalContentDate(LEGAL_CONTENT_DATES.privacy));
+	it('keeps configured identity and authored dates in literal side tables', () => {
+		expect(privacyMarkdown.markdown).toContain('# Privacy Policy');
+		expect(privacyMarkdown.markdown).toContain('{{BRAND_NAME}}');
+		expect(privacyMarkdown.markdown).toContain('{{OPERATOR_NAME}}');
+		expect(privacyMarkdown.markdown).toContain('{{LAST_UPDATED}}');
+		expect(privacyMarkdown.literals).toEqual({
+			BRAND_NAME: LEGAL_CONFIG.brandName,
+			LAST_UPDATED: formatLegalContentDate(LEGAL_CONTENT_DATES.privacy),
+			OPERATOR_NAME: LEGAL_CONFIG.operatorName
+		});
 
-		expect(termsMarkdown).toContain(`# Terms of Service`);
-		expect(termsMarkdown).toContain(LEGAL_CONFIG.brandName);
-		expect(termsMarkdown).toContain(formatLegalContentDate(LEGAL_CONTENT_DATES.terms));
-		expect(termsMarkdown).toContain('[Privacy Policy](privacy)');
+		expect(termsMarkdown.markdown).toContain('# Terms of Service');
+		expect(termsMarkdown.markdown).toContain('{{BRAND_NAME}}');
+		expect(termsMarkdown.markdown).toContain('[Privacy Policy](privacy)');
+		expect(termsMarkdown.literals).toEqual({
+			BRAND_NAME: LEGAL_CONFIG.brandName,
+			LAST_UPDATED: formatLegalContentDate(LEGAL_CONTENT_DATES.terms),
+			OPERATOR_NAME: LEGAL_CONFIG.operatorName
+		});
 
-		expect(impressumMarkdown).toContain(`# Impressum`);
-		expect(impressumMarkdown).toContain(LEGAL_CONFIG.operatorName);
-		expect(impressumMarkdown).toContain(LEGAL_CONFIG.address);
-		expect(impressumMarkdown).toContain(formatLegalContentDate(LEGAL_CONTENT_DATES.impressum));
+		expect(impressumMarkdown.markdown).toContain('# Impressum');
+		expect(impressumMarkdown.markdown).toContain('{{OPERATOR_NAME}}');
+		expect(impressumMarkdown.markdown).toContain('{{ADDRESS}}');
+		expect(impressumMarkdown.literals).toEqual({
+			ADDRESS: LEGAL_CONFIG.address,
+			LAST_UPDATED: formatLegalContentDate(LEGAL_CONTENT_DATES.impressum),
+			OPERATOR_NAME: LEGAL_CONFIG.operatorName
+		});
 	});
 
 	it('recognizes inline and reference-style destinations for route validation', () => {
@@ -45,9 +58,9 @@ describe('authored legal content', () => {
 	});
 
 	it.each([
-		['Privacy Policy', privacyMarkdown],
-		['Terms of Service', termsMarkdown],
-		['Impressum', impressumMarkdown]
+		['Privacy Policy', privacyMarkdown.markdown],
+		['Terms of Service', termsMarkdown.markdown],
+		['Impressum', impressumMarkdown.markdown]
 	])('keeps every relative link in %s on a public marketing route', (_name, document) => {
 		const allowed = new Set(
 			PUBLIC_MARKETING_ROUTES.map((route) => route.pathSuffix.replace(/^\//, '')).filter(Boolean)
@@ -61,7 +74,8 @@ describe('authored legal content', () => {
 
 	it('leaves contact addresses to the obfuscated page controls', () => {
 		for (const document of legalDocuments) {
-			expect(document).not.toContain(getLegalEmailAddress());
+			expect(document.markdown).not.toContain(getLegalEmailAddress());
+			expect(Object.values(document.literals)).not.toContain(getLegalEmailAddress());
 		}
 	});
 });

--- a/src/lib/content/impressum.ts
+++ b/src/lib/content/impressum.ts
@@ -1,9 +1,9 @@
 import { LEGAL_CONFIG } from '$lib/config/legal';
 import impressumTemplate from './legal/impressum.md?raw';
-import { renderAuthoredTemplate } from './authored-template';
 import { LEGAL_CONTENT_DATES, formatLegalContentDate } from './legal-metadata';
+import { createLegalMarkdown } from './legal-template';
 
-export const impressumMarkdown = renderAuthoredTemplate('Impressum', impressumTemplate, {
+export const impressumMarkdown = createLegalMarkdown('Impressum', impressumTemplate, {
 	ADDRESS: LEGAL_CONFIG.address,
 	LAST_UPDATED: formatLegalContentDate(LEGAL_CONTENT_DATES.impressum),
 	OPERATOR_NAME: LEGAL_CONFIG.operatorName

--- a/src/lib/content/legal-template.test.ts
+++ b/src/lib/content/legal-template.test.ts
@@ -1,0 +1,182 @@
+import { lex } from 'svelte-streamdown';
+import { describe, expect, it } from 'vitest';
+import { createLegalMarkdown, legalLiteralExtensions, resolveLegalLiteral } from './legal-template';
+
+interface TestToken {
+	readonly type: string;
+	readonly raw: string;
+	readonly name?: string;
+	readonly tokens?: readonly unknown[];
+}
+
+function tokenRecords(values: unknown): TestToken[] {
+	if (!Array.isArray(values)) return [];
+	return values.flatMap((value) => {
+		if (!value || typeof value !== 'object') return [];
+		const record = value as Record<string, unknown>;
+		if (typeof record.type !== 'string' || typeof record.raw !== 'string') return [];
+		const token = record as unknown as TestToken;
+		return [token, ...tokenRecords(token.tokens)];
+	});
+}
+
+describe('createLegalMarkdown', () => {
+	it('keeps repeated and adjacent values outside the Markdown source', () => {
+		const value = '*Northwind* {{OTHER}}';
+		const result = createLegalMarkdown('sample', '{{NAME}}{{NAME}} / {{EMPTY}}', {
+			NAME: value,
+			EMPTY: ''
+		});
+
+		expect(result.markdown).toBe('{{NAME}}{{NAME}} / {{EMPTY}}');
+		expect(result.literals).toEqual({ NAME: value, EMPTY: '' });
+		expect(Object.isFrozen(result)).toBe(true);
+		expect(Object.isFrozen(result.literals)).toBe(true);
+
+		const literalTokens = tokenRecords(
+			lex(result.markdown, legalLiteralExtensions) as unknown
+		).filter((token) => token.type === 'legalLiteral');
+		expect(literalTokens.map((token) => token.name)).toEqual(['NAME', 'NAME', 'EMPTY']);
+		expect(literalTokens.map((token) => Object.keys(token))).toEqual([
+			['type', 'raw', 'name'],
+			['type', 'raw', 'name'],
+			['type', 'raw', 'name']
+		]);
+		expect(JSON.stringify(literalTokens)).not.toContain(value);
+	});
+
+	it('normalizes line endings without trimming whitespace', () => {
+		const result = createLegalMarkdown('sample', 'Before\r\n{{VALUE}}\rAfter', {
+			VALUE: '\r\n\t  first\rsecond\n\n    fourth'
+		});
+
+		expect(result.markdown).toBe('Before\n{{VALUE}}\nAfter');
+		expect(result.literals.VALUE).toBe('\n\t  first\nsecond\n\n    fourth');
+	});
+
+	it('copies inputs before freezing the result', () => {
+		const values = { NAME: 'Original' };
+		const result = createLegalMarkdown('sample', '{{NAME}}', values);
+
+		values.NAME = 'Changed';
+		expect(result.literals.NAME).toBe('Original');
+	});
+
+	it('rejects missing and unused values', () => {
+		expect(() => createLegalMarkdown('sample', '{{NAME}}', {})).toThrow(
+			'Missing placeholder value NAME for sample.'
+		);
+		expect(() => createLegalMarkdown('sample', 'Authored', { NAME: 'value' })).toThrow(
+			'Unused placeholder value NAME for sample.'
+		);
+	});
+
+	it('rejects invalid names and non-string values', () => {
+		expect(() => createLegalMarkdown('sample', '{{lowercase}}', {})).toThrow(
+			'Invalid placeholder {{lowercase}} in sample.'
+		);
+		expect(() =>
+			createLegalMarkdown('sample', '{{NAME}}', { NAME: 42 } as unknown as Record<string, string>)
+		).toThrow('Invalid legal literal NAME for sample.');
+		expect(() =>
+			createLegalMarkdown('sample', 'Authored', {
+				'invalid-name': 'value'
+			} as unknown as Record<string, string>)
+		).toThrow('Invalid placeholder value name invalid-name for sample.');
+	});
+
+	it('uses only own enumerable values', () => {
+		const inherited = Object.create({ NAME: 'inherited' }) as Record<string, string>;
+		expect(() => createLegalMarkdown('sample', '{{NAME}}', inherited)).toThrow(
+			'Missing placeholder value NAME for sample.'
+		);
+		expect(createLegalMarkdown('sample', 'Authored', inherited).literals).toEqual({});
+
+		const hidden = {} as Record<string, string>;
+		Object.defineProperty(hidden, 'NAME', { enumerable: false, value: 'hidden' });
+		expect(() => createLegalMarkdown('sample', '{{NAME}}', hidden)).toThrow(
+			'Missing placeholder value NAME for sample.'
+		);
+	});
+
+	it.each([
+		['U+0000', 'before\0after'],
+		['lone high surrogate', '\ud800'],
+		['lone low surrogate', '\udc00']
+	])('rejects %s', (_name, value) => {
+		expect(() => createLegalMarkdown('sample', '{{VALUE}}', { VALUE: value })).toThrow(
+			'Invalid legal literal VALUE for sample.'
+		);
+	});
+
+	it('preserves well-formed astral Unicode', () => {
+		const result = createLegalMarkdown('sample', '{{VALUE}}', { VALUE: 'Legal 🚀 𝄞' });
+		expect(result.literals.VALUE).toBe('Legal 🚀 𝄞');
+	});
+
+	it.each([
+		['image alt text', '![{{VALUE}}](image.png)'],
+		['image destination', '![alt]({{VALUE}})'],
+		['image title', '![alt](image.png "{{VALUE}}")'],
+		['code fence', '```text\n{{VALUE}}\n```'],
+		['inline code', '`{{VALUE}}`'],
+		['link destination', '[label]({{VALUE}})'],
+		['link title', '[label](privacy "{{VALUE}}")'],
+		['HTML attribute', '<span title="{{VALUE}}">authored</span>'],
+		['MDX attribute', '<Notice title="{{VALUE}}">authored</Notice>']
+	])('rejects a marker in %s', (_name, template) => {
+		expect(() => createLegalMarkdown('sample', template, { VALUE: 'literal' })).toThrow();
+	});
+
+	it('keeps authored Markdown active', () => {
+		const result = createLegalMarkdown(
+			'sample',
+			'# Heading\n\n- Item with *emphasis* and [link](privacy)\n\n![authored alt](image.png)\n\n{{VALUE}}',
+			{ VALUE: 'literal' }
+		);
+		const types = tokenRecords(lex(result.markdown, legalLiteralExtensions) as unknown).map(
+			(token) => token.type
+		);
+
+		expect(types).toEqual(
+			expect.arrayContaining(['heading', 'list', 'em', 'link', 'image', 'legalLiteral'])
+		);
+	});
+});
+
+describe('resolveLegalLiteral', () => {
+	it('resolves own string values including empty strings', () => {
+		expect(
+			resolveLegalLiteral({ type: 'legalLiteral', raw: '{{VALUE}}', name: 'VALUE' }, { VALUE: '' })
+		).toBe('');
+		expect(
+			resolveLegalLiteral(
+				{ type: 'legalLiteral', raw: '{{VALUE}}', name: 'VALUE' },
+				{ VALUE: '{{OTHER}}' }
+			)
+		).toBe('{{OTHER}}');
+	});
+
+	it.each([
+		null,
+		{},
+		{ type: 'text', raw: '{{VALUE}}', name: 'VALUE' },
+		{ type: 'legalLiteral', raw: '{{OTHER}}', name: 'VALUE' },
+		{ type: 'legalLiteral', raw: '{{lowercase}}', name: 'lowercase' }
+	])('rejects an invalid token %#', (token) => {
+		expect(() => resolveLegalLiteral(token, { VALUE: 'literal' })).toThrow(
+			'Invalid legal literal token.'
+		);
+	});
+
+	it('rejects missing, inherited, and non-string entries', () => {
+		const token = { type: 'legalLiteral', raw: '{{VALUE}}', name: 'VALUE' };
+		expect(() => resolveLegalLiteral(token, {})).toThrow('Missing legal literal VALUE.');
+		expect(() => resolveLegalLiteral(token, Object.create({ VALUE: 'inherited' }))).toThrow(
+			'Missing legal literal VALUE.'
+		);
+		expect(() =>
+			resolveLegalLiteral(token, { VALUE: 42 } as unknown as Record<string, string>)
+		).toThrow('Invalid legal literal VALUE.');
+	});
+});

--- a/src/lib/content/legal-template.test.ts
+++ b/src/lib/content/legal-template.test.ts
@@ -4,7 +4,7 @@ import { createLegalMarkdown, legalLiteralExtensions, resolveLegalLiteral } from
 
 interface TestToken {
 	readonly type: string;
-	readonly raw: string;
+	readonly raw?: string;
 	readonly name?: string;
 	readonly tokens?: readonly unknown[];
 }
@@ -14,7 +14,12 @@ function tokenRecords(values: unknown): TestToken[] {
 	return values.flatMap((value) => {
 		if (!value || typeof value !== 'object') return [];
 		const record = value as Record<string, unknown>;
-		if (typeof record.type !== 'string' || typeof record.raw !== 'string') return [];
+		if (
+			typeof record.type !== 'string' ||
+			(record.raw !== undefined && typeof record.raw !== 'string')
+		) {
+			return [];
+		}
 		const token = record as unknown as TestToken;
 		return [token, ...tokenRecords(token.tokens)];
 	});
@@ -141,6 +146,20 @@ describe('createLegalMarkdown', () => {
 		expect(types).toEqual(
 			expect.arrayContaining(['heading', 'list', 'em', 'link', 'image', 'legalLiteral'])
 		);
+	});
+
+	it('keeps authored tables and table-cell literals active', () => {
+		const result = createLegalMarkdown('sample', '| Header |\n| --- |\n| {{VALUE}} |', {
+			VALUE: 'literal'
+		});
+		const tokens = tokenRecords(lex(result.markdown, legalLiteralExtensions) as unknown);
+
+		expect(tokens.map((token) => token.type)).toEqual(
+			expect.arrayContaining(['table', 'thead', 'tbody', 'tr', 'th', 'td', 'legalLiteral'])
+		);
+		expect(
+			tokens.filter((token) => token.type === 'legalLiteral').map((token) => token.name)
+		).toEqual(['VALUE']);
 	});
 });
 

--- a/src/lib/content/legal-template.ts
+++ b/src/lib/content/legal-template.ts
@@ -1,0 +1,210 @@
+import { lex, type Extension } from 'svelte-streamdown';
+import { renderAuthoredTemplate } from './authored-template';
+
+const PLACEHOLDER_NAME = /^[A-Z][A-Z0-9_]*$/;
+const PLACEHOLDER = /\{\{([A-Z][A-Z0-9_]*)\}\}/g;
+// Streamdown recurses through token.tokens only for branches that render children.
+const CHILDREN_RENDERING_TOKEN_TYPES = new Set([
+	'alert',
+	'blockquote',
+	'del',
+	'description',
+	'descriptionDetail',
+	'descriptionList',
+	'descriptionTerm',
+	'em',
+	'heading',
+	'link',
+	'list',
+	'list_item',
+	'mdx',
+	'paragraph',
+	'strong',
+	'sub',
+	'sup',
+	'table',
+	'tbody',
+	'td',
+	'text',
+	'tfoot',
+	'th',
+	'thead',
+	'tr'
+]);
+
+export interface LegalMarkdownContent {
+	readonly markdown: string;
+	readonly literals: Readonly<Record<string, string>>;
+}
+
+interface LegalLiteralToken {
+	readonly type: 'legalLiteral';
+	readonly raw: string;
+	readonly name: string;
+}
+
+interface TokenRecord {
+	readonly type: string;
+	readonly raw: string;
+	readonly tokens?: readonly unknown[];
+}
+
+const legalLiteralExtension: Extension = Object.freeze({
+	name: 'legalLiteral',
+	level: 'inline',
+	start(source) {
+		const index = source.indexOf('{{');
+		return index === -1 ? undefined : index;
+	},
+	tokenizer(source) {
+		const match = /^\{\{([A-Z][A-Z0-9_]*)\}\}/.exec(source);
+		if (!match) return undefined;
+		const token: LegalLiteralToken = {
+			type: 'legalLiteral',
+			raw: match[0]!,
+			name: match[1]!
+		};
+		return token;
+	}
+});
+
+export const legalLiteralExtensions: Extension[] = [legalLiteralExtension];
+Object.freeze(legalLiteralExtensions);
+
+function normalizeLineEndings(value: string): string {
+	return value.replace(/\r\n?/g, '\n');
+}
+
+function tokenRecord(value: unknown, documentName: string): TokenRecord {
+	if (!value || typeof value !== 'object') {
+		throw new Error(`Invalid Markdown token in ${documentName}.`);
+	}
+	const record = value as Record<string, unknown>;
+	if (typeof record.type !== 'string' || typeof record.raw !== 'string') {
+		throw new Error(`Invalid Markdown token in ${documentName}.`);
+	}
+	if (record.tokens !== undefined && !Array.isArray(record.tokens)) {
+		throw new Error(`Invalid Markdown token in ${documentName}.`);
+	}
+	return {
+		type: record.type,
+		raw: record.raw,
+		...(record.tokens === undefined ? {} : { tokens: record.tokens })
+	};
+}
+
+function literalName(raw: string, documentName: string): string {
+	const match = /^\{\{([A-Z][A-Z0-9_]*)\}\}$/.exec(raw);
+	if (!match) {
+		throw new Error(`Invalid legal literal token in ${documentName}.`);
+	}
+	return match[1]!;
+}
+
+function collectLegalLiterals(
+	values: readonly unknown[],
+	documentName: string,
+	pathRendersChildren = true
+): string[] {
+	const names: string[] = [];
+	for (const value of values) {
+		const token = tokenRecord(value, documentName);
+		if (token.type === 'legalLiteral') {
+			if (!pathRendersChildren) {
+				throw new Error(`Legal literal appears in a non-rendered position in ${documentName}.`);
+			}
+			names.push(literalName(token.raw, documentName));
+		}
+		if (token.tokens) {
+			names.push(
+				...collectLegalLiterals(
+					token.tokens,
+					documentName,
+					pathRendersChildren && CHILDREN_RENDERING_TOKEN_TYPES.has(token.type)
+				)
+			);
+		}
+	}
+	return names;
+}
+
+function placeholderNames(markdown: string): string[] {
+	return [...markdown.matchAll(PLACEHOLDER)].map((match) => match[1]!);
+}
+
+function assertSameMultiset(expected: string[], actual: string[], documentName: string): void {
+	const sortedExpected = expected.toSorted();
+	const sortedActual = actual.toSorted();
+	if (
+		sortedExpected.length !== sortedActual.length ||
+		sortedExpected.some((name, index) => name !== sortedActual[index])
+	) {
+		throw new Error(`Legal placeholders were not tokenized safely in ${documentName}.`);
+	}
+}
+
+export function createLegalMarkdown(
+	documentName: string,
+	template: string,
+	values: Readonly<Record<string, string>>
+): LegalMarkdownContent {
+	const literals: Record<string, string> = Object.create(null);
+	const identityValues: Record<string, string> = Object.create(null);
+
+	for (const name of Object.keys(values)) {
+		const value = values[name];
+		if (typeof value !== 'string') {
+			throw new Error(`Invalid legal literal ${name} for ${documentName}.`);
+		}
+		if (value.includes('\0') || !value.isWellFormed()) {
+			throw new Error(`Invalid legal literal ${name} for ${documentName}.`);
+		}
+		literals[name] = normalizeLineEndings(value);
+		identityValues[name] = `{{${name}}}`;
+	}
+
+	const markdown = renderAuthoredTemplate(
+		documentName,
+		normalizeLineEndings(template),
+		identityValues
+	);
+	const tokens: unknown = lex(markdown, legalLiteralExtensions);
+	if (!Array.isArray(tokens)) {
+		throw new Error(`Invalid Markdown tokens in ${documentName}.`);
+	}
+	assertSameMultiset(
+		placeholderNames(markdown),
+		collectLegalLiterals(tokens, documentName),
+		documentName
+	);
+
+	Object.freeze(literals);
+	return Object.freeze({ markdown, literals });
+}
+
+export function resolveLegalLiteral(
+	token: unknown,
+	literals: Readonly<Record<string, string>>
+): string {
+	if (!token || typeof token !== 'object') {
+		throw new Error('Invalid legal literal token.');
+	}
+	const record = token as Record<string, unknown>;
+	if (
+		record.type !== 'legalLiteral' ||
+		typeof record.raw !== 'string' ||
+		typeof record.name !== 'string' ||
+		!PLACEHOLDER_NAME.test(record.name) ||
+		record.raw !== `{{${record.name}}}`
+	) {
+		throw new Error('Invalid legal literal token.');
+	}
+	if (!Object.prototype.hasOwnProperty.call(literals, record.name)) {
+		throw new Error(`Missing legal literal ${record.name}.`);
+	}
+	const value = literals[record.name];
+	if (typeof value !== 'string') {
+		throw new Error(`Invalid legal literal ${record.name}.`);
+	}
+	return value;
+}

--- a/src/lib/content/legal-template.ts
+++ b/src/lib/content/legal-template.ts
@@ -45,7 +45,7 @@ interface LegalLiteralToken {
 
 interface TokenRecord {
 	readonly type: string;
-	readonly raw: string;
+	readonly raw?: string;
 	readonly tokens?: readonly unknown[];
 }
 
@@ -80,15 +80,16 @@ function tokenRecord(value: unknown, documentName: string): TokenRecord {
 		throw new Error(`Invalid Markdown token in ${documentName}.`);
 	}
 	const record = value as Record<string, unknown>;
-	if (typeof record.type !== 'string' || typeof record.raw !== 'string') {
-		throw new Error(`Invalid Markdown token in ${documentName}.`);
-	}
-	if (record.tokens !== undefined && !Array.isArray(record.tokens)) {
+	if (
+		typeof record.type !== 'string' ||
+		(record.raw !== undefined && typeof record.raw !== 'string') ||
+		(record.tokens !== undefined && !Array.isArray(record.tokens))
+	) {
 		throw new Error(`Invalid Markdown token in ${documentName}.`);
 	}
 	return {
 		type: record.type,
-		raw: record.raw,
+		...(record.raw === undefined ? {} : { raw: record.raw }),
 		...(record.tokens === undefined ? {} : { tokens: record.tokens })
 	};
 }
@@ -110,6 +111,9 @@ function collectLegalLiterals(
 	for (const value of values) {
 		const token = tokenRecord(value, documentName);
 		if (token.type === 'legalLiteral') {
+			if (typeof token.raw !== 'string') {
+				throw new Error(`Invalid legal literal token in ${documentName}.`);
+			}
 			if (!pathRendersChildren) {
 				throw new Error(`Legal literal appears in a non-rendered position in ${documentName}.`);
 			}

--- a/src/lib/content/privacy.ts
+++ b/src/lib/content/privacy.ts
@@ -1,9 +1,9 @@
 import { LEGAL_CONFIG } from '$lib/config/legal';
 import privacyTemplate from './legal/privacy.md?raw';
-import { renderAuthoredTemplate } from './authored-template';
 import { LEGAL_CONTENT_DATES, formatLegalContentDate } from './legal-metadata';
+import { createLegalMarkdown } from './legal-template';
 
-export const privacyMarkdown = renderAuthoredTemplate('Privacy Policy', privacyTemplate, {
+export const privacyMarkdown = createLegalMarkdown('Privacy Policy', privacyTemplate, {
 	BRAND_NAME: LEGAL_CONFIG.brandName,
 	LAST_UPDATED: formatLegalContentDate(LEGAL_CONTENT_DATES.privacy),
 	OPERATOR_NAME: LEGAL_CONFIG.operatorName

--- a/src/lib/content/terms.ts
+++ b/src/lib/content/terms.ts
@@ -1,9 +1,9 @@
 import { LEGAL_CONFIG } from '$lib/config/legal';
 import termsTemplate from './legal/terms.md?raw';
-import { renderAuthoredTemplate } from './authored-template';
 import { LEGAL_CONTENT_DATES, formatLegalContentDate } from './legal-metadata';
+import { createLegalMarkdown } from './legal-template';
 
-export const termsMarkdown = renderAuthoredTemplate('Terms of Service', termsTemplate, {
+export const termsMarkdown = createLegalMarkdown('Terms of Service', termsTemplate, {
 	BRAND_NAME: LEGAL_CONFIG.brandName,
 	LAST_UPDATED: formatLegalContentDate(LEGAL_CONTENT_DATES.terms),
 	OPERATOR_NAME: LEGAL_CONFIG.operatorName


### PR DESCRIPTION
Regression guard: added real Streamdown SSR coverage

Configured legal identity values currently enter the Markdown source before Streamdown parses it. Names or addresses containing headings, links, HTML, or lists can therefore change the rendered document structure despite setup accepting and preserving the entered text.

Legal documents now keep authored Markdown and placeholder markers in the source, store configured values in a document-local literal table, and render those values through Svelte text interpolation. The builder validates every marker against the real Streamdown lexer, rejects non-rendered positions, and preserves authored links, tables, and formatting.

Verified with 66 focused tests, changed-file static checks, full type checks, a production build, and an independent review.