### PR TITLE
fix(chat): Track message merge provenance

### DIFF
--- a/src/lib/chat/core/display-message-processor.test.ts
+++ b/src/lib/chat/core/display-message-processor.test.ts
@@ -11,6 +11,7 @@ import {
 } from './display-message-processor.js';
 import type { ChatMessage, MessagePart } from './types.js';
 import type { StreamCacheManager } from './stream-cache.js';
+import type { UIMessage } from '@convex-dev/agent';
 
 // Mock StreamCacheManager
 function createMockStreamCache(cachedReasoning?: Map<number, string>): StreamCacheManager {
@@ -247,6 +248,47 @@ describe('transformToDisplayMessage', () => {
 		expect(result.isStreaming).toBe(true);
 		expect(result.hasReasoningStream).toBe(true);
 	});
+
+	it.each([
+		{ listStatus: 'streaming', expectedState: 'done' },
+		{ listStatus: 'success', expectedState: 'streaming' },
+		{ listStatus: 'pending', expectedState: 'streaming' }
+	] as const)(
+		'uses $listStatus list status to choose the existing part provenance',
+		({ listStatus, expectedState }) => {
+			const msg = createMessage({
+				order: 5,
+				status: listStatus,
+				parts: [
+					{ type: 'text', text: 'Complete answer', state: 'done' }
+				] as unknown as MessagePart[]
+			});
+			const context: TransformContext = {
+				...baseContext,
+				streamMessageMap: new Map([
+					[
+						5,
+						{
+							id: 'stream:5',
+							key: 'thread-1-5-0',
+							order: 5,
+							stepOrder: 0,
+							agentName: 'assistant',
+							text: 'Complete answer',
+							_creationTime: 1,
+							role: 'assistant',
+							status: 'streaming',
+							parts: [{ type: 'text', text: 'Complete answer', state: 'streaming' }]
+						} as unknown as UIMessage
+					]
+				])
+			};
+
+			const result = transformToDisplayMessage(msg, context);
+
+			expect(result.parts).toMatchObject([{ state: expectedState }]);
+		}
+	);
 
 	it('does not apply streaming data to non-streamed messages', () => {
 		// streamedMsg would be at order 5, but we're testing otherMsg at order 6

--- a/src/lib/chat/core/display-message-processor.ts
+++ b/src/lib/chat/core/display-message-processor.ts
@@ -144,7 +144,8 @@ export function transformToDisplayMessage(
 		msg.role === 'assistant' && streamParts
 			? (mergeAssistantMessageParts(
 					(msg.parts ?? []) as UIMessage['parts'],
-					streamParts
+					streamParts,
+					msg.status === 'streaming' ? 'live' : 'persisted'
 				) as ChatMessage['parts'])
 			: (streamParts ?? msg.parts);
 

--- a/src/lib/chat/core/reasoning-handover.contract.test.ts
+++ b/src/lib/chat/core/reasoning-handover.contract.test.ts
@@ -18,9 +18,17 @@ import { describe, expect, it } from 'vitest';
 import { readUIMessageStream } from 'ai';
 import { toUIMessages } from '@convex-dev/agent';
 import type { UIMessage } from '@convex-dev/agent';
-import { mergeAssistantMessageParts } from './stream-materialization.js';
-import { getReasoningKey } from '../ui/reasoning-parts.js';
-import type { MessagePart } from './types.js';
+import type { StreamMessage } from '@convex-dev/agent/validators';
+import {
+	deriveUIMessagesFromDeltas,
+	mergeAssistantMessageParts
+} from './stream-materialization.js';
+import { normalizeMessage } from './message-extraction.js';
+import { StreamCacheManager } from './stream-cache.js';
+import { buildDisplayMessages } from '../ui/streaming-display.js';
+import { getActiveStreamingPartIndex, getReasoningKey } from '../ui/reasoning-parts.js';
+import { mergeMaterializedStreamsIntoPage } from '../../convex/support/messageListing.js';
+import type { ChatMessage, MessagePart } from './types.js';
 
 /** The wire chunks a two-step tool response produces, in order. */
 function responseChunks(firstThought: string, secondThought: string) {
@@ -121,10 +129,10 @@ const RESPONSES = [
 	}
 ];
 
-async function readLiveMessage(first: string, second: string): Promise<UIMessage> {
+async function readLiveChunks(chunks: ReturnType<typeof responseChunks>): Promise<UIMessage> {
 	const stream = new ReadableStream({
 		start(controller) {
-			for (const chunk of responseChunks(first, second)) controller.enqueue(chunk);
+			for (const chunk of chunks) controller.enqueue(chunk);
 			controller.close();
 		}
 	});
@@ -138,6 +146,10 @@ async function readLiveMessage(first: string, second: string): Promise<UIMessage
 	return latest;
 }
 
+async function readLiveMessage(first: string, second: string): Promise<UIMessage> {
+	return readLiveChunks(responseChunks(first, second));
+}
+
 function readPersistedMessage(first: string, second: string): UIMessage {
 	const messages = toUIMessages(responseRows(first, second) as any) as UIMessage[];
 	const assistant = messages.filter((message) => message.role === 'assistant');
@@ -145,6 +157,66 @@ function readPersistedMessage(first: string, second: string): UIMessage {
 		throw new Error(`expected one grouped assistant message, got ${assistant.length}`);
 	}
 	return assistant[0]!;
+}
+
+function readPersistedRunningMessage(): UIMessage {
+	const messages = toUIMessages([
+		{
+			_id: 'm-running',
+			_creationTime: 1,
+			order: 0,
+			stepOrder: 0,
+			status: 'pending',
+			threadId: 'thread-1',
+			tool: false,
+			message: {
+				role: 'assistant',
+				content: [
+					{ type: 'reasoning', text: 'second thought' },
+					{ type: 'text', text: 'the answer' }
+				]
+			}
+		}
+	] as any) as UIMessage[];
+
+	if (messages.length !== 1) {
+		throw new Error(`expected one running assistant message, got ${messages.length}`);
+	}
+	return messages[0]!;
+}
+
+function activeStreamMessage(): StreamMessage {
+	return {
+		streamId: 'stream-1',
+		order: 0,
+		stepOrder: 0,
+		status: 'streaming',
+		agentName: undefined,
+		format: 'UIMessageChunk'
+	} as StreamMessage;
+}
+
+async function materializeLiveChunks(
+	chunks: ReturnType<typeof responseChunks>
+): Promise<UIMessage> {
+	const messages = await deriveUIMessagesFromDeltas('thread-1', [activeStreamMessage()], [
+		{
+			streamId: 'stream-1',
+			start: 0,
+			end: chunks.length,
+			parts: chunks
+		}
+	] as any);
+	return messages[0]!;
+}
+
+function displayMessage(listMessage: ChatMessage, deltaMessage?: UIMessage) {
+	return buildDisplayMessages({
+		allMessages: [normalizeMessage(listMessage)],
+		streamMessages: deltaMessage ? [activeStreamMessage()] : [],
+		streamingUIMessages: deltaMessage ? [deltaMessage] : [],
+		streamCache: new StreamCacheManager()
+	})[0]!;
 }
 
 function reasoningKeys(parts: MessagePart[]): string[] {
@@ -180,6 +252,45 @@ describe('the reasoning shapes the two producers emit', () => {
 			expect(record.streamPartId).toBeUndefined();
 		}
 	});
+
+	it('changes only lifecycle state at reasoning-end and text-end', async () => {
+		const chunks = responseChunks('first thought', 'second thought');
+		const reasoningEndIndex = chunks.findIndex(
+			(chunk) => chunk.type === 'reasoning-end' && 'id' in chunk && chunk.id === 'r-first'
+		);
+		const textEndIndex = chunks.findIndex(
+			(chunk) => chunk.type === 'text-end' && 'id' in chunk && chunk.id === 't-1'
+		);
+		const [beforeReasoningEnd, afterReasoningEnd, beforeTextEnd, afterTextEnd] = await Promise.all([
+			readLiveChunks(chunks.slice(0, reasoningEndIndex)),
+			readLiveChunks(chunks.slice(0, reasoningEndIndex + 1)),
+			readLiveChunks(chunks.slice(0, textEndIndex)),
+			readLiveChunks(chunks.slice(0, textEndIndex + 1))
+		]);
+
+		expect(beforeReasoningEnd.parts.filter((part) => part.type === 'reasoning')).toMatchObject([
+			{ id: 'r-first', text: 'first thought', state: 'streaming' }
+		]);
+		expect(afterReasoningEnd.parts.filter((part) => part.type === 'reasoning')).toMatchObject([
+			{ id: 'r-first', text: 'first thought', state: 'done' }
+		]);
+		expect(beforeTextEnd.parts.filter((part) => part.type === 'text')).toEqual([
+			{ type: 'text', text: 'the answer', state: 'streaming' }
+		]);
+		expect(afterTextEnd.parts.filter((part) => part.type === 'text')).toEqual([
+			{ type: 'text', text: 'the answer', state: 'done' }
+		]);
+	});
+
+	it('reconstructs a pending persisted step with done content and no live ids', () => {
+		const persisted = readPersistedRunningMessage();
+
+		expect(persisted.status).toBe('pending');
+		expect(persisted.parts).toEqual([
+			{ state: 'done', type: 'reasoning', text: 'second thought' },
+			{ state: 'done', type: 'text', text: 'the answer' }
+		]);
+	});
 });
 
 describe.each(RESPONSES)('the persisted and streamed handover of $name', ({ first, second }) => {
@@ -187,7 +298,7 @@ describe.each(RESPONSES)('the persisted and streamed handover of $name', ({ firs
 		const live = await readLiveMessage(first, second);
 		const persisted = readPersistedMessage(first, second);
 
-		const merged = mergeAssistantMessageParts(persisted.parts, live.parts);
+		const merged = mergeAssistantMessageParts(persisted.parts, live.parts, 'persisted');
 
 		expect(merged.filter((part) => part.type === 'reasoning')).toHaveLength(2);
 		expect(merged.filter((part) => part.type === 'text')).toHaveLength(1);
@@ -200,11 +311,58 @@ describe.each(RESPONSES)('the persisted and streamed handover of $name', ({ firs
 		const live = await readLiveMessage(first, second);
 		const persisted = readPersistedMessage(first, second);
 
-		const merged = mergeAssistantMessageParts(persisted.parts, live.parts);
+		const merged = mergeAssistantMessageParts(persisted.parts, live.parts, 'persisted');
 
 		const whileLive = reasoningKeys(live.parts as MessagePart[]);
 		expect(whileLive).toHaveLength(2);
 		expect(reasoningKeys(merged as MessagePart[])).toEqual(whileLive);
 		expect(reasoningKeys(persisted.parts as MessagePart[])).toEqual(whileLive);
+	});
+});
+
+describe('the producer handover through list materialization and display', () => {
+	it('keeps lifecycle state monotonic across both query arrival orders', async () => {
+		const chunks = responseChunks('first thought', 'second thought');
+		const textEndIndex = chunks.findIndex(
+			(chunk) => chunk.type === 'text-end' && 'id' in chunk && chunk.id === 't-1'
+		);
+		const beforeTextEnd = await materializeLiveChunks(chunks.slice(0, textEndIndex));
+		const afterTextEnd = await materializeLiveChunks(chunks.slice(0, textEndIndex + 1));
+		const persistedRunning = readPersistedRunningMessage() as unknown as ChatMessage;
+		const persistedComplete = readPersistedMessage(
+			'first thought',
+			'second thought'
+		) as unknown as ChatMessage;
+
+		const olderList = mergeMaterializedStreamsIntoPage([persistedRunning], [beforeTextEnd])[0]!;
+		const newerList = mergeMaterializedStreamsIntoPage([persistedRunning], [afterTextEnd])[0]!;
+
+		const stillStreaming = displayMessage(olderList, beforeTextEnd);
+		const newerListWithOlderDeltas = displayMessage(newerList, beforeTextEnd);
+		const olderListWithNewerDeltas = displayMessage(olderList, afterTextEnd);
+		const persistedWithoutOverlay = displayMessage(persistedComplete);
+
+		const activeIndex = getActiveStreamingPartIndex(stillStreaming.parts, true);
+		expect(stillStreaming.parts?.[activeIndex]).toMatchObject({
+			type: 'text',
+			state: 'streaming'
+		});
+
+		for (const message of [newerListWithOlderDeltas, olderListWithNewerDeltas]) {
+			expect(message.parts?.filter((part) => part.type === 'text')).toMatchObject([
+				{ text: 'the answer', state: 'done' }
+			]);
+			expect(getActiveStreamingPartIndex(message.parts, true)).toBe(-1);
+			expect(message.parts?.filter((part) => part.type === 'reasoning')).toHaveLength(2);
+			expect(message.parts?.filter((part) => part.type.startsWith('tool-'))).toMatchObject([
+				{ toolCallId: 'call-1', state: 'output-available' }
+			]);
+		}
+
+		expect(persistedWithoutOverlay.status).toBe('success');
+		expect(persistedWithoutOverlay.parts?.filter((part) => part.type === 'text')).toEqual([
+			{ state: 'done', type: 'text', text: 'the answer' }
+		]);
+		expect(getActiveStreamingPartIndex(persistedWithoutOverlay.parts, false)).toBe(-1);
 	});
 });

--- a/src/lib/chat/core/stream-materialization.ts
+++ b/src/lib/chat/core/stream-materialization.ts
@@ -125,16 +125,6 @@ function getStreamPartId(part: UIMessage['parts'][number]): string | undefined {
 	return typeof streamPartId === 'string' ? streamPartId : undefined;
 }
 
-/**
- * Whether the part comes from a live materialization rather than a persisted
- * reconstruction. Only a live snapshot carries the AI SDK's part id, so only
- * there does its lifecycle `state` report what the model actually did.
- */
-function carriesStreamIdentity(part: UIMessage['parts'][number]): boolean {
-	const record = asRecord(part);
-	return typeof record.streamPartId === 'string' || typeof record.id === 'string';
-}
-
 function getReasoningPartId(part: UIMessage['parts'][number]): string | undefined {
 	if (part.type !== 'reasoning') return undefined;
 
@@ -461,7 +451,7 @@ export function combineStreamingUIMessages(messages: UIMessage[]): UIMessage[] {
 			return combined;
 		}
 
-		const mergedParts = mergeAssistantMessageParts(previous.parts, message.parts);
+		const mergedParts = mergeAssistantMessageParts(previous.parts, message.parts, 'live');
 
 		combined[combined.length - 1] = {
 			...previous,
@@ -477,7 +467,8 @@ export function combineStreamingUIMessages(messages: UIMessage[]): UIMessage[] {
 
 export function mergeAssistantMessageParts(
 	existingParts: UIMessage['parts'],
-	incomingParts: UIMessage['parts']
+	incomingParts: UIMessage['parts'],
+	existingView: 'live' | 'persisted'
 ): UIMessage['parts'] {
 	if (existingParts.length === 0) return [...incomingParts];
 	if (incomingParts.length === 0) return [...existingParts];
@@ -502,7 +493,7 @@ export function mergeAssistantMessageParts(
 	if (prefixCarriesContent && !hasToolPartAfter(existingParts, compatiblePrefixLength - 1)) {
 		const mergedPrefix = existingParts
 			.slice(0, compatiblePrefixLength)
-			.map((part, index) => mergeMatchedParts(part, incomingParts[index]!));
+			.map((part, index) => mergeMatchedParts(part, incomingParts[index]!, existingView));
 
 		const tail =
 			incomingParts.length > compatiblePrefixLength
@@ -553,7 +544,11 @@ export function mergeAssistantMessageParts(
 					: -1;
 
 				if (existingIndex !== -1) {
-					mergedParts[existingIndex] = mergeMatchedParts(mergedParts[existingIndex]!, part);
+					mergedParts[existingIndex] = mergeMatchedParts(
+						mergedParts[existingIndex]!,
+						part,
+						existingView
+					);
 					claimedIndices.add(existingIndex);
 					cursor = Math.max(cursor, existingIndex);
 					continue;
@@ -568,7 +563,11 @@ export function mergeAssistantMessageParts(
 				hasToolPartAfter(incomingParts, incomingIndex)
 			);
 			if (counterpartIndex !== -1) {
-				mergedParts[counterpartIndex] = mergeMatchedParts(mergedParts[counterpartIndex]!, part);
+				mergedParts[counterpartIndex] = mergeMatchedParts(
+					mergedParts[counterpartIndex]!,
+					part,
+					existingView
+				);
 				claimedIndices.add(counterpartIndex);
 				cursor = Math.max(cursor, counterpartIndex);
 				continue;
@@ -682,7 +681,8 @@ function hasToolPartAfter(parts: UIMessage['parts'], index: number): boolean {
 
 function mergeMatchedParts(
 	existingPart: UIMessage['parts'][number],
-	incomingPart: UIMessage['parts'][number]
+	incomingPart: UIMessage['parts'][number],
+	existingView: 'live' | 'persisted'
 ): UIMessage['parts'][number] {
 	const carriesText =
 		existingPart.type === incomingPart.type &&
@@ -719,22 +719,14 @@ function mergeMatchedParts(
 		}
 	} else if (
 		existingText.length === incomingText.length &&
-		asRecord(existingPart).state === 'done' &&
-		carriesStreamIdentity(existingPart)
+		existingView === 'live' &&
+		asRecord(existingPart).state === 'done'
 	) {
-		// `reasoning-end` and `text-end` close a block without adding to its text, so
-		// the two snapshots read identically and length cannot say which is newer.
-		// A `done` means the block really closed only on a live snapshot: the message
-		// list materializes an active stream into its own page, so this side is a
-		// second live view that can be the newer one. The persisted reconstruction
-		// stamps `done` on everything it rebuilds, including a step still running
-		// (measured), and carries no id, which is what tells the two apart.
-		//
-		// Only reasoning is covered, because only reasoning carries that id: a live
-		// text part holds nothing but its type, text and state (measured), so a
-		// settled answer can still be handed back its streaming presentation for one
-		// frame. Separating the two would need the caller to say which view each side
-		// came from, which is issue #893 rather than another guess here.
+		// `reasoning-end` und `text-end` schließen einen Block ohne neue Bytes. Daher
+		// sehen beide Live-Snapshots identisch aus und die Länge verrät nicht, welcher
+		// neuer ist. Der Listenstatus belegt die Live-Provenienz der vorhandenen Seite;
+		// Part-IDs können das nicht, da Live-Text keine trägt und die persistierte
+		// Rekonstruktion selbst Inhalte eines laufenden Schritts als `done` markiert.
 		merged.state = 'done';
 	}
 

--- a/src/lib/chat/core/stream-processor.test.ts
+++ b/src/lib/chat/core/stream-processor.test.ts
@@ -49,6 +49,13 @@ function createChatMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
 	};
 }
 
+function mergePersistedAndLiveParts(
+	existingParts: UIMessage['parts'],
+	incomingParts: UIMessage['parts']
+): UIMessage['parts'] {
+	return mergeAssistantMessageParts(existingParts, incomingParts, 'persisted');
+}
+
 // ─── blankUIMessage ───────────────────────────────────────────────────────────
 
 describe('blankUIMessage', () => {
@@ -589,7 +596,7 @@ describe('combineStreamingUIMessages', () => {
 
 describe('mergeAssistantMessageParts', () => {
 	it('treats a grouped streamed prefix as authoritative instead of appending duplicate reasoning blocks', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'step-start' },
 				{ type: 'reasoning', text: 'Find coordinates' },
@@ -614,7 +621,7 @@ describe('mergeAssistantMessageParts', () => {
 	});
 
 	it('keeps the persisted prefix when the live stream only exposes a new tail step', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: 'Find coordinates', streamPartId: 'reason-1' },
 				{
@@ -664,7 +671,7 @@ describe('mergeAssistantMessageParts', () => {
 	// with that `step-start` and stamps an `id` on. Nothing lines the two up, and
 	// the step separator lands between them.
 	it('grows a persisted reasoning block across the step separator the live stream adds', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[{ type: 'reasoning', text: 'Find coordinates', state: 'done' }] as UIMessage['parts'],
 			[
 				{ type: 'step-start' },
@@ -678,7 +685,7 @@ describe('mergeAssistantMessageParts', () => {
 	});
 
 	it('keeps a second live block apart across the step separator', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[{ type: 'reasoning', text: 'Analyze', state: 'done' }] as UIMessage['parts'],
 			[
 				{ type: 'step-start' },
@@ -698,7 +705,7 @@ describe('mergeAssistantMessageParts', () => {
 	// block back and restore it on the next frame, which reads as flicker, and a
 	// finished block would start showing as still running.
 	it('keeps the longer text when the live snapshot lags behind the persisted one', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[{ type: 'reasoning', text: 'Find coordinates', state: 'done' }] as UIMessage['parts'],
 			[
 				{ type: 'reasoning', text: 'Find coord', id: 'reason-1', state: 'streaming' }
@@ -709,7 +716,7 @@ describe('mergeAssistantMessageParts', () => {
 	});
 
 	it('grows a persisted reasoning block that the live stream carries an id for', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[{ type: 'reasoning', text: 'Find coord' }] as UIMessage['parts'],
 			[
 				{ type: 'reasoning', text: 'Find coordinates', streamPartId: 'reason-1' }
@@ -720,7 +727,7 @@ describe('mergeAssistantMessageParts', () => {
 	});
 
 	it('grows a reasoning block whose snapshot dropped the streaming id', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: 'Find coord', streamPartId: 'reason-1' }
 			] as unknown as UIMessage['parts'],
@@ -733,7 +740,7 @@ describe('mergeAssistantMessageParts', () => {
 	});
 
 	it('keeps two reasoning blocks apart when only one carries a streaming id', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: 'Find coordinates', streamPartId: 'reason-1' }
 			] as unknown as UIMessage['parts'],
@@ -751,7 +758,7 @@ describe('mergeAssistantMessageParts', () => {
 	// snapshot already claimed is off limits to the next one, so an overlap costs
 	// a missed merge and never a lost block.
 	it('does not fold two overlapping blocks into the one they both extend', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: 'Analyze', streamPartId: 'reason-1' }
 			] as unknown as UIMessage['parts'],
@@ -768,7 +775,7 @@ describe('mergeAssistantMessageParts', () => {
 	});
 
 	it('keeps a finished reasoning block when a later step opens an empty one', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: 'Check weather forecast' },
 				{
@@ -794,7 +801,7 @@ describe('mergeAssistantMessageParts', () => {
 	});
 
 	it('does not let an empty reasoning snapshot erase the block it follows', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'tool-getWeather', toolCallId: 'tool-2', state: 'output-available' },
 				{ type: 'reasoning', text: 'Draft final answer' }
@@ -814,7 +821,7 @@ describe('mergeAssistantMessageParts', () => {
 	// empty incoming block left the live copy with nothing to merge into, so the
 	// one block rendered as two rows for as long as the stream was open.
 	it('matches an empty reasoning block to its empty copy', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: '', state: 'done' },
 				{ type: 'step-start' },
@@ -849,7 +856,7 @@ describe('mergeAssistantMessageParts', () => {
 	});
 
 	it('merges a grown reasoning block that follows a completed tool call', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'tool-getWeather', toolCallId: 'tool-2', state: 'output-available' },
 				{ type: 'reasoning', text: 'Draft final' }
@@ -868,7 +875,7 @@ describe('mergeAssistantMessageParts', () => {
 	// continuation. Merging it backward would delete the earlier block and move
 	// the new one in front of the tool call that ran between them.
 	it('opens a new block when the words repeat one a tool call already closed', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: 'Analyze' },
 				{ type: 'tool-getGeocoding', toolCallId: 'tool-1', state: 'output-available' }
@@ -891,7 +898,7 @@ describe('mergeAssistantMessageParts', () => {
 	// carries the whole message, because there the tool call sits behind the
 	// incoming part too.
 	it('still grows a closed block when the snapshot repeats the tool call', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: 'Analyze' },
 				{ type: 'tool-getGeocoding', toolCallId: 'tool-1', state: 'output-available' }
@@ -913,7 +920,7 @@ describe('mergeAssistantMessageParts', () => {
 	// closed block and has to grow it; the sentence used to render a second time on
 	// the other side of the tool card until the next delta arrived.
 	it('grows a closed block from the snapshot that lags behind its tool call', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'step-start' },
 				{ type: 'text', text: 'I will check' },
@@ -938,7 +945,7 @@ describe('mergeAssistantMessageParts', () => {
 	// live id and the streaming state. The longer text and its finished state win,
 	// and the persisted block keeps its own key.
 	it('keeps a lagging reasoning snapshot inside its closed block', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: 'Find coordinates', state: 'done' },
 				{ type: 'step-start' },
@@ -966,7 +973,7 @@ describe('mergeAssistantMessageParts', () => {
 	// carries no counterpart for it. A persisted block holding a borrowed id would
 	// read as a live part to any consumer that matches on `id` or `streamPartId`.
 	it('leaves a persisted block without the id of the snapshot it merged', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[{ type: 'reasoning', text: 'Second block' }] as UIMessage['parts'],
 			[
 				{ type: 'step-start' },
@@ -984,7 +991,7 @@ describe('mergeAssistantMessageParts', () => {
 	// by length handed it to the first one, which left the second with nothing to
 	// merge into and appended a copy of the block and of the answer with it.
 	it('matches two blocks that share their opening words in order', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: 'Analyze' },
 				{ type: 'step-start' },
@@ -1013,7 +1020,7 @@ describe('mergeAssistantMessageParts', () => {
 	// cursor keeps each incoming block behind the one its predecessor matched, so
 	// neither block can be overwritten by the words of the other.
 	it('keeps two blocks of one step apart when the words overlap', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: 'Analyze' },
 				{ type: 'reasoning', text: 'Analyze more' },
@@ -1040,7 +1047,7 @@ describe('mergeAssistantMessageParts', () => {
 	// leaves the persisted answer one position further up. Merging text into the
 	// last part alone missed it there and rendered the answer a second time.
 	it('merges the answer across the separator pushed behind it', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'reasoning', text: 'think' },
 				{ type: 'text', text: 'answer' }
@@ -1070,7 +1077,8 @@ describe('mergeAssistantMessageParts', () => {
 			[
 				{ type: 'step-start' },
 				{ type: 'reasoning', id: 'r1', text: 'complete thought', state: 'streaming' }
-			] as unknown as UIMessage['parts']
+			] as unknown as UIMessage['parts'],
+			'live'
 		);
 
 		expect(merged.filter((part) => part.type === 'reasoning')).toMatchObject([
@@ -1078,11 +1086,90 @@ describe('mergeAssistantMessageParts', () => {
 		]);
 	});
 
+	it('keeps id-less live text done when an equally long live view lags', () => {
+		const merged = mergeAssistantMessageParts(
+			[{ type: 'text', text: 'complete answer', state: 'done' }] as unknown as UIMessage['parts'],
+			[
+				{ type: 'text', text: 'complete answer', state: 'streaming' }
+			] as unknown as UIMessage['parts'],
+			'live'
+		);
+
+		expect(merged).toMatchObject([{ text: 'complete answer', state: 'done' }]);
+	});
+
+	it.each(['reasoning', 'text'] as const)(
+		'lets a newer live %s end state close an equally long live block',
+		(type) => {
+			const merged = mergeAssistantMessageParts(
+				[{ type, text: 'complete', state: 'streaming' }] as unknown as UIMessage['parts'],
+				[{ type, text: 'complete', state: 'done' }] as unknown as UIMessage['parts'],
+				'live'
+			);
+
+			expect(merged).toMatchObject([{ text: 'complete', state: 'done' }]);
+		}
+	);
+
+	it('keeps a live done state through the text fallback path', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'text', text: 'complete answer', state: 'done' },
+				{ type: 'tool-lookup', toolCallId: 'call-1', state: 'output-available' }
+			] as unknown as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'text', text: 'complete answer', state: 'streaming' }
+			] as unknown as UIMessage['parts'],
+			'live'
+		);
+
+		expect(merged.filter((part) => part.type === 'text')).toMatchObject([
+			{ text: 'complete answer', state: 'done' }
+		]);
+	});
+
+	it('keeps a live done state through the reasoning id path', () => {
+		const merged = mergeAssistantMessageParts(
+			[
+				{ type: 'reasoning', id: 'r1', text: 'complete thought', state: 'done' }
+			] as unknown as UIMessage['parts'],
+			[
+				{ type: 'step-start' },
+				{ type: 'reasoning', id: 'r1', text: 'complete thought', state: 'streaming' }
+			] as unknown as UIMessage['parts'],
+			'live'
+		);
+
+		expect(merged.filter((part) => part.type === 'reasoning')).toMatchObject([
+			{ text: 'complete thought', state: 'done' }
+		]);
+	});
+
+	it.each(['reasoning', 'text'] as const)(
+		'lets the live %s state decide when persisted text is equally long',
+		(type) => {
+			const streaming = mergeAssistantMessageParts(
+				[{ type, text: 'complete', state: 'done' }] as unknown as UIMessage['parts'],
+				[{ type, text: 'complete', state: 'streaming' }] as unknown as UIMessage['parts'],
+				'persisted'
+			);
+			const done = mergeAssistantMessageParts(
+				[{ type, text: 'complete', state: 'done' }] as unknown as UIMessage['parts'],
+				[{ type, text: 'complete', state: 'done' }] as unknown as UIMessage['parts'],
+				'persisted'
+			);
+
+			expect(streaming).toMatchObject([{ text: 'complete', state: 'streaming' }]);
+			expect(done).toMatchObject([{ text: 'complete', state: 'done' }]);
+		}
+	);
+
 	// The persisted reconstruction stamps `done` on every block it rebuilds, even
 	// one whose step is still running, and carries no id. Its state says nothing,
 	// so the live side still decides.
 	it('lets the live side reopen a block the persisted copy only calls done', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[{ type: 'reasoning', text: 'Find coordinates', state: 'done' }] as UIMessage['parts'],
 			[
 				{ type: 'step-start' },
@@ -1098,7 +1185,7 @@ describe('mergeAssistantMessageParts', () => {
 	// A tool call runs once, so the side holding its result is the newer one. Taking
 	// the incoming state left a spinner sitting above a finished result.
 	it('keeps a settled tool call settled when the other side lags', () => {
-		const merged = mergeAssistantMessageParts(
+		const merged = mergePersistedAndLiveParts(
 			[
 				{ type: 'step-start' },
 				{


### PR DESCRIPTION
Closes #893

Regression guard: added explicit merge provenance and producer contract tests

The message list and streaming query can deliver overlapping live snapshots in either order. The merge previously inferred provenance from part IDs, which live text lacks, so a completed answer could revert to a streaming presentation. Persisted parts can also be marked done while their message is still pending.

Merge callers now explicitly identify the existing view as live or persisted. Equal-length live snapshots preserve completed text and reasoning, while persisted content still follows the incoming live state. Tool results and longer-text selection retain their existing behavior.

Verified with real producer contract tests, a regression that fails before the fix, 194 focused tests on the updated base, changed-file static checks, full type checks, and the Convex check.
