### PR TITLE
fix(markdown): Escape configured text

### DIFF
--- a/src/lib/markdown/literals.ts
+++ b/src/lib/markdown/literals.ts
@@ -9,6 +9,11 @@ export interface MarketingMarkdownText {
 
 export type MarketingMarkdownContent = string | MarketingMarkdownText;
 
+interface MarkdownTextParts {
+	readonly authoredSegments: readonly string[];
+	readonly interpolations: readonly string[];
+}
+
 function assertValidText(value: string): void {
 	for (let index = 0; index < value.length; index += 1) {
 		const codeUnit = value.charCodeAt(index);
@@ -38,14 +43,62 @@ function normalizePlainText(value: string): string {
 	return normalized;
 }
 
+function validateMarkdownTextParts(
+	authoredSegments: unknown,
+	interpolations: unknown
+): MarkdownTextParts {
+	if (
+		!Array.isArray(authoredSegments) ||
+		!authoredSegments.every((value) => typeof value === 'string')
+	) {
+		throw new Error('markdownText authoredSegments must be an array of strings.');
+	}
+	if (
+		!Array.isArray(interpolations) ||
+		!interpolations.every((value) => typeof value === 'string')
+	) {
+		throw new Error('markdownText interpolations must be an array of strings.');
+	}
+	if (authoredSegments.length !== interpolations.length + 1) {
+		throw new Error(
+			'markdownText authoredSegments must contain exactly one more item than interpolations.'
+		);
+	}
+
+	for (const segment of authoredSegments) {
+		assertValidText(segment);
+	}
+	for (const interpolation of interpolations) {
+		assertValidText(interpolation);
+	}
+
+	return { authoredSegments, interpolations };
+}
+
+function getMarkdownTextParts(value: unknown): MarkdownTextParts {
+	if (
+		typeof value !== 'object' ||
+		value === null ||
+		!Object.prototype.hasOwnProperty.call(value, MARKETING_MARKDOWN_TEXT) ||
+		(value as Record<PropertyKey, unknown>)[MARKETING_MARKDOWN_TEXT] !== true
+	) {
+		throw new Error('Markdown content objects must be created by markdownText.');
+	}
+
+	const branded = value as Record<PropertyKey, unknown>;
+	return validateMarkdownTextParts(branded.authoredSegments, branded.interpolations);
+}
+
 export function markdownText(
 	authoredSegments: TemplateStringsArray,
 	...interpolations: string[]
 ): MarketingMarkdownText {
+	const valid = validateMarkdownTextParts(authoredSegments, interpolations);
+
 	return Object.freeze({
 		[MARKETING_MARKDOWN_TEXT]: true as const,
-		authoredSegments: Object.freeze([...authoredSegments]),
-		interpolations: Object.freeze([...interpolations])
+		authoredSegments: Object.freeze([...valid.authoredSegments]),
+		interpolations: Object.freeze([...valid.interpolations])
 	});
 }
 
@@ -62,7 +115,7 @@ export function encodeMarkdownLiteral(value: string): string {
 			}
 			return line;
 		})
-		.join('\\\n');
+		.join('<br>');
 }
 
 export function renderMarkdownText(value: MarketingMarkdownContent): string {
@@ -71,14 +124,13 @@ export function renderMarkdownText(value: MarketingMarkdownContent): string {
 		return value;
 	}
 
-	return value.authoredSegments
-		.map((segment, index) => {
-			assertValidText(segment);
-			return index < value.interpolations.length
-				? `${segment}${encodeMarkdownLiteral(value.interpolations[index]!)}`
-				: segment;
-		})
-		.join('');
+	const { authoredSegments, interpolations } = getMarkdownTextParts(value);
+	let markdown = authoredSegments[0]!;
+	for (let index = 0; index < interpolations.length; index += 1) {
+		markdown += encodeMarkdownLiteral(interpolations[index]!);
+		markdown += authoredSegments[index + 1]!;
+	}
+	return markdown;
 }
 
 export function renderPlainText(value: MarketingMarkdownContent): string {
@@ -86,10 +138,11 @@ export function renderPlainText(value: MarketingMarkdownContent): string {
 		return normalizePlainText(value);
 	}
 
-	let plainText = value.authoredSegments[0] ?? '';
-	for (let index = 0; index < value.interpolations.length; index += 1) {
-		plainText += value.interpolations[index] ?? '';
-		plainText += value.authoredSegments[index + 1] ?? '';
+	const { authoredSegments, interpolations } = getMarkdownTextParts(value);
+	let plainText = authoredSegments[0]!;
+	for (let index = 0; index < interpolations.length; index += 1) {
+		plainText += interpolations[index]!;
+		plainText += authoredSegments[index + 1]!;
 	}
 
 	return normalizePlainText(plainText);

--- a/src/lib/markdown/literals.ts
+++ b/src/lib/markdown/literals.ts
@@ -103,7 +103,7 @@ export function markdownText(
 }
 
 export function encodeMarkdownLiteral(value: string): string {
-	return normalizePlainText(value)
+	const encoded = normalizePlainText(value)
 		.replace(COMMONMARK_ESCAPABLE_PUNCTUATION, '\\$&')
 		.split('\n')
 		.map((line) => {
@@ -116,6 +116,8 @@ export function encodeMarkdownLiteral(value: string): string {
 			return line;
 		})
 		.join('<br>');
+
+	return encoded === '<br>' ? `\u200b${encoded}` : encoded;
 }
 
 export function renderMarkdownText(value: MarketingMarkdownContent): string {

--- a/src/lib/markdown/literals.ts
+++ b/src/lib/markdown/literals.ts
@@ -1,0 +1,96 @@
+const MARKETING_MARKDOWN_TEXT: unique symbol = Symbol('MarketingMarkdownText');
+const COMMONMARK_ESCAPABLE_PUNCTUATION = /[!-/:-@[-`{-~]/g;
+
+export interface MarketingMarkdownText {
+	readonly [MARKETING_MARKDOWN_TEXT]: true;
+	readonly authoredSegments: readonly string[];
+	readonly interpolations: readonly string[];
+}
+
+export type MarketingMarkdownContent = string | MarketingMarkdownText;
+
+function assertValidText(value: string): void {
+	for (let index = 0; index < value.length; index += 1) {
+		const codeUnit = value.charCodeAt(index);
+
+		if (codeUnit === 0) {
+			throw new Error('Markdown text must not contain NUL characters.');
+		}
+
+		if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+			const nextCodeUnit = value.charCodeAt(index + 1);
+			if (!(nextCodeUnit >= 0xdc00 && nextCodeUnit <= 0xdfff)) {
+				throw new Error('Markdown text must not contain lone high UTF-16 surrogates.');
+			}
+			index += 1;
+			continue;
+		}
+
+		if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+			throw new Error('Markdown text must not contain lone low UTF-16 surrogates.');
+		}
+	}
+}
+
+function normalizePlainText(value: string): string {
+	const normalized = value.replace(/\r\n?/g, '\n');
+	assertValidText(normalized);
+	return normalized;
+}
+
+export function markdownText(
+	authoredSegments: TemplateStringsArray,
+	...interpolations: string[]
+): MarketingMarkdownText {
+	return Object.freeze({
+		[MARKETING_MARKDOWN_TEXT]: true as const,
+		authoredSegments: Object.freeze([...authoredSegments]),
+		interpolations: Object.freeze([...interpolations])
+	});
+}
+
+export function encodeMarkdownLiteral(value: string): string {
+	return normalizePlainText(value)
+		.replace(COMMONMARK_ESCAPABLE_PUNCTUATION, '\\$&')
+		.split('\n')
+		.map((line) => {
+			if (line.startsWith(' ')) {
+				return `&#32;${line.slice(1)}`;
+			}
+			if (line.startsWith('\t')) {
+				return `&#9;${line.slice(1)}`;
+			}
+			return line;
+		})
+		.join('\\\n');
+}
+
+export function renderMarkdownText(value: MarketingMarkdownContent): string {
+	if (typeof value === 'string') {
+		assertValidText(value);
+		return value;
+	}
+
+	return value.authoredSegments
+		.map((segment, index) => {
+			assertValidText(segment);
+			return index < value.interpolations.length
+				? `${segment}${encodeMarkdownLiteral(value.interpolations[index]!)}`
+				: segment;
+		})
+		.join('');
+}
+
+export function renderPlainText(value: MarketingMarkdownContent): string {
+	if (typeof value === 'string') {
+		return normalizePlainText(value);
+	}
+
+	let plainText = value.authoredSegments[0] ?? '';
+	for (let index = 0; index < value.interpolations.length; index += 1) {
+		plainText += value.interpolations[index] ?? '';
+		plainText += value.authoredSegments[index + 1] ?? '';
+	}
+
+	return normalizePlainText(plainText);
+}

--- a/src/lib/markdown/literals.ts
+++ b/src/lib/markdown/literals.ts
@@ -103,7 +103,7 @@ export function markdownText(
 }
 
 export function encodeMarkdownLiteral(value: string): string {
-	const encoded = normalizePlainText(value)
+	return normalizePlainText(value)
 		.replace(COMMONMARK_ESCAPABLE_PUNCTUATION, '\\$&')
 		.split('\n')
 		.map((line) => {
@@ -116,8 +116,6 @@ export function encodeMarkdownLiteral(value: string): string {
 			return line;
 		})
 		.join('<br>');
-
-	return encoded === '<br>' ? `\u200b${encoded}` : encoded;
 }
 
 export function renderMarkdownText(value: MarketingMarkdownContent): string {

--- a/src/lib/markdown/marketing.test.ts
+++ b/src/lib/markdown/marketing.test.ts
@@ -1,4 +1,37 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { lex } from 'svelte-streamdown';
+
+const { maliciousAddress, maliciousBrandName, maliciousEmail, maliciousOperatorName } = vi.hoisted(
+	() => ({
+		maliciousAddress: 'Hauptstrasse 5\n\n## Forged section',
+		maliciousBrandName: 'SaaS *Starter* [beta]',
+		maliciousEmail: 'legal [at] example [dot] test',
+		maliciousOperatorName: 'Operator #1'
+	})
+);
+
+vi.mock('$lib/config/legal', () => ({
+	LEGAL_CONFIG: {
+		address: maliciousAddress,
+		brandName: maliciousBrandName,
+		companyName: 'Example Company',
+		email: {
+			domain: 'example',
+			tld: 'test',
+			user: 'legal'
+		},
+		operatorName: maliciousOperatorName
+	},
+	getLegalEmailAddress: () => 'legal@example.test',
+	getObfuscatedLegalEmailAddress: () => maliciousEmail
+}));
+
+import {
+	encodeMarkdownLiteral,
+	markdownText,
+	renderMarkdownText,
+	renderPlainText
+} from './literals';
 import {
 	createLlmsTxtResponse,
 	createMarketingMarkdownResponse,
@@ -14,6 +47,7 @@ import {
 } from './marketing';
 import type { MarketingMarkdownDocument } from './types';
 import { marketingMarkdown as homeMarketingMarkdown } from '../../routes/[[lang]]/(marketing)/page.md';
+import { marketingMarkdown as impressumMarketingMarkdown } from '../../routes/[[lang]]/(marketing)/impressum/page.md';
 import { LEGAL_CONFIG } from '$lib/config/legal';
 
 const sampleDocument: MarketingMarkdownDocument = {
@@ -27,6 +61,127 @@ const sampleDocument: MarketingMarkdownDocument = {
 		}
 	]
 };
+
+const maliciousMarkdownLiteral = [
+	'Literal text',
+	'',
+	'## Forged heading',
+	'- Forged list',
+	'> Forged quote',
+	'```ts',
+	'forgedCode()',
+	'```',
+	'    Forged indented code',
+	'<div>Forged HTML</div>',
+	'[Forged link](https://evil.example)'
+].join('\r\n');
+
+type LexToken = {
+	type: string;
+	text?: string;
+	tokens?: LexToken[];
+};
+
+function collectTokenTypes(tokens: LexToken[]): string[] {
+	return tokens.flatMap((token) => [
+		token.type,
+		...(token.tokens ? collectTokenTypes(token.tokens) : [])
+	]);
+}
+
+function getMarketingBody(markdown: string): string {
+	const boundary = markdown.indexOf('---\n\n', 4);
+	return markdown.slice(boundary + 5);
+}
+
+describe('markdown text literals', () => {
+	it('keeps authored segments active and encodes only interpolations', () => {
+		const rendered = renderMarkdownText(markdownText`**Authored** ${'*runtime*'} text`);
+		const tokenTypes = collectTokenTypes(lex(rendered) as LexToken[]);
+
+		expect(rendered).toBe('**Authored** \\*runtime\\* text');
+		expect(tokenTypes.filter((type) => type === 'strong')).toHaveLength(1);
+		expect(tokenTypes).not.toContain('em');
+	});
+
+	it('escapes the complete CommonMark ASCII punctuation set', () => {
+		const punctuation = [
+			'!',
+			'"',
+			'#',
+			'$',
+			'%',
+			'&',
+			"'",
+			'(',
+			')',
+			'*',
+			'+',
+			',',
+			'-',
+			'.',
+			'/',
+			':',
+			';',
+			'<',
+			'=',
+			'>',
+			'?',
+			'@',
+			'[',
+			'\\',
+			']',
+			'^',
+			'_',
+			'`',
+			'{',
+			'|',
+			'}',
+			'~'
+		];
+
+		expect(encodeMarkdownLiteral(punctuation.join(''))).toBe(
+			punctuation.map((character) => `\\${character}`).join('')
+		);
+	});
+
+	it('normalizes line endings and keeps consecutive newlines as hard breaks', () => {
+		expect(encodeMarkdownLiteral('first\r\nsecond\rthird\nfourth')).toBe(
+			'first\\\nsecond\\\nthird\\\nfourth'
+		);
+		expect(encodeMarkdownLiteral('before\n\n## after')).toBe('before\\\n\\\n\\#\\# after');
+		expect(
+			collectTokenTypes(lex(encodeMarkdownLiteral('before\n\n## after')) as LexToken[])
+		).not.toContain('heading');
+	});
+
+	it('keeps leading indentation out of code blocks', () => {
+		for (const value of ['    indented code', '\tindented code']) {
+			const encoded = encodeMarkdownLiteral(value);
+			const tokenTypes = collectTokenTypes(lex(encoded) as LexToken[]);
+
+			expect(tokenTypes).not.toContain('code');
+			expect(tokenTypes).toContain('paragraph');
+		}
+	});
+
+	it.each([
+		['NUL', '\0', 'NUL characters'],
+		['lone high surrogate', '\ud800', 'lone high UTF-16 surrogates'],
+		['lone low surrogate', '\udc00', 'lone low UTF-16 surrogates']
+	])('rejects %s', (_name, value, message) => {
+		expect(() => encodeMarkdownLiteral(value)).toThrow(message);
+		expect(() => renderPlainText(markdownText`${value}`)).toThrow(message);
+	});
+
+	it('renders plain text without markdown escapes', () => {
+		expect(renderPlainText(markdownText`Authored *\r\n${'value_[x]\rline'}`)).toBe(
+			'Authored *\nvalue_[x]\nline'
+		);
+		expect(renderPlainText('plain\r\ntext')).toBe('plain\ntext');
+		expect(renderPlainText(markdownText`${'Valid 😀 pair'}`)).toBe('Valid 😀 pair');
+	});
+});
 
 describe('marketing markdown helpers', () => {
 	it('detects markdown accept headers case-insensitively', () => {
@@ -67,6 +222,98 @@ describe('marketing markdown helpers', () => {
 		expect(markdown).toContain('- First bullet');
 	});
 
+	it('measures the forged heading produced by direct interpolation', () => {
+		const markdown = renderMarketingMarkdown(
+			{
+				title: 'Legal notice',
+				description: 'Provider details.',
+				sections: [
+					{
+						heading: 'Contact',
+						paragraphs: ['Address: Hauptstrasse 5\n\n## Forged section']
+					}
+				]
+			},
+			{ origin: 'https://example.com', pathname: '/en/impressum', lang: 'en' }
+		);
+
+		expect(
+			lex(getMarketingBody(markdown)).some(
+				(token) => token.type === 'heading' && token.text === 'Forged section'
+			)
+		).toBe(true);
+	});
+
+	it('keeps configured values literal in every rendered text field', () => {
+		const literal = markdownText`${maliciousMarkdownLiteral}`;
+		const markdown = renderMarketingMarkdown(
+			{
+				title: literal,
+				description: literal,
+				sections: [
+					{
+						heading: literal,
+						paragraphs: [literal],
+						bullets: [literal],
+						links: [
+							{
+								label: literal,
+								href: 'https://example.com/resource',
+								description: literal
+							}
+						]
+					}
+				]
+			},
+			{ origin: 'https://example.com', pathname: '/en/test', lang: 'en' }
+		);
+		const tokens = lex(getMarketingBody(markdown)) as LexToken[];
+		const tokenTypes = collectTokenTypes(tokens);
+
+		expect(tokenTypes.filter((type) => type === 'heading')).toHaveLength(2);
+		expect(tokenTypes.filter((type) => type === 'list')).toHaveLength(1);
+		expect(tokenTypes.filter((type) => type === 'link')).toHaveLength(1);
+		expect(tokenTypes).not.toContain('code');
+		expect(tokenTypes).not.toContain('html');
+		expect(tokenTypes).not.toContain('blockquote');
+		expect(markdown).toContain('(https://example.com/resource)');
+		expect(JSON.stringify(tokens)).toContain('Forged heading');
+		expect(JSON.stringify(tokens)).toContain('Forged indented code');
+		expect(JSON.stringify(tokens)).toContain('Forged HTML');
+	});
+
+	it('keeps structured frontmatter plain and on one physical line per value', () => {
+		const markdown = renderMarketingMarkdown(
+			{
+				title: markdownText`${'Brand *name*\r\nsecond line'}`,
+				description: markdownText`Address: ${maliciousAddress}`,
+				sections: []
+			},
+			{ origin: 'https://example.com', pathname: '/en/test', lang: 'en' }
+		);
+		const frontmatter = markdown.slice(0, markdown.indexOf('---\n\n', 4));
+
+		expect(frontmatter).toContain('title: "Brand *name*\\nsecond line"');
+		expect(frontmatter).toContain('description: "Address: Hauptstrasse 5\\n\\n## Forged section"');
+		expect(frontmatter).not.toContain('\\*name\\*');
+		expect(frontmatter.split('\n')).not.toContain('second line');
+		expect(frontmatter.split('\n')).not.toContain('## Forged section');
+	});
+
+	it('keeps the configured legal address inside the Impressum paragraph', () => {
+		const markdown = renderMarketingMarkdown(impressumMarketingMarkdown, {
+			origin: 'https://example.com',
+			pathname: '/en/impressum',
+			lang: 'en'
+		});
+		const bodyTokens = lex(getMarketingBody(markdown));
+
+		expect(markdown).toContain('Address: Hauptstrasse 5\\\n\\\n\\#\\# Forged section');
+		expect(
+			bodyTokens.some((token) => token.type === 'heading' && token.text === 'Forged section')
+		).toBe(false);
+	});
+
 	it('returns markdown responses with caching and vary headers', async () => {
 		const response = createMarketingMarkdownResponse(homeMarketingMarkdown, {
 			origin: 'https://example.com',
@@ -84,6 +331,9 @@ describe('marketing markdown helpers', () => {
 
 		const body = await response.text();
 		expect(body).toContain('# Build & Ship Your Product Faster');
+		expect(body).toContain(
+			`${encodeMarkdownLiteral(LEGAL_CONFIG.brandName)} packages the core infrastructure`
+		);
 		expect(body).toContain('lang_served: "de"');
 		expect(body).toContain('content_language: "en"');
 	});
@@ -98,8 +348,12 @@ describe('marketing markdown helpers', () => {
 
 	it('renders llms discovery content with canonical marketing links', () => {
 		const llms = renderLlmsTxt('https://example.com');
+		const heading = lex(llms).find((token) => token.type === 'heading');
 
-		expect(llms).toContain(`# ${LEGAL_CONFIG.brandName}`);
+		expect(llms).toContain(`# ${encodeMarkdownLiteral(LEGAL_CONFIG.brandName)}`);
+		expect(heading?.text).toBe(encodeMarkdownLiteral(LEGAL_CONFIG.brandName));
+		expect(collectTokenTypes([heading as LexToken])).not.toContain('em');
+		expect(collectTokenTypes([heading as LexToken])).not.toContain('link');
 		expect(llms).toContain('https://example.com/en/privacy');
 		expect(llms).toContain('https://example.com/en/terms');
 		expect(llms).toContain('https://example.com/en/impressum');

--- a/src/lib/markdown/marketing.test.ts
+++ b/src/lib/markdown/marketing.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import { lex } from 'svelte-streamdown';
 
@@ -99,7 +100,7 @@ function renderInlineText(token: LexToken): string {
 	if (token.tokens) {
 		return token.tokens.map(renderInlineText).join('');
 	}
-	return (token.text ?? '').replaceAll('\u200b', '');
+	return token.text ?? '';
 }
 
 function getMarketingBody(markdown: string): string {
@@ -159,15 +160,28 @@ describe('markdown text literals', () => {
 	});
 
 	it('normalizes line endings and keeps consecutive newlines as controlled breaks', () => {
-		expect(encodeMarkdownLiteral('first\r\nsecond\rthird\nfourth')).toBe(
-			'first<br>second<br>third<br>fourth'
-		);
-		expect(encodeMarkdownLiteral('\n')).toBe('\u200b<br>');
-		expect(encodeMarkdownLiteral('\n\n')).toBe('<br><br>');
-		expect(encodeMarkdownLiteral('\ntext')).toBe('<br>text');
-		expect(encodeMarkdownLiteral('before\n\n## after')).toBe('before<br><br>\\#\\# after');
-		const tokens = lex(encodeMarkdownLiteral('before\n\n## after')) as LexToken[];
+		const forbiddenCharacter = String.fromCodePoint(8203);
+		const encodedValues = [
+			encodeMarkdownLiteral('first\r\nsecond\rthird\nfourth'),
+			encodeMarkdownLiteral('\n'),
+			encodeMarkdownLiteral('\n\n'),
+			encodeMarkdownLiteral('\ntext'),
+			encodeMarkdownLiteral('before\n\n## after')
+		];
 
+		expect(encodedValues).toEqual([
+			'first<br>second<br>third<br>fourth',
+			'<br>',
+			'<br><br>',
+			'<br>text',
+			'before<br><br>\\#\\# after'
+		]);
+		expect(encodedValues.join('')).not.toContain(forbiddenCharacter);
+		for (const sourcePath of ['src/lib/markdown/literals.ts', 'src/lib/markdown/marketing.ts']) {
+			expect(readFileSync(sourcePath, 'utf8')).not.toContain(forbiddenCharacter);
+		}
+
+		const tokens = lex(encodedValues[4]!) as LexToken[];
 		expect(collectTokenTypes(tokens)).not.toContain('heading');
 		expect(collectTokens(tokens).filter((token) => token.type === 'br')).toEqual([
 			expect.objectContaining({ raw: '<br>' }),
@@ -176,7 +190,7 @@ describe('markdown text literals', () => {
 	});
 
 	it.each(['document description', 'paragraph'] as const)(
-		'keeps a standalone break inline in a %s',
+		'rejects a standalone structured break in a %s before returning a response',
 		(location) => {
 			const standaloneBreak = markdownText`${'\n'}`;
 			const document: MarketingMarkdownDocument =
@@ -191,33 +205,18 @@ describe('markdown text literals', () => {
 							description: '',
 							sections: [{ heading: 'Break', paragraphs: [standaloneBreak] }]
 						};
-			const markdown = renderMarketingMarkdown(document, {
-				origin: 'https://example.com',
-				pathname: '/en/test',
-				lang: 'en'
-			});
-			const bodyTokens = lex(getMarketingBody(markdown)) as LexToken[];
-			const paragraphs = bodyTokens.filter((token) => token.type === 'paragraph');
-			const paragraphTokens = collectTokens(paragraphs);
-			const tokenTypes = paragraphTokens.map((token) => token.type);
+			let response: Response | undefined;
 
-			expect(paragraphs).toHaveLength(1);
-			expect(paragraphTokens.filter((token) => token.type === 'br')).toEqual([
-				expect.objectContaining({ raw: '<br>' })
-			]);
-			expect(
-				paragraphTokens.filter((token) => token.type === 'text' && token.text === '\u200b')
-			).toHaveLength(1);
-			for (const type of ['html', 'heading', 'link', 'code', 'blockquote']) {
-				expect(tokenTypes).not.toContain(type);
-			}
-			expect(
-				paragraphTokens.some((token) => token.type === 'text' && token.text?.includes('\\'))
-			).toBe(false);
-			expect(renderInlineText(paragraphs[0]!)).toBe('\n');
-			expect(markdown).toContain('\u200b<br>');
+			expect(() => {
+				response = createMarketingMarkdownResponse(document, {
+					origin: 'https://example.com',
+					pathname: '/en/test',
+					lang: 'en'
+				});
+			}).toThrow('A standalone marketing markdown block must not contain only a line break.');
+			expect(response).toBeUndefined();
+			expect(renderMarkdownText(standaloneBreak)).toBe('<br>');
 			expect(renderPlainText(standaloneBreak)).toBe('\n');
-			expect(renderPlainText(standaloneBreak)).not.toContain('\u200b');
 		}
 	);
 
@@ -241,10 +240,14 @@ describe('markdown text literals', () => {
 		);
 	});
 
-	it('escapes authored break text before inserting controlled breaks', () => {
+	it('keeps authored break markup active while escaping runtime break text', () => {
 		const encoded = encodeMarkdownLiteral('User <br>\ncontrolled');
 		const tokens = lex(encoded) as LexToken[];
 		const allTokens = collectTokens(tokens);
+		const authoredMarkdown = renderMarketingMarkdown(
+			{ title: 'Authored break', description: '<br>', sections: [] },
+			{ origin: 'https://example.com', pathname: '/en/test', lang: 'en' }
+		);
 
 		expect(encoded).toBe('User \\<br\\><br>controlled');
 		expect(renderInlineText(tokens[0]!)).toBe('User <br>\ncontrolled');
@@ -252,6 +255,10 @@ describe('markdown text literals', () => {
 			expect.objectContaining({ raw: '<br>' })
 		]);
 		expect(allTokens).not.toContainEqual(expect.objectContaining({ type: 'html' }));
+		expect(getMarketingBody(authoredMarkdown)).toBe('# Authored break\n\n<br>\n');
+		expect(collectTokenTypes(lex(getMarketingBody(authoredMarkdown)) as LexToken[])).toContain(
+			'html'
+		);
 	});
 
 	it('keeps leading indentation out of code blocks', () => {
@@ -389,28 +396,53 @@ describe('marketing markdown helpers', () => {
 		).toBe(true);
 	});
 
-	it('keeps multiline literal titles inside their intended headings', () => {
-		const value = 'Acme\n## forged';
-		const literal = markdownText`${value}`;
+	it('keeps standalone structured breaks inside surrounding inline syntax', () => {
+		const standaloneBreak = markdownText`${'\n'}`;
 		const markdown = renderMarketingMarkdown(
 			{
-				title: literal,
+				title: standaloneBreak,
 				description: 'Description',
-				sections: [{ heading: literal }]
+				sections: [
+					{
+						heading: standaloneBreak,
+						bullets: [standaloneBreak],
+						links: [
+							{
+								label: standaloneBreak,
+								href: 'https://example.com/resource',
+								description: standaloneBreak
+							}
+						]
+					}
+				]
 			},
 			{ origin: 'https://example.com', pathname: '/en/test', lang: 'en' }
 		);
 		const tokens = lex(getMarketingBody(markdown)) as LexToken[];
+		const allTokens = collectTokens(tokens);
 		const headings = tokens.filter((token) => token.type === 'heading');
+		const listItems = allTokens.filter((token) => token.type === 'list_item');
+		const links = allTokens.filter((token) => token.type === 'link');
+		const tokenTypes = allTokens.map((token) => token.type);
 
-		expect(tokens.map((token) => token.type)).toEqual(['heading', 'paragraph', 'heading']);
+		expect(tokens.map((token) => token.type)).toEqual(['heading', 'paragraph', 'heading', 'list']);
 		expect(headings.map((heading) => heading.depth)).toEqual([1, 2]);
-		expect(headings.map(renderInlineText)).toEqual([value, value]);
-		expect(
-			headings
-				.flatMap((heading) => collectTokens(heading.tokens ?? []))
-				.filter((token) => token.type === 'br')
-		).toHaveLength(2);
+		expect(headings.map(renderInlineText)).toEqual(['\n', '\n']);
+		expect(listItems).toHaveLength(2);
+		expect(links).toHaveLength(1);
+		expect(renderInlineText(links[0]!)).toBe('\n');
+		expect(getMarketingBody(markdown)).toBe(
+			'# <br>\n\nDescription\n\n## <br>\n\n- <br>\n\n- [<br>](https://example.com/resource): <br>\n'
+		);
+		expect(markdown.match(/<br>/g)).toHaveLength(5);
+		expect(allTokens.filter((token) => token.type === 'br')).toEqual(
+			Array.from({ length: 4 }, () => expect.objectContaining({ raw: '<br>' }))
+		);
+		expect(tokenTypes.filter((type) => type === 'heading')).toHaveLength(2);
+		for (const type of ['code', 'blockquote']) {
+			expect(tokenTypes).not.toContain(type);
+		}
+		expect(markdown).not.toContain(String.fromCodePoint(8203));
 	});
 
 	it('keeps multiline literals inside paragraph, bullet, and link contexts', () => {
@@ -498,6 +530,7 @@ describe('marketing markdown helpers', () => {
 				.filter((token) => token.type === 'br')
 				.every((token) => token.raw === '<br>')
 		).toBe(true);
+		expect(markdown.match(/<br>/g)).toHaveLength(70);
 		expect(tokenTypes.filter((type) => type === 'br')).toHaveLength(70);
 		expect(tokenTypes).not.toContain('code');
 		expect(tokenTypes).not.toContain('html');
@@ -511,7 +544,7 @@ describe('marketing markdown helpers', () => {
 	it('keeps structured frontmatter plain and on one physical line per value', () => {
 		const markdown = renderMarketingMarkdown(
 			{
-				title: markdownText`${'Brand *name*\r\nsecond line'}`,
+				title: markdownText`${'\n'}`,
 				description: markdownText`Address: ${maliciousAddress}`,
 				sections: []
 			},
@@ -519,11 +552,10 @@ describe('marketing markdown helpers', () => {
 		);
 		const frontmatter = markdown.slice(0, markdown.indexOf('---\n\n', 4));
 
-		expect(frontmatter).toContain('title: "Brand *name*\\nsecond line"');
+		expect(frontmatter).toContain('title: "\\n"');
 		expect(frontmatter).toContain('description: "Address: Hauptstrasse 5\\n\\n## Forged section"');
-		expect(frontmatter).not.toContain('\\*name\\*');
-		expect(frontmatter.split('\n')).not.toContain('second line');
 		expect(frontmatter.split('\n')).not.toContain('## Forged section');
+		expect(frontmatter).not.toContain(String.fromCodePoint(8203));
 	});
 
 	it('keeps the configured legal address inside the Impressum paragraph', () => {

--- a/src/lib/markdown/marketing.test.ts
+++ b/src/lib/markdown/marketing.test.ts
@@ -99,7 +99,7 @@ function renderInlineText(token: LexToken): string {
 	if (token.tokens) {
 		return token.tokens.map(renderInlineText).join('');
 	}
-	return token.text ?? '';
+	return (token.text ?? '').replaceAll('\u200b', '');
 }
 
 function getMarketingBody(markdown: string): string {
@@ -162,6 +162,9 @@ describe('markdown text literals', () => {
 		expect(encodeMarkdownLiteral('first\r\nsecond\rthird\nfourth')).toBe(
 			'first<br>second<br>third<br>fourth'
 		);
+		expect(encodeMarkdownLiteral('\n')).toBe('\u200b<br>');
+		expect(encodeMarkdownLiteral('\n\n')).toBe('<br><br>');
+		expect(encodeMarkdownLiteral('\ntext')).toBe('<br>text');
 		expect(encodeMarkdownLiteral('before\n\n## after')).toBe('before<br><br>\\#\\# after');
 		const tokens = lex(encodeMarkdownLiteral('before\n\n## after')) as LexToken[];
 
@@ -171,6 +174,52 @@ describe('markdown text literals', () => {
 			expect.objectContaining({ raw: '<br>' })
 		]);
 	});
+
+	it.each(['document description', 'paragraph'] as const)(
+		'keeps a standalone break inline in a %s',
+		(location) => {
+			const standaloneBreak = markdownText`${'\n'}`;
+			const document: MarketingMarkdownDocument =
+				location === 'document description'
+					? {
+							title: 'Standalone break',
+							description: standaloneBreak,
+							sections: []
+						}
+					: {
+							title: 'Standalone break',
+							description: '',
+							sections: [{ heading: 'Break', paragraphs: [standaloneBreak] }]
+						};
+			const markdown = renderMarketingMarkdown(document, {
+				origin: 'https://example.com',
+				pathname: '/en/test',
+				lang: 'en'
+			});
+			const bodyTokens = lex(getMarketingBody(markdown)) as LexToken[];
+			const paragraphs = bodyTokens.filter((token) => token.type === 'paragraph');
+			const paragraphTokens = collectTokens(paragraphs);
+			const tokenTypes = paragraphTokens.map((token) => token.type);
+
+			expect(paragraphs).toHaveLength(1);
+			expect(paragraphTokens.filter((token) => token.type === 'br')).toEqual([
+				expect.objectContaining({ raw: '<br>' })
+			]);
+			expect(
+				paragraphTokens.filter((token) => token.type === 'text' && token.text === '\u200b')
+			).toHaveLength(1);
+			for (const type of ['html', 'heading', 'link', 'code', 'blockquote']) {
+				expect(tokenTypes).not.toContain(type);
+			}
+			expect(
+				paragraphTokens.some((token) => token.type === 'text' && token.text?.includes('\\'))
+			).toBe(false);
+			expect(renderInlineText(paragraphs[0]!)).toBe('\n');
+			expect(markdown).toContain('\u200b<br>');
+			expect(renderPlainText(standaloneBreak)).toBe('\n');
+			expect(renderPlainText(standaloneBreak)).not.toContain('\u200b');
+		}
+	);
 
 	it.each([
 		['one', 'Line 1\n', 1],

--- a/src/lib/markdown/marketing.test.ts
+++ b/src/lib/markdown/marketing.test.ts
@@ -4,7 +4,7 @@ import { lex } from 'svelte-streamdown';
 const { maliciousAddress, maliciousBrandName, maliciousEmail, maliciousOperatorName } = vi.hoisted(
 	() => ({
 		maliciousAddress: 'Hauptstrasse 5\n\n## Forged section',
-		maliciousBrandName: 'SaaS *Starter* [beta]',
+		maliciousBrandName: 'SaaS *Starter* [beta]\n## Forged brand',
 		maliciousEmail: 'legal [at] example [dot] test',
 		maliciousOperatorName: 'Operator #1'
 	})
@@ -78,15 +78,28 @@ const maliciousMarkdownLiteral = [
 
 type LexToken = {
 	type: string;
+	depth?: number;
+	raw?: string;
 	text?: string;
 	tokens?: LexToken[];
 };
 
+function collectTokens(tokens: LexToken[]): LexToken[] {
+	return tokens.flatMap((token) => [token, ...(token.tokens ? collectTokens(token.tokens) : [])]);
+}
+
 function collectTokenTypes(tokens: LexToken[]): string[] {
-	return tokens.flatMap((token) => [
-		token.type,
-		...(token.tokens ? collectTokenTypes(token.tokens) : [])
-	]);
+	return collectTokens(tokens).map((token) => token.type);
+}
+
+function renderInlineText(token: LexToken): string {
+	if (token.type === 'br') {
+		return '\n';
+	}
+	if (token.tokens) {
+		return token.tokens.map(renderInlineText).join('');
+	}
+	return token.text ?? '';
 }
 
 function getMarketingBody(markdown: string): string {
@@ -145,14 +158,51 @@ describe('markdown text literals', () => {
 		);
 	});
 
-	it('normalizes line endings and keeps consecutive newlines as hard breaks', () => {
+	it('normalizes line endings and keeps consecutive newlines as controlled breaks', () => {
 		expect(encodeMarkdownLiteral('first\r\nsecond\rthird\nfourth')).toBe(
-			'first\\\nsecond\\\nthird\\\nfourth'
+			'first<br>second<br>third<br>fourth'
 		);
-		expect(encodeMarkdownLiteral('before\n\n## after')).toBe('before\\\n\\\n\\#\\# after');
-		expect(
-			collectTokenTypes(lex(encodeMarkdownLiteral('before\n\n## after')) as LexToken[])
-		).not.toContain('heading');
+		expect(encodeMarkdownLiteral('before\n\n## after')).toBe('before<br><br>\\#\\# after');
+		const tokens = lex(encodeMarkdownLiteral('before\n\n## after')) as LexToken[];
+
+		expect(collectTokenTypes(tokens)).not.toContain('heading');
+		expect(collectTokens(tokens).filter((token) => token.type === 'br')).toEqual([
+			expect.objectContaining({ raw: '<br>' }),
+			expect.objectContaining({ raw: '<br>' })
+		]);
+	});
+
+	it.each([
+		['one', 'Line 1\n', 1],
+		['multiple', 'Line 1\n\n', 2]
+	])('keeps %s terminal newline without visible markers', (_name, value, breakCount) => {
+		const encoded = encodeMarkdownLiteral(value);
+		const tokens = lex(encoded) as LexToken[];
+		const allTokens = collectTokens(tokens);
+
+		expect(tokens).toHaveLength(1);
+		expect(tokens[0]?.type).toBe('paragraph');
+		expect(renderInlineText(tokens[0]!)).toBe(value);
+		expect(allTokens.filter((token) => token.type === 'br')).toHaveLength(breakCount);
+		expect(allTokens.filter((token) => token.type === 'br').map((token) => token.raw)).toEqual(
+			Array.from({ length: breakCount }, () => '<br>')
+		);
+		expect(allTokens.some((token) => token.type === 'text' && token.text?.includes('\\'))).toBe(
+			false
+		);
+	});
+
+	it('escapes authored break text before inserting controlled breaks', () => {
+		const encoded = encodeMarkdownLiteral('User <br>\ncontrolled');
+		const tokens = lex(encoded) as LexToken[];
+		const allTokens = collectTokens(tokens);
+
+		expect(encoded).toBe('User \\<br\\><br>controlled');
+		expect(renderInlineText(tokens[0]!)).toBe('User <br>\ncontrolled');
+		expect(allTokens.filter((token) => token.type === 'br')).toEqual([
+			expect.objectContaining({ raw: '<br>' })
+		]);
+		expect(allTokens).not.toContainEqual(expect.objectContaining({ type: 'html' }));
 	});
 
 	it('keeps leading indentation out of code blocks', () => {
@@ -180,6 +230,52 @@ describe('markdown text literals', () => {
 		);
 		expect(renderPlainText('plain\r\ntext')).toBe('plain\ntext');
 		expect(renderPlainText(markdownText`${'Valid 😀 pair'}`)).toBe('Valid 😀 pair');
+	});
+
+	it('rejects malformed direct markdownText calls', () => {
+		const callMarkdownText = markdownText as unknown as (
+			authoredSegments: unknown,
+			...interpolations: unknown[]
+		) => unknown;
+
+		expect(() => callMarkdownText(['A'], 'B', 'C')).toThrow(
+			'exactly one more item than interpolations'
+		);
+		expect(() => callMarkdownText(['A', 1, 'C'], 'B', 'D')).toThrow(
+			'authoredSegments must be an array of strings'
+		);
+		expect(() => callMarkdownText(['A', 'C', 'E'], 'B', 1)).toThrow(
+			'interpolations must be an array of strings'
+		);
+	});
+
+	it('rejects unbranded and malformed branded values in both renderers', () => {
+		const unbranded = {
+			authoredSegments: Object.freeze(['A', 'C']),
+			interpolations: Object.freeze(['B'])
+		};
+		const valid = markdownText`A${'B'}C`;
+		const brand = Object.getOwnPropertySymbols(valid)[0]!;
+		const malformedBranded = {
+			[brand]: true,
+			authoredSegments: Object.freeze(['A']),
+			interpolations: Object.freeze(['B'])
+		};
+
+		for (const render of [renderMarkdownText, renderPlainText]) {
+			expect(() => render(unbranded as never)).toThrow('created by markdownText');
+			expect(() => render(malformedBranded as never)).toThrow(
+				'exactly one more item than interpolations'
+			);
+		}
+	});
+
+	it('returns immutable markdownText values and lists', () => {
+		const value = markdownText`A${'B'}C`;
+
+		expect(Object.isFrozen(value)).toBe(true);
+		expect(Object.isFrozen(value.authoredSegments)).toBe(true);
+		expect(Object.isFrozen(value.interpolations)).toBe(true);
 	});
 });
 
@@ -244,6 +340,81 @@ describe('marketing markdown helpers', () => {
 		).toBe(true);
 	});
 
+	it('keeps multiline literal titles inside their intended headings', () => {
+		const value = 'Acme\n## forged';
+		const literal = markdownText`${value}`;
+		const markdown = renderMarketingMarkdown(
+			{
+				title: literal,
+				description: 'Description',
+				sections: [{ heading: literal }]
+			},
+			{ origin: 'https://example.com', pathname: '/en/test', lang: 'en' }
+		);
+		const tokens = lex(getMarketingBody(markdown)) as LexToken[];
+		const headings = tokens.filter((token) => token.type === 'heading');
+
+		expect(tokens.map((token) => token.type)).toEqual(['heading', 'paragraph', 'heading']);
+		expect(headings.map((heading) => heading.depth)).toEqual([1, 2]);
+		expect(headings.map(renderInlineText)).toEqual([value, value]);
+		expect(
+			headings
+				.flatMap((heading) => collectTokens(heading.tokens ?? []))
+				.filter((token) => token.type === 'br')
+		).toHaveLength(2);
+	});
+
+	it('keeps multiline literals inside paragraph, bullet, and link contexts', () => {
+		const paragraph = 'Paragraph\ninside\n\nend\n';
+		const bullet = 'Bullet\r\ninside\r\rend\r';
+		const label = 'Label\n\nend\n';
+		const description = 'Description\ninside\n\n';
+		const markdown = renderMarketingMarkdown(
+			{
+				title: 'Contexts',
+				description: 'Description',
+				sections: [
+					{
+						heading: 'Fields',
+						paragraphs: [markdownText`${paragraph}`],
+						bullets: [markdownText`${bullet}`],
+						links: [
+							{
+								label: markdownText`${label}`,
+								href: 'https://example.com/resource',
+								description: markdownText`${description}`
+							}
+						]
+					}
+				]
+			},
+			{ origin: 'https://example.com', pathname: '/en/test', lang: 'en' }
+		);
+		const tokens = lex(getMarketingBody(markdown)) as LexToken[];
+		const allTokens = collectTokens(tokens);
+		const paragraphToken = tokens.find(
+			(token) => token.type === 'paragraph' && renderInlineText(token).startsWith('Paragraph')
+		);
+		const listItems = allTokens.filter((token) => token.type === 'list_item');
+		const link = allTokens.find((token) => token.type === 'link');
+
+		expect(tokens.map((token) => token.type)).toEqual([
+			'heading',
+			'paragraph',
+			'heading',
+			'paragraph',
+			'list'
+		]);
+		expect(renderInlineText(paragraphToken!)).toBe(paragraph);
+		expect(renderInlineText(listItems[0]!)).toBe(bullet.replace(/\r\n?/g, '\n'));
+		expect(renderInlineText(link!)).toBe(label);
+		expect(renderInlineText(listItems[1]!)).toBe(`${label}: ${description}`);
+		expect(allTokens.filter((token) => token.type === 'br')).toHaveLength(14);
+		expect(collectTokenTypes(tokens)).not.toContain('code');
+		expect(collectTokenTypes(tokens)).not.toContain('html');
+		expect(collectTokenTypes(tokens)).not.toContain('blockquote');
+	});
+
 	it('keeps configured values literal in every rendered text field', () => {
 		const literal = markdownText`${maliciousMarkdownLiteral}`;
 		const markdown = renderMarketingMarkdown(
@@ -273,6 +444,12 @@ describe('marketing markdown helpers', () => {
 		expect(tokenTypes.filter((type) => type === 'heading')).toHaveLength(2);
 		expect(tokenTypes.filter((type) => type === 'list')).toHaveLength(1);
 		expect(tokenTypes.filter((type) => type === 'link')).toHaveLength(1);
+		expect(
+			collectTokens(tokens)
+				.filter((token) => token.type === 'br')
+				.every((token) => token.raw === '<br>')
+		).toBe(true);
+		expect(tokenTypes.filter((type) => type === 'br')).toHaveLength(70);
 		expect(tokenTypes).not.toContain('code');
 		expect(tokenTypes).not.toContain('html');
 		expect(tokenTypes).not.toContain('blockquote');
@@ -308,7 +485,7 @@ describe('marketing markdown helpers', () => {
 		});
 		const bodyTokens = lex(getMarketingBody(markdown));
 
-		expect(markdown).toContain('Address: Hauptstrasse 5\\\n\\\n\\#\\# Forged section');
+		expect(markdown).toContain('Address: Hauptstrasse 5<br><br>\\#\\# Forged section');
 		expect(
 			bodyTokens.some((token) => token.type === 'heading' && token.text === 'Forged section')
 		).toBe(false);
@@ -348,12 +525,20 @@ describe('marketing markdown helpers', () => {
 
 	it('renders llms discovery content with canonical marketing links', () => {
 		const llms = renderLlmsTxt('https://example.com');
-		const heading = lex(llms).find((token) => token.type === 'heading');
+		const tokens = lex(llms) as LexToken[];
+		const documentHeadings = tokens.filter(
+			(token) => token.type === 'heading' && token.depth === 1
+		);
+		const heading = documentHeadings[0]!;
 
 		expect(llms).toContain(`# ${encodeMarkdownLiteral(LEGAL_CONFIG.brandName)}`);
-		expect(heading?.text).toBe(encodeMarkdownLiteral(LEGAL_CONFIG.brandName));
-		expect(collectTokenTypes([heading as LexToken])).not.toContain('em');
-		expect(collectTokenTypes([heading as LexToken])).not.toContain('link');
+		expect(documentHeadings).toHaveLength(1);
+		expect(renderInlineText(heading)).toBe(LEGAL_CONFIG.brandName);
+		expect(collectTokens(heading.tokens ?? []).filter((token) => token.type === 'br')).toEqual([
+			expect.objectContaining({ raw: '<br>' })
+		]);
+		expect(collectTokenTypes([heading])).not.toContain('em');
+		expect(collectTokenTypes([heading])).not.toContain('link');
 		expect(llms).toContain('https://example.com/en/privacy');
 		expect(llms).toContain('https://example.com/en/terms');
 		expect(llms).toContain('https://example.com/en/impressum');

--- a/src/lib/markdown/marketing.ts
+++ b/src/lib/markdown/marketing.ts
@@ -38,11 +38,19 @@ function quoteFrontmatterValue(value: MarketingMarkdownContent): string {
 	return JSON.stringify(renderPlainText(value));
 }
 
+function renderMarkdownBlock(value: MarketingMarkdownContent): string {
+	const markdown = renderMarkdownText(value);
+	if (typeof value !== 'string' && markdown === '<br>') {
+		throw new Error('A standalone marketing markdown block must not contain only a line break.');
+	}
+	return markdown;
+}
+
 function renderSection(section: MarketingMarkdownSection): string {
 	const parts: string[] = [`## ${renderMarkdownText(section.heading)}`];
 
 	for (const paragraph of section.paragraphs ?? []) {
-		parts.push(renderMarkdownText(paragraph));
+		parts.push(renderMarkdownBlock(paragraph));
 	}
 
 	if (section.bullets?.length) {
@@ -98,7 +106,7 @@ export function renderMarketingMarkdown(
 
 	const body = [
 		`# ${renderMarkdownText(document.title)}`,
-		renderMarkdownText(document.description),
+		renderMarkdownBlock(document.description),
 		...document.sections.map((section) => renderSection(section))
 	].join('\n\n');
 

--- a/src/lib/markdown/marketing.ts
+++ b/src/lib/markdown/marketing.ts
@@ -3,6 +3,12 @@ import type {
 	MarketingMarkdownRenderContext,
 	MarketingMarkdownSection
 } from './types';
+import {
+	encodeMarkdownLiteral,
+	renderMarkdownText,
+	renderPlainText,
+	type MarketingMarkdownContent
+} from './literals';
 import { getLocalizedMarketingUrl, PUBLIC_MARKETING_ROUTES } from '$lib/marketing/public-routes';
 import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '$lib/i18n/languages';
 import { LEGAL_CONFIG } from '$lib/config/legal';
@@ -28,29 +34,31 @@ interface PublicMarkdownNotFoundContext {
 	head?: boolean;
 }
 
-function quoteFrontmatterValue(value: string): string {
-	return JSON.stringify(value);
+function quoteFrontmatterValue(value: MarketingMarkdownContent): string {
+	return JSON.stringify(renderPlainText(value));
 }
 
 function renderSection(section: MarketingMarkdownSection): string {
-	const parts: string[] = [`## ${section.heading}`];
+	const parts: string[] = [`## ${renderMarkdownText(section.heading)}`];
 
 	for (const paragraph of section.paragraphs ?? []) {
-		parts.push(paragraph);
+		parts.push(renderMarkdownText(paragraph));
 	}
 
 	if (section.bullets?.length) {
-		parts.push(section.bullets.map((bullet) => `- ${bullet}`).join('\n'));
+		parts.push(section.bullets.map((bullet) => `- ${renderMarkdownText(bullet)}`).join('\n'));
 	}
 
 	if (section.links?.length) {
 		parts.push(
 			section.links
-				.map((link) =>
-					link.description
-						? `- [${link.label}](${link.href}): ${link.description}`
-						: `- [${link.label}](${link.href})`
-				)
+				.map((link) => {
+					const label = renderMarkdownText(link.label);
+					const description = link.description ? renderMarkdownText(link.description) : undefined;
+					return description
+						? `- [${label}](${link.href}): ${description}`
+						: `- [${label}](${link.href})`;
+				})
 				.join('\n')
 		);
 	}
@@ -68,7 +76,7 @@ export function renderMarketingMarkdown(
 ): string {
 	const canonicalPath = document.canonicalPath ?? context.pathname;
 	const canonical = new URL(canonicalPath, context.origin).toString();
-	const frontmatterEntries = [
+	const frontmatterEntries: Array<[string, MarketingMarkdownContent]> = [
 		['title', document.title],
 		['description', document.description],
 		['canonical', canonical],
@@ -89,8 +97,8 @@ export function renderMarketingMarkdown(
 	].join('\n');
 
 	const body = [
-		`# ${document.title}`,
-		document.description,
+		`# ${renderMarkdownText(document.title)}`,
+		renderMarkdownText(document.description),
 		...document.sections.map((section) => renderSection(section))
 	].join('\n\n');
 
@@ -189,7 +197,7 @@ export function renderLlmsTxt(origin: string): string {
 
 	return renderAuthoredTemplate('llms.txt', llmsTemplate, {
 		AGENT_INSTRUCTIONS_URL: getRepositoryDocumentUrl('AGENTS.md'),
-		BRAND_NAME: LEGAL_CONFIG.brandName,
+		BRAND_NAME: encodeMarkdownLiteral(LEGAL_CONFIG.brandName),
 		CANONICAL_PAGES: canonicalPages,
 		DEVELOPER_GUIDE_URL: getRepositoryDocumentUrl('README.md'),
 		REPOSITORY_URL: getRepositoryUrl()

--- a/src/lib/markdown/types.ts
+++ b/src/lib/markdown/types.ts
@@ -1,21 +1,23 @@
+import type { MarketingMarkdownContent } from './literals';
+
 export interface MarkdownLink {
-	label: string;
+	label: MarketingMarkdownContent;
 	href: string;
-	description?: string;
+	description?: MarketingMarkdownContent;
 }
 
 export interface MarketingMarkdownSection {
-	heading: string;
-	paragraphs?: string[];
-	bullets?: string[];
+	heading: MarketingMarkdownContent;
+	paragraphs?: MarketingMarkdownContent[];
+	bullets?: MarketingMarkdownContent[];
 	links?: MarkdownLink[];
 }
 
 export interface MarketingMarkdownDocument {
-	title: string;
-	description: string;
+	title: MarketingMarkdownContent;
+	description: MarketingMarkdownContent;
 	canonicalPath?: string;
-	robots?: string;
+	robots?: MarketingMarkdownContent;
 	sections: MarketingMarkdownSection[];
 }
 

--- a/src/routes/[[lang]]/(marketing)/impressum/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/impressum/page.md.ts
@@ -1,19 +1,20 @@
 import { LEGAL_CONFIG, getObfuscatedLegalEmailAddress } from '$lib/config/legal';
 import { LEGAL_CONTENT_DATES, formatLegalContentDate } from '$lib/content/legal-metadata';
+import { markdownText } from '$lib/markdown/literals';
 import type { MarketingMarkdownDocument } from '$lib/markdown/types';
 
 export const marketingMarkdown: MarketingMarkdownDocument = {
 	title: 'Impressum',
-	description: `Provider identification and contact details for ${LEGAL_CONFIG.brandName}.`,
+	description: markdownText`Provider identification and contact details for ${LEGAL_CONFIG.brandName}.`,
 	sections: [
 		{
 			heading: 'Impressum',
 			paragraphs: [
-				`Last Updated: ${formatLegalContentDate(LEGAL_CONTENT_DATES.impressum)}`,
+				markdownText`Last Updated: ${formatLegalContentDate(LEGAL_CONTENT_DATES.impressum)}`,
 				'Information pursuant to Section 5 DDG.',
-				`Provider: ${LEGAL_CONFIG.operatorName}`,
-				`Address: ${LEGAL_CONFIG.address}`,
-				`Email: ${getObfuscatedLegalEmailAddress()}`
+				markdownText`Provider: ${LEGAL_CONFIG.operatorName}`,
+				markdownText`Address: ${LEGAL_CONFIG.address}`,
+				markdownText`Email: ${getObfuscatedLegalEmailAddress()}`
 			]
 		}
 	]

--- a/src/routes/[[lang]]/(marketing)/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/page.md.ts
@@ -1,5 +1,6 @@
-import type { MarketingMarkdownDocument } from '$lib/markdown/types';
 import { LEGAL_CONFIG } from '$lib/config/legal';
+import { markdownText } from '$lib/markdown/literals';
+import type { MarketingMarkdownDocument } from '$lib/markdown/types';
 
 export const marketingMarkdown: MarketingMarkdownDocument = {
 	title: 'Build & Ship Your Product Faster',
@@ -9,7 +10,7 @@ export const marketingMarkdown: MarketingMarkdownDocument = {
 		{
 			heading: 'What this starter is',
 			paragraphs: [
-				`${LEGAL_CONFIG.brandName} packages the core infrastructure needed to launch a production-ready SaaS product with SvelteKit, Convex, Better Auth, Tolgee, and modern billing, email, and analytics tooling.`,
+				markdownText`${LEGAL_CONFIG.brandName} packages the core infrastructure needed to launch a production-ready SaaS product with SvelteKit, Convex, Better Auth, Tolgee, and modern billing, email, and analytics tooling.`,
 				'It is designed for founders and product teams who want to focus on product differentiation rather than rebuilding authentication, billing, localization, and operational plumbing.'
 			]
 		},

--- a/src/routes/[[lang]]/(marketing)/pricing/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/pricing/page.md.ts
@@ -1,9 +1,10 @@
-import type { MarketingMarkdownDocument } from '$lib/markdown/types';
 import { LEGAL_CONFIG } from '$lib/config/legal';
+import { markdownText } from '$lib/markdown/literals';
+import type { MarketingMarkdownDocument } from '$lib/markdown/types';
 
 export const marketingMarkdown: MarketingMarkdownDocument = {
 	title: 'Pricing',
-	description: `Review the public pricing structure for the ${LEGAL_CONFIG.brandName} template, including the free, pro, and enterprise tiers shown on the marketing site.`,
+	description: markdownText`Review the public pricing structure for the ${LEGAL_CONFIG.brandName} template, including the free, pro, and enterprise tiers shown on the marketing site.`,
 	sections: [
 		{
 			heading: 'Pricing summary',

--- a/src/routes/[[lang]]/(marketing)/privacy/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/privacy/page.md.ts
@@ -1,4 +1,5 @@
 import { LEGAL_CONFIG, getObfuscatedLegalEmailAddress } from '$lib/config/legal';
+import { markdownText } from '$lib/markdown/literals';
 import type { MarketingMarkdownDocument } from '$lib/markdown/types';
 
 export const marketingMarkdown: MarketingMarkdownDocument = {
@@ -8,12 +9,12 @@ export const marketingMarkdown: MarketingMarkdownDocument = {
 		{
 			heading: 'Privacy Policy',
 			paragraphs: [
-				`${LEGAL_CONFIG.brandName} is operated by ${LEGAL_CONFIG.operatorName} as a personal project. This Privacy Policy explains how we handle your personal data in accordance with the GDPR.`,
+				markdownText`${LEGAL_CONFIG.brandName} is operated by ${LEGAL_CONFIG.operatorName} as a personal project. This Privacy Policy explains how we handle your personal data in accordance with the GDPR.`,
 				'We collect account data (name, email, auth provider), usage data (analytics), and support data (chat messages).',
 				'We use your data to provide your account, send transactional emails, and improve the Service. We do not sell or share your data.',
 				'Third-party processors: Convex (EU Ireland, database), Vercel (Frankfurt, hosting), Resend (email), PostHog (analytics). All are GDPR-compliant.',
 				'Under the GDPR you have the right to access, rectify, delete, restrict, port, and object to processing of your personal data.',
-				`Contact: ${getObfuscatedLegalEmailAddress()}`
+				markdownText`Contact: ${getObfuscatedLegalEmailAddress()}`
 			]
 		}
 	]

--- a/src/routes/[[lang]]/(marketing)/terms/page.md.ts
+++ b/src/routes/[[lang]]/(marketing)/terms/page.md.ts
@@ -1,15 +1,16 @@
 import { LEGAL_CONFIG } from '$lib/config/legal';
+import { markdownText } from '$lib/markdown/literals';
 import type { MarketingMarkdownDocument } from '$lib/markdown/types';
 
 export const marketingMarkdown: MarketingMarkdownDocument = {
 	title: 'Terms of Service',
-	description: `The terms and conditions for using ${LEGAL_CONFIG.brandName}.`,
+	description: markdownText`The terms and conditions for using ${LEGAL_CONFIG.brandName}.`,
 	sections: [
 		{
 			heading: 'Terms of Service',
 			paragraphs: [
-				`By accessing or using ${LEGAL_CONFIG.brandName} you agree to be bound by these Terms of Service.`,
-				`${LEGAL_CONFIG.brandName} is a web application template and starter kit provided by ${LEGAL_CONFIG.operatorName} as a personal project.`,
+				markdownText`By accessing or using ${LEGAL_CONFIG.brandName} you agree to be bound by these Terms of Service.`,
+				markdownText`${LEGAL_CONFIG.brandName} is a web application template and starter kit provided by ${LEGAL_CONFIG.operatorName} as a personal project.`,
 				'You are responsible for maintaining the confidentiality of your account credentials.',
 				'The Service is provided "as is" without warranties of any kind.',
 				'These Terms are governed by the laws of the Federal Republic of Germany.'


### PR DESCRIPTION
Regression guard: covered by marketing Markdown lexer tests

Configured branding and legal values were interpolated into authored Markdown, so punctuation and multiline content could create headings, links, HTML, or other document structure.

This adds a branded template boundary that preserves authored Markdown while encoding every runtime interpolation as literal text. It normalizes line endings, retains controlled inline breaks, rejects malformed text and standalone structured break blocks, and uses plain text for frontmatter. Public marketing documents now apply the boundary at each configured value.

Verification: 42 focused tests, changed-file static checks, full type checks, production build, and independent review. The full unit suite exposed pre-existing timeout-sensitive static-check cases; every failed case passed in isolated reruns.