### PR TITLE
test(e2e): Stabilize audit search

### DIFF
--- a/e2e/admin-audit-log.spec.ts
+++ b/e2e/admin-audit-log.spec.ts
@@ -327,7 +327,11 @@ test.describe('Admin Audit Log', () => {
 		// Typing the target's email into the free-text search narrows the log to
 		// rows referencing that user (matched via the target column). The canonical
 		// `search` URL param carries the query.
-		await page.getByTestId('admin-audit-log-search').fill(targetEmail);
+		const searchInput = page.getByTestId('admin-audit-log-search');
+		const noMatch = `${targetEmail}.no-match`;
+		await searchInput.fill(noMatch);
+		await expect(page.getByTestId('admin-audit-log-empty')).toBeVisible({ timeout: 10000 });
+		await searchInput.fill(targetEmail);
 		await expect.poll(() => new URL(page.url()).searchParams.get('search')).toBe(targetEmail);
 		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
 
@@ -346,7 +350,10 @@ test.describe('Admin Audit Log', () => {
 		// A partial substring still matches: the backend does a case-insensitive
 		// substring match on email + name, mirroring the users table.
 		const partial = targetEmail.split('@')[0]!;
-		await page.getByTestId('admin-audit-log-search').fill(partial);
+		await searchInput.fill(noMatch);
+		await expect(page.getByTestId('admin-audit-log-empty')).toBeVisible({ timeout: 10000 });
+		await searchInput.fill(partial);
+		await expect.poll(() => new URL(page.url()).searchParams.get('search')).toBe(partial);
 		await expect.poll(async () => page.getByTestId('admin-audit-log-loading').count()).toBe(0);
 		await expect(
 			page.getByTestId('audit-log-target-cell').filter({ hasText: targetEmail }).first()

--- a/e2e/admin-audit-log.spec.ts
+++ b/e2e/admin-audit-log.spec.ts
@@ -333,12 +333,15 @@ test.describe('Admin Audit Log', () => {
 
 		// Every visible row references our target.
 		const targetCells = page.getByTestId('audit-log-target-cell');
-		await expect(targetCells.first()).toBeVisible({ timeout: 10000 });
-		const count = await targetCells.count();
-		expect(count).toBeGreaterThan(0);
-		for (let i = 0; i < count; i++) {
-			await expect(targetCells.nth(i)).toContainText(targetEmail);
-		}
+		await expect
+			.poll(
+				async () => {
+					const targets = await targetCells.allTextContents();
+					return targets.length > 0 && targets.every((target) => target.includes(targetEmail));
+				},
+				{ timeout: 10000 }
+			)
+			.toBe(true);
 
 		// A partial substring still matches: the backend does a case-insensitive
 		// substring match on email + name, mirroring the users table.


### PR DESCRIPTION
Closes #842
Regression guard: covered by the deployed Playwright search flow

The audit-log search test could read rows from the previous query before its 300 ms debounce elapsed. It then captured a row count and indexed a live locator list while Convex replaced the result set.

The test now crosses a visible empty-result boundary before exact and partial searches, then validates one current text snapshot. This proves each query completed and removes the count/index race without production instrumentation.

Verified with the targeted flow repeated twice, the full 110-test E2E suite, changed-file static checks, and an independent committed-diff review.
