### PR TITLE
ci(pr): Validate pull request titles

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,42 @@
+name: PR Title
+
+# GitHub suppresses pull_request_target for SHA-like source branch names.
+# Renaming a head branch closes its pull request. Open a replacement pull
+# request from a non-SHA-like source branch so this check can run.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: PR Title
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Checkout the trusted workflow revision
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Fetch current pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            > "$RUNNER_TEMP/pull-request.json"
+
+      - name: Validate current pull request title
+        run: bun scripts/check-pr-title.ts --pr-json "$RUNNER_TEMP/pull-request.json"

--- a/scripts/check-pr-title.test.ts
+++ b/scripts/check-pr-title.test.ts
@@ -20,8 +20,6 @@ import {
 const REPO_ROOT = path.resolve(import.meta.dirname, '..');
 const SCRIPT = path.join(REPO_ROOT, 'scripts/check-pr-title.ts');
 const WORKFLOW_PATH = path.join(REPO_ROOT, '.github/workflows/check-pr-title.yml');
-const CHECKOUT = 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0';
-const SETUP_BUN = 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6';
 
 function runCli(title?: string, prJson?: string) {
 	const env = { ...process.env };
@@ -282,12 +280,14 @@ describe('PR Title workflow', () => {
 
 	it('checks out and executes only the trusted workflow revision', () => {
 		const checkout = job.steps.find((step) => step.uses?.startsWith('actions/checkout@'))!;
-		expect(checkout.uses).toBe(CHECKOUT);
+		expect(checkout.uses).toMatch(/^actions\/checkout@[0-9a-f]{40}$/);
 		expect(checkout.with).toEqual({
 			ref: '${{ github.workflow_sha }}',
 			'persist-credentials': false
 		});
-		expect(job.steps.some((step) => step.uses === SETUP_BUN)).toBe(true);
+		expect(
+			job.steps.some((step) => /^oven-sh\/setup-bun@[0-9a-f]{40}$/.test(step.uses ?? ''))
+		).toBe(true);
 		expect(source).not.toMatch(/github\.event\.pull_request\.head|github\.head_ref|refs\/pull\//);
 		expect(source).not.toMatch(/bun install|npm |pnpm |yarn /);
 	});

--- a/scripts/check-pr-title.test.ts
+++ b/scripts/check-pr-title.test.ts
@@ -1,0 +1,319 @@
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+import {
+	ALLOWED_TYPES,
+	FINAL_PERIOD,
+	INVALID_PR_DATA,
+	INVALID_SCOPE,
+	INVALID_SHAPE,
+	INVALID_SUBJECT,
+	MISSING_TITLE,
+	UNSAFE_CHARACTER,
+	UNSUPPORTED_TYPE,
+	validateTitle
+} from './check-pr-title';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const SCRIPT = path.join(REPO_ROOT, 'scripts/check-pr-title.ts');
+const WORKFLOW_PATH = path.join(REPO_ROOT, '.github/workflows/check-pr-title.yml');
+const CHECKOUT = 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0';
+const SETUP_BUN = 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6';
+
+function runCli(title?: string, prJson?: string) {
+	const env = { ...process.env };
+	if (title === undefined) delete env.PR_TITLE;
+	else env.PR_TITLE = title;
+	const args = [SCRIPT];
+	if (prJson !== undefined) args.push('--pr-json', prJson);
+	return spawnSync('bun', args, { cwd: REPO_ROOT, env, encoding: 'utf-8' });
+}
+
+function withTempDirectory(run: (directory: string) => void): void {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-title-'));
+	try {
+		run(directory);
+	} finally {
+		fs.rmSync(directory, { recursive: true, force: true });
+	}
+}
+
+describe('validateTitle', () => {
+	it.each([
+		'feat: Add title validation',
+		'fix(parser): Reject an invalid title',
+		'docs!: Rewrite the guide',
+		'refactor(release workflow)!: Restore required checks'
+	])('accepts the supported shape: %s', (title) => {
+		expect(validateTitle(title)).toBeUndefined();
+	});
+
+	it('exposes exactly the repository-supported types', () => {
+		expect(ALLOWED_TYPES).toEqual([
+			'feat',
+			'fix',
+			'docs',
+			'style',
+			'refactor',
+			'test',
+			'chore',
+			'perf',
+			'ci'
+		]);
+	});
+
+	it.each(ALLOWED_TYPES)('accepts the allowed type %s', (type) => {
+		expect(validateTitle(`${type}: Accept this title`)).toBeUndefined();
+	});
+
+	it('accepts Renovate-compatible lowercase subjects', () => {
+		expect(validateTitle('chore(deps): update dependency svelte to v5.57.0')).toBeUndefined();
+	});
+
+	it('rejects unsupported types without treating them as malformed', () => {
+		expect(validateTitle('build: Package the release')).toBe(UNSUPPORTED_TYPE);
+	});
+
+	it.each([
+		['fix:Add spacing', INVALID_SHAPE],
+		['fix : Add spacing', INVALID_SHAPE],
+		[' fix: Add spacing', INVALID_SHAPE],
+		['fix(scope) : Add spacing', INVALID_SHAPE],
+		['fix(scope)! : Add spacing', INVALID_SHAPE],
+		['fix(scope)!!: Add spacing', INVALID_SHAPE],
+		['fix!!: Add spacing', INVALID_SHAPE],
+		['fix!extra: Add spacing', INVALID_SHAPE],
+		['fix(): Add spacing', INVALID_SCOPE],
+		['fix: ', INVALID_SUBJECT],
+		['fix:  ', INVALID_SUBJECT],
+		['fix:  Add spacing', INVALID_SUBJECT],
+		['fix: Add spacing ', INVALID_SUBJECT],
+		['fix: Add spacing.', FINAL_PERIOD]
+	] as const)('returns a fixed diagnostic for %s', (title, diagnostic) => {
+		expect(validateTitle(title)).toBe(diagnostic);
+	});
+
+	it.each([0x20, 0x00a0, 0x1680, 0x2000, 0x202f, 0x205f, 0x3000])(
+		'rejects separator boundaries at code point %s',
+		(codepoint) => {
+			const separator = String.fromCodePoint(codepoint);
+			expect(validateTitle(`fix(${separator}scope): Keep boundaries`)).toBe(INVALID_SCOPE);
+			expect(validateTitle(`fix(scope${separator}): Keep boundaries`)).toBe(INVALID_SCOPE);
+			expect(validateTitle(`fix: ${separator}Keep boundaries`)).toBe(INVALID_SUBJECT);
+			expect(validateTitle(`fix: Keep boundaries${separator}`)).toBe(INVALID_SUBJECT);
+		}
+	);
+
+	it.each([0x00ad, 0x180e, 0x200d])(
+		'rejects format characters at boundaries at code point %s',
+		(codepoint) => {
+			const character = String.fromCodePoint(codepoint);
+			expect(validateTitle(`fix(${character}scope): Keep boundaries`)).toBe(INVALID_SCOPE);
+			expect(validateTitle(`fix(scope${character}): Keep boundaries`)).toBe(INVALID_SCOPE);
+			expect(validateTitle(`fix: ${character}Keep boundaries`)).toBe(INVALID_SUBJECT);
+			expect(validateTitle(`fix: Keep boundaries${character}`)).toBe(INVALID_SUBJECT);
+		}
+	);
+
+	it.each([
+		...Array.from({ length: 0x20 }, (_, codepoint) => codepoint),
+		...Array.from({ length: 0x21 }, (_, index) => 0x7f + index),
+		0x061c,
+		0x200b,
+		0x200e,
+		0x200f,
+		...Array.from({ length: 7 }, (_, index) => 0x2028 + index),
+		0x2060,
+		...Array.from({ length: 4 }, (_, index) => 0x2066 + index),
+		0xfeff,
+		0xfffd
+	])('rejects unsafe code point U+%s anywhere', (codepoint) => {
+		const character = String.fromCodePoint(codepoint);
+		expect(validateTitle(`fix: Before${character}after`)).toBe(UNSAFE_CHARACTER);
+	});
+
+	it('requires substantive scope and subject content', () => {
+		const combiningAcute = String.fromCodePoint(0x0301);
+		expect(validateTitle(`fix(${combiningAcute}): Subject`)).toBe(INVALID_SCOPE);
+		expect(validateTitle(`fix: ${combiningAcute}`)).toBe(INVALID_SUBJECT);
+	});
+
+	it.each([0x00ad, 0x0301])(
+		'finds a final ASCII period before non-substantive code point %s',
+		(codepoint) => {
+			expect(validateTitle(`fix: Do not hide.${String.fromCodePoint(codepoint)}`)).toBe(
+				FINAL_PERIOD
+			);
+		}
+	);
+
+	it('preserves decomposed accents', () => {
+		const combiningAcute = String.fromCodePoint(0x0301);
+		expect(
+			validateTitle(`fix(cafe${combiningAcute}): Handle resume${combiningAcute}`)
+		).toBeUndefined();
+	});
+
+	it('preserves internal emoji ZWJ sequences', () => {
+		const zwj = String.fromCodePoint(0x200d);
+		expect(validateTitle(`fix: Support 👩${zwj}💻 profiles`)).toBeUndefined();
+	});
+
+	it.each([
+		'feat(HTTP/API v2): Preserve internal punctuation',
+		'fix: Handle déjà vu safely',
+		'docs: Explain 日本語 titles',
+		'test: Permit commas, semicolons; and question marks?',
+		'chore: Permit a Unicode full stop。',
+		'perf(scope! #42): Permit punctuation in scope'
+	])('accepts safe Unicode and punctuation: %s', (title) => {
+		expect(validateTitle(title)).toBeUndefined();
+	});
+});
+
+describe('title validator CLI', () => {
+	it.each([
+		'build: payload%0A::warning::leaked',
+		'build: ::warning:: forged annotation',
+		'fix: actual\rcontrol',
+		'fix: actual\ncontrol',
+		`fix: Invisible${String.fromCodePoint(0x200b)}content`
+	])('emits one safe fixed annotation for invalid input', (title) => {
+		const result = runCli(title);
+		const output = result.stdout + result.stderr;
+
+		expect(result.status).not.toBe(0);
+		expect(output.split('\n').filter((line) => line.startsWith('::error::'))).toHaveLength(1);
+		expect(output).toContain('Expected: type: subject');
+		expect(output).not.toContain(title);
+		expect(output).not.toContain('::warning::');
+	});
+
+	it('reports a missing environment title without outputting input', () => {
+		const result = runCli();
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain(`::error::${MISSING_TITLE}`);
+	});
+
+	it('exits silently for a valid environment title', () => {
+		const result = runCli('fix(cli): Accept safe input');
+		expect(result.status).toBe(0);
+		expect(result.stdout).toBe('');
+		expect(result.stderr).toBe('');
+	});
+
+	it('reads the current title from PR JSON instead of the environment', () => {
+		withTempDirectory((directory) => {
+			const prJson = path.join(directory, 'pull-request.json');
+			fs.writeFileSync(prJson, JSON.stringify({ title: 'fix(cli): Read current API data' }));
+			const result = runCli('build: Ignore stale event data', prJson);
+			expect(result.status).toBe(0);
+			expect(result.stdout + result.stderr).toBe('');
+		});
+	});
+
+	it.each(['{', '{}', '{"title":null}', '[]'])(
+		'rejects malformed PR JSON safely: %s',
+		(contents) => {
+			withTempDirectory((directory) => {
+				const prJson = path.join(directory, 'pull-request.json');
+				fs.writeFileSync(prJson, contents);
+				const result = runCli('fix: Stale event title', prJson);
+				const output = result.stdout + result.stderr;
+				expect(result.status).not.toBe(0);
+				expect(
+					output.split('\n').filter((line) => line === `::error::${INVALID_PR_DATA}`)
+				).toHaveLength(1);
+				expect(output).not.toContain(contents);
+				expect(output).not.toContain('Stale event title');
+			});
+		}
+	);
+
+	it('rejects a missing PR JSON file without echoing its path', () => {
+		withTempDirectory((directory) => {
+			const prJson = path.join(directory, 'missing.json');
+			const result = runCli('fix: Stale event title', prJson);
+			expect(result.status).not.toBe(0);
+			expect(result.stderr).toContain(`::error::${INVALID_PR_DATA}`);
+			expect(result.stdout + result.stderr).not.toContain(prJson);
+		});
+	});
+});
+
+describe('PR Title workflow', () => {
+	const source = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+	const workflow = parseYaml(source) as {
+		name: string;
+		on: Record<string, { types: string[] }>;
+		permissions: Record<string, string>;
+		concurrency: { group: string; 'cancel-in-progress': boolean };
+		jobs: Record<
+			string,
+			{
+				name: string;
+				steps: Array<{
+					name?: string;
+					uses?: string;
+					with?: Record<string, unknown>;
+					env?: Record<string, string>;
+					run?: string;
+				}>;
+			}
+		>;
+	};
+	const job = workflow.jobs.check!;
+
+	it('uses the exact automatic trigger, permissions, concurrency, and check name', () => {
+		expect(workflow.name).toBe('PR Title');
+		expect(job.name).toBe('PR Title');
+		expect(workflow.on).toEqual({
+			pull_request_target: { types: ['opened', 'edited', 'reopened', 'synchronize'] }
+		});
+		expect(workflow.permissions).toEqual({ contents: 'read', 'pull-requests': 'read' });
+		expect(workflow.concurrency).toEqual({
+			group: 'pr-title-${{ github.event.pull_request.number }}',
+			'cancel-in-progress': true
+		});
+	});
+
+	it('checks out and executes only the trusted workflow revision', () => {
+		const checkout = job.steps.find((step) => step.uses?.startsWith('actions/checkout@'))!;
+		expect(checkout.uses).toBe(CHECKOUT);
+		expect(checkout.with).toEqual({
+			ref: '${{ github.workflow_sha }}',
+			'persist-credentials': false
+		});
+		expect(job.steps.some((step) => step.uses === SETUP_BUN)).toBe(true);
+		expect(source).not.toMatch(/github\.event\.pull_request\.head|github\.head_ref|refs\/pull\//);
+		expect(source).not.toMatch(/bun install|npm |pnpm |yarn /);
+	});
+
+	it('fetches current PR JSON with the token before running the dependency-free validator', () => {
+		const fetch = job.steps.find((step) => step.name === 'Fetch current pull request')!;
+		const validate = job.steps.find((step) => step.name === 'Validate current pull request title')!;
+		expect(fetch.env).toEqual({
+			GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
+			PR_NUMBER: '${{ github.event.pull_request.number }}'
+		});
+		expect(fetch.run).toContain('gh api --method GET');
+		expect(fetch.run).toContain('"repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"');
+		expect(fetch.run).toContain('> "$RUNNER_TEMP/pull-request.json"');
+		expect(validate.run).toBe(
+			'bun scripts/check-pr-title.ts --pr-json "$RUNNER_TEMP/pull-request.json"'
+		);
+		expect(validate.env).toBeUndefined();
+		expect(source).not.toContain('github.event.pull_request.title');
+	});
+
+	it('has no comment or status fallback and documents SHA-like branch recovery', () => {
+		expect(source).not.toMatch(/issue_comment|workflow_dispatch|statuses: write|\/statuses\//);
+		expect(source).toContain('suppresses pull_request_target for SHA-like source branch names');
+		expect(source).toContain('Renaming a head branch closes its pull request');
+		expect(source).toContain('Open a replacement pull');
+		expect(source).toContain('request from a non-SHA-like source branch');
+	});
+});

--- a/scripts/check-pr-title.ts
+++ b/scripts/check-pr-title.ts
@@ -1,0 +1,121 @@
+export const ALLOWED_TYPES = [
+	'feat',
+	'fix',
+	'docs',
+	'style',
+	'refactor',
+	'test',
+	'chore',
+	'perf',
+	'ci'
+] as const;
+
+export const MISSING_TITLE = 'PR title is missing.';
+export const INVALID_PR_DATA = 'Unable to read current pull request data.';
+export const UNSAFE_CHARACTER = 'PR title contains an unsafe character.';
+export const INVALID_SHAPE = 'PR title must use an accepted conventional-commit shape.';
+export const UNSUPPORTED_TYPE = 'PR title uses an unsupported type.';
+export const INVALID_SCOPE = 'PR title has an invalid scope.';
+export const INVALID_SUBJECT = 'PR title has an invalid subject.';
+export const FINAL_PERIOD = 'PR title subject must not end with an ASCII period.';
+
+export const HINT =
+	'Expected: type: subject, type(scope): subject, type!: subject, or type(scope)!: subject. ' +
+	`Allowed types: ${ALLOWED_TYPES.join(', ')}.`;
+
+const TITLE = /^(?<type>[a-z]+)(?:\((?<scope>[^()]*)\))?(?<breaking>!)?: (?<subject>.*)$/u;
+const BIDI_FORMATTING = new Set([
+	0x061c,
+	0x200e,
+	0x200f,
+	...range(0x202a, 0x202f),
+	...range(0x2066, 0x206a)
+]);
+const NON_SUBSTANTIVE = /[\p{C}\p{M}\p{Z}]/u;
+const INVALID_BOUNDARY = /[\p{Cf}\p{Z}]/u;
+
+function range(start: number, end: number): number[] {
+	return Array.from({ length: end - start }, (_, index) => start + index);
+}
+
+function isUnsafe(character: string): boolean {
+	const codepoint = character.codePointAt(0)!;
+	return (
+		codepoint <= 0x001f ||
+		(codepoint >= 0x007f && codepoint <= 0x009f) ||
+		[0x200b, 0x2028, 0x2029, 0x2060, 0xfeff, 0xfffd].includes(codepoint) ||
+		BIDI_FORMATTING.has(codepoint)
+	);
+}
+
+function lastSubstantive(value: string): string | undefined {
+	return Array.from(value)
+		.reverse()
+		.find((character) => !NON_SUBSTANTIVE.test(character));
+}
+
+function hasInvalidBoundary(value: string): boolean {
+	const characters = Array.from(value);
+	return (
+		characters.length > 0 &&
+		(INVALID_BOUNDARY.test(characters[0]!) || INVALID_BOUNDARY.test(characters.at(-1)!))
+	);
+}
+
+export function validateTitle(title: string): string | undefined {
+	if (Array.from(title).some(isUnsafe)) return UNSAFE_CHARACTER;
+
+	const match = TITLE.exec(title);
+	if (!match?.groups) return INVALID_SHAPE;
+
+	if (!ALLOWED_TYPES.includes(match.groups.type as (typeof ALLOWED_TYPES)[number])) {
+		return UNSUPPORTED_TYPE;
+	}
+
+	const scope = match.groups.scope;
+	if (scope !== undefined && (lastSubstantive(scope) === undefined || hasInvalidBoundary(scope))) {
+		return INVALID_SCOPE;
+	}
+
+	const subject = match.groups.subject!;
+	const last = lastSubstantive(subject);
+	if (last === undefined) return INVALID_SUBJECT;
+	if (last === '.') return FINAL_PERIOD;
+	if (hasInvalidBoundary(subject)) return INVALID_SUBJECT;
+
+	return undefined;
+}
+
+async function readPullRequestTitle(path: string): Promise<string | undefined> {
+	try {
+		const data: unknown = JSON.parse(await Bun.file(path).text());
+		if (typeof data !== 'object' || data === null || Array.isArray(data)) return undefined;
+		const title = (data as Record<string, unknown>).title;
+		return typeof title === 'string' && title.length > 0 ? title : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function main(): Promise<number> {
+	const args = process.argv.slice(2);
+	let diagnostic: string | undefined;
+
+	if (args[0] === '--pr-json' && args.length === 2) {
+		const title = await readPullRequestTitle(args[1]!);
+		diagnostic = title === undefined ? INVALID_PR_DATA : validateTitle(title);
+	} else if (args.length === 0) {
+		const title = process.env.PR_TITLE;
+		diagnostic = title ? validateTitle(title) : MISSING_TITLE;
+	} else {
+		diagnostic = INVALID_PR_DATA;
+	}
+
+	if (diagnostic === undefined) return 0;
+
+	console.error(`::error::${diagnostic}`);
+	console.error(HINT);
+	return 1;
+}
+
+if (import.meta.main) process.exit(await main());


### PR DESCRIPTION
Closes #916

Pull request titles become squash-merge commit subjects, but the repository previously relied on review to catch malformed titles before merge.

This adds a dependency-free TypeScript validator and a fork-safe `pull_request_target` workflow that reads the current title from the GitHub API while executing only trusted base-branch code. It accepts the documented Conventional Commit forms, keeps Renovate-compatible lowercase subjects, rejects unsafe invisible characters, and returns fixed diagnostics without reproducing untrusted input.

Verified with 151 focused tests, a mutation that made the suite fail, changed-file static checks, full type checks, and the 2,192-test unit suite.
