### PR TITLE
fix(chat): Restore rejected send drafts

### DIFF
--- a/src/lib/chat/core/chat-attachment-store.svelte.ts
+++ b/src/lib/chat/core/chat-attachment-store.svelte.ts
@@ -222,6 +222,43 @@ export class ChatAttachmentStore {
 		this.stored.current = next;
 	}
 
+	/** Restore one rejected send without overwriting newer persisted work. */
+	restoreThreadAttachments(threadId: string | null, snapshot: Attachment[]): void {
+		const key = threadId ?? '';
+		const previous = this.parse();
+		const current = previous[key] ?? [];
+		// Local collections used once to build a deterministic stored snapshot.
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const currentById = new Map(current.map((item) => [item.id, item]));
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const included = new Set<string>();
+		const merged: StoredAttachment[] = [];
+		const now = Date.now();
+
+		for (const attachment of snapshot) {
+			const transfer = ChatAttachmentStore.transferId(attachment);
+			if (!transfer || included.has(transfer)) continue;
+			const existing = currentById.get(transfer);
+			const restored = existing ?? toStored(attachment, this.stamps.get(transfer) ?? now);
+			if (!restored) continue;
+			this.stamps.set(transfer, restored.savedAt);
+			included.add(transfer);
+			merged.push(restored);
+		}
+		for (const attachment of current) {
+			if (included.has(attachment.id)) continue;
+			included.add(attachment.id);
+			merged.push(attachment);
+		}
+
+		const alive = this.fresh({ [key]: merged })[key] ?? [];
+		const next = { ...previous };
+		if (alive.length > 0) next[key] = alive;
+		else delete next[key];
+		if (JSON.stringify(next) === JSON.stringify(previous)) return;
+		this.stored.current = next;
+	}
+
 	/** Drop what the vacuum may already have collected. */
 	private fresh(record: StoredRecord): StoredRecord {
 		const cutoff = Date.now() - MAX_AGE_MS;

--- a/src/lib/chat/core/chat-attachment-store.svelte.ts
+++ b/src/lib/chat/core/chat-attachment-store.svelte.ts
@@ -1,7 +1,10 @@
 import { PersistedState } from 'runed';
 import * as v from 'valibot';
 import type { Attachment } from './types.js';
-import { ATTACHMENT_STORAGE_PREFIX } from './chat-persisted-state.js';
+import {
+	ATTACHMENT_STORAGE_PREFIX,
+	reconcilePersistedChatAttachments
+} from './chat-persisted-state.js';
 
 /**
  * How long a stored attachment is offered back.
@@ -119,6 +122,7 @@ function fromStored(stored: StoredAttachment): Attachment {
  * in storage once its upload finished.
  */
 export class ChatAttachmentStore {
+	readonly namespace: string;
 	private readonly stored: PersistedState<StoredRecord>;
 
 	/**
@@ -152,7 +156,8 @@ export class ChatAttachmentStore {
 	 * is added here so no caller can spell it differently.
 	 */
 	constructor(surface: string) {
-		this.stored = new PersistedState<StoredRecord>(`${ATTACHMENT_STORAGE_PREFIX}${surface}`, {});
+		this.namespace = `${ATTACHMENT_STORAGE_PREFIX}${surface}`;
+		this.stored = new PersistedState<StoredRecord>(this.namespace, {});
 	}
 
 	/** Everything still on offer, anything too old already dropped. */
@@ -255,8 +260,15 @@ export class ChatAttachmentStore {
 		const next = { ...previous };
 		if (alive.length > 0) next[key] = alive;
 		else delete next[key];
-		if (JSON.stringify(next) === JSON.stringify(previous)) return;
-		this.stored.current = next;
+		try {
+			if (JSON.stringify(next) !== JSON.stringify(previous)) this.stored.current = next;
+		} finally {
+			reconcilePersistedChatAttachments(
+				this.namespace,
+				threadId,
+				alive.map((item) => this.revive(item))
+			);
+		}
 	}
 
 	/** Drop what the vacuum may already have collected. */

--- a/src/lib/chat/core/chat-attachment-store.test.ts
+++ b/src/lib/chat/core/chat-attachment-store.test.ts
@@ -248,6 +248,59 @@ describe('ChatAttachmentStore', () => {
 		]);
 	});
 
+	it('restores a sent snapshot before later attachments without touching other threads', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-01T08:00:00Z'));
+		const store = new ChatAttachmentStore(surface);
+		const first = uploaded({ key: 'upload-a', name: 'a.txt', url: 'https://files.example/a' });
+		const second = uploaded({ key: 'upload-b', name: 'b.txt', url: 'https://files.example/b' });
+		const later = uploaded({ key: 'upload-c', name: 'c.txt', url: 'https://files.example/c' });
+		const other = uploaded({ key: 'upload-other', url: 'https://files.example/other' });
+		store.write(
+			new Map([
+				['thread-1', [first, second]],
+				['thread-2', [other]]
+			])
+		);
+		const savedAt = (written() as Record<string, Array<{ savedAt: number }>>)['thread-1']?.[0]
+			?.savedAt;
+		store.write(new Map([['thread-1', [later]]]));
+
+		vi.setSystemTime(new Date('2026-08-01T09:00:00Z'));
+		store.restoreThreadAttachments('thread-1', [first, second]);
+
+		expect(
+			store
+				.readThread('thread-1')
+				.map((attachment) => ('key' in attachment ? attachment.key : undefined))
+		).toEqual(['upload-a', 'upload-b', 'upload-c']);
+		expect(
+			store
+				.readThread('thread-2')
+				.map((attachment) => ('key' in attachment ? attachment.key : undefined))
+		).toEqual(['upload-other']);
+		expect(
+			(written() as Record<string, Array<{ savedAt: number }>>)['thread-1']
+				?.slice(0, 2)
+				.map((attachment) => attachment.savedAt)
+		).toEqual([savedAt, savedAt]);
+	});
+
+	it('deduplicates restored attachments by transfer identity and omits dead previews', () => {
+		const store = new ChatAttachmentStore(surface);
+		const snapshot = uploaded({
+			key: 'upload-a',
+			preview: 'blob:https://chat.test/dead-preview'
+		});
+		store.write(new Map([['thread-1', [snapshot]]]));
+
+		store.restoreThreadAttachments('thread-1', [snapshot, snapshot]);
+
+		const restored = store.readThread('thread-1');
+		expect(restored).toEqual([expect.objectContaining({ key: 'upload-a' })]);
+		expect(restored[0]).not.toHaveProperty('preview');
+	});
+
 	it('does not rewrite storage when nothing changed', () => {
 		const store = new ChatAttachmentStore(surface);
 		store.write(new Map([['thread-1', [uploaded()]]]));

--- a/src/lib/chat/core/chat-core.svelte.ts
+++ b/src/lib/chat/core/chat-core.svelte.ts
@@ -16,6 +16,7 @@ import type {
 import { DEFAULT_CHAT_CONFIG } from './types.js';
 import { StreamCacheManager } from './stream-cache.js';
 import { createOptimisticUpdate, type ListMessagesArgs } from './optimistic.js';
+import { getChatSessionEpoch, isChatSessionCurrent } from './chat-persisted-state.js';
 
 /**
  * Result from creating a thread
@@ -88,6 +89,7 @@ export class ChatCore {
 	// Configuration
 	private readonly api: ChatCoreAPI;
 	private readonly config: Required<ChatConfig>;
+	private sendRevision = 0;
 
 	constructor(options: ChatCoreOptions) {
 		this.threadId = options.threadId ?? null;
@@ -191,6 +193,8 @@ export class ChatCore {
 			throw new Error('Cannot send message: validation failed');
 		}
 
+		const sessionEpoch = getChatSessionEpoch();
+		const sendRevision = ++this.sendRevision;
 		this.setSending(true);
 		this.setAwaitingStream(true);
 
@@ -209,6 +213,7 @@ export class ChatCore {
 					this.api.createThread,
 					options?.createThreadOptions ?? {}
 				)) as CreateThreadResult;
+				if (!isChatSessionCurrent(sessionEpoch)) throw new Error('Chat session ended');
 
 				threadId = result.threadId;
 				threadCreated = result;
@@ -247,6 +252,7 @@ export class ChatCore {
 				},
 				mutationOptions
 			);
+			if (!isChatSessionCurrent(sessionEpoch)) return { ...result, threadCreated };
 
 			// Request widget to open if requested
 			if (options?.openWidgetAfter) {
@@ -255,13 +261,17 @@ export class ChatCore {
 
 			return { ...result, threadCreated };
 		} catch (error) {
-			console.error('[ChatCore.sendMessage] Failed to send message:', error);
-			this.setError('Failed to send message. Please try again.');
-			this.setAwaitingStream(false);
+			if (isChatSessionCurrent(sessionEpoch)) {
+				console.error('[ChatCore.sendMessage] Failed to send message:', error);
+				this.setError('Failed to send message. Please try again.');
+				this.setAwaitingStream(false);
+			}
 			// Optimistic update automatically rolled back on failure
 			throw error;
 		} finally {
-			this.setSending(false);
+			if (isChatSessionCurrent(sessionEpoch) && this.sendRevision === sendRevision) {
+				this.setSending(false);
+			}
 		}
 	}
 
@@ -295,6 +305,15 @@ export class ChatCore {
 		} finally {
 			this.setLoading(false);
 		}
+	}
+
+	/** Reset session-owned flags without changing the selected thread. */
+	forgetChatSession(): void {
+		this.sendRevision++;
+		this.isSending = false;
+		this.isAwaitingStream = false;
+		this.error = null;
+		this.shouldOpenWidget = false;
 	}
 
 	/**

--- a/src/lib/chat/core/chat-draft-manager.svelte.ts
+++ b/src/lib/chat/core/chat-draft-manager.svelte.ts
@@ -1,6 +1,12 @@
 import { PersistedState } from 'runed';
 import { DRAFT_STORAGE_PREFIX } from './chat-persisted-state.js';
 
+export type ChatDraftCheckpoint = Readonly<{
+	threadId: string | null;
+	value: string;
+	revision: number;
+}>;
+
 /**
  * Manages per-thread draft text persistence via localStorage.
  *
@@ -8,6 +14,9 @@ import { DRAFT_STORAGE_PREFIX } from './chat-persisted-state.js';
  */
 export class ChatDraftManager {
 	readonly drafts: PersistedState<Record<string, string>>;
+	// Instance-local because each manager already owns one persisted namespace.
+	// eslint-disable-next-line svelte/prefer-svelte-reactivity
+	private readonly revisions = new Map<string, number>();
 
 	/**
 	 * @param surface which chat this belongs to, e.g. `ai-chat`. The namespace
@@ -25,7 +34,16 @@ export class ChatDraftManager {
 		return threadId ? (this.drafts.current[threadId] ?? '') : '';
 	}
 
+	captureCheckpoint(threadId: string | null): ChatDraftCheckpoint {
+		return {
+			threadId,
+			value: this.getDraft(threadId),
+			revision: this.revision(threadId)
+		};
+	}
+
 	setDraft(threadId: string | null, text: string): void {
+		this.advance(threadId);
 		if (!threadId) return;
 		if (text.trim()) {
 			this.drafts.current[threadId] = text;
@@ -38,8 +56,33 @@ export class ChatDraftManager {
 	}
 
 	clearDraft(threadId: string | null): void {
+		this.advance(threadId);
 		if (!threadId) return;
 		const { [threadId]: _, ...rest } = this.drafts.current;
 		this.drafts.current = rest;
+	}
+
+	clearDraftIfUnchanged(
+		checkpoint: ChatDraftCheckpoint,
+		threadId: string | null = checkpoint.threadId
+	): boolean {
+		const expectedRevision = threadId === checkpoint.threadId ? checkpoint.revision : 0;
+		if (
+			this.revision(threadId) !== expectedRevision ||
+			this.getDraft(threadId) !== checkpoint.value
+		) {
+			return false;
+		}
+		this.clearDraft(threadId);
+		return true;
+	}
+
+	private revision(threadId: string | null): number {
+		return this.revisions.get(threadId ?? '') ?? 0;
+	}
+
+	private advance(threadId: string | null): void {
+		const key = threadId ?? '';
+		this.revisions.set(key, this.revision(threadId) + 1);
 	}
 }

--- a/src/lib/chat/core/chat-draft-manager.svelte.ts
+++ b/src/lib/chat/core/chat-draft-manager.svelte.ts
@@ -1,11 +1,30 @@
 import { PersistedState } from 'runed';
-import { DRAFT_STORAGE_PREFIX } from './chat-persisted-state.js';
+import {
+	DRAFT_STORAGE_PREFIX,
+	getChatSessionEpoch,
+	isChatSessionCurrent
+} from './chat-persisted-state.js';
 
 export type ChatDraftCheckpoint = Readonly<{
 	threadId: string | null;
 	value: string;
 	revision: number;
+	sessionEpoch: number;
 }>;
+
+type ThreadRevisions = Map<string, number>;
+type NamespaceRevisions = Map<string, ThreadRevisions>;
+
+/** Document-local revisions shared by every manager using the same Storage. */
+const storageRevisions = new WeakMap<Storage, NamespaceRevisions>();
+
+function getStorage(): Storage | null {
+	try {
+		return typeof localStorage === 'undefined' ? null : localStorage;
+	} catch {
+		return null;
+	}
+}
 
 /**
  * Manages per-thread draft text persistence via localStorage.
@@ -14,9 +33,8 @@ export type ChatDraftCheckpoint = Readonly<{
  */
 export class ChatDraftManager {
 	readonly drafts: PersistedState<Record<string, string>>;
-	// Instance-local because each manager already owns one persisted namespace.
-	// eslint-disable-next-line svelte/prefer-svelte-reactivity
-	private readonly revisions = new Map<string, number>();
+	private readonly namespace: string;
+	private readonly storage: Storage | null;
 
 	/**
 	 * @param surface which chat this belongs to, e.g. `ai-chat`. The namespace
@@ -24,10 +42,9 @@ export class ChatDraftManager {
 	 * `clearPersistedChatState` find every surface.
 	 */
 	constructor(surface: string) {
-		this.drafts = new PersistedState<Record<string, string>>(
-			`${DRAFT_STORAGE_PREFIX}${surface}`,
-			{}
-		);
+		this.namespace = `${DRAFT_STORAGE_PREFIX}${surface}`;
+		this.storage = getStorage();
+		this.drafts = new PersistedState<Record<string, string>>(this.namespace, {});
 	}
 
 	getDraft(threadId: string | null): string {
@@ -38,7 +55,8 @@ export class ChatDraftManager {
 		return {
 			threadId,
 			value: this.getDraft(threadId),
-			revision: this.revision(threadId)
+			revision: this.revision(threadId),
+			sessionEpoch: getChatSessionEpoch()
 		};
 	}
 
@@ -68,6 +86,7 @@ export class ChatDraftManager {
 	): boolean {
 		const expectedRevision = threadId === checkpoint.threadId ? checkpoint.revision : 0;
 		if (
+			!isChatSessionCurrent(checkpoint.sessionEpoch) ||
 			this.revision(threadId) !== expectedRevision ||
 			this.getDraft(threadId) !== checkpoint.value
 		) {
@@ -78,11 +97,32 @@ export class ChatDraftManager {
 	}
 
 	private revision(threadId: string | null): number {
-		return this.revisions.get(threadId ?? '') ?? 0;
+		return this.threadRevisions()?.get(threadId ?? '') ?? 0;
 	}
 
 	private advance(threadId: string | null): void {
+		const revisions = this.threadRevisions();
+		if (!revisions) return;
 		const key = threadId ?? '';
-		this.revisions.set(key, this.revision(threadId) + 1);
+		revisions.set(key, (revisions.get(key) ?? 0) + 1);
+	}
+
+	private threadRevisions(): ThreadRevisions | null {
+		if (!this.storage) return null;
+		let namespaces = storageRevisions.get(this.storage);
+		if (!namespaces) {
+			// Document-local bookkeeping that never participates in rendering.
+			// eslint-disable-next-line svelte/prefer-svelte-reactivity
+			namespaces = new Map();
+			storageRevisions.set(this.storage, namespaces);
+		}
+		let revisions = namespaces.get(this.namespace);
+		if (!revisions) {
+			// Document-local bookkeeping that never participates in rendering.
+			// eslint-disable-next-line svelte/prefer-svelte-reactivity
+			revisions = new Map();
+			namespaces.set(this.namespace, revisions);
+		}
+		return revisions;
 	}
 }

--- a/src/lib/chat/core/chat-draft-manager.test.ts
+++ b/src/lib/chat/core/chat-draft-manager.test.ts
@@ -115,4 +115,16 @@ describe('ChatDraftManager', () => {
 		expect(manager.clearDraftIfUnchanged(checkpoint, 'thread-created')).toBe(true);
 		expect(manager.getDraft('thread-created')).toBe('');
 	});
+
+	it('two managers do not clear an equal-valued later write from another manager', () => {
+		const surface = 'shared-' + Math.random();
+		const managerA = new ChatDraftManager(surface);
+		const managerB = new ChatDraftManager(surface);
+		managerA.setDraft('same-thread', 'identical text');
+		const checkpoint = managerA.captureCheckpoint('same-thread');
+		managerB.setDraft('same-thread', 'identical text');
+
+		expect(managerA.clearDraftIfUnchanged(checkpoint)).toBe(false);
+		expect(managerB.getDraft('same-thread')).toBe('identical text');
+	});
 });

--- a/src/lib/chat/core/chat-draft-manager.test.ts
+++ b/src/lib/chat/core/chat-draft-manager.test.ts
@@ -86,4 +86,33 @@ describe('ChatDraftManager', () => {
 		expect(manager.getDraft('thread-1')).toBe('');
 		expect(manager.getDraft('thread-2')).toBe('draft 2');
 	});
+
+	it('clears only the unchanged draft captured by a checkpoint', () => {
+		manager.setDraft('thread-1', 'send this');
+		const checkpoint = manager.captureCheckpoint('thread-1');
+		manager.setDraft('thread-2', 'keep this');
+
+		expect(manager.clearDraftIfUnchanged(checkpoint)).toBe(true);
+		expect(manager.getDraft('thread-1')).toBe('');
+		expect(manager.getDraft('thread-2')).toBe('keep this');
+	});
+
+	it.each(['a newer draft', 'send this'])(
+		'preserves a later %s write after the checkpoint',
+		(later) => {
+			manager.setDraft('thread-1', 'send this');
+			const checkpoint = manager.captureCheckpoint('thread-1');
+			manager.setDraft('thread-1', later);
+
+			expect(manager.clearDraftIfUnchanged(checkpoint)).toBe(false);
+			expect(manager.getDraft('thread-1')).toBe(later);
+		}
+	);
+
+	it('can clear the created thread for a null-origin conversation', () => {
+		const checkpoint = manager.captureCheckpoint(null);
+
+		expect(manager.clearDraftIfUnchanged(checkpoint, 'thread-created')).toBe(true);
+		expect(manager.getDraft('thread-created')).toBe('');
+	});
 });

--- a/src/lib/chat/core/chat-persisted-state.test.ts
+++ b/src/lib/chat/core/chat-persisted-state.test.ts
@@ -12,7 +12,11 @@ const localStorageMock: Storage = {
 	key: (index: number) => [...storage.keys()][index] ?? null
 };
 
-import { clearPersistedChatState } from './chat-persisted-state.ts';
+import {
+	clearPersistedChatState,
+	getChatSessionEpoch,
+	registerPersistedChatHolder
+} from './chat-persisted-state.ts';
 
 /** What the composers are keeping, without the signal that sits beside them. */
 function composerValues(): string[] {
@@ -80,5 +84,44 @@ describe('clearPersistedChatState', () => {
 		expect(() => clearPersistedChatState()).not.toThrow();
 
 		vi.stubGlobal('localStorage', localStorageMock);
+	});
+
+	it('advances the epoch before holders and before failing storage cleanup', () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const before = getChatSessionEpoch();
+		const holderEpochs: number[] = [];
+		const unregister = registerPersistedChatHolder({
+			forgetPersistedState: () => holderEpochs.push(getChatSessionEpoch())
+		});
+		const denied: Storage = {
+			...localStorageMock,
+			setItem: () => {
+				throw new DOMException('QuotaExceededError');
+			}
+		};
+		vi.stubGlobal('localStorage', denied);
+
+		clearPersistedChatState();
+
+		expect(getChatSessionEpoch()).toBe(before + 1);
+		expect(holderEpochs).toEqual([before + 1]);
+		unregister();
+		vi.stubGlobal('localStorage', localStorageMock);
+	});
+
+	it('advances the epoch before forgetting state from another document', () => {
+		const before = getChatSessionEpoch();
+		const holderEpochs: number[] = [];
+		const unregister = registerPersistedChatHolder({
+			forgetPersistedState: () => holderEpochs.push(getChatSessionEpoch())
+		});
+
+		window.dispatchEvent(
+			new StorageEvent('storage', { key: 'chat:session-ended', newValue: 'new-session' })
+		);
+
+		expect(getChatSessionEpoch()).toBe(before + 1);
+		expect(holderEpochs).toEqual([before + 1]);
+		unregister();
 	});
 });

--- a/src/lib/chat/core/chat-persisted-state.ts
+++ b/src/lib/chat/core/chat-persisted-state.ts
@@ -1,3 +1,5 @@
+import type { Attachment } from './types.js';
+
 /**
  * The chat state that outlives a document, and how to get rid of it.
  *
@@ -16,6 +18,12 @@ const PREFIXES = [DRAFT_STORAGE_PREFIX, ATTACHMENT_STORAGE_PREFIX];
 export interface PersistedChatHolder {
 	/** Let go of everything belonging to the session that is ending. */
 	forgetPersistedState(): void;
+	/** Adopt a rejected send restored for this holder's current composer. */
+	reconcilePersistedAttachments?(
+		namespace: string,
+		threadId: string | null,
+		attachments: Attachment[]
+	): void;
 }
 
 /**
@@ -25,6 +33,24 @@ export interface PersistedChatHolder {
  * anything it would otherwise have to import back.
  */
 const holders = new Set<PersistedChatHolder>();
+
+/** Invalidates asynchronous work captured by the previous browser session. */
+let sessionEpoch = 0;
+
+/** The current document-local chat session epoch. */
+export function getChatSessionEpoch(): number {
+	return sessionEpoch;
+}
+
+/** Whether asynchronous chat work still belongs to this browser session. */
+export function isChatSessionCurrent(epoch: number): boolean {
+	return epoch === sessionEpoch;
+}
+
+/** Start a new local session boundary before any fallible cleanup runs. */
+function advanceSessionEpoch(): void {
+	sessionEpoch++;
+}
 
 /**
  * The one key here that is not a composer: word that a session has ended.
@@ -43,6 +69,7 @@ function listenForSessionEnd(): void {
 	listening = true;
 	window.addEventListener('storage', (event) => {
 		if (event.key !== SESSION_END_KEY || event.newValue === null) return;
+		advanceSessionEpoch();
 		forgetEverything();
 	});
 }
@@ -65,6 +92,21 @@ export function registerPersistedChatHolder(holder: PersistedChatHolder): () => 
 	return () => holders.delete(holder);
 }
 
+/** Reconcile a restored attachment list into matching mounted composers. */
+export function reconcilePersistedChatAttachments(
+	namespace: string,
+	threadId: string | null,
+	attachments: Attachment[]
+): void {
+	for (const holder of holders) {
+		try {
+			holder.reconcilePersistedAttachments?.(namespace, threadId, attachments);
+		} catch (error) {
+			console.error('[chat] A composer could not reconcile restored attachments:', error);
+		}
+	}
+}
+
 /**
  * Drop every draft and every stored attachment.
  *
@@ -78,6 +120,7 @@ export function registerPersistedChatHolder(holder: PersistedChatHolder): () => 
  * on a page they have already signed out of.
  */
 export function clearPersistedChatState(): void {
+	advanceSessionEpoch();
 	// The composers on screen first, because storage is not where they keep it.
 	// One survives every sign-out: the support widget belongs to the shell, so
 	// it is still mounted on the page the user lands on afterwards, holding what

--- a/src/lib/chat/core/index.ts
+++ b/src/lib/chat/core/index.ts
@@ -64,6 +64,7 @@ export { ChatCore } from './chat-core.svelte.ts';
 
 // Composer persistence
 export { ChatDraftManager } from './chat-draft-manager.svelte.ts';
+export type { ChatDraftCheckpoint } from './chat-draft-manager.svelte.ts';
 export { ChatAttachmentStore } from './chat-attachment-store.svelte.ts';
 export type { AttachmentsByThread } from './chat-attachment-store.svelte.ts';
 export { clearPersistedChatState } from './chat-persisted-state.ts';

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -202,31 +202,18 @@
 	async function handleSend() {
 		if (!canSend) return;
 		haptic.trigger('medium');
-		const prompt = ctx.inputValue.trim();
-		const prevAttachments = [...ctx.attachments];
-		ctx.clearInput();
+		const snapshot = ctx.captureSendSnapshot();
+		const prompt = snapshot.inputValue.trim();
+		ctx.clearInputForSend(snapshot);
 		try {
-			// Invoke onSend before clearAttachments so consumers can still read
-			// ctx.attachments synchronously in their onSend prefix.
+			// Invoke onSend before clearing attachments so existing consumers can
+			// capture their exact transport payload synchronously.
 			const sendPromise = onSend?.(prompt);
-			ctx.clearAttachments();
+			ctx.clearAttachmentsForSend(snapshot);
 			await sendPromise;
 		} catch (error) {
 			console.error('[ChatInput] onSend failed:', error);
-			// Rollback so a failed send does not silently eat the message.
-			// Consumers that handle errors themselves (toasts, rate limits)
-			// rethrow so this restore still runs. Skip restore if the user
-			// already typed or attached something new in the meantime.
-			if (!ctx.inputValue.trim()) ctx.setInputValue(prompt);
-			if (ctx.attachments.length === 0) {
-				// clearAttachments revoked blob: previews; strip them so the
-				// thumbnail falls back to the uploaded url, not a dead blob.
-				ctx.addAttachments(
-					prevAttachments.map((a) =>
-						'preview' in a && a.preview?.startsWith('blob:') ? { ...a, preview: undefined } : a
-					)
-				);
-			}
+			ctx.restoreSendSnapshot(snapshot);
 		}
 	}
 

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -24,6 +24,7 @@
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import { getChatUIContext } from './chat-context.svelte.ts';
 	import { processImage } from '$lib/media/process-image';
+	import { isChatSessionCurrent } from '../core/chat-persisted-state.ts';
 	import {
 		ALLOWED_FILE_EXT_MIME,
 		ALLOWED_FILE_EXTENSIONS,
@@ -212,6 +213,7 @@
 			ctx.clearAttachmentsForSend(snapshot);
 			await sendPromise;
 		} catch (error) {
+			if (!isChatSessionCurrent(snapshot.sessionEpoch)) return;
 			console.error('[ChatInput] onSend failed:', error);
 			ctx.restoreSendSnapshot(snapshot);
 		}

--- a/src/lib/chat/ui/chat-context-persisted-attachments.test.ts
+++ b/src/lib/chat/ui/chat-context-persisted-attachments.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import type { ConvexClient } from 'convex/browser';
 import type { ChatCore } from '../core/chat-core.svelte.ts';
+import type { Attachment } from '../core/types.js';
 
 const uploadFileWithProgress = vi.fn();
 
@@ -96,6 +97,18 @@ async function uploadInto(ctx: InstanceType<typeof ChatUIContext>, filename: str
 
 function names(ctx: InstanceType<typeof ChatUIContext>) {
 	return ctx.attachments.map((a) => ('name' in a ? a.name : undefined));
+}
+
+function storedFile(key: string, name: string): Attachment {
+	return {
+		type: 'file',
+		key,
+		name,
+		size: name.length,
+		mimeType: 'text/plain',
+		url: `https://example.test/${name}`,
+		uploadState: { status: 'success', progress: 100, fileId: `file-${key}` }
+	};
 }
 
 describe('ChatUIContext persisted attachments', () => {
@@ -375,5 +388,49 @@ describe('ChatUIContext persisted attachments', () => {
 		reloaded.switchTo('thread-b');
 		reloaded.switchTo('thread-a');
 		expect(names(reloaded.ctx)).toEqual(['shot.png']);
+	});
+
+	it('reconciles only the matching surface and thread without replacing a later upload', () => {
+		const matching = chatAt('thread-a');
+		const otherThread = chatAt('thread-b');
+		const later: Attachment = {
+			type: 'file',
+			key: 'later',
+			name: 'later.txt',
+			size: 5,
+			mimeType: 'text/plain',
+			uploadState: { status: 'uploading', progress: 50 }
+		};
+		matching.ctx.addAttachments([later]);
+		const matchingSurface = surface;
+		surface = 'other-' + Math.random();
+		const otherSurface = chatAt('thread-a');
+
+		new ChatAttachmentStore(matchingSurface).restoreThreadAttachments('thread-a', [
+			storedFile('restored', 'restored.txt')
+		]);
+
+		expect(names(matching.ctx)).toEqual(['restored.txt', 'later.txt']);
+		expect(matching.ctx.attachments[1]).toEqual(later);
+		expect(otherThread.ctx.attachments).toHaveLength(0);
+		expect(otherSurface.ctx.attachments).toHaveLength(0);
+	});
+
+	it('reconciles a replacement context when persistence fails and permits removal', () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const replacement = chatAt('thread-a');
+		const setItem = vi.spyOn(localStorageMock, 'setItem').mockImplementation(() => {
+			throw new DOMException('QuotaExceededError');
+		});
+
+		new ChatAttachmentStore(surface).restoreThreadAttachments('thread-a', [
+			storedFile('restored', 'restored.txt')
+		]);
+
+		expect(names(replacement.ctx)).toEqual(['restored.txt']);
+		setItem.mockRestore();
+		replacement.ctx.removeAttachment(0);
+		expect(replacement.ctx.attachments).toHaveLength(0);
+		expect(new ChatAttachmentStore(surface).readThread('thread-a')).toHaveLength(0);
 	});
 });

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -16,7 +16,11 @@ import type {
 	AttachmentsByThread,
 	ChatAttachmentStore
 } from '../core/chat-attachment-store.svelte.ts';
-import { registerPersistedChatHolder } from '../core/chat-persisted-state.ts';
+import {
+	getChatSessionEpoch,
+	isChatSessionCurrent,
+	registerPersistedChatHolder
+} from '../core/chat-persisted-state.ts';
 import { FadeOnLoad } from '$lib/utils/fade-on-load.svelte.ts';
 
 /**
@@ -100,10 +104,14 @@ export interface ActiveUploadsRegistry {
 	release(owner: object): void;
 }
 
-export type ChatSendSnapshot = {
+type ChatConversationOrigin = {
+	generation: number;
 	threadId: string | null;
-	threadGeneration: number;
-	wasNewConversation: boolean;
+};
+
+export type ChatSendSnapshot = {
+	sessionEpoch: number;
+	origin: ChatConversationOrigin;
 	inputValue: string;
 	inputRevision: number;
 	inputClearedRevision?: number;
@@ -209,8 +217,8 @@ export class ChatUIContext {
 
 	/** Last known thread ID for detecting navigation */
 	private _lastThreadId: string | null | undefined = undefined;
-	/** The real thread assigned to the current new-conversation generation. */
-	private resolvedNewConversation?: { threadId: string; generation: number };
+	/** Identity object shared with snapshots from the current conversation. */
+	private conversationOrigin: ChatConversationOrigin;
 
 	/**
 	 * Whether the surface this belongs to is gone.
@@ -233,6 +241,20 @@ export class ChatUIContext {
 		this.uploadConfig = uploadConfig;
 		this.userAlignment = userAlignment;
 		this.activeUploads = activeUploads;
+		this.conversationOrigin = {
+			generation: untrack(() => core.threadGeneration),
+			threadId: untrack(() => core.threadId)
+		};
+		const originOwner = core as ChatCore & {
+			setThreadOriginBinder?: (
+				binder: ((threadId: string, epoch: number, generation: number) => void) | undefined
+			) => void;
+		};
+		originOwner.setThreadOriginBinder?.((threadId, epoch, generation) => {
+			if (!isChatSessionCurrent(epoch)) return;
+			const origin = this.syncConversationOrigin();
+			if (origin.generation === generation && origin.threadId === null) origin.threadId = threadId;
+		});
 
 		// Composers a reload took away arrive parked, under the thread they were
 		// left in. From here on nothing knows the difference between one that came
@@ -260,6 +282,12 @@ export class ChatUIContext {
 	 * still mounted on whatever page the user lands on after signing out.
 	 */
 	forgetPersistedState(): void {
+		const resettableCore = this.core as ChatCore & { forgetChatSession?: () => void };
+		resettableCore.forgetChatSession?.();
+		this.conversationOrigin = {
+			generation: untrack(() => this.core.threadGeneration),
+			threadId: untrack(() => this.core.threadId)
+		};
 		const abandoned = [...this.parked.keys()];
 		for (const attachments of this.parked.values()) {
 			for (const attachment of attachments) {
@@ -271,7 +299,7 @@ export class ChatUIContext {
 		// A transfer still running belongs to an identity that is gone, so it is
 		// stopped here for the same reason sign-out does not wait for one.
 		this.clearAttachments();
-		this.inputValue = '';
+		this.setInputValue('');
 		// Named so they are struck from storage rather than merely dropped here.
 		// The sweep empties the whole key anyway; doing it from this side too
 		// means letting go stays complete on its own terms.
@@ -365,6 +393,7 @@ export class ChatUIContext {
 	setDisplayMessages(messages: DisplayMessage[]): void {
 		// Detect thread navigation (reset when changing between existing threads)
 		const currentThreadId = untrack(() => this.core.threadId);
+		this.syncConversationOrigin();
 
 		// Reset only on actual navigation between threads
 		// NOT on null → threadId (thread creation) or during brief empty states
@@ -375,12 +404,6 @@ export class ChatUIContext {
 			this.adoptParked(currentThreadId);
 		} else if (currentThreadId !== this._lastThreadId) {
 			if (this._lastThreadId === null) {
-				if (currentThreadId && untrack(() => this.core.isNewConversation)) {
-					this.resolvedNewConversation = {
-						threadId: currentThreadId,
-						generation: untrack(() => this.core.threadGeneration)
-					};
-				}
 				// The conversation with no id is this thread now, and what its
 				// composer holds comes along in the live list. Its own leavings may
 				// not stay behind under the empty key: sending would clear this
@@ -455,9 +478,8 @@ export class ChatUIContext {
 
 	captureSendSnapshot(): ChatSendSnapshot {
 		return {
-			threadId: untrack(() => this.core.threadId),
-			threadGeneration: untrack(() => this.core.threadGeneration),
-			wasNewConversation: untrack(() => this.core.isNewConversation),
+			sessionEpoch: getChatSessionEpoch(),
+			origin: this.syncConversationOrigin(),
 			inputValue: this.inputValue,
 			inputRevision: this.inputRevision,
 			attachments: this.attachments.map((attachment) =>
@@ -468,8 +490,28 @@ export class ChatUIContext {
 		};
 	}
 
+	private syncConversationOrigin(): ChatConversationOrigin {
+		const generation = untrack(() => this.core.threadGeneration);
+		const threadId = untrack(() => this.core.threadId);
+		if (this.conversationOrigin.generation !== generation) {
+			this.conversationOrigin = { generation, threadId };
+		} else if (this.conversationOrigin.threadId !== threadId) {
+			const assignedCurrentConversation =
+				this.conversationOrigin.threadId === null &&
+				threadId !== null &&
+				untrack(() => this.core.isNewConversation);
+			if (assignedCurrentConversation) this.conversationOrigin.threadId = threadId;
+			else this.conversationOrigin = { generation, threadId };
+		}
+		return this.conversationOrigin;
+	}
+
 	clearInputForSend(snapshot: ChatSendSnapshot): void {
-		if (this.inputRevision !== snapshot.inputRevision || this.inputValue !== snapshot.inputValue) {
+		if (
+			!isChatSessionCurrent(snapshot.sessionEpoch) ||
+			this.inputRevision !== snapshot.inputRevision ||
+			this.inputValue !== snapshot.inputValue
+		) {
 			return;
 		}
 		this.clearInput();
@@ -606,6 +648,7 @@ export class ChatUIContext {
 	}
 
 	clearAttachmentsForSend(snapshot: ChatSendSnapshot): void {
+		if (!isChatSessionCurrent(snapshot.sessionEpoch)) return;
 		// Counts preserve exact multiplicity for legacy unkeyed attachments while
 		// keyed uploads use their transfer identity.
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity
@@ -632,14 +675,16 @@ export class ChatUIContext {
 	}
 
 	restoreSendSnapshot(snapshot: ChatSendSnapshot): void {
-		const sameConversation = this.isSnapshotConversationCurrent(snapshot);
-		const originThreadId = this.snapshotOriginThreadId(snapshot, sameConversation);
+		if (!isChatSessionCurrent(snapshot.sessionEpoch)) return;
+		const sameConversation = this.syncConversationOrigin() === snapshot.origin;
 
 		if (this.disposed || !sameConversation) {
-			this.uploadConfig?.attachmentStore?.restoreThreadAttachments(
-				originThreadId,
-				snapshot.attachments
-			);
+			if (snapshot.origin.threadId !== null) {
+				this.uploadConfig?.attachmentStore?.restoreThreadAttachments(
+					snapshot.origin.threadId,
+					snapshot.attachments
+				);
+			}
 			return;
 		}
 
@@ -657,28 +702,19 @@ export class ChatUIContext {
 		this.persist();
 	}
 
-	private snapshotOriginThreadId(
-		snapshot: ChatSendSnapshot,
-		sameConversation: boolean
-	): string | null {
-		if (snapshot.threadId !== null) return snapshot.threadId;
-		const resolved = this.resolvedNewConversation;
-		if (snapshot.wasNewConversation && resolved?.generation === snapshot.threadGeneration) {
-			return resolved.threadId;
+	reconcilePersistedAttachments(
+		namespace: string,
+		threadId: string | null,
+		attachments: Attachment[]
+	): void {
+		if (
+			this.disposed ||
+			this.uploadConfig?.attachmentStore?.namespace !== namespace ||
+			untrack(() => this.core.threadId) !== threadId
+		) {
+			return;
 		}
-		return sameConversation ? untrack(() => this.core.threadId) : null;
-	}
-
-	private isSnapshotConversationCurrent(snapshot: ChatSendSnapshot): boolean {
-		const currentThreadId = untrack(() => this.core.threadId);
-		if (currentThreadId === snapshot.threadId) return true;
-		return (
-			snapshot.threadId === null &&
-			currentThreadId !== null &&
-			snapshot.wasNewConversation &&
-			untrack(() => this.core.isNewConversation) &&
-			untrack(() => this.core.threadGeneration) === snapshot.threadGeneration
-		);
+		this.attachments = ChatUIContext.mergeSnapshotAttachments(attachments, this.attachments);
 	}
 
 	private static mergeSnapshotAttachments(
@@ -851,6 +887,12 @@ export class ChatUIContext {
 	 */
 	dispose(): void {
 		this.unregister();
+		const originOwner = this.core as ChatCore & {
+			setThreadOriginBinder?: (
+				binder: ((threadId: string, epoch: number, generation: number) => void) | undefined
+			) => void;
+		};
+		originOwner.setThreadOriginBinder?.(undefined);
 		// Before anything is dropped. What follows empties both lists, and saving
 		// that would erase the composers this surface is supposed to hand back the
 		// next time it is built. Leaving is not the same as letting go.

--- a/src/lib/chat/ui/chat-context.svelte.ts
+++ b/src/lib/chat/ui/chat-context.svelte.ts
@@ -100,6 +100,16 @@ export interface ActiveUploadsRegistry {
 	release(owner: object): void;
 }
 
+export type ChatSendSnapshot = {
+	threadId: string | null;
+	threadGeneration: number;
+	wasNewConversation: boolean;
+	inputValue: string;
+	inputRevision: number;
+	inputClearedRevision?: number;
+	attachments: Attachment[];
+};
+
 /**
  * Chat UI Context class
  *
@@ -138,6 +148,7 @@ export class ChatUIContext {
 
 	/** Current input value */
 	inputValue = $state('');
+	private inputRevision = 0;
 
 	/** Attachments for current message. Each entry's `key` is the stable id
 	 * used by upload methods to apply progress/success/error updates by value
@@ -198,6 +209,8 @@ export class ChatUIContext {
 
 	/** Last known thread ID for detecting navigation */
 	private _lastThreadId: string | null | undefined = undefined;
+	/** The real thread assigned to the current new-conversation generation. */
+	private resolvedNewConversation?: { threadId: string; generation: number };
 
 	/**
 	 * Whether the surface this belongs to is gone.
@@ -362,6 +375,12 @@ export class ChatUIContext {
 			this.adoptParked(currentThreadId);
 		} else if (currentThreadId !== this._lastThreadId) {
 			if (this._lastThreadId === null) {
+				if (currentThreadId && untrack(() => this.core.isNewConversation)) {
+					this.resolvedNewConversation = {
+						threadId: currentThreadId,
+						generation: untrack(() => this.core.threadGeneration)
+					};
+				}
 				// The conversation with no id is this thread now, and what its
 				// composer holds comes along in the live list. Its own leavings may
 				// not stay behind under the empty key: sending would clear this
@@ -422,14 +441,39 @@ export class ChatUIContext {
 	 * Set input value
 	 */
 	setInputValue(value: string): void {
+		if (this.inputValue === value) return;
 		this.inputValue = value;
+		this.inputRevision++;
 	}
 
 	/**
 	 * Clear input
 	 */
 	clearInput(): void {
-		this.inputValue = '';
+		this.setInputValue('');
+	}
+
+	captureSendSnapshot(): ChatSendSnapshot {
+		return {
+			threadId: untrack(() => this.core.threadId),
+			threadGeneration: untrack(() => this.core.threadGeneration),
+			wasNewConversation: untrack(() => this.core.isNewConversation),
+			inputValue: this.inputValue,
+			inputRevision: this.inputRevision,
+			attachments: this.attachments.map((attachment) =>
+				(attachment.type === 'file' || attachment.type === 'screenshot') && attachment.uploadState
+					? { ...attachment, uploadState: { ...attachment.uploadState } }
+					: { ...attachment }
+			)
+		};
+	}
+
+	clearInputForSend(snapshot: ChatSendSnapshot): void {
+		if (this.inputRevision !== snapshot.inputRevision || this.inputValue !== snapshot.inputValue) {
+			return;
+		}
+		this.clearInput();
+		snapshot.inputClearedRevision = this.inputRevision;
 	}
 
 	/**
@@ -559,6 +603,124 @@ export class ChatUIContext {
 		}
 		this.attachments = [];
 		this.persist();
+	}
+
+	clearAttachmentsForSend(snapshot: ChatSendSnapshot): void {
+		// Counts preserve exact multiplicity for legacy unkeyed attachments while
+		// keyed uploads use their transfer identity.
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const remaining = new Map<string, number>();
+		for (const attachment of snapshot.attachments) {
+			const identity = ChatUIContext.attachmentIdentity(attachment);
+			remaining.set(identity, (remaining.get(identity) ?? 0) + 1);
+		}
+
+		const kept: Attachment[] = [];
+		for (const attachment of this.attachments) {
+			const identity = ChatUIContext.attachmentIdentity(attachment);
+			const count = remaining.get(identity) ?? 0;
+			if (count === 0) {
+				kept.push(attachment);
+				continue;
+			}
+			remaining.set(identity, count - 1);
+			this.releaseUpload(attachment);
+			this.revokePreview(attachment);
+		}
+		this.attachments = kept;
+		this.persist();
+	}
+
+	restoreSendSnapshot(snapshot: ChatSendSnapshot): void {
+		const sameConversation = this.isSnapshotConversationCurrent(snapshot);
+		const originThreadId = this.snapshotOriginThreadId(snapshot, sameConversation);
+
+		if (this.disposed || !sameConversation) {
+			this.uploadConfig?.attachmentStore?.restoreThreadAttachments(
+				originThreadId,
+				snapshot.attachments
+			);
+			return;
+		}
+
+		if (
+			snapshot.inputClearedRevision !== undefined &&
+			this.inputRevision === snapshot.inputClearedRevision &&
+			this.inputValue === ''
+		) {
+			this.setInputValue(snapshot.inputValue);
+		}
+		this.attachments = ChatUIContext.mergeSnapshotAttachments(
+			snapshot.attachments,
+			this.attachments
+		);
+		this.persist();
+	}
+
+	private snapshotOriginThreadId(
+		snapshot: ChatSendSnapshot,
+		sameConversation: boolean
+	): string | null {
+		if (snapshot.threadId !== null) return snapshot.threadId;
+		const resolved = this.resolvedNewConversation;
+		if (snapshot.wasNewConversation && resolved?.generation === snapshot.threadGeneration) {
+			return resolved.threadId;
+		}
+		return sameConversation ? untrack(() => this.core.threadId) : null;
+	}
+
+	private isSnapshotConversationCurrent(snapshot: ChatSendSnapshot): boolean {
+		const currentThreadId = untrack(() => this.core.threadId);
+		if (currentThreadId === snapshot.threadId) return true;
+		return (
+			snapshot.threadId === null &&
+			currentThreadId !== null &&
+			snapshot.wasNewConversation &&
+			untrack(() => this.core.isNewConversation) &&
+			untrack(() => this.core.threadGeneration) === snapshot.threadGeneration
+		);
+	}
+
+	private static mergeSnapshotAttachments(
+		snapshot: Attachment[],
+		current: Attachment[]
+	): Attachment[] {
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const currentByIdentity = new Map(
+			current.map((attachment) => [ChatUIContext.attachmentIdentity(attachment), attachment])
+		);
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const included = new Set<string>();
+		const merged: Attachment[] = [];
+		for (const attachment of snapshot) {
+			const identity = ChatUIContext.attachmentIdentity(attachment);
+			if (included.has(identity)) continue;
+			included.add(identity);
+			merged.push(
+				currentByIdentity.get(identity) ?? ChatUIContext.withoutRevokedPreview(attachment)
+			);
+		}
+		for (const attachment of current) {
+			const identity = ChatUIContext.attachmentIdentity(attachment);
+			if (included.has(identity)) continue;
+			included.add(identity);
+			merged.push(attachment);
+		}
+		return merged;
+	}
+
+	private static withoutRevokedPreview(attachment: Attachment): Attachment {
+		return 'preview' in attachment && attachment.preview?.startsWith('blob:')
+			? { ...attachment, preview: undefined }
+			: attachment;
+	}
+
+	private static attachmentIdentity(attachment: Attachment): string {
+		if ('key' in attachment && attachment.key) return `transfer:${attachment.key}`;
+		if (attachment.type === 'file' || attachment.type === 'screenshot') {
+			return `upload:${attachment.type}:${attachment.name}:${attachment.size}:${attachment.mimeType}:${attachment.url ?? ''}:${attachment.uploadState?.fileId ?? ''}`;
+		}
+		return `${attachment.type}:${attachment.url}:${attachment.filename ?? ''}`;
 	}
 
 	/**

--- a/src/lib/chat/ui/chat-input-send.test.ts
+++ b/src/lib/chat/ui/chat-input-send.test.ts
@@ -1,19 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mount, tick, unmount } from 'svelte';
+import { flushSync, mount, tick, unmount } from 'svelte';
 import type * as Svelte from 'svelte';
 import { ConvexClient } from 'convex/browser';
 import { api } from '$lib/convex/_generated/api';
+import { getFunctionName } from 'convex/server';
+import { SupportThreadContext } from '$lib/components/customer-support/support-thread-context.svelte.ts';
 import { ChatCore } from '../core/chat-core.svelte.ts';
+import { ChatAttachmentStore } from '../core/chat-attachment-store.svelte.ts';
 import type { Attachment } from '../core/types.js';
 import { ChatUIContext } from './chat-context.svelte.ts';
 import ChatTestProvider from './test-fixtures/ChatTestProvider.svelte';
 import ChatInputHarness from './test-fixtures/ChatInputHarness.svelte';
+import KeyedChatInputLifecycleHarness, {
+	keyedChatInputLifecycle
+} from './test-fixtures/KeyedChatInputLifecycleHarness.svelte';
 import en from '../../../i18n/en.json';
 
 // Vitest resolves Svelte's server entry by default; use its real client runtime for mounting.
 vi.mock('svelte', () =>
 	vi.importActual<typeof Svelte>('../../../../node_modules/svelte/src/index-client.js')
 );
+vi.mock('esm-env', () => ({ BROWSER: true, DEV: true }));
 vi.mock('$lib/hooks/use-haptic.svelte.ts', () => ({ haptic: { trigger: vi.fn() } }));
 vi.mock('./ChatAttachments.svelte', () => ({ default: () => {} }));
 
@@ -45,16 +52,51 @@ const originalRevokeObjectURL = Object.getOwnPropertyDescriptor(URL, 'revokeObje
 let component: ReturnType<typeof mount> | undefined;
 let client: ConvexClient;
 let ctx: ChatUIContext;
+let surface: string;
 
-beforeEach(() => {
-	client = new ConvexClient('https://chat-test.convex.cloud', { disabled: true });
-	ctx = new ChatUIContext(
+function stallUpload() {
+	const handlers: Record<string, () => void> = {};
+	const abort = vi.fn(() => handlers.abort?.());
+	vi.stubGlobal('XMLHttpRequest', function XMLHttpRequestStub() {
+		return {
+			status: 200,
+			responseText: '',
+			upload: { addEventListener: () => {} },
+			addEventListener: (event: string, handler: () => void) => {
+				handlers[event] = handler;
+			},
+			open: () => {},
+			setRequestHeader: () => {},
+			abort,
+			send: () => {}
+		};
+	});
+	return abort;
+}
+
+function createContext(threadId: string | null): ChatUIContext {
+	return new ChatUIContext(
 		new ChatCore({
-			threadId: 'thread-input',
+			threadId,
 			api: { sendMessage: api.aiChat.messages.sendMessage }
 		}),
-		client
+		client,
+		{
+			generateUploadUrl: api.aiChat.files.generateUploadUrl,
+			saveUploadedFile: api.aiChat.files.saveUploadedFile,
+			attachmentStore: new ChatAttachmentStore(surface)
+		}
 	);
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	surface = 'chat-input-' + Math.random();
+	client = new ConvexClient('https://chat-test.convex.cloud', { disabled: true });
+	ctx = createContext('thread-input');
+	ctx.setDisplayMessages([]);
+	delete keyedChatInputLifecycle.context;
+	delete keyedChatInputLifecycle.setThreadId;
 	vi.spyOn(console, 'error').mockImplementation(() => {});
 	// jsdom has no object URL implementation.
 	Object.defineProperty(URL, 'revokeObjectURL', { value: vi.fn(), configurable: true });
@@ -65,7 +107,9 @@ afterEach(async () => {
 	component = undefined;
 	ctx.dispose();
 	await client.close();
+	localStorage.clear();
 	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
 	if (originalRevokeObjectURL) {
 		Object.defineProperty(URL, 'revokeObjectURL', originalRevokeObjectURL);
 	} else {
@@ -150,7 +194,203 @@ describe('ChatInput send rollback through ChatRoot', () => {
 			expect(input.value).toBe(editText ? 'A newer draft' : 'Retry this message')
 		);
 		expect(ctx.attachments).toEqual(
-			addAttachment ? [newer] : [{ ...attachments[0], preview: undefined }, attachments[1]]
+			addAttachment
+				? [{ ...attachments[0], preview: undefined }, attachments[1], newer]
+				: [{ ...attachments[0], preview: undefined }, attachments[1]]
 		);
+	});
+
+	it('merges the rejected snapshot before a later active upload without aborting it', async () => {
+		const { pending } = await startSend();
+		vi.spyOn(client, 'mutation').mockResolvedValue({
+			uploadUrl: 'https://storage.test',
+			uploadToken: 'token'
+		});
+		const abort = stallUpload();
+		void ctx.uploadFile(new File(['later'], 'later.txt', { type: 'text/plain' }));
+		await vi.waitFor(() => expect(ctx.hasUploadingFiles).toBe(true));
+		const error = new Error('Send rejected');
+
+		pending.reject(error);
+		await vi.waitFor(() =>
+			expect(console.error).toHaveBeenCalledWith('[ChatInput] onSend failed:', error)
+		);
+
+		expect(
+			ctx.attachments.map((attachment) => ('name' in attachment ? attachment.name : ''))
+		).toEqual(['screenshot.png', 'notes.txt', 'later.txt']);
+		expect(ctx.attachments[2]).toEqual(
+			expect.objectContaining({ uploadState: { status: 'uploading', progress: 0 } })
+		);
+		expect(abort).not.toHaveBeenCalled();
+	});
+
+	it('does not restore an origin-thread snapshot into the thread now on screen', async () => {
+		const { pending, input } = await startSend();
+		ctx.core.setThread('thread-b');
+		ctx.setDisplayMessages([]);
+		const newer: Attachment = { type: 'image', url: 'https://chat.test/thread-b.png' };
+		ctx.addAttachments([newer]);
+		const restoreStored = vi.spyOn(ctx.uploadConfig!.attachmentStore!, 'restoreThreadAttachments');
+		const error = new Error('Send rejected');
+
+		pending.reject(error);
+		await tick();
+
+		await vi.waitFor(() =>
+			expect(console.error).toHaveBeenCalledWith('[ChatInput] onSend failed:', error)
+		);
+		expect(input.value).toBe('');
+		expect(ctx.attachments).toEqual([newer]);
+		expect(restoreStored).toHaveBeenCalledWith('thread-input', expect.any(Array));
+		expect(restoreStored.mock.calls[0]?.[1]).toEqual(attachments);
+		expect(
+			new ChatAttachmentStore(surface)
+				.readThread('thread-input')
+				.map((attachment) => ('key' in attachment ? attachment.key : undefined))
+		).toEqual(['screenshot-first', 'document-second']);
+	});
+
+	it('keeps a created null-origin snapshot bound after later navigation', async () => {
+		ctx.dispose();
+		ctx = createContext(null);
+		ctx.core.isNewConversation = true;
+		ctx.setDisplayMessages([]);
+		const pending = Promise.withResolvers<void>();
+		const contentProps = { context: ctx, onSend: () => pending.promise };
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: { client, content: ChatInputHarness, contentProps }
+		});
+		await tick();
+		const input = document.querySelector('textarea')!;
+		input.value = 'Retry the created conversation';
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+		ctx.addAttachments(attachments);
+		await tick();
+		document.querySelector<HTMLButtonElement>(`button[aria-label="${en.chat.aria.send}"]`)!.click();
+		await tick();
+		ctx.core.threadId = 'thread-created';
+		ctx.setDisplayMessages([]);
+		ctx.core.threadId = 'thread-b';
+		ctx.core.isNewConversation = false;
+		ctx.setDisplayMessages([]);
+		const newer: Attachment = { type: 'image', url: 'https://chat.test/thread-b.png' };
+		ctx.addAttachments([newer]);
+
+		pending.reject(new Error('Send rejected'));
+		await vi.waitFor(() => expect(console.error).toHaveBeenCalled());
+
+		expect(input.value).toBe('');
+		expect(ctx.attachments).toEqual([newer]);
+		expect(
+			new ChatAttachmentStore(surface)
+				.readThread('thread-created')
+				.map((attachment) => ('key' in attachment ? attachment.key : undefined))
+		).toEqual(['screenshot-first', 'document-second']);
+	});
+
+	it('restores a keyed admin origin after its context is disposed', async () => {
+		ctx.dispose();
+		const pending = Promise.withResolvers<void>();
+		const onSend = vi.fn(() => pending.promise);
+		const contentProps = { initialThreadId: 'thread-admin-a', surface, onSend };
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: { client, content: KeyedChatInputLifecycleHarness, contentProps }
+		});
+		await tick();
+		const originContext = keyedChatInputLifecycle.context!;
+		const input = document.querySelector('textarea')!;
+		input.value = 'Retry the admin reply';
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+		originContext.addAttachments(attachments);
+		await tick();
+		document.querySelector<HTMLButtonElement>(`button[aria-label="${en.chat.aria.send}"]`)!.click();
+		await tick();
+		expect(originContext.attachments).toEqual([]);
+
+		flushSync(() => keyedChatInputLifecycle.setThreadId?.('thread-admin-b'));
+		await tick();
+		expect(keyedChatInputLifecycle.context?.attachments).toEqual([]);
+		const error = new Error('Send rejected');
+		pending.reject(error);
+		await vi.waitFor(() =>
+			expect(console.error).toHaveBeenCalledWith('[ChatInput] onSend failed:', error)
+		);
+		expect(
+			new ChatAttachmentStore(surface)
+				.readThread('thread-admin-a')
+				.map((attachment) => ('key' in attachment ? attachment.key : undefined))
+		).toEqual(['screenshot-first', 'document-second']);
+
+		await unmount(component!);
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: {
+				client,
+				content: KeyedChatInputLifecycleHarness,
+				contentProps: { ...contentProps, initialThreadId: 'thread-admin-a' }
+			}
+		});
+		await tick();
+		expect(keyedChatInputLifecycle.context?.core.threadId).toBe('thread-admin-a');
+		expect(
+			keyedChatInputLifecycle.context?.attachments.map((attachment) =>
+				'key' in attachment ? attachment.key : undefined
+			)
+		).toEqual(['screenshot-first', 'document-second']);
+	});
+
+	it('keeps a lazy support conversation retryable after thread creation fails to send', async () => {
+		ctx.dispose();
+		const support = new SupportThreadContext();
+		support.startNewThread();
+		ctx = new ChatUIContext(support as unknown as ChatCore, client, {
+			generateUploadUrl: api.support.files.generateUploadUrl,
+			saveUploadedFile: api.support.files.saveUploadedFile,
+			attachmentStore: new ChatAttachmentStore(surface)
+		});
+		ctx.setDisplayMessages([]);
+		const error = new Error('Send rejected');
+		vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+			const name = getFunctionName(reference);
+			if (name === 'support/threads:getOrCreateWarmThread') {
+				return Promise.resolve({ threadId: 'thread-created', notificationEmail: null });
+			}
+			if (name === 'support/messages:sendMessage') return Promise.reject(error);
+			throw new Error(`Unexpected mutation: ${name}`);
+		});
+		const onSend = async (prompt: string) => {
+			await support.sendMessage(client, prompt, {
+				fileIds: ctx.uploadedFileIds,
+				attachments: [...ctx.attachments]
+			});
+		};
+		const contentProps = { context: ctx, onSend };
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: { client, content: ChatInputHarness, contentProps }
+		});
+		await tick();
+		const input = document.querySelector('textarea')!;
+		input.value = 'Retry the new conversation';
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+		ctx.addAttachments(attachments);
+		await tick();
+		document.querySelector<HTMLButtonElement>(`button[aria-label="${en.chat.aria.send}"]`)!.click();
+		await tick();
+		await vi.waitFor(() => expect(client.mutation).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() => expect(input.value).toBe('Retry the new conversation'));
+		expect(support.threadId).toBe('thread-created');
+		expect(console.error).toHaveBeenCalledWith('[ChatInput] onSend failed:', error);
+		expect(
+			ctx.attachments.map((attachment) => ('key' in attachment ? attachment.key : undefined))
+		).toEqual(['screenshot-first', 'document-second']);
+		expect(
+			new ChatAttachmentStore(surface)
+				.readThread('thread-created')
+				.map((attachment) => ('key' in attachment ? attachment.key : undefined))
+		).toEqual(['screenshot-first', 'document-second']);
 	});
 });

--- a/src/lib/chat/ui/chat-input-send.test.ts
+++ b/src/lib/chat/ui/chat-input-send.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, tick, unmount } from 'svelte';
+import type * as Svelte from 'svelte';
+import { ConvexClient } from 'convex/browser';
+import { api } from '$lib/convex/_generated/api';
+import { ChatCore } from '../core/chat-core.svelte.ts';
+import type { Attachment } from '../core/types.js';
+import { ChatUIContext } from './chat-context.svelte.ts';
+import ChatTestProvider from './test-fixtures/ChatTestProvider.svelte';
+import ChatInputHarness from './test-fixtures/ChatInputHarness.svelte';
+import en from '../../../i18n/en.json';
+
+// Vitest resolves Svelte's server entry by default; use its real client runtime for mounting.
+vi.mock('svelte', () =>
+	vi.importActual<typeof Svelte>('../../../../node_modules/svelte/src/index-client.js')
+);
+vi.mock('$lib/hooks/use-haptic.svelte.ts', () => ({ haptic: { trigger: vi.fn() } }));
+vi.mock('./ChatAttachments.svelte', () => ({ default: () => {} }));
+
+const attachments: Attachment[] = [
+	{
+		type: 'screenshot',
+		key: 'screenshot-first',
+		name: 'screenshot.png',
+		size: 2048,
+		mimeType: 'image/png',
+		preview: 'blob:https://chat.test/screenshot',
+		url: 'https://chat.test/screenshot.png',
+		width: 800,
+		height: 600,
+		uploadState: { status: 'success', progress: 100, fileId: 'screenshot-file' }
+	},
+	{
+		type: 'file',
+		key: 'document-second',
+		name: 'notes.txt',
+		size: 42,
+		mimeType: 'text/plain',
+		url: 'https://chat.test/notes.txt',
+		uploadState: { status: 'success', progress: 100, fileId: 'document-file' }
+	}
+];
+
+const originalRevokeObjectURL = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+let component: ReturnType<typeof mount> | undefined;
+let client: ConvexClient;
+let ctx: ChatUIContext;
+
+beforeEach(() => {
+	client = new ConvexClient('https://chat-test.convex.cloud', { disabled: true });
+	ctx = new ChatUIContext(
+		new ChatCore({
+			threadId: 'thread-input',
+			api: { sendMessage: api.aiChat.messages.sendMessage }
+		}),
+		client
+	);
+	vi.spyOn(console, 'error').mockImplementation(() => {});
+	// jsdom has no object URL implementation.
+	Object.defineProperty(URL, 'revokeObjectURL', { value: vi.fn(), configurable: true });
+});
+
+afterEach(async () => {
+	if (component) await unmount(component);
+	component = undefined;
+	ctx.dispose();
+	await client.close();
+	vi.restoreAllMocks();
+	if (originalRevokeObjectURL) {
+		Object.defineProperty(URL, 'revokeObjectURL', originalRevokeObjectURL);
+	} else {
+		Reflect.deleteProperty(URL, 'revokeObjectURL');
+	}
+});
+
+async function startSend() {
+	const pending = Promise.withResolvers<void>();
+	const onSend = vi.fn(() => {
+		expect(ctx.inputValue).toBe('');
+		expect(ctx.attachments).toEqual(attachments);
+		return pending.promise;
+	});
+	const contentProps = { context: ctx, onSend };
+	component = mount(ChatTestProvider<typeof contentProps>, {
+		target: document.body,
+		props: { client, content: ChatInputHarness, contentProps }
+	});
+	await tick();
+	const input = document.querySelector('textarea')!;
+	input.value = 'Retry this message';
+	input.dispatchEvent(new Event('input', { bubbles: true }));
+	ctx.addAttachments(attachments);
+	await tick();
+	const button = document.querySelector<HTMLButtonElement>(
+		`button[aria-label="${en.chat.aria.send}"]`
+	)!;
+	expect(button.disabled).toBe(false);
+	button.click();
+	await tick();
+	expect(onSend).toHaveBeenCalledExactlyOnceWith('Retry this message');
+	expect(input.value).toBe('');
+	expect(ctx.attachments).toEqual([]);
+	return { pending, input };
+}
+
+describe('ChatInput send rollback through ChatRoot', () => {
+	it('restores text and the ordered attachment snapshot without revoked blob previews', async () => {
+		const { pending, input } = await startSend();
+		const error = new Error('Send rejected');
+		pending.reject(error);
+		await tick();
+
+		expect(console.error).toHaveBeenCalledWith('[ChatInput] onSend failed:', error);
+		await vi.waitFor(() => expect(input.value).toBe('Retry this message'));
+		expect(ctx.attachments).toEqual([{ ...attachments[0], preview: undefined }, attachments[1]]);
+		expect(ctx.uploadedFileIds).toEqual(['screenshot-file', 'document-file']);
+		expect(URL.revokeObjectURL).toHaveBeenCalledExactlyOnceWith(
+			'blob:https://chat.test/screenshot'
+		);
+	});
+
+	it('keeps the composer cleared when sending succeeds', async () => {
+		const { pending, input } = await startSend();
+		pending.resolve();
+		await tick();
+
+		expect(input.value).toBe('');
+		expect(ctx.attachments).toEqual([]);
+		expect(console.error).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ name: 'text', editText: true, addAttachment: false },
+		{ name: 'attachments', editText: false, addAttachment: true },
+		{ name: 'text and attachments', editText: true, addAttachment: true }
+	])('preserves $name added while the send is pending', async ({ editText, addAttachment }) => {
+		const { pending, input } = await startSend();
+		if (editText) {
+			input.value = 'A newer draft';
+			input.dispatchEvent(new Event('input', { bubbles: true }));
+		}
+		const newer: Attachment = { type: 'image', url: 'https://chat.test/newer.png' };
+		if (addAttachment) ctx.addAttachments([newer]);
+		const error = new Error('Send rejected');
+		pending.reject(error);
+		await tick();
+
+		expect(console.error).toHaveBeenCalledWith('[ChatInput] onSend failed:', error);
+		await vi.waitFor(() =>
+			expect(input.value).toBe(editText ? 'A newer draft' : 'Retry this message')
+		);
+		expect(ctx.attachments).toEqual(
+			addAttachment ? [newer] : [{ ...attachments[0], preview: undefined }, attachments[1]]
+		);
+	});
+});

--- a/src/lib/chat/ui/chat-send-consumers.test.ts
+++ b/src/lib/chat/ui/chat-send-consumers.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, tick, unmount } from 'svelte';
+import type * as Svelte from 'svelte';
+import en from '../../../i18n/en.json';
+import { ConvexClient } from 'convex/browser';
+import { getFunctionName } from 'convex/server';
+import { toast } from 'svelte-sonner';
+import AIThreadChat from '../../../routes/[[lang]]/app/ai-chat/thread-chat.svelte';
+import AdminThreadChat from '../../../routes/[[lang]]/admin/support/thread-chat.svelte';
+import ChatTestProvider from './test-fixtures/ChatTestProvider.svelte';
+import { capturedInput } from './test-fixtures/CapturedChatInput.svelte';
+
+// Vitest resolves Svelte's server entry by default; use its real client runtime for mounting.
+vi.mock('svelte', () =>
+	vi.importActual<typeof Svelte>('../../../../node_modules/svelte/src/index-client.js')
+);
+vi.mock('$lib/chat/ui/ChatInput.svelte', async () => ({
+	default: (await import('./test-fixtures/CapturedChatInput.svelte')).default
+}));
+vi.mock('$lib/chat/ui/ChatMessages.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/message-quota-banner.svelte', () => ({ default: () => {} }));
+vi.mock('svelte-sonner', () => ({ toast: { error: vi.fn() } }));
+vi.mock('$app/state', () => ({ page: { data: { lang: 'en' } } }));
+vi.mock('$lib/auth-client', () => ({ authClient: {} }));
+vi.mock('$lib/hooks/use-media.svelte.ts', () => ({ useMedia: () => ({ lg: false }) }));
+
+let component: ReturnType<typeof mount> | undefined;
+let client: ConvexClient;
+
+beforeEach(() => {
+	localStorage.clear();
+	client = new ConvexClient('https://chat-test.convex.cloud', { disabled: true });
+	vi.spyOn(console, 'error').mockImplementation(() => {});
+	vi.mocked(toast.error).mockClear();
+	delete capturedInput.props;
+	delete capturedInput.context;
+});
+
+afterEach(async () => {
+	if (component) await unmount(component);
+	component = undefined;
+	await client.close();
+	vi.restoreAllMocks();
+	localStorage.clear();
+});
+
+describe.each([
+	{
+		name: 'AI chat',
+		content: AIThreadChat,
+		contentProps: { threadId: 'thread-ai', hasMessagesAvailable: true },
+		mutationName: 'aiChat/messages:sendMessage',
+		log: '[AI Chat sendMessage] Error:',
+		translation: en.chat.messages.send_failed
+	},
+	{
+		name: 'admin support',
+		content: AdminThreadChat,
+		contentProps: { threadId: 'thread-admin' },
+		mutationName: 'admin/support/mutations:sendAdminReply',
+		log: '[Admin sendAdminReply] Error:',
+		translation: en.admin.support.chat.send_error
+	}
+])('$name send callback', ({ content, contentProps, mutationName, log, translation }) => {
+	it('rethrows the mutation error after reporting it and leaves input rollback to ChatInput', async () => {
+		const error = new Error('Send rejected');
+		const pending = Promise.withResolvers<never>();
+		const mutation = vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: { client, content, contentProps }
+		});
+		await tick();
+		const ctx = capturedInput.context!;
+		ctx.addAttachments([
+			{
+				type: 'file',
+				key: 'attached-document',
+				name: 'notes.txt',
+				size: 42,
+				mimeType: 'text/plain',
+				uploadState: { status: 'success', progress: 100, fileId: 'document-file' }
+			}
+		]);
+		const restore = vi.spyOn(ctx, 'setInputValue');
+		const result = capturedInput.props!.onSend!('Retry this message');
+		const rejection = expect
+			.soft(result, 'Consumers must reject so ChatInput restores its attachment snapshot')
+			.rejects.toBe(error);
+		expect(mutation).toHaveBeenCalledTimes(1);
+		const [reference, args, options] = mutation.mock.calls[0]!;
+		expect(getFunctionName(reference)).toBe(mutationName);
+		expect(args).toEqual({
+			threadId: contentProps.threadId,
+			prompt: 'Retry this message',
+			fileIds: ['document-file'],
+			...(content === AIThreadChat ? { userId: undefined } : {})
+		});
+		expect(options?.optimisticUpdate).toBeTypeOf('function');
+		pending.reject(error);
+		await rejection;
+
+		expect(console.error).toHaveBeenCalledWith(log, error);
+		expect(toast.error).toHaveBeenCalledExactlyOnceWith(translation);
+		expect(
+			restore,
+			'Only ChatInput may restore the captured composer state'
+		).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/chat/ui/chat-send-consumers.test.ts
+++ b/src/lib/chat/ui/chat-send-consumers.test.ts
@@ -5,35 +5,78 @@ import en from '../../../i18n/en.json';
 import { ConvexClient } from 'convex/browser';
 import { getFunctionName } from 'convex/server';
 import { toast } from 'svelte-sonner';
+import { ConvexError } from 'convex/values';
 import AIThreadChat from '../../../routes/[[lang]]/app/ai-chat/thread-chat.svelte';
 import AdminThreadChat from '../../../routes/[[lang]]/admin/support/thread-chat.svelte';
+import FeedbackWidget from '../../components/customer-support/feedback-widget.svelte';
+import { SupportThreadContext } from '../../components/customer-support/support-thread-context.svelte.ts';
+import { ChatUIContext } from './chat-context.svelte.ts';
+import type { ChatCore } from '../core/chat-core.svelte.ts';
+import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 import ChatTestProvider from './test-fixtures/ChatTestProvider.svelte';
+import ThreadChatConsumerHarness, {
+	threadChatConsumerHarness
+} from './test-fixtures/ThreadChatConsumerHarness.svelte';
 import { capturedInput } from './test-fixtures/CapturedChatInput.svelte';
 
 // Vitest resolves Svelte's server entry by default; use its real client runtime for mounting.
 vi.mock('svelte', () =>
 	vi.importActual<typeof Svelte>('../../../../node_modules/svelte/src/index-client.js')
 );
+vi.mock('esm-env', () => ({ BROWSER: true, DEV: true }));
 vi.mock('$lib/chat/ui/ChatInput.svelte', async () => ({
 	default: (await import('./test-fixtures/CapturedChatInput.svelte')).default
+}));
+vi.mock('$lib/chat', async () => ({
+	ChatRoot: (await import('./ChatRoot.svelte')).default,
+	ChatMessages: () => {},
+	ChatInput: (await import('./test-fixtures/CapturedChatInput.svelte')).default
 }));
 vi.mock('$lib/chat/ui/ChatMessages.svelte', () => ({ default: () => {} }));
 vi.mock('$lib/components/message-quota-banner.svelte', () => ({ default: () => {} }));
 vi.mock('svelte-sonner', () => ({ toast: { error: vi.fn() } }));
 vi.mock('$app/state', () => ({ page: { data: { lang: 'en' } } }));
-vi.mock('$lib/auth-client', () => ({ authClient: {} }));
-vi.mock('$lib/hooks/use-media.svelte.ts', () => ({ useMedia: () => ({ lg: false }) }));
+vi.mock('$lib/auth-client', () => ({
+	authClient: { useSession: () => ({ subscribe: () => () => {} }) }
+}));
+vi.mock('$lib/hooks/use-media.svelte.ts', () => ({
+	useMedia: () => ({ sm: false, lg: false, xl: false })
+}));
+vi.mock('$lib/hooks/use-haptic.svelte.ts', () => ({ haptic: { trigger: vi.fn() } }));
+vi.mock('$lib/components/customer-support/threads-overview.svelte', () => ({ default: () => {} }));
 
 let component: ReturnType<typeof mount> | undefined;
 let client: ConvexClient;
+
+function stallUpload() {
+	const handlers: Record<string, () => void> = {};
+	const abort = vi.fn(() => handlers.abort?.());
+	vi.stubGlobal('XMLHttpRequest', function XMLHttpRequestStub() {
+		return {
+			status: 200,
+			responseText: '',
+			upload: { addEventListener: () => {} },
+			addEventListener: (event: string, handler: () => void) => {
+				handlers[event] = handler;
+			},
+			open: () => {},
+			setRequestHeader: () => {},
+			abort,
+			send: () => {}
+		};
+	});
+	return abort;
+}
 
 beforeEach(() => {
 	localStorage.clear();
 	client = new ConvexClient('https://chat-test.convex.cloud', { disabled: true });
 	vi.spyOn(console, 'error').mockImplementation(() => {});
 	vi.mocked(toast.error).mockClear();
+	vi.mocked(haptic.trigger).mockClear();
 	delete capturedInput.props;
 	delete capturedInput.context;
+	delete threadChatConsumerHarness.setThreadId;
 });
 
 afterEach(async () => {
@@ -41,6 +84,7 @@ afterEach(async () => {
 	component = undefined;
 	await client.close();
 	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
 	localStorage.clear();
 });
 
@@ -106,5 +150,200 @@ describe.each([
 			restore,
 			'Only ChatInput may restore the captured composer state'
 		).not.toHaveBeenCalled();
+	});
+
+	it('leaves a later pending upload active after success', async () => {
+		const pending = Promise.withResolvers<Record<string, never>>();
+		vi.spyOn(client, 'mutation').mockImplementation((reference) =>
+			getFunctionName(reference) === mutationName
+				? pending.promise
+				: Promise.resolve({ uploadUrl: 'https://storage.test', uploadToken: 'token' })
+		);
+		const abort = stallUpload();
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: { client, content, contentProps }
+		});
+		await tick();
+		const ctx = capturedInput.context!;
+		ctx.addAttachments([
+			{
+				type: 'file',
+				key: 'sent-file',
+				name: 'sent.txt',
+				size: 10,
+				mimeType: 'text/plain',
+				url: 'https://chat.test/sent.txt',
+				uploadState: { status: 'success', progress: 100, fileId: 'sent-file-id' }
+			}
+		]);
+		const result = capturedInput.props!.onSend!('Send this');
+		ctx.clearAttachments();
+		const clearAttachments = vi.spyOn(ctx, 'clearAttachments');
+		void ctx.uploadFile(new File(['later'], 'later.txt', { type: 'text/plain' }));
+		await vi.waitFor(() => expect(ctx.hasUploadingFiles).toBe(true));
+
+		pending.resolve({});
+		await expect(result).resolves.toBeUndefined();
+
+		expect(clearAttachments).not.toHaveBeenCalled();
+		expect(abort).not.toHaveBeenCalled();
+		expect(ctx.attachments).toEqual([
+			expect.objectContaining({
+				name: 'later.txt',
+				uploadState: { status: 'uploading', progress: 0 }
+			})
+		]);
+	});
+});
+
+function storedDrafts(surface: 'ai-chat' | 'admin-support'): Record<string, string> {
+	return JSON.parse(localStorage.getItem(`drafts:${surface}`) ?? '{}');
+}
+
+describe.each([
+	{ kind: 'ai' as const, surface: 'ai-chat' as const },
+	{ kind: 'admin' as const, surface: 'admin-support' as const }
+])('$kind draft checkpoint', ({ kind, surface }) => {
+	async function mountHarness() {
+		const contentProps = { kind, initialThreadId: 'thread-a' };
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: { client, content: ThreadChatConsumerHarness, contentProps }
+		});
+		await tick();
+		return capturedInput.context!;
+	}
+
+	it('clears only the unchanged origin draft after switching threads', async () => {
+		const pending = Promise.withResolvers<Record<string, never>>();
+		vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		const ctx = await mountHarness();
+		ctx.setInputValue('send from A');
+		await tick();
+		const result = capturedInput.props!.onSend!('send from A');
+		ctx.clearInput();
+		threadChatConsumerHarness.setThreadId?.('thread-b');
+		await tick();
+		capturedInput.context!.setInputValue('keep in B');
+		await tick();
+
+		pending.resolve({});
+		await expect(result).resolves.toBeUndefined();
+
+		expect(storedDrafts(surface)).toEqual({ 'thread-b': 'keep in B' });
+	});
+
+	it.each(['a newer draft', 'send this'])(
+		'preserves later same-thread text %s after success',
+		async (later) => {
+			const pending = Promise.withResolvers<Record<string, never>>();
+			vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+			const ctx = await mountHarness();
+			ctx.setInputValue('send this');
+			await tick();
+			const result = capturedInput.props!.onSend!('send this');
+			ctx.clearInput();
+			ctx.setInputValue(later);
+			await tick();
+
+			pending.resolve({});
+			await expect(result).resolves.toBeUndefined();
+
+			expect(storedDrafts(surface)).toEqual({ 'thread-a': later });
+		}
+	);
+});
+
+describe('AI thread switch failure', () => {
+	it('keeps the origin draft and leaves the visible thread unchanged', async () => {
+		const error = new Error('Send rejected');
+		const pending = Promise.withResolvers<Record<string, never>>();
+		vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		const contentProps = { kind: 'ai' as const, initialThreadId: 'thread-a' };
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: { client, content: ThreadChatConsumerHarness, contentProps }
+		});
+		await tick();
+		const ctx = capturedInput.context!;
+		ctx.setInputValue('retry in A');
+		await tick();
+		const result = capturedInput.props!.onSend!('retry in A');
+		ctx.clearInput();
+		threadChatConsumerHarness.setThreadId?.('thread-b');
+		await tick();
+
+		pending.reject(error);
+		await expect(result).rejects.toBe(error);
+
+		expect(capturedInput.context!.inputValue).toBe('');
+		expect(storedDrafts('ai-chat')).toEqual({ 'thread-a': 'retry in A' });
+	});
+});
+
+describe('support feedback send callback', () => {
+	it('keeps rate-limit UX, rethrows the same error, and leaves rollback to ChatInput', async () => {
+		const thread = new SupportThreadContext();
+		thread.setThread('thread-support');
+		thread.currentView = 'chat';
+		const ctx = new ChatUIContext(thread as unknown as ChatCore, client);
+		const contentProps = { chatUIContext: ctx };
+		const error = new ConvexError({ code: 'RATE_LIMITED', retryAfter: 3000 });
+		vi.spyOn(client, 'mutation').mockRejectedValue(error);
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: {
+				client,
+				content: FeedbackWidget,
+				contentProps,
+				supportThread: thread
+			}
+		});
+		await tick();
+		const restore = vi.spyOn(ctx, 'setInputValue');
+
+		const result = capturedInput.props!.onSend!('Retry this message');
+
+		await expect(result).rejects.toBe(error);
+		expect(console.error).toHaveBeenCalledWith('[handleSend] Error:', error);
+		expect(thread.isRateLimited).toBe(true);
+		expect(haptic.trigger).toHaveBeenCalledExactlyOnceWith('error');
+		expect(toast.error).toHaveBeenCalledExactlyOnceWith(
+			en.support.widget.error.rate_limit.replace('{seconds}', '3')
+		);
+		expect(restore).not.toHaveBeenCalled();
+		ctx.dispose();
+	});
+
+	it('preserves a later support draft after success', async () => {
+		const thread = new SupportThreadContext();
+		thread.setThread('thread-support');
+		thread.currentView = 'chat';
+		thread.setDraft('thread-support', 'send this');
+		const ctx = new ChatUIContext(thread as unknown as ChatCore, client);
+		const contentProps = { chatUIContext: ctx };
+		const pending = Promise.withResolvers<Record<string, never>>();
+		vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: {
+				client,
+				content: FeedbackWidget,
+				contentProps,
+				supportThread: thread
+			}
+		});
+		await tick();
+		const result = capturedInput.props!.onSend!('send this');
+		ctx.clearInput();
+		ctx.setInputValue('keep this');
+		thread.setDraft('thread-support', 'keep this');
+
+		pending.resolve({});
+		await expect(result).resolves.toBeUndefined();
+
+		expect(thread.getDraft('thread-support')).toBe('keep this');
+		ctx.dispose();
 	});
 });

--- a/src/lib/chat/ui/chat-send-consumers.test.ts
+++ b/src/lib/chat/ui/chat-send-consumers.test.ts
@@ -13,6 +13,7 @@ import { SupportThreadContext } from '../../components/customer-support/support-
 import { ChatUIContext } from './chat-context.svelte.ts';
 import type { ChatCore } from '../core/chat-core.svelte.ts';
 import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+import { clearPersistedChatState } from '../core/chat-persisted-state.ts';
 import ChatTestProvider from './test-fixtures/ChatTestProvider.svelte';
 import ThreadChatConsumerHarness, {
 	threadChatConsumerHarness
@@ -280,6 +281,43 @@ describe('AI thread switch failure', () => {
 		expect(capturedInput.context!.inputValue).toBe('');
 		expect(storedDrafts('ai-chat')).toEqual({ 'thread-a': 'retry in A' });
 	});
+});
+
+describe('AI session boundary', () => {
+	it.each(['success', 'rejection'] as const)(
+		'suppresses stale $0 side effects after session clear',
+		async (outcome) => {
+			const pending = Promise.withResolvers<Record<string, never>>();
+			vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+			const onMessageSent = vi.fn();
+			const contentProps = {
+				threadId: 'thread-ai',
+				hasMessagesAvailable: true,
+				onMessageSent
+			};
+			component = mount(ChatTestProvider<typeof contentProps>, {
+				target: document.body,
+				props: { client, content: AIThreadChat, contentProps }
+			});
+			await tick();
+			const result = capturedInput.props!.onSend!('old session message');
+			clearPersistedChatState();
+
+			if (outcome === 'success') {
+				pending.resolve({});
+				await expect(result).resolves.toBeUndefined();
+			} else {
+				const error = new Error('Send rejected');
+				pending.reject(error);
+				await expect(result).rejects.toBe(error);
+			}
+
+			expect(onMessageSent).not.toHaveBeenCalled();
+			expect(toast.error).not.toHaveBeenCalled();
+			expect(capturedInput.context?.core.isSending).toBe(false);
+			expect(capturedInput.context?.core.isAwaitingStream).toBe(false);
+		}
+	);
 });
 
 describe('support feedback send callback', () => {

--- a/src/lib/chat/ui/chat-session-lifecycle.test.ts
+++ b/src/lib/chat/ui/chat-session-lifecycle.test.ts
@@ -101,15 +101,6 @@ function sendButton(): HTMLButtonElement {
 	return document.querySelector<HTMLButtonElement>(`button[aria-label="${en.chat.aria.send}"]`)!;
 }
 
-function sendLoader(): SVGElement | null {
-	const loaderClass = ['motion-safe', ['animate', 'spin'].join('-')].join(':');
-	return (
-		[...sendButton().querySelectorAll('svg')].find((icon) =>
-			icon.classList.contains(loaderClass)
-		) ?? null
-	);
-}
-
 async function settleComponentWork(): Promise<void> {
 	await Promise.resolve();
 	await tick();
@@ -745,6 +736,94 @@ describe('chat session lifecycle', () => {
 		expect(input.value).toBe('');
 		expect(thread.getDraft('assigned-after-clear')).toBe('');
 	});
+
+	it.each([
+		{
+			boundary: 'goBack',
+			navigate: async (thread: SupportThreadContext) => thread.goBack(),
+			expectedThreadId: null,
+			expectedView: 'overview' as const
+		},
+		{
+			boundary: 'selected thread',
+			navigate: async (thread: SupportThreadContext) => thread.selectThread('selected-thread'),
+			expectedThreadId: 'selected-thread',
+			expectedView: 'chat' as const
+		},
+		{
+			boundary: 'newer generation',
+			navigate: async (thread: SupportThreadContext) => {
+				thread.startNewThread();
+				await vi.waitFor(() => expect(thread.threadId).toBe('new-thread'));
+			},
+			expectedThreadId: 'new-thread',
+			expectedView: 'chat' as const
+		},
+		{
+			boundary: 'session clear',
+			navigate: async (thread: SupportThreadContext) => {
+				clearPersistedChatState();
+				thread.startNewThread();
+				await vi.waitFor(() => expect(thread.threadId).toBe('new-thread'));
+			},
+			expectedThreadId: 'new-thread',
+			expectedView: 'chat' as const
+		}
+	])(
+		'an eager rejection after $boundary does not write stale diagnostics',
+		async ({ navigate, expectedThreadId, expectedView }) => {
+			const thread = new SupportThreadContext();
+			const context = new ChatUIContext(thread as unknown as ChatCore, client);
+			contexts.push(context);
+			const oldCreation = Promise.withResolvers<{
+				threadId: string;
+				notificationEmail: null;
+			}>();
+			let warmCalls = 0;
+			const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+				if (getFunctionName(reference) === 'support/threads:getOrCreateWarmThread') {
+					warmCalls++;
+					return warmCalls === 1
+						? oldCreation.promise
+						: Promise.resolve({ threadId: 'new-thread', notificationEmail: null });
+				}
+				return Promise.resolve({});
+			});
+			const oldError = new Error('Old eager creation rejected');
+			thread.setClient(client);
+			thread.startNewThread();
+			await vi.waitFor(() => expect(mutation).toHaveBeenCalledTimes(1));
+
+			await navigate(thread);
+			vi.mocked(console.error).mockClear();
+			oldCreation.reject(oldError);
+			await new Promise<void>((resolve) => setTimeout(resolve, 0));
+			await tick();
+
+			expect(thread.error).toBeNull();
+			expect(thread.threadId).toBe(expectedThreadId);
+			expect(thread.currentView).toBe(expectedView);
+			expect(console.error).not.toHaveBeenCalledWith(
+				'[startNewThread] Thread creation failed:',
+				oldError
+			);
+		}
+	);
+
+	it('reports the original eager acquisition error for the current conversation', async () => {
+		const thread = new SupportThreadContext();
+		const error = new Error('Current eager creation rejected');
+		const mutation = vi.spyOn(client, 'mutation').mockRejectedValue(error);
+		thread.setClient(client);
+
+		thread.startNewThread();
+		await vi.waitFor(() =>
+			expect(thread.error).toBe('Failed to start conversation. Please try again.')
+		);
+
+		expect(mutation).toHaveBeenCalledTimes(1);
+		expect(console.error).toHaveBeenCalledWith('[startNewThread] Thread creation failed:', error);
+	});
 });
 
 describe('AI chatbar session lifecycle', () => {
@@ -797,19 +876,13 @@ describe('AI chatbar session lifecycle', () => {
 			expect(mutation).toHaveBeenCalledTimes(2);
 			expect(thread.isSending).toBe(true);
 			expect(sendButton().disabled).toBe(true);
-			expect(sendLoader()).not.toBeNull();
-
 			flushSync(() => navigate(thread));
 			expect(thread.isSending).toBe(false);
 			expect(sendButton().disabled).toBe(false);
-			expect(sendLoader()).toBeNull();
-
 			const newerSend = thread.sendMessage(client, 'newer prompt');
 			await settleComponentWork();
 			expect(mutation).toHaveBeenCalledTimes(3);
 			expect(thread.isSending).toBe(true);
-			expect(sendLoader()).not.toBeNull();
-
 			if (oldOutcome === 'fulfilled') {
 				oldCreation.resolve({ threadId: 'old-created-thread', notificationEmail: null });
 				await expect(oldSend).rejects.toThrow('Support conversation changed');
@@ -819,7 +892,6 @@ describe('AI chatbar session lifecycle', () => {
 			}
 			await settleComponentWork();
 			expect(thread.isSending).toBe(true);
-			expect(sendLoader()).not.toBeNull();
 			expect(thread.error).toBeNull();
 
 			if (boundary === 'goBack') {
@@ -852,11 +924,8 @@ describe('AI chatbar session lifecycle', () => {
 
 		flushSync(() => thread.goBack());
 		expect(thread.isSending).toBe(true);
-		expect(sendLoader()).not.toBeNull();
 		flushSync(() => thread.selectThread('existing-thread'));
 		expect(thread.isSending).toBe(true);
-		expect(sendLoader()).not.toBeNull();
-
 		message.resolve({});
 		await expect(result).resolves.toEqual({
 			threadId: 'existing-thread',

--- a/src/lib/chat/ui/chat-session-lifecycle.test.ts
+++ b/src/lib/chat/ui/chat-session-lifecycle.test.ts
@@ -1,0 +1,512 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, tick, unmount } from 'svelte';
+import type * as Svelte from 'svelte';
+import { ConvexClient } from 'convex/browser';
+import { getFunctionName } from 'convex/server';
+import { api } from '$lib/convex/_generated/api';
+import { clearPersistedChatState } from '../core/chat-persisted-state.ts';
+import { ChatAttachmentStore } from '../core/chat-attachment-store.svelte.ts';
+import type { Attachment } from '../core/types.js';
+import type { ChatCore } from '../core/chat-core.svelte.ts';
+import { ChatUIContext } from './chat-context.svelte.ts';
+import { SupportThreadContext } from '$lib/components/customer-support/support-thread-context.svelte.ts';
+import FeedbackWidget from '$lib/components/customer-support/feedback-widget.svelte';
+import AIChatbar from '$lib/components/customer-support/ai-chatbar.svelte';
+import { toast } from 'svelte-sonner';
+import ChatTestProvider from './test-fixtures/ChatTestProvider.svelte';
+import KeyedAdminThreadLifecycleHarness, {
+	keyedAdminThreadLifecycle
+} from './test-fixtures/KeyedAdminThreadLifecycleHarness.svelte';
+import { capturedAttachments } from './test-fixtures/CapturedChatAttachments.svelte';
+import en from '../../../i18n/en.json';
+
+vi.mock('svelte', () =>
+	vi.importActual<typeof Svelte>('../../../../node_modules/svelte/src/index-client.js')
+);
+vi.mock('esm-env', () => ({ BROWSER: true, DEV: true }));
+vi.mock('svelte-sonner', () => ({ toast: { error: vi.fn() } }));
+vi.mock('$app/state', () => ({ page: { data: { lang: 'en' } } }));
+vi.mock('$lib/auth-client', () => ({
+	authClient: { useSession: () => ({ subscribe: () => () => {} }) }
+}));
+vi.mock('$lib/hooks/use-media.svelte.ts', () => ({
+	useMedia: () => ({ sm: false, lg: false, xl: false })
+}));
+vi.mock('$lib/hooks/use-haptic.svelte.ts', () => ({ haptic: { trigger: vi.fn() } }));
+vi.mock('$lib/components/customer-support/threads-overview.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/chat', async () => ({
+	ChatRoot: (await import('./ChatRoot.svelte')).default,
+	ChatMessages: () => {},
+	ChatInput: (await import('./ChatInput.svelte')).default
+}));
+vi.mock('$lib/chat/ui/ChatMessages.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/chat/ui/ChatAttachments.svelte', async () => ({
+	default: (await import('./test-fixtures/CapturedChatAttachments.svelte')).default
+}));
+
+const oldAttachment: Attachment = {
+	type: 'file',
+	key: 'old-file',
+	name: 'old.txt',
+	size: 12,
+	mimeType: 'text/plain',
+	url: 'https://chat.test/old.txt',
+	uploadState: { status: 'success', progress: 100, fileId: 'old-file-id' }
+};
+
+const generationTwoAttachment: Attachment = {
+	type: 'file',
+	key: 'generation-two-file',
+	name: 'generation-two.txt',
+	size: 18,
+	mimeType: 'text/plain',
+	url: 'https://chat.test/generation-two.txt',
+	uploadState: { status: 'success', progress: 100, fileId: 'generation-two-file-id' }
+};
+
+let component: ReturnType<typeof mount> | undefined;
+let client: ConvexClient;
+const contexts: ChatUIContext[] = [];
+
+function storedAttachment(attachment: Extract<Attachment, { type: 'file' | 'screenshot' }>) {
+	return {
+		id: attachment.key,
+		type: attachment.type,
+		name: attachment.name,
+		size: attachment.size,
+		mimeType: attachment.mimeType,
+		url: attachment.url,
+		fileId: attachment.uploadState?.fileId,
+		savedAt: Date.now()
+	};
+}
+
+function typeInto(input: HTMLTextAreaElement, value: string): void {
+	input.value = value;
+	input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function sendButton(): HTMLButtonElement {
+	return document.querySelector<HTMLButtonElement>(`button[aria-label="${en.chat.aria.send}"]`)!;
+}
+
+function mockUnsubscribe() {
+	const unsubscribe = vi.fn();
+	return Object.assign(unsubscribe, {
+		unsubscribe,
+		getCurrentValue: vi.fn()
+	});
+}
+
+async function mountSupport(thread: SupportThreadContext, context: ChatUIContext): Promise<void> {
+	contexts.push(context);
+	context.setDisplayMessages([]);
+	const contentProps = { chatUIContext: context };
+	component = mount(ChatTestProvider<typeof contentProps>, {
+		target: document.body,
+		props: {
+			client,
+			content: FeedbackWidget,
+			contentProps,
+			supportThread: thread
+		}
+	});
+	await tick();
+}
+
+async function mountChatbar(thread: SupportThreadContext): Promise<HTMLTextAreaElement> {
+	const contentProps = { isFeedbackOpen: false };
+	component = mount(ChatTestProvider<typeof contentProps>, {
+		target: document.body,
+		props: { client, content: AIChatbar, contentProps, supportThread: thread }
+	});
+	await tick();
+	return document.querySelector('textarea')!;
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	client = new ConvexClient('https://chat-test.convex.cloud', { disabled: true });
+	delete keyedAdminThreadLifecycle.setThreadId;
+	delete capturedAttachments.props;
+	vi.mocked(toast.error).mockClear();
+	vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(async () => {
+	if (component) await unmount(component);
+	component = undefined;
+	for (const context of contexts.splice(0)) context.dispose();
+	await client.close();
+	localStorage.clear();
+	vi.restoreAllMocks();
+});
+
+describe('chat session lifecycle', () => {
+	it('session clear prevents a rejected real admin send from restoring prior-session composer state', async () => {
+		const threadId = 'session-thread';
+		localStorage.setItem(
+			'drafts:admin-support',
+			JSON.stringify({ [threadId]: 'old session text' })
+		);
+		localStorage.setItem(
+			'attachments:admin-support',
+			JSON.stringify({ [threadId]: [storedAttachment(oldAttachment)] })
+		);
+		const pending = Promise.withResolvers<Record<string, never>>();
+		const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+			if (getFunctionName(reference) === 'admin/support/mutations:sendAdminReply') {
+				return pending.promise;
+			}
+			return Promise.resolve({});
+		});
+		const contentProps = { initialThreadId: threadId };
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: { client, content: KeyedAdminThreadLifecycleHarness, contentProps }
+		});
+		await tick();
+		const input = document.querySelector('textarea')!;
+		await vi.waitFor(() => expect(input.value).toBe('old session text'));
+		expect(capturedAttachments.props?.attachments?.[0]).toEqual(
+			expect.objectContaining({ name: 'old.txt' })
+		);
+
+		sendButton().click();
+		await vi.waitFor(() => expect(mutation).toHaveBeenCalled());
+		clearPersistedChatState();
+		expect(input.value).toBe('');
+
+		pending.reject(new Error('Send rejected'));
+		await tick();
+
+		expect(console.error).not.toHaveBeenCalled();
+		expect(input.value).toBe('');
+		expect(JSON.parse(localStorage.getItem('drafts:admin-support') ?? '{}')).toEqual({});
+		expect(JSON.parse(localStorage.getItem('attachments:admin-support') ?? '{}')).toEqual({});
+	});
+
+	it('a generation-one null-origin rejection cannot contaminate generation two', async () => {
+		const thread = new SupportThreadContext();
+		thread.startNewThread();
+		const context = new ChatUIContext(thread as unknown as ChatCore, client, {
+			generateUploadUrl: api.support.files.generateUploadUrl,
+			saveUploadedFile: api.support.files.saveUploadedFile,
+			attachmentStore: new ChatAttachmentStore('support')
+		});
+		const message = Promise.withResolvers<Record<string, never>>();
+		vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+			const name = getFunctionName(reference);
+			if (name === 'support/threads:getOrCreateWarmThread') {
+				return Promise.resolve({ threadId: 'generation-one-thread', notificationEmail: null });
+			}
+			if (name === 'support/messages:sendMessage') return message.promise;
+			return Promise.resolve({});
+		});
+		await mountSupport(thread, context);
+		const input = document.querySelector('textarea')!;
+		typeInto(input, 'generation one text');
+		context.addAttachments([oldAttachment]);
+		await tick();
+		sendButton().click();
+		await vi.waitFor(() => expect(thread.threadId).toBe('generation-one-thread'));
+
+		thread.goBack();
+		thread.startNewThread();
+		context.setDisplayMessages([]);
+		await tick();
+		typeInto(input, 'generation two text');
+		context.addAttachments([generationTwoAttachment]);
+		await tick();
+		message.reject(new Error('Generation one rejected'));
+		await vi.waitFor(() => expect(console.error).toHaveBeenCalled());
+
+		expect(input.value).toBe('generation two text');
+		expect(
+			context.attachments.map((attachment) => ('key' in attachment ? attachment.key : ''))
+		).toEqual(['generation-two-file']);
+		expect(
+			new ChatAttachmentStore('support')
+				.readThread(null)
+				.map((attachment) => ('key' in attachment ? attachment.key : ''))
+		).toEqual(['generation-two-file']);
+		expect(
+			new ChatAttachmentStore('support')
+				.readThread('generation-one-thread')
+				.map((attachment) => ('key' in attachment ? attachment.key : ''))
+		).toEqual(['old-file']);
+	});
+
+	it('keyed admin A to B to A preserves a rejected A snapshot in the new A instance', async () => {
+		localStorage.setItem(
+			'attachments:admin-support',
+			JSON.stringify({ 'thread-a': [storedAttachment(oldAttachment)] })
+		);
+		const pending = Promise.withResolvers<Record<string, never>>();
+		vi.spyOn(client, 'mutation').mockImplementation((reference) =>
+			getFunctionName(reference) === 'admin/support/mutations:sendAdminReply'
+				? pending.promise
+				: Promise.resolve({})
+		);
+		const contentProps = { initialThreadId: 'thread-a' };
+		component = mount(ChatTestProvider<typeof contentProps>, {
+			target: document.body,
+			props: { client, content: KeyedAdminThreadLifecycleHarness, contentProps }
+		});
+		await tick();
+		const input = document.querySelector('textarea')!;
+		typeInto(input, 'reply from A');
+		await tick();
+		sendButton().click();
+		await tick();
+
+		flushSync(() => keyedAdminThreadLifecycle.setThreadId?.('thread-b'));
+		await tick();
+		flushSync(() => keyedAdminThreadLifecycle.setThreadId?.('thread-a'));
+		await tick();
+		expect(capturedAttachments.props?.attachments?.[0]).toBeUndefined();
+
+		pending.reject(new Error('Send rejected'));
+		await vi.waitFor(() => expect(console.error).toHaveBeenCalled());
+
+		expect(capturedAttachments.props?.attachments?.[0]).toEqual(
+			expect.objectContaining({ name: 'old.txt' })
+		);
+	});
+
+	it.each(['success', 'rejection'] as const)(
+		'lazy support assignment preserves later typing after $0',
+		async (outcome) => {
+			const thread = new SupportThreadContext();
+			thread.startNewThread();
+			const context = new ChatUIContext(thread as unknown as ChatCore, client, {
+				generateUploadUrl: api.support.files.generateUploadUrl,
+				saveUploadedFile: api.support.files.saveUploadedFile,
+				attachmentStore: new ChatAttachmentStore('support')
+			});
+			const creation = Promise.withResolvers<{
+				threadId: string;
+				notificationEmail: null;
+			}>();
+			const message = Promise.withResolvers<Record<string, never>>();
+			vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+				const name = getFunctionName(reference);
+				if (name === 'support/threads:getOrCreateWarmThread') return creation.promise;
+				if (name === 'support/messages:sendMessage') return message.promise;
+				return Promise.resolve({});
+			});
+			await mountSupport(thread, context);
+			const input = document.querySelector('textarea')!;
+			typeInto(input, 'send this');
+			await tick();
+			sendButton().click();
+			await tick();
+			typeInto(input, 'later support draft');
+			await tick();
+
+			creation.resolve({ threadId: `support-created-${outcome}`, notificationEmail: null });
+			await vi.waitFor(() => expect(thread.threadId).toBe(`support-created-${outcome}`));
+			if (outcome === 'success') message.resolve({});
+			else message.reject(new Error('Send rejected'));
+			await vi.waitFor(() => expect(client.mutation).toHaveBeenCalledTimes(2));
+			await tick();
+
+			expect(input.value).toBe('later support draft');
+			expect(context.inputValue).toBe('later support draft');
+			expect(thread.getDraft(`support-created-${outcome}`)).toBe('later support draft');
+		}
+	);
+
+	it('loads support drafts on mount and navigation and resets a new generation', async () => {
+		const thread = new SupportThreadContext();
+		thread.setDraft('thread-a', 'draft A');
+		thread.setDraft('thread-b', 'draft B');
+		thread.setThread('thread-a');
+		thread.currentView = 'chat';
+		const context = new ChatUIContext(thread as unknown as ChatCore, client);
+		await mountSupport(thread, context);
+		const input = document.querySelector('textarea')!;
+		await vi.waitFor(() => expect(input.value).toBe('draft A'));
+
+		thread.selectThread('thread-b');
+		await vi.waitFor(() => expect(input.value).toBe('draft B'));
+		thread.startNewThread();
+		await vi.waitFor(() => expect(input.value).toBe(''));
+	});
+
+	it('session clear resets support send state synchronously', () => {
+		const thread = new SupportThreadContext();
+		const context = new ChatUIContext(thread as unknown as ChatCore, client);
+		contexts.push(context);
+		thread.isSending = true;
+		thread.isAwaitingStream = true;
+		thread.error = 'old error';
+		thread.shouldOpenWidget = true;
+		thread.setRateLimited(60_000);
+
+		clearPersistedChatState();
+
+		expect(thread.isSending).toBe(false);
+		expect(thread.isAwaitingStream).toBe(false);
+		expect(thread.error).toBeNull();
+		expect(thread.shouldOpenWidget).toBe(false);
+		expect(thread.rateLimitedUntil).toBeNull();
+	});
+
+	it.each([
+		{ boundary: 'generation' as const, outcome: 'success' as const },
+		{ boundary: 'generation' as const, outcome: 'rejection' as const },
+		{ boundary: 'session' as const, outcome: 'success' as const },
+		{ boundary: 'session' as const, outcome: 'rejection' as const }
+	])(
+		'an old creation $outcome after a $boundary change performs no new mutation',
+		async ({ boundary, outcome }) => {
+			const thread = new SupportThreadContext();
+			thread.startNewThread();
+			const context = new ChatUIContext(thread as unknown as ChatCore, client);
+			contexts.push(context);
+			const creation = Promise.withResolvers<{
+				threadId: string;
+				notificationEmail: null;
+			}>();
+			const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+				if (getFunctionName(reference) === 'support/threads:getOrCreateWarmThread') {
+					return creation.promise;
+				}
+				throw new Error('The old send must not submit a message');
+			});
+			const result = thread.sendMessage(client, 'old prompt');
+			await vi.waitFor(() => expect(mutation).toHaveBeenCalledTimes(1));
+
+			if (boundary === 'generation') thread.startNewThread();
+			else clearPersistedChatState();
+
+			if (outcome === 'success') {
+				creation.resolve({ threadId: 'old-thread', notificationEmail: null });
+				await expect(result).rejects.toThrow('Support conversation changed');
+			} else {
+				const error = new Error('Creation rejected');
+				creation.reject(error);
+				await expect(result).rejects.toBe(error);
+			}
+			expect(mutation).toHaveBeenCalledTimes(1);
+			expect(thread.threadId).toBeNull();
+			expect(thread.isSending).toBe(false);
+		}
+	);
+
+	it('later support text cleared before assignment is not rolled back', async () => {
+		const thread = new SupportThreadContext();
+		thread.startNewThread();
+		const context = new ChatUIContext(thread as unknown as ChatCore, client);
+		const creation = Promise.withResolvers<{
+			threadId: string;
+			notificationEmail: null;
+		}>();
+		vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+			const name = getFunctionName(reference);
+			if (name === 'support/threads:getOrCreateWarmThread') return creation.promise;
+			if (name === 'support/messages:sendMessage') return Promise.resolve({});
+			return Promise.resolve({});
+		});
+		await mountSupport(thread, context);
+		const input = document.querySelector('textarea')!;
+		typeInto(input, 'send this');
+		await tick();
+		sendButton().click();
+		await tick();
+		typeInto(input, 'later text');
+		typeInto(input, '');
+
+		creation.resolve({ threadId: 'assigned-after-clear', notificationEmail: null });
+		await vi.waitFor(() => expect(thread.threadId).toBe('assigned-after-clear'));
+		await tick();
+
+		expect(input.value).toBe('');
+		expect(thread.getDraft('assigned-after-clear')).toBe('');
+	});
+});
+
+describe('AI chatbar session lifecycle', () => {
+	it.each(['success', 'rejection'] as const)(
+		'forgets input and ignores stale warm creation $0 after session clear',
+		async (outcome) => {
+			const thread = new SupportThreadContext();
+			const first = Promise.withResolvers<{ threadId: string; notificationEmail: null }>();
+			const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+				if (getFunctionName(reference) !== 'support/threads:getOrCreateWarmThread') {
+					throw new Error('A stale warm thread must not send a message');
+				}
+				return mutation.mock.calls.length === 1
+					? first.promise
+					: Promise.resolve({ threadId: 'new-warm-thread', notificationEmail: null });
+			});
+			const onUpdate = vi.spyOn(client, 'onUpdate').mockReturnValue(mockUnsubscribe());
+			const input = await mountChatbar(thread);
+			typeInto(input, 'old chatbar input');
+			await vi.waitFor(() => expect(mutation).toHaveBeenCalledTimes(1));
+
+			clearPersistedChatState();
+			if (outcome === 'success') {
+				first.resolve({ threadId: 'old-warm-thread', notificationEmail: null });
+			} else {
+				first.reject(new Error('Old creation rejected'));
+			}
+			await tick();
+
+			expect(input.value).toBe('');
+			expect(thread.threadId).toBeNull();
+			expect(onUpdate).not.toHaveBeenCalled();
+			expect(toast.error).not.toHaveBeenCalled();
+
+			typeInto(input, 'new chatbar input');
+			await vi.waitFor(() => expect(mutation).toHaveBeenCalledTimes(2));
+		}
+	);
+
+	it('releases a prewarmed subscription when the session ends', async () => {
+		const thread = new SupportThreadContext();
+		vi.spyOn(client, 'mutation').mockResolvedValue({
+			threadId: 'prewarmed-thread',
+			notificationEmail: null
+		});
+		const unsubscribe = mockUnsubscribe();
+		const onUpdate = vi.spyOn(client, 'onUpdate').mockReturnValue(unsubscribe);
+		const input = await mountChatbar(thread);
+		typeInto(input, 'prewarm this');
+		await vi.waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+
+		clearPersistedChatState();
+		await tick();
+
+		expect(input.value).toBe('');
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
+		expect(thread.threadId).toBeNull();
+	});
+
+	it('stops after session clear during the render tick before sending', async () => {
+		const thread = new SupportThreadContext();
+		const mutation = vi.spyOn(client, 'mutation').mockResolvedValue({
+			threadId: 'tick-thread',
+			notificationEmail: null
+		});
+		const unsubscribe = mockUnsubscribe();
+		vi.spyOn(client, 'onUpdate').mockReturnValue(unsubscribe);
+		const input = await mountChatbar(thread);
+		typeInto(input, 'send after prewarm');
+		await vi.waitFor(() => expect(mutation).toHaveBeenCalledTimes(1));
+		await tick();
+		thread.setOnThreadChange((threadId) => {
+			if (threadId === 'tick-thread') clearPersistedChatState();
+		});
+
+		sendButton().click();
+		await tick();
+
+		expect(thread.threadId).toBeNull();
+		expect(input.value).toBe('');
+		expect(mutation).toHaveBeenCalledTimes(1);
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/chat/ui/chat-session-lifecycle.test.ts
+++ b/src/lib/chat/ui/chat-session-lifecycle.test.ts
@@ -6,7 +6,7 @@ import { getFunctionName } from 'convex/server';
 import { api } from '$lib/convex/_generated/api';
 import { clearPersistedChatState } from '../core/chat-persisted-state.ts';
 import { ChatAttachmentStore } from '../core/chat-attachment-store.svelte.ts';
-import type { Attachment } from '../core/types.js';
+import { CHAT_PAGE_SIZE, type Attachment } from '../core/types.js';
 import type { ChatCore } from '../core/chat-core.svelte.ts';
 import { ChatUIContext } from './chat-context.svelte.ts';
 import { SupportThreadContext } from '$lib/components/customer-support/support-thread-context.svelte.ts';
@@ -64,9 +64,20 @@ const generationTwoAttachment: Attachment = {
 	uploadState: { status: 'success', progress: 100, fileId: 'generation-two-file-id' }
 };
 
+const sharedFileAttachment: Attachment = {
+	type: 'file',
+	key: 'shared-file-second-key',
+	name: 'shared-copy.txt',
+	size: 24,
+	mimeType: 'text/plain',
+	url: 'https://chat.test/shared-copy.txt',
+	uploadState: { status: 'success', progress: 100, fileId: 'old-file-id' }
+};
+
 let component: ReturnType<typeof mount> | undefined;
 let client: ConvexClient;
 const contexts: ChatUIContext[] = [];
+const originalElementAnimate = Element.prototype.animate;
 
 function storedAttachment(attachment: Extract<Attachment, { type: 'file' | 'screenshot' }>) {
 	return {
@@ -88,6 +99,12 @@ function typeInto(input: HTMLTextAreaElement, value: string): void {
 
 function sendButton(): HTMLButtonElement {
 	return document.querySelector<HTMLButtonElement>(`button[aria-label="${en.chat.aria.send}"]`)!;
+}
+
+async function settleComponentWork(): Promise<void> {
+	await Promise.resolve();
+	await tick();
+	await Promise.resolve();
 }
 
 function mockUnsubscribe() {
@@ -124,8 +141,39 @@ async function mountChatbar(thread: SupportThreadContext): Promise<HTMLTextAreaE
 	return document.querySelector('textarea')!;
 }
 
+const navigationBoundaries = [
+	{
+		name: 'goBack',
+		navigate: (thread: SupportThreadContext) => thread.goBack(),
+		selectedThreadId: null,
+		view: 'overview' as const
+	},
+	{
+		name: 'selectThread',
+		navigate: (thread: SupportThreadContext) => thread.selectThread('thread-b'),
+		selectedThreadId: 'thread-b',
+		view: 'chat' as const
+	},
+	{
+		name: 'selectThreadFromUrl',
+		navigate: (thread: SupportThreadContext) => thread.selectThreadFromUrl('thread-b'),
+		selectedThreadId: 'thread-b',
+		view: 'chat' as const
+	}
+];
+
 beforeEach(() => {
 	localStorage.clear();
+	Object.defineProperty(Element.prototype, 'animate', {
+		configurable: true,
+		value: vi.fn(() => ({
+			cancel: vi.fn(),
+			currentTime: 0,
+			effect: null,
+			onfinish: null,
+			playState: 'finished'
+		}))
+	});
 	client = new ConvexClient('https://chat-test.convex.cloud', { disabled: true });
 	delete keyedAdminThreadLifecycle.setThreadId;
 	delete capturedAttachments.props;
@@ -134,12 +182,20 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-	if (component) await unmount(component);
-	component = undefined;
-	for (const context of contexts.splice(0)) context.dispose();
-	await client.close();
-	localStorage.clear();
-	vi.restoreAllMocks();
+	try {
+		if (component) await unmount(component);
+		component = undefined;
+		for (const context of contexts.splice(0)) context.dispose();
+		await client.close();
+		localStorage.clear();
+		vi.restoreAllMocks();
+	} finally {
+		Object.defineProperty(Element.prototype, 'animate', {
+			configurable: true,
+			value: originalElementAnimate
+		});
+		vi.useRealTimers();
+	}
 });
 
 describe('chat session lifecycle', () => {
@@ -353,6 +409,225 @@ describe('chat session lifecycle', () => {
 		expect(thread.rateLimitedUntil).toBeNull();
 	});
 
+	it('does not retry a rejected eager send into a thread selected after going back', async () => {
+		const thread = new SupportThreadContext();
+		const context = new ChatUIContext(thread as unknown as ChatCore, client, {
+			generateUploadUrl: api.support.files.generateUploadUrl,
+			saveUploadedFile: api.support.files.saveUploadedFile,
+			attachmentStore: new ChatAttachmentStore('support')
+		});
+		const creation = Promise.withResolvers<{
+			threadId: string;
+			notificationEmail: null;
+		}>();
+		const creationError = new Error('Original eager creation rejected');
+		const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+			const name = getFunctionName(reference);
+			if (name === 'support/threads:getOrCreateWarmThread') return creation.promise;
+			if (name === 'support/messages:sendMessage') return Promise.resolve({});
+			return Promise.resolve({});
+		});
+		thread.setClient(client);
+		thread.startNewThread();
+		await mountSupport(thread, context);
+		await vi.waitFor(() => expect(mutation).toHaveBeenCalledTimes(1));
+		context.addAttachments([oldAttachment, sharedFileAttachment]);
+
+		const result = thread.sendMessage(client, ' old prompt ', {
+			fileIds: context.uploadedFileIds,
+			attachments: [...context.attachments]
+		});
+		expect(thread.isSending).toBe(true);
+		thread.goBack();
+		thread.selectThread('thread-b');
+		expect(thread.isSending).toBe(false);
+
+		creation.reject(creationError);
+		await expect(result).rejects.toBe(creationError);
+		await tick();
+
+		expect(thread.isSending).toBe(false);
+		expect(thread.threadId).toBe('thread-b');
+		expect(context.captureSendSnapshot().origin).toEqual({
+			generation: thread.threadGeneration,
+			threadId: 'thread-b'
+		});
+		expect(context.displayMessages).toEqual([]);
+		expect(mutation).toHaveBeenCalledTimes(1);
+		const [reference, args] = mutation.mock.calls[0]!;
+		expect(getFunctionName(reference)).toBe('support/threads:getOrCreateWarmThread');
+		expect(args).toEqual({
+			anonymousUserId: undefined,
+			pageUrl: window.location.href
+		});
+	});
+
+	it.each(
+		navigationBoundaries.flatMap((boundary) =>
+			(['fulfilled', 'rejected'] as const).map((outcome) => ({ ...boundary, outcome }))
+		)
+	)(
+		'a $outcome eager creation after $name neither binds nor dispatches',
+		async ({ navigate, selectedThreadId, view, outcome }) => {
+			const thread = new SupportThreadContext();
+			const context = new ChatUIContext(thread as unknown as ChatCore, client);
+			const creation = Promise.withResolvers<{
+				threadId: string;
+				notificationEmail: null;
+			}>();
+			const creationError = new Error('Retained creation error');
+			const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+				if (getFunctionName(reference) === 'support/threads:getOrCreateWarmThread') {
+					return creation.promise;
+				}
+				throw new Error('A stale send must not dispatch');
+			});
+			thread.setClient(client);
+			thread.startNewThread();
+			await mountSupport(thread, context);
+			const result = thread.sendMessage(client, 'stale prompt');
+			await vi.waitFor(() => expect(mutation).toHaveBeenCalledTimes(1));
+
+			navigate(thread);
+			if (outcome === 'fulfilled') {
+				creation.resolve({ threadId: 'stale-created-thread', notificationEmail: null });
+				await expect(result).rejects.toThrow('Support conversation changed');
+			} else {
+				creation.reject(creationError);
+				await expect(result).rejects.toBe(creationError);
+			}
+
+			expect(mutation).toHaveBeenCalledTimes(1);
+			expect(thread.threadId).toBe(selectedThreadId);
+			expect(context.captureSendSnapshot().origin).toEqual({
+				generation: thread.threadGeneration,
+				threadId: selectedThreadId
+			});
+			expect(thread.currentView).toBe(view);
+			expect(thread.isSending).toBe(false);
+		}
+	);
+
+	it('uses a same-navigation eager creation with exact attachment order and optimistic payload', async () => {
+		const thread = new SupportThreadContext();
+		const context = new ChatUIContext(thread as unknown as ChatCore, client, {
+			generateUploadUrl: api.support.files.generateUploadUrl,
+			saveUploadedFile: api.support.files.saveUploadedFile,
+			attachmentStore: new ChatAttachmentStore('support')
+		});
+		contexts.push(context);
+		const creation = Promise.withResolvers<{
+			threadId: string;
+			notificationEmail: null;
+		}>();
+		const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+			if (getFunctionName(reference) === 'support/threads:getOrCreateWarmThread') {
+				return creation.promise;
+			}
+			return Promise.resolve({});
+		});
+		thread.setClient(client);
+		thread.startNewThread();
+		context.addAttachments([oldAttachment, sharedFileAttachment, generationTwoAttachment]);
+		const attachments = [...context.attachments];
+		const result = thread.sendMessage(client, ' ordered prompt ', {
+			fileIds: context.uploadedFileIds,
+			attachments
+		});
+
+		creation.resolve({ threadId: 'same-navigation-thread', notificationEmail: null });
+		await expect(result).resolves.toEqual({
+			threadId: 'same-navigation-thread',
+			threadCreated: false
+		});
+		expect(context.captureSendSnapshot().origin).toEqual({
+			generation: thread.threadGeneration,
+			threadId: 'same-navigation-thread'
+		});
+		expect(mutation).toHaveBeenCalledTimes(2);
+		const [warmReference, warmArgs] = mutation.mock.calls[0]!;
+		expect(getFunctionName(warmReference)).toBe('support/threads:getOrCreateWarmThread');
+		expect(warmArgs).toEqual({
+			anonymousUserId: undefined,
+			pageUrl: window.location.href
+		});
+		const [messageReference, messageArgs, options] = mutation.mock.calls[1]!;
+		expect(getFunctionName(messageReference)).toBe('support/messages:sendMessage');
+		expect(messageArgs).toEqual({
+			threadId: 'same-navigation-thread',
+			prompt: 'ordered prompt',
+			anonymousUserId: undefined,
+			fileIds: ['old-file-id', 'old-file-id', 'generation-two-file-id']
+		});
+
+		const current = { page: [], isDone: true, continueCursor: '' };
+		const store = {
+			getQuery: vi.fn().mockReturnValue(current),
+			setQuery: vi.fn()
+		};
+		expect(options?.optimisticUpdate).toBeTypeOf('function');
+		(options!.optimisticUpdate as (store: unknown) => void)(store);
+		expect(store.getQuery).toHaveBeenCalledWith(expect.anything(), {
+			threadId: 'same-navigation-thread',
+			paginationOpts: { numItems: CHAT_PAGE_SIZE, cursor: null },
+			streamArgs: { kind: 'list', startOrder: 0 }
+		});
+		expect(getFunctionName(store.getQuery.mock.calls[0]![0])).toBe('support/messages:listMessages');
+		expect(store.setQuery).toHaveBeenCalledTimes(1);
+		const [listReference, listArgs, optimisticResult] = store.setQuery.mock.calls[0]!;
+		expect(getFunctionName(listReference)).toBe('support/messages:listMessages');
+		expect(listArgs).toEqual(store.getQuery.mock.calls[0]![1]);
+		expect(optimisticResult).toEqual({
+			...current,
+			page: [
+				expect.objectContaining({
+					threadId: 'same-navigation-thread',
+					role: 'user',
+					message: { role: 'user', content: 'ordered prompt' },
+					text: 'ordered prompt',
+					status: 'success',
+					order: 0,
+					metadata: { optimistic: true },
+					localAttachments: attachments
+				})
+			]
+		});
+	});
+
+	it('retries a rejected eager creation when the conversation has not navigated', async () => {
+		const thread = new SupportThreadContext();
+		const firstCreation = Promise.withResolvers<{
+			threadId: string;
+			notificationEmail: null;
+		}>();
+		let warmCalls = 0;
+		const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+			const name = getFunctionName(reference);
+			if (name === 'support/threads:getOrCreateWarmThread') {
+				warmCalls++;
+				return warmCalls === 1
+					? firstCreation.promise
+					: Promise.resolve({ threadId: 'retry-thread', notificationEmail: null });
+			}
+			if (name === 'support/messages:sendMessage') return Promise.resolve({});
+			return Promise.resolve({});
+		});
+		thread.setClient(client);
+		thread.startNewThread();
+		const result = thread.sendMessage(client, 'retry prompt');
+		const firstError = new Error('First eager creation rejected');
+		firstCreation.reject(firstError);
+
+		await expect(result).resolves.toEqual({ threadId: 'retry-thread', threadCreated: true });
+		expect(mutation.mock.calls.map(([reference]) => getFunctionName(reference))).toEqual([
+			'support/threads:getOrCreateWarmThread',
+			'support/threads:getOrCreateWarmThread',
+			'support/messages:sendMessage'
+		]);
+		expect(thread.threadId).toBe('retry-thread');
+		expect(thread.isSending).toBe(false);
+	});
+
 	it.each([
 		{ boundary: 'generation' as const, outcome: 'success' as const },
 		{ boundary: 'generation' as const, outcome: 'rejection' as const },
@@ -394,6 +669,42 @@ describe('chat session lifecycle', () => {
 			expect(thread.isSending).toBe(false);
 		}
 	);
+
+	it('does not roll a successful dispatched send back into a later selected thread', async () => {
+		const thread = new SupportThreadContext();
+		thread.selectThread('thread-a');
+		const context = new ChatUIContext(thread as unknown as ChatCore, client, {
+			generateUploadUrl: api.support.files.generateUploadUrl,
+			saveUploadedFile: api.support.files.saveUploadedFile,
+			attachmentStore: new ChatAttachmentStore('support')
+		});
+		const message = Promise.withResolvers<Record<string, never>>();
+		const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+			if (getFunctionName(reference) === 'support/messages:sendMessage') return message.promise;
+			return Promise.resolve({});
+		});
+		await mountSupport(thread, context);
+		const input = document.querySelector('textarea')!;
+		typeInto(input, 'send from A');
+		context.addAttachments([oldAttachment]);
+		await tick();
+		sendButton().click();
+		await vi.waitFor(() => expect(mutation).toHaveBeenCalledTimes(1));
+
+		thread.selectThread('thread-b');
+		await tick();
+		typeInto(input, 'keep in B');
+		context.addAttachments([generationTwoAttachment]);
+		await tick();
+		message.resolve({});
+		await tick();
+
+		expect(thread.threadId).toBe('thread-b');
+		expect(input.value).toBe('keep in B');
+		expect(
+			context.attachments.map((attachment) => ('key' in attachment ? attachment.key : ''))
+		).toEqual(['generation-two-file']);
+	});
 
 	it('later support text cleared before assignment is not rolled back', async () => {
 		const thread = new SupportThreadContext();
@@ -463,6 +774,135 @@ describe('AI chatbar session lifecycle', () => {
 			await vi.waitFor(() => expect(mutation).toHaveBeenCalledTimes(2));
 		}
 	);
+
+	it('retires a replaced warm subscription without its old timer touching the replacement', async () => {
+		vi.useFakeTimers();
+		const firstUnsubscribe = mockUnsubscribe();
+		const secondUnsubscribe = mockUnsubscribe();
+		const onUpdate = vi
+			.spyOn(client, 'onUpdate')
+			.mockReturnValueOnce(firstUnsubscribe)
+			.mockReturnValueOnce(secondUnsubscribe);
+		const message = Promise.withResolvers<Record<string, never>>();
+		let warmThread = 0;
+		const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+			const name = getFunctionName(reference);
+			if (name === 'support/threads:getOrCreateWarmThread') {
+				warmThread++;
+				return Promise.resolve({ threadId: `warm-thread-${warmThread}`, notificationEmail: null });
+			}
+			if (name === 'support/messages:sendMessage') return message.promise;
+			return Promise.resolve({});
+		});
+		const input = await mountChatbar(new SupportThreadContext());
+		typeInto(input, 'first prompt');
+		await settleComponentWork();
+		expect(onUpdate).toHaveBeenCalledTimes(1);
+		sendButton().click();
+		await settleComponentWork();
+		await settleComponentWork();
+		expect(mutation.mock.calls.map(([reference]) => getFunctionName(reference))).toEqual([
+			'support/threads:getOrCreateWarmThread',
+			'support/messages:sendMessage'
+		]);
+		message.resolve({});
+		await settleComponentWork();
+		await settleComponentWork();
+
+		await vi.advanceTimersByTimeAsync(250);
+		typeInto(input, 'second prompt');
+		await settleComponentWork();
+		expect(onUpdate).toHaveBeenCalledTimes(2);
+		expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+		expect(secondUnsubscribe).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(250);
+		expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+		expect(secondUnsubscribe).not.toHaveBeenCalled();
+
+		clearPersistedChatState();
+		expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+		expect(secondUnsubscribe).toHaveBeenCalledTimes(1);
+	});
+
+	it('releases an unreplaced warm subscription once after the grace period', async () => {
+		vi.useFakeTimers();
+		const unsubscribe = mockUnsubscribe();
+		const onUpdate = vi.spyOn(client, 'onUpdate').mockReturnValue(unsubscribe);
+		const message = Promise.withResolvers<Record<string, never>>();
+		const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+			const name = getFunctionName(reference);
+			if (name === 'support/threads:getOrCreateWarmThread') {
+				return Promise.resolve({ threadId: 'ordinary-warm-thread', notificationEmail: null });
+			}
+			if (name === 'support/messages:sendMessage') return message.promise;
+			return Promise.resolve({});
+		});
+		const input = await mountChatbar(new SupportThreadContext());
+		typeInto(input, 'ordinary prompt');
+		await settleComponentWork();
+		expect(onUpdate).toHaveBeenCalledTimes(1);
+		sendButton().click();
+		await settleComponentWork();
+		await settleComponentWork();
+		expect(mutation).toHaveBeenCalledTimes(2);
+		message.resolve({});
+		await settleComponentWork();
+		await settleComponentWork();
+
+		await vi.advanceTimersByTimeAsync(499);
+		expect(unsubscribe).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(1);
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
+
+		clearPersistedChatState();
+		await unmount(component!);
+		component = undefined;
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
+	});
+
+	it('releases the current replacement on unmount without repeating the retired owner', async () => {
+		vi.useFakeTimers();
+		const firstUnsubscribe = mockUnsubscribe();
+		const secondUnsubscribe = mockUnsubscribe();
+		const onUpdate = vi
+			.spyOn(client, 'onUpdate')
+			.mockReturnValueOnce(firstUnsubscribe)
+			.mockReturnValueOnce(secondUnsubscribe);
+		const message = Promise.withResolvers<Record<string, never>>();
+		let warmThread = 0;
+		const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+			const name = getFunctionName(reference);
+			if (name === 'support/threads:getOrCreateWarmThread') {
+				warmThread++;
+				return Promise.resolve({ threadId: `unmount-warm-${warmThread}`, notificationEmail: null });
+			}
+			if (name === 'support/messages:sendMessage') return message.promise;
+			return Promise.resolve({});
+		});
+		const input = await mountChatbar(new SupportThreadContext());
+		typeInto(input, 'first prompt');
+		await settleComponentWork();
+		expect(onUpdate).toHaveBeenCalledTimes(1);
+		sendButton().click();
+		await settleComponentWork();
+		await settleComponentWork();
+		expect(mutation).toHaveBeenCalledTimes(2);
+		message.resolve({});
+		await settleComponentWork();
+		await settleComponentWork();
+		typeInto(input, 'replacement prompt');
+		await settleComponentWork();
+		expect(onUpdate).toHaveBeenCalledTimes(2);
+
+		await unmount(component!);
+		component = undefined;
+		expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+		expect(secondUnsubscribe).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(500);
+		expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+		expect(secondUnsubscribe).toHaveBeenCalledTimes(1);
+	});
 
 	it('releases a prewarmed subscription when the session ends', async () => {
 		const thread = new SupportThreadContext();

--- a/src/lib/chat/ui/chat-session-lifecycle.test.ts
+++ b/src/lib/chat/ui/chat-session-lifecycle.test.ts
@@ -101,6 +101,15 @@ function sendButton(): HTMLButtonElement {
 	return document.querySelector<HTMLButtonElement>(`button[aria-label="${en.chat.aria.send}"]`)!;
 }
 
+function sendLoader(): SVGElement | null {
+	const loaderClass = ['motion-safe', ['animate', 'spin'].join('-')].join(':');
+	return (
+		[...sendButton().querySelectorAll('svg')].find((icon) =>
+			icon.classList.contains(loaderClass)
+		) ?? null
+	);
+}
+
 async function settleComponentWork(): Promise<void> {
 	await Promise.resolve();
 	await tick();
@@ -739,6 +748,127 @@ describe('chat session lifecycle', () => {
 });
 
 describe('AI chatbar session lifecycle', () => {
+	it.each([
+		{
+			boundary: 'goBack',
+			navigate: (thread: SupportThreadContext) => thread.goBack(),
+			oldOutcome: 'fulfilled' as const
+		},
+		{
+			boundary: 'selectThreadFromUrl',
+			navigate: (thread: SupportThreadContext) => thread.selectThreadFromUrl('thread-b-b-b'),
+			oldOutcome: 'rejected' as const
+		}
+	])(
+		'$boundary releases an abandoned acquisition without letting it disturb a newer send',
+		async ({ boundary, navigate, oldOutcome }) => {
+			const thread = new SupportThreadContext();
+			const oldCreation = Promise.withResolvers<{
+				threadId: string;
+				notificationEmail: null;
+			}>();
+			const newerCreation = Promise.withResolvers<{
+				threadId: string;
+				notificationEmail: null;
+			}>();
+			const newerMessage = Promise.withResolvers<Record<string, never>>();
+			const oldError = new Error('Old acquisition rejected');
+			let warmCalls = 0;
+			const mutation = vi.spyOn(client, 'mutation').mockImplementation((reference) => {
+				const name = getFunctionName(reference);
+				if (name === 'support/threads:getOrCreateWarmThread') {
+					warmCalls++;
+					if (warmCalls === 1) {
+						return Promise.resolve({ threadId: 'chatbar-warm-thread', notificationEmail: null });
+					}
+					return warmCalls === 2 ? oldCreation.promise : newerCreation.promise;
+				}
+				if (name === 'support/messages:sendMessage') return newerMessage.promise;
+				return Promise.resolve({});
+			});
+			vi.spyOn(client, 'onUpdate').mockReturnValue(mockUnsubscribe());
+			const input = await mountChatbar(thread);
+			typeInto(input, 'visible prompt');
+			await settleComponentWork();
+			expect(mutation).toHaveBeenCalledTimes(1);
+
+			const oldSend = thread.sendMessage(client, 'old prompt');
+			await settleComponentWork();
+			expect(mutation).toHaveBeenCalledTimes(2);
+			expect(thread.isSending).toBe(true);
+			expect(sendButton().disabled).toBe(true);
+			expect(sendLoader()).not.toBeNull();
+
+			flushSync(() => navigate(thread));
+			expect(thread.isSending).toBe(false);
+			expect(sendButton().disabled).toBe(false);
+			expect(sendLoader()).toBeNull();
+
+			const newerSend = thread.sendMessage(client, 'newer prompt');
+			await settleComponentWork();
+			expect(mutation).toHaveBeenCalledTimes(3);
+			expect(thread.isSending).toBe(true);
+			expect(sendLoader()).not.toBeNull();
+
+			if (oldOutcome === 'fulfilled') {
+				oldCreation.resolve({ threadId: 'old-created-thread', notificationEmail: null });
+				await expect(oldSend).rejects.toThrow('Support conversation changed');
+			} else {
+				oldCreation.reject(oldError);
+				await expect(oldSend).rejects.toBe(oldError);
+			}
+			await settleComponentWork();
+			expect(thread.isSending).toBe(true);
+			expect(sendLoader()).not.toBeNull();
+			expect(thread.error).toBeNull();
+
+			if (boundary === 'goBack') {
+				newerCreation.resolve({ threadId: 'newer-created-thread', notificationEmail: null });
+				await settleComponentWork();
+			}
+			newerMessage.resolve({});
+			await expect(newerSend).resolves.toEqual({
+				threadId: boundary === 'goBack' ? 'newer-created-thread' : 'thread-b-b-b',
+				threadCreated: boundary === 'goBack'
+			});
+		}
+	);
+
+	it('keeps an existing thread locked while its dispatched mutation completes behind the overview', async () => {
+		const thread = new SupportThreadContext();
+		thread.selectThread('existing-thread');
+		const message = Promise.withResolvers<Record<string, never>>();
+		const mutation = vi
+			.spyOn(client, 'mutation')
+			.mockImplementation((reference) =>
+				getFunctionName(reference) === 'support/messages:sendMessage'
+					? message.promise
+					: Promise.resolve({})
+			);
+		await mountChatbar(thread);
+		const result = thread.sendMessage(client, 'existing thread prompt');
+		await settleComponentWork();
+		expect(mutation).toHaveBeenCalledTimes(1);
+
+		flushSync(() => thread.goBack());
+		expect(thread.isSending).toBe(true);
+		expect(sendLoader()).not.toBeNull();
+		flushSync(() => thread.selectThread('existing-thread'));
+		expect(thread.isSending).toBe(true);
+		expect(sendLoader()).not.toBeNull();
+
+		message.resolve({});
+		await expect(result).resolves.toEqual({
+			threadId: 'existing-thread',
+			threadCreated: false
+		});
+		expect(thread.isSending).toBe(false);
+		expect(thread.isAwaitingStream).toBe(true);
+
+		thread.goBack();
+		expect(thread.isAwaitingStream).toBe(true);
+	});
+
 	it.each(['success', 'rejection'] as const)(
 		'forgets input and ignores stale warm creation $0 after session clear',
 		async (outcome) => {

--- a/src/lib/chat/ui/test-fixtures/CapturedChatAttachments.svelte
+++ b/src/lib/chat/ui/test-fixtures/CapturedChatAttachments.svelte
@@ -1,0 +1,15 @@
+<script module lang="ts">
+	import type { ComponentProps } from 'svelte';
+	import type ChatAttachments from '../ChatAttachments.svelte';
+
+	export const capturedAttachments: {
+		props?: ComponentProps<typeof ChatAttachments>;
+	} = {};
+</script>
+
+<script lang="ts">
+	let props: ComponentProps<typeof ChatAttachments> = $props();
+	$effect(() => {
+		capturedAttachments.props = props;
+	});
+</script>

--- a/src/lib/chat/ui/test-fixtures/CapturedChatInput.svelte
+++ b/src/lib/chat/ui/test-fixtures/CapturedChatInput.svelte
@@ -1,0 +1,20 @@
+<script module lang="ts">
+	import type { ComponentProps } from 'svelte';
+	import type ChatInput from '../ChatInput.svelte';
+	import type { ChatUIContext } from '../chat-context.svelte.ts';
+
+	export const capturedInput: {
+		props?: ComponentProps<typeof ChatInput>;
+		context?: ChatUIContext;
+	} = {};
+</script>
+
+<script lang="ts">
+	import { getChatUIContext } from '../chat-context.svelte.ts';
+
+	let props: ComponentProps<typeof ChatInput> = $props();
+	capturedInput.context = getChatUIContext();
+	$effect(() => {
+		capturedInput.props = props;
+	});
+</script>

--- a/src/lib/chat/ui/test-fixtures/ChatInputHarness.svelte
+++ b/src/lib/chat/ui/test-fixtures/ChatInputHarness.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { ComponentProps } from 'svelte';
+	import { api } from '$lib/convex/_generated/api';
+	import ChatRoot from '../ChatRoot.svelte';
+	import ChatInput from '../ChatInput.svelte';
+	import type { ChatUIContext } from '../chat-context.svelte.ts';
+
+	let {
+		context,
+		onSend
+	}: { context: ChatUIContext } & Pick<ComponentProps<typeof ChatInput>, 'onSend'> = $props();
+</script>
+
+<ChatRoot
+	threadId={context.core.threadId}
+	externalCore={context.core}
+	externalUIContext={context}
+	api={{
+		listMessages: api.aiChat.messages.listMessages,
+		sendMessage: api.aiChat.messages.sendMessage
+	}}
+>
+	<ChatInput {onSend} showFileButton={false} />
+</ChatRoot>

--- a/src/lib/chat/ui/test-fixtures/ChatTestProvider.svelte
+++ b/src/lib/chat/ui/test-fixtures/ChatTestProvider.svelte
@@ -1,0 +1,31 @@
+<script lang="ts" generics="Props extends Record<string, unknown>">
+	import type { Component } from 'svelte';
+	import type { ConvexClient } from 'convex/browser';
+	import { setConvexClientContext } from 'convex-svelte';
+	import { FormatSimple, Tolgee, TolgeeProvider } from '@tolgee/svelte';
+	import en from '../../../../i18n/en.json';
+	import {
+		AdminSupportUIManager,
+		adminSupportUIContext
+	} from '$lib/hooks/admin-support-ui.svelte.ts';
+
+	let {
+		client,
+		content: Content,
+		contentProps
+	}: {
+		client: ConvexClient;
+		content: Component<Props>;
+		contentProps: Props;
+	} = $props();
+
+	// The provider is fixed for the mounted test instance.
+	// svelte-ignore state_referenced_locally
+	setConvexClientContext(client);
+	adminSupportUIContext.set(new AdminSupportUIManager());
+	const tolgee = Tolgee().use(FormatSimple()).init({ language: 'en', staticData: { en } });
+</script>
+
+<TolgeeProvider {tolgee}>
+	<Content {...contentProps} />
+</TolgeeProvider>

--- a/src/lib/chat/ui/test-fixtures/ChatTestProvider.svelte
+++ b/src/lib/chat/ui/test-fixtures/ChatTestProvider.svelte
@@ -8,21 +8,30 @@
 		AdminSupportUIManager,
 		adminSupportUIContext
 	} from '$lib/hooks/admin-support-ui.svelte.ts';
+	import {
+		supportThreadContext,
+		type SupportThreadContext
+	} from '$lib/components/customer-support/support-thread-context.svelte.ts';
 
 	let {
 		client,
 		content: Content,
-		contentProps
+		contentProps,
+		supportThread
 	}: {
 		client: ConvexClient;
 		content: Component<Props>;
 		contentProps: Props;
+		supportThread?: SupportThreadContext;
 	} = $props();
 
 	// The provider is fixed for the mounted test instance.
 	// svelte-ignore state_referenced_locally
 	setConvexClientContext(client);
 	adminSupportUIContext.set(new AdminSupportUIManager());
+	// The optional support context is fixed for the mounted test instance.
+	// svelte-ignore state_referenced_locally
+	if (supportThread) supportThreadContext.set(supportThread);
 	const tolgee = Tolgee().use(FormatSimple()).init({ language: 'en', staticData: { en } });
 </script>
 

--- a/src/lib/chat/ui/test-fixtures/KeyedAdminThreadLifecycleHarness.svelte
+++ b/src/lib/chat/ui/test-fixtures/KeyedAdminThreadLifecycleHarness.svelte
@@ -1,0 +1,21 @@
+<script module lang="ts">
+	export const keyedAdminThreadLifecycle: {
+		setThreadId?: (threadId: string) => void;
+	} = {};
+</script>
+
+<script lang="ts">
+	import { ChatDraftManager } from '../../core/chat-draft-manager.svelte.ts';
+	import AdminThreadChat from '../../../../routes/[[lang]]/admin/support/thread-chat.svelte';
+
+	let { initialThreadId }: { initialThreadId: string } = $props();
+	// Initial seed for the fixture's own keyed thread state.
+	// svelte-ignore state_referenced_locally
+	let threadId = $state(initialThreadId);
+	const draftManager = new ChatDraftManager('admin-support');
+	keyedAdminThreadLifecycle.setThreadId = (next) => (threadId = next);
+</script>
+
+{#key threadId}
+	<AdminThreadChat {threadId} {draftManager} />
+{/key}

--- a/src/lib/chat/ui/test-fixtures/KeyedChatInputLifecycleHarness.svelte
+++ b/src/lib/chat/ui/test-fixtures/KeyedChatInputLifecycleHarness.svelte
@@ -1,0 +1,62 @@
+<script module lang="ts">
+	import type { ChatUIContext as CapturedChatUIContext } from '../chat-context.svelte.ts';
+
+	export const keyedChatInputLifecycle: {
+		context?: CapturedChatUIContext;
+		setThreadId?: (threadId: string) => void;
+	} = {};
+</script>
+
+<script lang="ts">
+	import type { ComponentProps } from 'svelte';
+	import { useConvexClient } from 'convex-svelte';
+	import { api } from '$lib/convex/_generated/api';
+	import { ChatCore } from '../../core/chat-core.svelte.ts';
+	import { ChatAttachmentStore } from '../../core/chat-attachment-store.svelte.ts';
+	import { ChatUIContext } from '../chat-context.svelte.ts';
+	import ChatInputHarness from './ChatInputHarness.svelte';
+	import type ChatInput from '../ChatInput.svelte';
+
+	let {
+		initialThreadId,
+		surface,
+		onSend
+	}: {
+		initialThreadId: string;
+		surface: string;
+	} & Pick<ComponentProps<typeof ChatInput>, 'onSend'> = $props();
+	// Initial seed for the fixture's own keyed thread state.
+	// svelte-ignore state_referenced_locally
+	let threadId = $state(initialThreadId);
+	const client = useConvexClient();
+	keyedChatInputLifecycle.setThreadId = (next) => (threadId = next);
+
+	function createContext(currentThreadId: string): ChatUIContext {
+		const context = new ChatUIContext(
+			new ChatCore({
+				threadId: currentThreadId,
+				api: { sendMessage: api.aiChat.messages.sendMessage }
+			}),
+			client,
+			{
+				generateUploadUrl: api.aiChat.files.generateUploadUrl,
+				saveUploadedFile: api.aiChat.files.saveUploadedFile,
+				attachmentStore: new ChatAttachmentStore(surface)
+			}
+		);
+		context.setDisplayMessages([]);
+		keyedChatInputLifecycle.context = context;
+		return context;
+	}
+
+	function disposeContext(_node: HTMLElement, context: ChatUIContext) {
+		return { destroy: () => context.dispose() };
+	}
+</script>
+
+{#key threadId}
+	{@const context = createContext(threadId)}
+	<div use:disposeContext={context}>
+		<ChatInputHarness {context} {onSend} />
+	</div>
+{/key}

--- a/src/lib/chat/ui/test-fixtures/ThreadChatConsumerHarness.svelte
+++ b/src/lib/chat/ui/test-fixtures/ThreadChatConsumerHarness.svelte
@@ -1,0 +1,26 @@
+<script module lang="ts">
+	export const threadChatConsumerHarness: {
+		setThreadId?: (threadId: string) => void;
+	} = {};
+</script>
+
+<script lang="ts">
+	import { ChatDraftManager } from '../../core/chat-draft-manager.svelte.ts';
+	import AIThreadChat from '../../../../routes/[[lang]]/app/ai-chat/thread-chat.svelte';
+	import AdminThreadChat from '../../../../routes/[[lang]]/admin/support/thread-chat.svelte';
+
+	let { kind, initialThreadId }: { kind: 'ai' | 'admin'; initialThreadId: string } = $props();
+	// Initial seed for the fixture's own mutable thread prop.
+	// svelte-ignore state_referenced_locally
+	let threadId = $state(initialThreadId);
+	const adminDraftManager = new ChatDraftManager('admin-support');
+	threadChatConsumerHarness.setThreadId = (next) => (threadId = next);
+</script>
+
+{#if kind === 'ai'}
+	<AIThreadChat {threadId} hasMessagesAvailable={true} />
+{:else}
+	{#key threadId}
+		<AdminThreadChat {threadId} draftManager={adminDraftManager} />
+	{/key}
+{/if}

--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -13,6 +13,11 @@
 	import { CHAT_PAGE_SIZE, MAX_MESSAGE_LENGTH } from '$lib/chat/core/types';
 	import { getTranslate } from '@tolgee/svelte';
 	import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';
+	import {
+		getChatSessionEpoch,
+		isChatSessionCurrent,
+		registerPersistedChatHolder
+	} from '$lib/chat/core/chat-persisted-state.ts';
 
 	const { t } = getTranslate();
 
@@ -36,8 +41,13 @@
 
 	// Local thread tracking - separate from shared context
 	// A warm support thread is acquired on first keystroke and reused until submit.
-	let pendingThreadId = $state<string | null>(null);
-	let threadCreationPromise: Promise<string> | null = null;
+	let pendingThread: { epoch: number; generation: number; threadId: string } | null = null;
+	let threadCreation: {
+		epoch: number;
+		generation: number;
+		promise: Promise<string>;
+	} | null = null;
+	let warmGeneration = 0;
 	// After a failed creation (e.g. rate limited), passive keystroke retries
 	// are suppressed until this timestamp; an explicit submit always retries.
 	let threadCreationBlockedUntil = 0;
@@ -53,23 +63,45 @@
 	// after cleanup already ran (mutation still in flight during unmount)
 	let destroyed = false;
 
-	// The pre-warm subscription lives on the module-level ConvexClient singleton,
-	// so it must not outlive this component (user types, then navigates away
-	// before submitting)
-	onDestroy(() => {
-		destroyed = true;
+	function releaseWarmResources(): void {
 		if (cleanupTimeoutId !== null) {
 			clearTimeout(cleanupTimeoutId);
 			cleanupTimeoutId = null;
 		}
 		queryUnsubscribe?.();
 		queryUnsubscribe = null;
+	}
+
+	function forgetPersistedState(): void {
+		warmGeneration++;
+		input = '';
+		const ownedThreadId = pendingThread?.threadId;
+		if (ownedThreadId && threadContext.threadId === ownedThreadId) threadContext.setThread(null);
+		pendingThread = null;
+		threadCreation = null;
+		threadCreationBlockedUntil = 0;
+		releaseWarmResources();
+	}
+
+	const unregisterPersistedHolder = registerPersistedChatHolder({ forgetPersistedState });
+
+	// The pre-warm subscription lives on the module-level ConvexClient singleton,
+	// so it must not outlive this component (user types, then navigates away
+	// before submitting)
+	onDestroy(() => {
+		destroyed = true;
+		unregisterPersistedHolder();
+		releaseWarmResources();
 	});
 
 	async function handleSubmit() {
 		if (!input.trim() || threadContext.isSending) return;
 
 		const trimmedPrompt = input.trim();
+		const sessionEpoch = getChatSessionEpoch();
+		const generation = warmGeneration;
+		const isCurrent = () =>
+			isChatSessionCurrent(sessionEpoch) && warmGeneration === generation && !destroyed;
 
 		// Clear input and request widget open before sending
 		// (isSending flag is set by sendMessage)
@@ -77,33 +109,42 @@
 		threadContext.requestWidgetOpen();
 
 		try {
-			// Wait for pending thread if still creating; if the first-keystroke
-			// attempt failed earlier, retry creation now instead of re-awaiting
-			// a cached rejection
-			const threadId = pendingThreadId ?? (await (threadCreationPromise ?? createWarmThread()));
+			const warm = pendingThread;
+			const threadId =
+				warm?.epoch === sessionEpoch && warm.generation === generation
+					? warm.threadId
+					: await (threadCreation?.epoch === sessionEpoch &&
+						threadCreation.generation === generation
+							? threadCreation.promise
+							: createWarmThread());
+			if (!isCurrent()) return;
 
 			// Update shared context (selectThread sets view='chat' + URL sync)
 			threadContext.selectThread(threadId);
 
 			// Force Svelte to re-render so ChatRoot subscribes before mutation
 			await tick();
+			if (!isCurrent()) return;
 
 			// Send message using centralized method (handles flags + optimistic update)
 			await threadContext.sendMessage(client, trimmedPrompt, { threadId });
+			if (!isCurrent()) return;
 
-			// Reset local state so the next interaction can acquire a fresh warm thread
-			pendingThreadId = null;
-			threadCreationPromise = null;
+			warmGeneration++;
+			pendingThread = null;
+			threadCreation = null;
 
-			// Cleanup query subscription after ChatRoot takes over
+			// Cleanup only the subscription this send handed to ChatRoot.
+			const ownedUnsubscribe = queryUnsubscribe;
 			cleanupTimeoutId = setTimeout(() => {
 				cleanupTimeoutId = null;
-				if (queryUnsubscribe) {
-					queryUnsubscribe();
+				if (queryUnsubscribe === ownedUnsubscribe) {
+					queryUnsubscribe?.();
 					queryUnsubscribe = null;
 				}
 			}, 500);
 		} catch (error) {
+			if (!isCurrent()) return;
 			console.error('[AI Chatbar] handleSubmit Error:', error);
 
 			// Restore the cleared input so the visitor's message is not lost
@@ -127,49 +168,55 @@
 	}
 
 	function createWarmThread(): Promise<string> {
-		threadCreationPromise = client
+		const epoch = getChatSessionEpoch();
+		const generation = warmGeneration;
+		const operation = {} as NonNullable<typeof threadCreation>;
+		operation.epoch = epoch;
+		operation.generation = generation;
+		operation.promise = client
 			.mutation(api.support.threads.getOrCreateWarmThread, {
 				anonymousUserId,
 				pageUrl: typeof window !== 'undefined' ? window.location.href : undefined
 			})
 			.then((result) => {
-				pendingThreadId = result.threadId;
-
-				// Pre-subscribe to messages query so it's cached by submit time
-				// This ensures optimistic update finds the query in cache.
-				// Skip if the component was destroyed while the mutation was in
-				// flight: onDestroy already ran, so nothing would unsubscribe it.
-				if (!destroyed) {
-					const preSubscribeArgs = {
-						threadId: result.threadId,
-						...(anonymousUserId ? { anonymousUserId } : {}),
-						paginationOpts: { numItems: CHAT_PAGE_SIZE, cursor: null },
-						streamArgs: { kind: 'list' as const, startOrder: 0 }
-					};
-					queryUnsubscribe = client.onUpdate(
-						api.support.messages.listMessages,
-						preSubscribeArgs,
-						() => {
-							// Query cache warmed
-						}
-					);
+				if (!isChatSessionCurrent(epoch) || warmGeneration !== generation || destroyed) {
+					return result.threadId;
 				}
+				pendingThread = { epoch, generation, threadId: result.threadId };
+
+				// Pre-subscribe to messages query so it's cached by submit time.
+				const preSubscribeArgs = {
+					threadId: result.threadId,
+					...(anonymousUserId ? { anonymousUserId } : {}),
+					paginationOpts: { numItems: CHAT_PAGE_SIZE, cursor: null },
+					streamArgs: { kind: 'list' as const, startOrder: 0 }
+				};
+				queryUnsubscribe = client.onUpdate(
+					api.support.messages.listMessages,
+					preSubscribeArgs,
+					() => {
+						// Query cache warmed
+					}
+				);
 
 				return result.threadId;
 			})
 			.catch((error) => {
-				console.error('[AI Chatbar] Thread creation failed:', error);
-				// Don't cache the rejection: clear the promise so a later submit or
-				// keystroke (after the cooldown) can retry instead of re-awaiting it
-				threadCreationPromise = null;
-				const data =
-					error instanceof ConvexError
-						? (error.data as { retryAfter?: number } | undefined)
-						: undefined;
-				threadCreationBlockedUntil = Date.now() + (data?.retryAfter ?? 30000);
+				if (isChatSessionCurrent(epoch) && warmGeneration === generation && !destroyed) {
+					console.error('[AI Chatbar] Thread creation failed:', error);
+					const data =
+						error instanceof ConvexError
+							? (error.data as { retryAfter?: number } | undefined)
+							: undefined;
+					threadCreationBlockedUntil = Date.now() + (data?.retryAfter ?? 30000);
+				}
 				throw error;
+			})
+			.finally(() => {
+				if (threadCreation === operation) threadCreation = null;
 			});
-		return threadCreationPromise;
+		threadCreation = operation;
+		return operation.promise;
 	}
 
 	function handleValueChange(value: string) {
@@ -178,8 +225,8 @@
 		// Acquire a warm thread on first keystroke (or reuse the existing pending one)
 		if (
 			value.trim() &&
-			!pendingThreadId &&
-			!threadCreationPromise &&
+			!pendingThread &&
+			!threadCreation &&
 			Date.now() >= threadCreationBlockedUntil
 		) {
 			// Keystroke-time failure is non-fatal: submit retries and surfaces errors

--- a/src/lib/components/customer-support/ai-chatbar.svelte
+++ b/src/lib/components/customer-support/ai-chatbar.svelte
@@ -68,8 +68,9 @@
 			clearTimeout(cleanupTimeoutId);
 			cleanupTimeoutId = null;
 		}
-		queryUnsubscribe?.();
+		const unsubscribe = queryUnsubscribe;
 		queryUnsubscribe = null;
+		unsubscribe?.();
 	}
 
 	function forgetPersistedState(): void {
@@ -138,10 +139,8 @@
 			const ownedUnsubscribe = queryUnsubscribe;
 			cleanupTimeoutId = setTimeout(() => {
 				cleanupTimeoutId = null;
-				if (queryUnsubscribe === ownedUnsubscribe) {
-					queryUnsubscribe?.();
-					queryUnsubscribe = null;
-				}
+				if (queryUnsubscribe === ownedUnsubscribe) queryUnsubscribe = null;
+				ownedUnsubscribe?.();
 			}, 500);
 		} catch (error) {
 			if (!isCurrent()) return;
@@ -191,6 +190,7 @@
 					paginationOpts: { numItems: CHAT_PAGE_SIZE, cursor: null },
 					streamArgs: { kind: 'list' as const, startOrder: 0 }
 				};
+				releaseWarmResources();
 				queryUnsubscribe = client.onUpdate(
 					api.support.messages.listMessages,
 					preSubscribeArgs,

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -368,24 +368,18 @@
 						// In handed-off mode, allow fire-and-forget like admin view
 						if (!isHumanOnly && chatUIContext.isProcessing) return;
 
+						const originThreadId = threadContext.threadId;
+						const draftCheckpoint = threadContext.captureDraftCheckpoint(originThreadId);
+						const fileIds = chatUIContext.uploadedFileIds;
+						const attachments = [...chatUIContext.attachments];
 						try {
-							await threadContext.sendMessage(client, prompt, {
-								fileIds: chatUIContext.uploadedFileIds,
-								attachments: chatUIContext.attachments
+							const result = await threadContext.sendMessage(client, prompt, {
+								fileIds,
+								attachments
 							});
-							// The composer clears these itself, synchronously, before this
-							// await can yield. Clearing them again here reaches only what
-							// was attached afterwards, which a human-only thread invites:
-							// nothing blocks the composer while a send is in flight, so a
-							// second screenshot picked meanwhile would vanish.
-							// Clear draft after successful send
-							threadContext.clearDraft(threadContext.threadId);
+							threadContext.clearDraftIfUnchanged(draftCheckpoint, result.threadId);
 						} catch (error) {
 							console.error('[handleSend] Error:', error);
-
-							// Restore the cleared input so the visitor's message is not
-							// lost, unless they already started typing again
-							if (!chatUIContext.inputValue.trim()) chatUIContext.setInputValue(prompt);
 
 							// Handle rate limit errors with user-friendly toast
 							if (error instanceof ConvexError) {
@@ -405,9 +399,7 @@
 								toast.error($t('support.widget.error.send_failed'));
 							}
 
-							// Rethrow so ChatInput's rollback restores the attachments.
-							// Its input-restore guard sees the value set above and skips
-							// the double restore.
+							// Rethrow so ChatInput restores its captured composer state.
 							throw error;
 						}
 					}}

--- a/src/lib/components/customer-support/feedback-widget.svelte
+++ b/src/lib/components/customer-support/feedback-widget.svelte
@@ -14,6 +14,7 @@
 	import { slide } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
 	import { prefersReducedMotion } from 'svelte/motion';
+	import { getChatSessionEpoch } from '$lib/chat/core/chat-persisted-state.ts';
 
 	// Import new chat components
 	import { ChatRoot, ChatMessages, ChatInput, type ChatUIContext } from '$lib/chat';
@@ -169,27 +170,28 @@
 		() => void markVisibleReplyRead()
 	);
 
-	// Sync drafts when thread changes
+	// Sync drafts when the selected conversation changes.
 	watch(
-		() => threadContext.threadId,
-		(currentThreadId, previousThreadId) => {
-			// Save draft from old thread (if we had one and input has content)
+		() => [threadContext.threadId, threadContext.threadGeneration] as const,
+		([currentThreadId, currentGeneration], previous) => {
+			const [previousThreadId, previousGeneration] = previous ?? [undefined, -1];
+			const assignedCurrentConversation =
+				previousThreadId === null &&
+				currentThreadId !== null &&
+				currentGeneration === previousGeneration &&
+				threadContext.isNewConversation;
+			if (assignedCurrentConversation) {
+				threadContext.setDraft(currentThreadId, chatUIContext.inputValue);
+				return;
+			}
+
 			if (previousThreadId && chatUIContext.inputValue.trim()) {
 				threadContext.setDraft(previousThreadId, chatUIContext.inputValue);
 			}
+			chatUIContext.setInputValue(threadContext.getDraft(currentThreadId));
 
-			// Load draft for new thread (or empty for new conversation)
-			const draft = threadContext.getDraft(currentThreadId);
-			chatUIContext.setInputValue(draft);
-
-			// ChatUIContext drops attachments when the thread id changes, but it
-			// cannot tell an abandoned compose from a conversation receiving its
-			// warm id: both look like null -> id. Compose that is left without
-			// ever getting an id (back out, or creation fails) would otherwise
-			// carry its attachment into whichever thread is opened next.
-			// isNewConversation is the missing signal — selectThread clears it,
-			// warm-id assignment does not.
-			if (previousThreadId === null && !threadContext.isNewConversation) {
+			const generationChanged = currentGeneration !== previousGeneration;
+			if (generationChanged || (previousThreadId === null && !threadContext.isNewConversation)) {
 				chatUIContext.clearAttachments();
 			}
 		}
@@ -369,6 +371,8 @@
 						if (!isHumanOnly && chatUIContext.isProcessing) return;
 
 						const originThreadId = threadContext.threadId;
+						const sessionEpoch = getChatSessionEpoch();
+						const threadGeneration = threadContext.threadGeneration;
 						const draftCheckpoint = threadContext.captureDraftCheckpoint(originThreadId);
 						const fileIds = chatUIContext.uploadedFileIds;
 						const attachments = [...chatUIContext.attachments];
@@ -377,8 +381,12 @@
 								fileIds,
 								attachments
 							});
+							if (!threadContext.isSendOperationCurrent(sessionEpoch, threadGeneration)) return;
 							threadContext.clearDraftIfUnchanged(draftCheckpoint, result.threadId);
 						} catch (error) {
+							if (!threadContext.isSendOperationCurrent(sessionEpoch, threadGeneration)) {
+								throw error;
+							}
 							console.error('[handleSend] Error:', error);
 
 							// Handle rate limit errors with user-friendly toast

--- a/src/lib/components/customer-support/support-thread-context.svelte.ts
+++ b/src/lib/components/customer-support/support-thread-context.svelte.ts
@@ -21,6 +21,7 @@ export type SupportView = 'overview' | 'chat' | 'compose';
 type ThreadCreation = {
 	epoch: number;
 	generation: number;
+	navigationRevision: number;
 	promise: Promise<string>;
 };
 
@@ -42,6 +43,7 @@ export class SupportThreadContext {
 
 	// Track in-flight thread creation to avoid duplicates within one conversation.
 	private threadCreation: ThreadCreation | null = null;
+	private navigationRevision = 0;
 	private sendRevision = 0;
 	private bindThreadOrigin?: (threadId: string, epoch: number, generation: number) => void;
 
@@ -148,6 +150,17 @@ export class SupportThreadContext {
 		return isChatSessionCurrent(epoch) && this.threadGeneration === generation;
 	}
 
+	private isSendOwnershipCurrent(
+		epoch: number,
+		generation: number,
+		navigationRevision: number
+	): boolean {
+		return (
+			this.isSendOperationCurrent(epoch, generation) &&
+			this.navigationRevision === navigationRevision
+		);
+	}
+
 	/**
 	 * Ensure a thread exists, creating one if needed
 	 * Returns existing threadId or acquires a warm one
@@ -158,19 +171,29 @@ export class SupportThreadContext {
 
 		const epoch = getChatSessionEpoch();
 		const generation = this.threadGeneration;
+		const navigationRevision = this.navigationRevision;
 		const current = this.threadCreation;
-		if (current?.epoch === epoch && current.generation === generation) return current.promise;
+		if (
+			current?.epoch === epoch &&
+			current.generation === generation &&
+			current.navigationRevision === navigationRevision
+		) {
+			return current.promise;
+		}
 
 		const creation = {} as ThreadCreation;
 		creation.epoch = epoch;
 		creation.generation = generation;
+		creation.navigationRevision = navigationRevision;
 		creation.promise = client
 			.mutation(api.support.threads.getOrCreateWarmThread, {
 				anonymousUserId: this.getAnonymousUserId(),
 				pageUrl: typeof window !== 'undefined' ? window.location.href : undefined
 			})
 			.then((result) => {
-				if (!this.isSendOperationCurrent(epoch, generation)) return result.threadId;
+				if (!this.isSendOwnershipCurrent(epoch, generation, navigationRevision)) {
+					return result.threadId;
+				}
 				this.bindThreadOrigin?.(result.threadId, epoch, generation);
 				// Only update state if user is still in chat view (didn't navigate away)
 				if (!this.threadId && this.currentView === 'chat') {
@@ -231,6 +254,7 @@ export class SupportThreadContext {
 		// clear it and the next conversation's composer stays blocked. Kept when
 		// re-entering the same thread, whose reply may still be streaming.
 		if (threadId !== this.threadId) {
+			this.navigationRevision++;
 			this.isSending = false;
 			this.isAwaitingStream = false;
 		}
@@ -414,6 +438,7 @@ export class SupportThreadContext {
 
 		const sessionEpoch = getChatSessionEpoch();
 		const generation = this.threadGeneration;
+		const navigationRevision = this.navigationRevision;
 		const sendRevision = ++this.sendRevision;
 		// Set sending state (used for blocking in AI mode)
 		this.setSending(true);
@@ -424,14 +449,21 @@ export class SupportThreadContext {
 			// Use provided threadId, context threadId, or await in-flight creation.
 			let threadId = options?.threadId ?? this.threadId;
 			const inFlight = this.threadCreation;
-			if (!threadId && inFlight?.epoch === sessionEpoch && inFlight.generation === generation) {
+			if (
+				!threadId &&
+				inFlight?.epoch === sessionEpoch &&
+				inFlight.generation === generation &&
+				inFlight.navigationRevision === navigationRevision
+			) {
 				try {
 					threadId = await inFlight.promise;
 				} catch (error) {
-					if (!this.isSendOperationCurrent(sessionEpoch, generation)) throw error;
+					if (!this.isSendOwnershipCurrent(sessionEpoch, generation, navigationRevision)) {
+						throw error;
+					}
 					// The same conversation may retry a failed eager acquisition below.
 				}
-				if (!this.isSendOperationCurrent(sessionEpoch, generation)) {
+				if (!this.isSendOwnershipCurrent(sessionEpoch, generation, navigationRevision)) {
 					throw new Error('Support conversation changed');
 				}
 			}
@@ -439,9 +471,13 @@ export class SupportThreadContext {
 			if (!threadId) {
 				threadId = await this.ensureThread(client);
 				threadCreated = true;
-				if (!this.isSendOperationCurrent(sessionEpoch, generation)) {
+				if (!this.isSendOwnershipCurrent(sessionEpoch, generation, navigationRevision)) {
 					throw new Error('Support conversation changed');
 				}
+			}
+
+			if (!this.isSendOwnershipCurrent(sessionEpoch, generation, navigationRevision)) {
+				throw new Error('Support conversation changed');
 			}
 
 			if (!this.threadId) {
@@ -450,7 +486,7 @@ export class SupportThreadContext {
 				this.currentView = 'chat';
 			}
 
-			if (!this.isSendOperationCurrent(sessionEpoch, generation)) {
+			if (!this.isSendOwnershipCurrent(sessionEpoch, generation, navigationRevision)) {
 				throw new Error('Support conversation changed');
 			}
 
@@ -466,6 +502,9 @@ export class SupportThreadContext {
 			// Send message with optimistic update
 			// Note: File dimensions are now stored in fileMetadata table at upload time,
 			// so we no longer need to pass fileDimensions here
+			if (!this.isSendOwnershipCurrent(sessionEpoch, generation, navigationRevision)) {
+				throw new Error('Support conversation changed');
+			}
 			await client.mutation(
 				api.support.messages.sendMessage,
 				{
@@ -600,6 +639,7 @@ export class SupportThreadContext {
 		// Set thread ID and switch to chat view
 		// Full thread details (agentName, isHandedOff, etc.) will be loaded
 		// reactively by the chat component's query
+		if (threadId !== this.threadId) this.navigationRevision++;
 		this.threadId = threadId;
 		this.currentView = 'chat';
 		this.isNewConversation = false;
@@ -637,6 +677,7 @@ export class SupportThreadContext {
 	 * State is cleared when entering a new thread/compose via setThread().
 	 */
 	goBack() {
+		this.navigationRevision++;
 		this.currentView = 'overview';
 		this.onThreadChange?.(null);
 	}

--- a/src/lib/components/customer-support/support-thread-context.svelte.ts
+++ b/src/lib/components/customer-support/support-thread-context.svelte.ts
@@ -11,11 +11,18 @@ import { createOptimisticUpdate, type ListMessagesArgs } from '$lib/chat/core/op
 import { CHAT_PAGE_SIZE } from '$lib/chat/core/types.js';
 import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';
 import { isSupportAiEnabled } from '$lib/config/support';
+import { getChatSessionEpoch, isChatSessionCurrent } from '$lib/chat/core/chat-persisted-state.ts';
 
 /**
  * View types for the support widget navigation
  */
 export type SupportView = 'overview' | 'chat' | 'compose';
+
+type ThreadCreation = {
+	epoch: number;
+	generation: number;
+	promise: Promise<string>;
+};
 
 /**
  * Thread context state
@@ -33,8 +40,10 @@ export class SupportThreadContext {
 	// Convex client for mutations (set via setClient)
 	private client: ConvexClient | null = null;
 
-	// Track in-flight thread creation to avoid duplicates
-	private threadCreationPromise: Promise<string> | null = null;
+	// Track in-flight thread creation to avoid duplicates within one conversation.
+	private threadCreation: ThreadCreation | null = null;
+	private sendRevision = 0;
+	private bindThreadOrigin?: (threadId: string, epoch: number, generation: number) => void;
 
 	private getAnonymousUserId(): string | undefined {
 		const userId = this.userId;
@@ -128,25 +137,41 @@ export class SupportThreadContext {
 		this.client = client;
 	}
 
+	/** Bind assigned thread IDs to the ChatUIContext conversation origin. */
+	setThreadOriginBinder(
+		binder: ((threadId: string, epoch: number, generation: number) => void) | undefined
+	): void {
+		this.bindThreadOrigin = binder;
+	}
+
+	isSendOperationCurrent(epoch: number, generation: number): boolean {
+		return isChatSessionCurrent(epoch) && this.threadGeneration === generation;
+	}
+
 	/**
 	 * Ensure a thread exists, creating one if needed
 	 * Returns existing threadId or acquires a warm one
 	 * Safe to call multiple times - deduplicates in-flight requests
 	 */
 	async ensureThread(client: ConvexClient): Promise<string> {
-		// Already have a thread
 		if (this.threadId) return this.threadId;
 
-		// Creation already in flight - return existing promise
-		if (this.threadCreationPromise) return this.threadCreationPromise;
+		const epoch = getChatSessionEpoch();
+		const generation = this.threadGeneration;
+		const current = this.threadCreation;
+		if (current?.epoch === epoch && current.generation === generation) return current.promise;
 
-		// Acquire a warm support thread
-		this.threadCreationPromise = client
+		const creation = {} as ThreadCreation;
+		creation.epoch = epoch;
+		creation.generation = generation;
+		creation.promise = client
 			.mutation(api.support.threads.getOrCreateWarmThread, {
 				anonymousUserId: this.getAnonymousUserId(),
 				pageUrl: typeof window !== 'undefined' ? window.location.href : undefined
 			})
 			.then((result) => {
+				if (!this.isSendOperationCurrent(epoch, generation)) return result.threadId;
+				this.bindThreadOrigin?.(result.threadId, epoch, generation);
 				// Only update state if user is still in chat view (didn't navigate away)
 				if (!this.threadId && this.currentView === 'chat') {
 					this.threadId = result.threadId;
@@ -156,10 +181,10 @@ export class SupportThreadContext {
 				return result.threadId;
 			})
 			.finally(() => {
-				this.threadCreationPromise = null;
+				if (this.threadCreation === creation) this.threadCreation = null;
 			});
-
-		return this.threadCreationPromise;
+		this.threadCreation = creation;
+		return creation.promise;
 	}
 
 	// Derived state
@@ -387,42 +412,46 @@ export class SupportThreadContext {
 			throw new Error('Cannot send message: waiting for AI response');
 		}
 
+		const sessionEpoch = getChatSessionEpoch();
+		const generation = this.threadGeneration;
+		const sendRevision = ++this.sendRevision;
 		// Set sending state (used for blocking in AI mode)
 		this.setSending(true);
 
 		let threadCreated = false;
 
 		try {
-			// Use provided threadId, context threadId, or await in-flight creation
+			// Use provided threadId, context threadId, or await in-flight creation.
 			let threadId = options?.threadId ?? this.threadId;
-
-			// Wait for any in-flight thread creation to complete (prevents duplicate threads)
-			if (!threadId && this.threadCreationPromise) {
+			const inFlight = this.threadCreation;
+			if (!threadId && inFlight?.epoch === sessionEpoch && inFlight.generation === generation) {
 				try {
-					threadId = await this.threadCreationPromise;
-				} catch {
-					// If warm-thread acquisition failed, we'll retry below
+					threadId = await inFlight.promise;
+				} catch (error) {
+					if (!this.isSendOperationCurrent(sessionEpoch, generation)) throw error;
+					// The same conversation may retry a failed eager acquisition below.
+				}
+				if (!this.isSendOperationCurrent(sessionEpoch, generation)) {
+					throw new Error('Support conversation changed');
 				}
 			}
 
-			// Acquire a warm thread if none exists yet
 			if (!threadId) {
-				const result = await client.mutation(api.support.threads.getOrCreateWarmThread, {
-					anonymousUserId: this.getAnonymousUserId(),
-					pageUrl: typeof window !== 'undefined' ? window.location.href : undefined
-				});
-				threadId = result.threadId;
+				threadId = await this.ensureThread(client);
 				threadCreated = true;
+				if (!this.isSendOperationCurrent(sessionEpoch, generation)) {
+					throw new Error('Support conversation changed');
+				}
+			}
 
-				// Update context state directly (setThread would reset isHandedOff,
-				// assignedAdmin, and the pagination cursors)
-				this.threadId = threadId;
-				this.notificationEmail = result.notificationEmail ?? null;
-				this.currentView = 'chat';
-			} else if (!this.threadId) {
-				// Thread was pre-created (e.g., by chatbar), update context
+			if (!this.threadId) {
+				this.bindThreadOrigin?.(threadId, sessionEpoch, generation);
 				this.threadId = threadId;
 				this.currentView = 'chat';
+			}
+
+			if (!this.isSendOperationCurrent(sessionEpoch, generation)) {
+				throw new Error('Support conversation changed');
 			}
 
 			// Build query args for optimistic update (must match ChatRoot's query exactly)
@@ -455,6 +484,9 @@ export class SupportThreadContext {
 					)
 				}
 			);
+			if (!this.isSendOperationCurrent(sessionEpoch, generation)) {
+				throw new Error('Support conversation changed');
+			}
 
 			// Mark as awaiting stream until the model starts responding, which
 			// blocks further sends until its answer finishes.
@@ -464,12 +496,18 @@ export class SupportThreadContext {
 
 			return { threadId, threadCreated };
 		} catch (error) {
-			console.error('[sendMessage] Failed:', error);
-			this.setError(error instanceof Error ? error.message : 'Failed to send message');
+			if (this.isSendOperationCurrent(sessionEpoch, generation)) {
+				console.error('[sendMessage] Failed:', error);
+				this.setError(error instanceof Error ? error.message : 'Failed to send message');
+			}
 			throw error;
 		} finally {
-			// Clear sending state
-			this.setSending(false);
+			if (
+				this.isSendOperationCurrent(sessionEpoch, generation) &&
+				this.sendRevision === sendRevision
+			) {
+				this.setSending(false);
+			}
 		}
 	}
 
@@ -574,6 +612,9 @@ export class SupportThreadContext {
 	 * A warm thread is acquired eagerly for immediate optimistic updates
 	 */
 	startNewThread() {
+		this.sendRevision++;
+		this.isSending = false;
+		this.isAwaitingStream = false;
 		this.setThread(null);
 		this.currentView = 'chat';
 		this.isNewConversation = true;
@@ -598,6 +639,17 @@ export class SupportThreadContext {
 	goBack() {
 		this.currentView = 'overview';
 		this.onThreadChange?.(null);
+	}
+
+	/** Reset session-owned async state while the support shell stays mounted. */
+	forgetChatSession(): void {
+		this.sendRevision++;
+		this.threadCreation = null;
+		this.isSending = false;
+		this.isAwaitingStream = false;
+		this.error = null;
+		this.shouldOpenWidget = false;
+		this.rateLimitedUntil = null;
 	}
 
 	/**

--- a/src/lib/components/customer-support/support-thread-context.svelte.ts
+++ b/src/lib/components/customer-support/support-thread-context.svelte.ts
@@ -45,6 +45,7 @@ export class SupportThreadContext {
 	private threadCreation: ThreadCreation | null = null;
 	private navigationRevision = 0;
 	private sendRevision = 0;
+	private threadAcquisitionSendRevision: number | null = null;
 	private bindThreadOrigin?: (threadId: string, epoch: number, generation: number) => void;
 
 	private getAnonymousUserId(): string | undefined {
@@ -161,6 +162,12 @@ export class SupportThreadContext {
 		);
 	}
 
+	private releaseAbandonedThreadAcquisition(): void {
+		if (this.threadAcquisitionSendRevision !== this.sendRevision) return;
+		this.threadAcquisitionSendRevision = null;
+		this.isSending = false;
+	}
+
 	/**
 	 * Ensure a thread exists, creating one if needed
 	 * Returns existing threadId or acquires a warm one
@@ -255,6 +262,7 @@ export class SupportThreadContext {
 		// re-entering the same thread, whose reply may still be streaming.
 		if (threadId !== this.threadId) {
 			this.navigationRevision++;
+			this.threadAcquisitionSendRevision = null;
 			this.isSending = false;
 			this.isAwaitingStream = false;
 		}
@@ -440,14 +448,17 @@ export class SupportThreadContext {
 		const generation = this.threadGeneration;
 		const navigationRevision = this.navigationRevision;
 		const sendRevision = ++this.sendRevision;
+		this.threadAcquisitionSendRevision = null;
 		// Set sending state (used for blocking in AI mode)
 		this.setSending(true);
 
 		let threadCreated = false;
+		let messageDispatched = false;
 
 		try {
 			// Use provided threadId, context threadId, or await in-flight creation.
 			let threadId = options?.threadId ?? this.threadId;
+			if (!threadId) this.threadAcquisitionSendRevision = sendRevision;
 			const inFlight = this.threadCreation;
 			if (
 				!threadId &&
@@ -505,6 +516,10 @@ export class SupportThreadContext {
 			if (!this.isSendOwnershipCurrent(sessionEpoch, generation, navigationRevision)) {
 				throw new Error('Support conversation changed');
 			}
+			if (this.threadAcquisitionSendRevision === sendRevision) {
+				this.threadAcquisitionSendRevision = null;
+			}
+			messageDispatched = true;
 			await client.mutation(
 				api.support.messages.sendMessage,
 				{
@@ -535,18 +550,22 @@ export class SupportThreadContext {
 
 			return { threadId, threadCreated };
 		} catch (error) {
-			if (this.isSendOperationCurrent(sessionEpoch, generation)) {
+			const operationCurrent = messageDispatched
+				? this.isSendOperationCurrent(sessionEpoch, generation)
+				: this.isSendOwnershipCurrent(sessionEpoch, generation, navigationRevision);
+			if (operationCurrent) {
 				console.error('[sendMessage] Failed:', error);
 				this.setError(error instanceof Error ? error.message : 'Failed to send message');
 			}
 			throw error;
 		} finally {
-			if (
-				this.isSendOperationCurrent(sessionEpoch, generation) &&
-				this.sendRevision === sendRevision
-			) {
-				this.setSending(false);
+			if (this.threadAcquisitionSendRevision === sendRevision) {
+				this.threadAcquisitionSendRevision = null;
 			}
+			const operationCurrent = messageDispatched
+				? this.isSendOperationCurrent(sessionEpoch, generation)
+				: this.isSendOwnershipCurrent(sessionEpoch, generation, navigationRevision);
+			if (operationCurrent && this.sendRevision === sendRevision) this.setSending(false);
 		}
 	}
 
@@ -639,7 +658,12 @@ export class SupportThreadContext {
 		// Set thread ID and switch to chat view
 		// Full thread details (agentName, isHandedOff, etc.) will be loaded
 		// reactively by the chat component's query
-		if (threadId !== this.threadId) this.navigationRevision++;
+		if (threadId !== this.threadId) {
+			this.navigationRevision++;
+			this.threadAcquisitionSendRevision = null;
+			this.isSending = false;
+			this.isAwaitingStream = false;
+		}
 		this.threadId = threadId;
 		this.currentView = 'chat';
 		this.isNewConversation = false;
@@ -653,6 +677,7 @@ export class SupportThreadContext {
 	 */
 	startNewThread() {
 		this.sendRevision++;
+		this.threadAcquisitionSendRevision = null;
 		this.isSending = false;
 		this.isAwaitingStream = false;
 		this.setThread(null);
@@ -678,6 +703,7 @@ export class SupportThreadContext {
 	 */
 	goBack() {
 		this.navigationRevision++;
+		this.releaseAbandonedThreadAcquisition();
 		this.currentView = 'overview';
 		this.onThreadChange?.(null);
 	}
@@ -686,6 +712,7 @@ export class SupportThreadContext {
 	forgetChatSession(): void {
 		this.sendRevision++;
 		this.threadCreation = null;
+		this.threadAcquisitionSendRevision = null;
 		this.isSending = false;
 		this.isAwaitingStream = false;
 		this.error = null;

--- a/src/lib/components/customer-support/support-thread-context.svelte.ts
+++ b/src/lib/components/customer-support/support-thread-context.svelte.ts
@@ -688,7 +688,11 @@ export class SupportThreadContext {
 
 		// Trigger eager thread creation if client is available
 		if (this.client) {
+			const epoch = getChatSessionEpoch();
+			const generation = this.threadGeneration;
+			const navigationRevision = this.navigationRevision;
 			void this.ensureThread(this.client).catch((error) => {
+				if (!this.isSendOwnershipCurrent(epoch, generation, navigationRevision)) return;
 				console.error('[startNewThread] Thread creation failed:', error);
 				this.setError('Failed to start conversation. Please try again.');
 			});

--- a/src/lib/components/customer-support/support-thread-context.svelte.ts
+++ b/src/lib/components/customer-support/support-thread-context.svelte.ts
@@ -1,5 +1,8 @@
 import { Context } from 'runed';
-import { ChatDraftManager } from '$lib/chat/core/chat-draft-manager.svelte.ts';
+import {
+	ChatDraftManager,
+	type ChatDraftCheckpoint
+} from '$lib/chat/core/chat-draft-manager.svelte.ts';
 import type { ConvexClient } from 'convex/browser';
 import { api } from '$lib/convex/_generated/api';
 import type { Attachment } from '$lib/chat';
@@ -83,6 +86,17 @@ export class SupportThreadContext {
 
 	clearDraft(threadId: string | null): void {
 		this.draftManager.clearDraft(threadId);
+	}
+
+	captureDraftCheckpoint(threadId: string | null): ChatDraftCheckpoint {
+		return this.draftManager.captureCheckpoint(threadId);
+	}
+
+	clearDraftIfUnchanged(
+		checkpoint: ChatDraftCheckpoint,
+		threadId: string | null = checkpoint.threadId
+	): boolean {
+		return this.draftManager.clearDraftIfUnchanged(checkpoint, threadId);
 	}
 
 	/**

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -412,9 +412,8 @@
 					draftManager?.clearDraft(threadId);
 				} catch (error) {
 					console.error('[Admin sendAdminReply] Error:', error);
-					// Restore prompt so user can retry and $effect re-persists draft
-					chatUIContext.setInputValue(prompt);
 					toast.error($t('admin.support.chat.send_error'));
+					throw error;
 				} finally {
 					sending = false;
 				}

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -31,6 +31,10 @@
 	import { localizedHref } from '$lib/utils/i18n';
 	import { isAnonymousUser } from '$lib/convex/utils/anonymousUser';
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
+	import {
+		getChatSessionEpoch,
+		isChatSessionCurrent
+	} from '$lib/chat/core/chat-persisted-state.ts';
 
 	const { t } = getTranslate();
 
@@ -97,6 +101,7 @@
 
 	// Draft persistence — load saved draft on mount, save continuously
 	let sending = $state(false);
+	let sendRevision = 0;
 
 	// Load saved draft on mount (threadId is constant per {#key} instance)
 	// svelte-ignore state_referenced_locally
@@ -375,6 +380,8 @@
 
 				const originThreadId = threadId;
 				const draftCheckpoint = draftManager?.captureCheckpoint(originThreadId);
+				const sessionEpoch = getChatSessionEpoch();
+				const operationRevision = ++sendRevision;
 				// Get uploaded file IDs and attachments from context
 				const fileIds = chatUIContext.uploadedFileIds;
 				const attachments = [...chatUIContext.attachments];
@@ -410,13 +417,18 @@
 						}
 					);
 
+					if (!isChatSessionCurrent(sessionEpoch)) return;
 					if (draftCheckpoint) draftManager?.clearDraftIfUnchanged(draftCheckpoint);
 				} catch (error) {
-					console.error('[Admin sendAdminReply] Error:', error);
-					toast.error($t('admin.support.chat.send_error'));
+					if (isChatSessionCurrent(sessionEpoch)) {
+						console.error('[Admin sendAdminReply] Error:', error);
+						toast.error($t('admin.support.chat.send_error'));
+					}
 					throw error;
 				} finally {
-					sending = false;
+					if (isChatSessionCurrent(sessionEpoch) && sendRevision === operationRevision) {
+						sending = false;
+					}
 				}
 			}}
 		/>

--- a/src/routes/[[lang]]/admin/support/thread-chat.svelte
+++ b/src/routes/[[lang]]/admin/support/thread-chat.svelte
@@ -99,6 +99,7 @@
 	let sending = $state(false);
 
 	// Load saved draft on mount (threadId is constant per {#key} instance)
+	// svelte-ignore state_referenced_locally
 	if (draftManager) {
 		const draft = draftManager.getDraft(threadId);
 		if (draft) chatUIContext.setInputValue(draft);
@@ -372,13 +373,15 @@
 			onSend={async (prompt) => {
 				if (!prompt?.trim()) return;
 
+				const originThreadId = threadId;
+				const draftCheckpoint = draftManager?.captureCheckpoint(originThreadId);
 				// Get uploaded file IDs and attachments from context
 				const fileIds = chatUIContext.uploadedFileIds;
-				const attachments = chatUIContext.attachments;
+				const attachments = [...chatUIContext.attachments];
 
 				// Build query args for optimistic update (must match ChatRoot's query)
 				const queryArgs: ListMessagesArgs = {
-					threadId,
+					threadId: originThreadId,
 					paginationOpts: { numItems: CHAT_PAGE_SIZE, cursor: null },
 					streamArgs: { kind: 'list' as const, startOrder: 0 }
 				};
@@ -389,7 +392,7 @@
 					await client.mutation(
 						api.admin.support.mutations.sendAdminReply,
 						{
-							threadId,
+							threadId: originThreadId,
 							prompt,
 							fileIds: fileIds.length > 0 ? fileIds : undefined
 						},
@@ -407,9 +410,7 @@
 						}
 					);
 
-					// Clear attachments and draft after successful send
-					chatUIContext.clearAttachments();
-					draftManager?.clearDraft(threadId);
+					if (draftCheckpoint) draftManager?.clearDraftIfUnchanged(draftCheckpoint);
 				} catch (error) {
 					console.error('[Admin sendAdminReply] Error:', error);
 					toast.error($t('admin.support.chat.send_error'));

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -203,8 +203,8 @@
 						onMessageSent?.();
 					} catch (error) {
 						console.error('[AI Chat sendMessage] Error:', error);
-						chatUIContext.setInputValue(prompt);
 						toast.error($t('chat.messages.send_failed'));
+						throw error;
 					} finally {
 						sending = false;
 					}

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -192,14 +192,14 @@
 				isRateLimited={!hasMessagesAvailable}
 				onSend={async (prompt) => {
 					if (!hasMessagesAvailable || !prompt?.trim()) return;
+					const originThreadId = threadId;
+					const draftCheckpoint = draftManager.captureCheckpoint(originThreadId);
+					const fileIds = chatUIContext.uploadedFileIds;
+					const attachments = [...chatUIContext.attachments];
 					sending = true;
 					try {
-						await chatCore.sendMessage(client, prompt, {
-							fileIds: chatUIContext.uploadedFileIds,
-							attachments: chatUIContext.attachments
-						});
-						chatUIContext.clearAttachments();
-						draftManager.clearDraft(threadId);
+						await chatCore.sendMessage(client, prompt, { fileIds, attachments });
+						draftManager.clearDraftIfUnchanged(draftCheckpoint);
 						onMessageSent?.();
 					} catch (error) {
 						console.error('[AI Chat sendMessage] Error:', error);

--- a/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
+++ b/src/routes/[[lang]]/app/ai-chat/thread-chat.svelte
@@ -16,6 +16,10 @@
 	import { page } from '$app/state';
 	import { onDestroy, tick } from 'svelte';
 	import { activeUploadsContext } from '$lib/hooks/active-uploads.svelte.ts';
+	import {
+		getChatSessionEpoch,
+		isChatSessionCurrent
+	} from '$lib/chat/core/chat-persisted-state.ts';
 
 	const { t } = getTranslate();
 
@@ -91,6 +95,7 @@
 	// Draft persistence across thread switches and page refreshes
 	const draftManager = new ChatDraftManager('ai-chat');
 	let sending = $state(false);
+	let sendRevision = 0;
 
 	// Save draft on leave, restore on enter
 	watch(
@@ -194,19 +199,26 @@
 					if (!hasMessagesAvailable || !prompt?.trim()) return;
 					const originThreadId = threadId;
 					const draftCheckpoint = draftManager.captureCheckpoint(originThreadId);
+					const sessionEpoch = getChatSessionEpoch();
+					const operationRevision = ++sendRevision;
 					const fileIds = chatUIContext.uploadedFileIds;
 					const attachments = [...chatUIContext.attachments];
 					sending = true;
 					try {
 						await chatCore.sendMessage(client, prompt, { fileIds, attachments });
+						if (!isChatSessionCurrent(sessionEpoch)) return;
 						draftManager.clearDraftIfUnchanged(draftCheckpoint);
 						onMessageSent?.();
 					} catch (error) {
-						console.error('[AI Chat sendMessage] Error:', error);
-						toast.error($t('chat.messages.send_failed'));
+						if (isChatSessionCurrent(sessionEpoch)) {
+							console.error('[AI Chat sendMessage] Error:', error);
+							toast.error($t('chat.messages.send_failed'));
+						}
 						throw error;
 					} finally {
-						sending = false;
+						if (isChatSessionCurrent(sessionEpoch) && sendRevision === operationRevision) {
+							sending = false;
+						}
 					}
 				}}
 			/>


### PR DESCRIPTION
Regression guard: covered by chat lifecycle tests

A rejected chat send cleared the composer before the mutation settled, then restored only a trimmed prompt and a shallow attachment copy. Navigation, keyed remounts, session changes, overlapping sends, and warm-thread creation could lose retry data or let stale work affect another conversation.

This binds each send to its session and conversation origin, restores the exact draft and attachment identities only while ownership remains current, and gives warm-thread promises, subscriptions, timers, and abandoned send locks explicit owners. Successful mutations retain their existing behavior.

| Viewport | Before | After |
| --- | --- | --- |
| 390 px | ![Before: failed send trims the draft](https://github.com/user-attachments/assets/e50dc78e-69ee-4a6f-b893-caa314a40cf0) | ![After: failed send restores the exact draft](https://github.com/user-attachments/assets/39d72b3f-89c2-4fd3-8e25-94ea4d0fd17b) |

Verified with 2,700 unit tests, changed-file and full type checks, production build, focused browser measurement, 110 passing E2E tests, and independent lifecycle reviews through a no-blocker round.
