### PR TITLE
fix(auth): Block preview admin emails

### DIFF
--- a/src/lib/convex/admin/notificationPreferences/helpers.ts
+++ b/src/lib/convex/admin/notificationPreferences/helpers.ts
@@ -12,6 +12,16 @@
 
 import type { MutationCtx } from '../../_generated/server';
 
+export const PREVIEW_ADMIN_EMAIL = 'admin@preview.dev';
+
+function normalizeNotificationEmail(email: string): string {
+	return email.trim().toLowerCase();
+}
+
+export function isPreviewAdminEmail(email: string): boolean {
+	return normalizeNotificationEmail(email) === PREVIEW_ADMIN_EMAIL;
+}
+
 /**
  * Upsert admin notification preferences
  *
@@ -21,13 +31,23 @@ import type { MutationCtx } from '../../_generated/server';
  * - User signs up as admin (rare)
  *
  * If preference exists: updates isAdminUser=true and email
- * If not exists: creates with all toggles ON
+ * If not exists: creates with the identity's notification defaults
+ * Preview admins keep the admin role marker but never receive email
  */
 export async function syncAdminPreferences(
 	ctx: MutationCtx,
 	args: { userId: string; email: string }
 ): Promise<void> {
 	const now = Date.now();
+	const email = normalizeNotificationEmail(args.email);
+	const receivesAdminNotifications = !isPreviewAdminEmail(email);
+	const previewAdminPatch = receivesAdminNotifications
+		? {}
+		: {
+				notifyNewSupportTickets: false,
+				notifyUserReplies: false,
+				notifyNewSignups: false
+			};
 
 	// Check if preference already exists for this user
 	const existing = await ctx.db
@@ -38,15 +58,16 @@ export async function syncAdminPreferences(
 	if (existing) {
 		// Reactivate and update email if changed
 		await ctx.db.patch(existing._id, {
-			email: args.email.toLowerCase().trim(),
+			email,
 			isAdminUser: true,
+			...previewAdminPatch,
 			updatedAt: now
 		});
 	} else {
 		// Check if there's a custom email entry with same email
 		const existingByEmail = await ctx.db
 			.query('adminNotificationPreferences')
-			.withIndex('by_email', (q) => q.eq('email', args.email.toLowerCase().trim()))
+			.withIndex('by_email', (q) => q.eq('email', email))
 			.first();
 
 		if (existingByEmail && existingByEmail.userId === undefined) {
@@ -54,17 +75,18 @@ export async function syncAdminPreferences(
 			await ctx.db.patch(existingByEmail._id, {
 				userId: args.userId,
 				isAdminUser: true,
+				...previewAdminPatch,
 				updatedAt: now
 			});
 		} else if (!existingByEmail) {
-			// Create new preference with all notifications enabled
+			// Create new preference with the appropriate notification defaults
 			await ctx.db.insert('adminNotificationPreferences', {
-				email: args.email.toLowerCase().trim(),
+				email,
 				userId: args.userId,
 				isAdminUser: true,
-				notifyNewSupportTickets: true,
-				notifyUserReplies: true,
-				notifyNewSignups: true,
+				notifyNewSupportTickets: receivesAdminNotifications,
+				notifyUserReplies: receivesAdminNotifications,
+				notifyNewSignups: receivesAdminNotifications,
 				createdAt: now,
 				updatedAt: now
 			});
@@ -73,7 +95,7 @@ export async function syncAdminPreferences(
 			// Log warning but don't throw to avoid blocking auth flow
 			console.warn(
 				`[syncAdminPreferences] Email collision detected: ` +
-					`email=${args.email} already belongs to userId=${existingByEmail.userId} ` +
+					`email=${email} already belongs to userId=${existingByEmail.userId} ` +
 					`but attempting to assign to userId=${args.userId}. Skipping update.`
 			);
 		}

--- a/src/lib/convex/admin/notificationPreferences/helpers.ts
+++ b/src/lib/convex/admin/notificationPreferences/helpers.ts
@@ -78,6 +78,13 @@ export async function syncAdminPreferences(
 				...previewAdminPatch,
 				updatedAt: now
 			});
+		} else if (existingByEmail && isPreviewAdminEmail(email)) {
+			await ctx.db.patch(existingByEmail._id, {
+				userId: args.userId,
+				isAdminUser: true,
+				...previewAdminPatch,
+				updatedAt: now
+			});
 		} else if (!existingByEmail) {
 			// Create new preference with the appropriate notification defaults
 			await ctx.db.insert('adminNotificationPreferences', {

--- a/src/lib/convex/admin/notificationPreferences/previewAdmin.test.ts
+++ b/src/lib/convex/admin/notificationPreferences/previewAdmin.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { MutationCtx } from '../../_generated/server';
+import { ensurePreviewAdmin } from '../../previewDev';
+import { syncAdminPreferences } from './helpers';
+import { getRecipientsForNotificationType, type NotificationType } from './queries';
+
+type Preference = {
+	_id: string;
+	_creationTime: number;
+	email: string;
+	userId?: string;
+	isAdminUser: boolean;
+	notifyNewSupportTickets: boolean;
+	notifyUserReplies: boolean;
+	notifyNewSignups: boolean;
+	createdAt: number;
+	updatedAt: number;
+};
+
+type ConvexHandler<TArgs, TResult> = {
+	_handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const ensurePreviewAdminHandler = (
+	ensurePreviewAdmin as unknown as ConvexHandler<
+		Record<string, never>,
+		{
+			created: boolean;
+			updatedRole: boolean;
+			updatedVerification: boolean;
+			skipped: boolean;
+		}
+	>
+)._handler;
+
+const getRecipientsHandler = (
+	getRecipientsForNotificationType as unknown as ConvexHandler<{ type: NotificationType }, string[]>
+)._handler;
+
+function makePreference(
+	email: string,
+	userId: string,
+	overrides: Partial<Preference> = {}
+): Preference {
+	return {
+		_id: `preference_${userId}`,
+		_creationTime: 1,
+		email,
+		userId,
+		isAdminUser: true,
+		notifyNewSupportTickets: true,
+		notifyUserReplies: true,
+		notifyNewSignups: true,
+		createdAt: 1,
+		updatedAt: 1,
+		...overrides
+	};
+}
+
+function createPreferenceStore(initial: Preference[] = []) {
+	const rows = initial.map((row) => ({ ...row }));
+	let nextId = rows.length + 1;
+
+	const db = {
+		query: (table: string) => {
+			expect(table).toBe('adminNotificationPreferences');
+			return {
+				collect: async () => [...rows],
+				withIndex: (
+					_index: string,
+					configure: (query: { eq: (field: string, value: unknown) => unknown }) => unknown
+				) => {
+					const filters: Record<string, unknown> = {};
+					const query = {
+						eq: (field: string, value: unknown) => {
+							filters[field] = value;
+							return query;
+						}
+					};
+					configure(query);
+					return {
+						first: async () =>
+							rows.find((row) =>
+								Object.entries(filters).every(
+									([field, value]) => row[field as keyof Preference] === value
+								)
+							) ?? null
+					};
+				}
+			};
+		},
+		insert: async (table: string, value: Omit<Preference, '_id' | '_creationTime'>) => {
+			expect(table).toBe('adminNotificationPreferences');
+			const id = `preference_${nextId++}`;
+			rows.push({ _id: id, _creationTime: Date.now(), ...value });
+			return id;
+		},
+		patch: async (id: string, value: Partial<Preference>) => {
+			const row = rows.find((candidate) => candidate._id === id);
+			if (!row) throw new Error(`Unknown preference: ${id}`);
+			Object.assign(row, value);
+		}
+	};
+
+	return { db, rows };
+}
+
+function expectEmailToggles(preference: Preference, enabled: boolean) {
+	expect(preference).toMatchObject({
+		notifyNewSupportTickets: enabled,
+		notifyUserReplies: enabled,
+		notifyNewSignups: enabled
+	});
+}
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe('preview admin notification preferences', () => {
+	it('creates a normalized preview admin preference with email disabled', async () => {
+		const { db, rows } = createPreferenceStore();
+
+		await syncAdminPreferences(dbContext(db), {
+			userId: 'preview-user',
+			email: '  ADMIN@PREVIEW.DEV '
+		});
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			email: 'admin@preview.dev',
+			userId: 'preview-user',
+			isAdminUser: true
+		});
+		expectEmailToggles(rows[0], false);
+	});
+
+	it('repairs an unchanged preview admin on every idempotent ensure run', async () => {
+		const { db, rows } = createPreferenceStore([
+			makePreference('admin@preview.dev', 'preview-user')
+		]);
+		const user = {
+			_id: 'preview-user',
+			email: 'admin@preview.dev',
+			role: 'admin',
+			emailVerified: true
+		};
+		const ctx = {
+			db,
+			runQuery: vi.fn(async () => user),
+			runMutation: vi.fn()
+		};
+		vi.stubEnv('PREVIEW_ADMIN_PASSWORD', 'preview-password');
+		vi.stubEnv('LOCAL_CONVEX_DEV', 'false');
+
+		const first = await ensurePreviewAdminHandler(ctx, {});
+		const second = await ensurePreviewAdminHandler(ctx, {});
+
+		expect(first).toEqual({
+			created: false,
+			updatedRole: false,
+			updatedVerification: false,
+			skipped: true
+		});
+		expect(second).toEqual(first);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].isAdminUser).toBe(true);
+		expectEmailToggles(rows[0], false);
+		expect(ctx.runMutation).not.toHaveBeenCalled();
+	});
+
+	it('excludes the preview admin from every recipient type despite stored toggles', async () => {
+		const { db } = createPreferenceStore([
+			makePreference('  ADMIN@PREVIEW.DEV ', 'preview-user'),
+			makePreference('owner@example.com', 'owner-user')
+		]);
+
+		for (const type of ['newTickets', 'userReplies', 'newSignups'] as const) {
+			await expect(getRecipientsHandler({ db }, { type })).resolves.toEqual(['owner@example.com']);
+		}
+	});
+
+	it('keeps real admin defaults enabled and eligible for every recipient type', async () => {
+		const { db, rows } = createPreferenceStore();
+
+		await syncAdminPreferences(dbContext(db), {
+			userId: 'owner-user',
+			email: ' Owner@Example.com '
+		});
+
+		expect(rows[0]).toMatchObject({
+			email: 'owner@example.com',
+			isAdminUser: true
+		});
+		expectEmailToggles(rows[0], true);
+		for (const type of ['newTickets', 'userReplies', 'newSignups'] as const) {
+			await expect(getRecipientsHandler({ db }, { type })).resolves.toEqual(['owner@example.com']);
+		}
+	});
+});
+
+function dbContext(db: ReturnType<typeof createPreferenceStore>['db']): MutationCtx {
+	return { db } as unknown as MutationCtx;
+}

--- a/src/lib/convex/admin/notificationPreferences/previewAdmin.test.ts
+++ b/src/lib/convex/admin/notificationPreferences/previewAdmin.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { MutationCtx } from '../../_generated/server';
 import { ensurePreviewAdmin } from '../../previewDev';
 import { syncAdminPreferences } from './helpers';
+import { getNotificationTargetEmails } from '../support/notifications';
 import { getRecipientsForNotificationType, type NotificationType } from './queries';
 
 type Preference = {
@@ -35,6 +36,16 @@ const ensurePreviewAdminHandler = (
 
 const getRecipientsHandler = (
 	getRecipientsForNotificationType as unknown as ConvexHandler<{ type: NotificationType }, string[]>
+)._handler;
+
+const getSupportRecipientsHandler = (
+	getNotificationTargetEmails as unknown as ConvexHandler<
+		{
+			assignedTo?: string;
+			notificationType: 'newTickets' | 'userReplies';
+		},
+		string[]
+	>
 )._handler;
 
 function makePreference(
@@ -114,6 +125,7 @@ function expectEmailToggles(preference: Preference, enabled: boolean) {
 }
 
 afterEach(() => {
+	vi.restoreAllMocks();
 	vi.unstubAllEnvs();
 });
 
@@ -135,12 +147,12 @@ describe('preview admin notification preferences', () => {
 		expectEmailToggles(rows[0], false);
 	});
 
-	it('repairs an unchanged preview admin on every idempotent ensure run', async () => {
+	it('reattaches a stale preview preference during idempotent ensure runs', async () => {
 		const { db, rows } = createPreferenceStore([
-			makePreference('admin@preview.dev', 'preview-user')
+			makePreference('admin@preview.dev', 'stale-preview-user')
 		]);
 		const user = {
-			_id: 'preview-user',
+			_id: 'current-preview-user',
 			email: 'admin@preview.dev',
 			role: 'admin',
 			emailVerified: true
@@ -164,9 +176,29 @@ describe('preview admin notification preferences', () => {
 		});
 		expect(second).toEqual(first);
 		expect(rows).toHaveLength(1);
-		expect(rows[0].isAdminUser).toBe(true);
+		expect(rows[0]).toMatchObject({
+			email: 'admin@preview.dev',
+			userId: 'current-preview-user',
+			isAdminUser: true
+		});
 		expectEmailToggles(rows[0], false);
 		expect(ctx.runMutation).not.toHaveBeenCalled();
+	});
+
+	it('keeps a real email collision attached to its existing user', async () => {
+		const existing = makePreference('owner@example.com', 'existing-owner');
+		const { db, rows } = createPreferenceStore([existing]);
+		const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+		await syncAdminPreferences(dbContext(db), {
+			userId: 'different-owner',
+			email: ' OWNER@EXAMPLE.COM '
+		});
+
+		expect(rows).toEqual([existing]);
+		expect(warning).toHaveBeenCalledWith(
+			expect.stringContaining('email=owner@example.com already belongs to userId=existing-owner')
+		);
 	});
 
 	it('excludes the preview admin from every recipient type despite stored toggles', async () => {
@@ -177,6 +209,32 @@ describe('preview admin notification preferences', () => {
 
 		for (const type of ['newTickets', 'userReplies', 'newSignups'] as const) {
 			await expect(getRecipientsHandler({ db }, { type })).resolves.toEqual(['owner@example.com']);
+		}
+	});
+
+	it('excludes a normalized preview address from both support notification types', async () => {
+		const { db } = createPreferenceStore([
+			makePreference('  ADMIN@PREVIEW.DEV ', 'preview-user'),
+			makePreference('owner@example.com', 'owner-user')
+		]);
+
+		for (const notificationType of ['newTickets', 'userReplies'] as const) {
+			await expect(getSupportRecipientsHandler({ db }, { notificationType })).resolves.toEqual([
+				'owner@example.com'
+			]);
+		}
+	});
+
+	it('falls back to a real admin when a support ticket is assigned to the preview admin', async () => {
+		const { db } = createPreferenceStore([
+			makePreference('admin@preview.dev', 'preview-user'),
+			makePreference('owner@example.com', 'owner-user')
+		]);
+
+		for (const notificationType of ['newTickets', 'userReplies'] as const) {
+			await expect(
+				getSupportRecipientsHandler({ db }, { assignedTo: 'preview-user', notificationType })
+			).resolves.toEqual(['owner@example.com']);
 		}
 	});
 

--- a/src/lib/convex/admin/notificationPreferences/queries.ts
+++ b/src/lib/convex/admin/notificationPreferences/queries.ts
@@ -11,6 +11,7 @@ import { internalQuery } from '../../_generated/server';
 import type { QueryCtx } from '../../_generated/server';
 import { components } from '../../_generated/api';
 import { parseBetterAuthUsers } from '../types';
+import { isPreviewAdminEmail } from './helpers';
 
 /**
  * Notification type validator for internal queries
@@ -339,7 +340,8 @@ export const getRecipientsForNotificationType = internalQuery({
 
 		// Filter to active recipients with this notification enabled
 		const activePrefs = allPrefs.filter(
-			(p) => (p.isAdminUser || p.userId === undefined) && p[toggleField]
+			(p) =>
+				!isPreviewAdminEmail(p.email) && (p.isAdminUser || p.userId === undefined) && p[toggleField]
 		);
 
 		return activePrefs.map((p) => p.email);

--- a/src/lib/convex/admin/support/notifications.ts
+++ b/src/lib/convex/admin/support/notifications.ts
@@ -21,6 +21,7 @@ import type { Id } from '../../_generated/dataModel';
 import { internalMutation, internalAction, internalQuery } from '../../_generated/server';
 import { internal, components } from '../../_generated/api';
 import { supportThreadFields } from '../../support/supportThreadFields';
+import { isPreviewAdminEmail } from '../notificationPreferences/helpers';
 
 /** Delay before sending a notification after the latest message. */
 const NOTIFICATION_DELAY_MS = 4 * 60 * 1000;
@@ -459,7 +460,8 @@ export const getNotificationTargetEmails = internalQuery({
 
 		// Filter to active recipients (admins or custom emails) with this notification enabled
 		const activePrefs = allPrefs.filter(
-			(p) => (p.isAdminUser || p.userId === undefined) && p[toggleField]
+			(p) =>
+				!isPreviewAdminEmail(p.email) && (p.isAdminUser || p.userId === undefined) && p[toggleField]
 		);
 
 		// If assigned admin has this notification enabled, prioritize them

--- a/src/lib/convex/previewDev.ts
+++ b/src/lib/convex/previewDev.ts
@@ -2,9 +2,7 @@ import { v } from 'convex/values';
 import { components } from './_generated/api';
 import { internalMutation, type MutationCtx } from './_generated/server';
 import { createAuth } from './auth';
-import { syncAdminPreferences } from './admin/notificationPreferences/helpers';
-
-const PREVIEW_ADMIN_EMAIL = 'admin@preview.dev';
+import { PREVIEW_ADMIN_EMAIL, syncAdminPreferences } from './admin/notificationPreferences/helpers';
 const PREVIEW_ADMIN_NAME = 'Preview Admin';
 
 type BetterAuthUser = {
@@ -107,6 +105,7 @@ export const ensurePreviewAdmin = internalMutation({
 			});
 		}
 
+		// Unchanged users still reach the idempotent preference repair.
 		await syncAdminPreferences(ctx, { userId: user._id, email });
 
 		return {


### PR DESCRIPTION
Closes #912

Regression guard: added previewAdmin.test.ts.

The seeded `admin@preview.dev` account was treated like a real administrator by notification preferences, so preview deployments could attempt to send signup and support mail to a synthetic address. Existing rows could also keep active toggles across repeated seed runs.

The preview identity now receives disabled defaults and is excluded at every outbound recipient query, including assigned support tickets. Repeated seeding repairs active or stale preferences while ordinary email collisions remain untouched. Regression coverage exercises all three notification types, assignment priority, normalized addresses, stale user bindings and real administrator defaults.

Verified with focused Convex tests, changed-file static checks, full type checks and the Convex check.