### PR TITLE
feat(capabilities): Guard provider runtimes

### DIFF
--- a/src/lib/convex/__tests__/authEmailCapabilities.test.ts
+++ b/src/lib/convex/__tests__/authEmailCapabilities.test.ts
@@ -85,7 +85,8 @@ describe('authentication email capability failures', () => {
 			secret: 'test-secret-that-is-long-enough-for-signing',
 			database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
 			emailAndPassword: options.emailAndPassword,
-			emailVerification: options.emailVerification
+			emailVerification: options.emailVerification,
+			hooks: options.hooks
 		});
 
 		await auth.api.signUpEmail({ body: credentials });
@@ -133,16 +134,100 @@ describe('authentication email capability failures', () => {
 			})
 		).rejects.toBeInstanceOf(CapabilityConfigurationError);
 
-		const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
 		await expect(
 			auth.api.sendVerificationEmail({ body: { email: credentials.email } })
 		).rejects.toThrow();
-		const resetResult = await auth.api.requestPasswordReset({
+		await expect(
+			auth.api.requestPasswordReset({
+				body: { email: credentials.email, redirectTo: '/reset-password' }
+			})
+		).rejects.toThrow();
+		expect(enqueue).not.toHaveBeenCalled();
+	});
+
+	it('rejects malformed email routes before Better Auth writes state', async () => {
+		vi.stubEnv('SITE_URL', 'https://example.test');
+		vi.stubEnv('BETTER_AUTH_SECRET', 'test-secret-that-is-long-enough-for-signing');
+		vi.stubEnv('RESEND_API_KEY', 'configured-resend-key');
+		vi.stubEnv('AUTH_EMAIL', 'malformed-sender');
+		vi.stubEnv('EMAIL_ASSET_URL', 'https://assets.example.com');
+
+		const [{ createAuthOptions }, resendModule] = await Promise.all([
+			import('../auth'),
+			import('../emails/resend')
+		]);
+		const enqueue = vi.spyOn(resendModule.resend, 'sendEmail');
+		const runMutation = vi.fn().mockResolvedValue(null);
+		const options = createAuthOptions({ runMutation } as never);
+		const existingUser = {
+			id: 'existing-user',
+			email: 'known@example.test',
+			name: 'Known User',
+			emailVerified: true,
+			createdAt: new Date('2026-01-01T00:00:00.000Z'),
+			updatedAt: new Date('2026-01-01T00:00:00.000Z')
+		};
+		const database = {
+			user: [existingUser] as Array<Record<string, unknown>>,
+			session: [] as Array<Record<string, unknown>>,
+			account: [] as Array<Record<string, unknown>>,
+			verification: [] as Array<Record<string, unknown>>
+		};
+		const auth = betterAuth({
+			baseURL: 'https://example.test',
+			secret: 'test-secret-that-is-long-enough-for-signing',
+			database: memoryAdapter(database),
+			emailAndPassword: options.emailAndPassword,
+			emailVerification: options.emailVerification,
+			hooks: options.hooks
+		});
+
+		await expect(auth.api.signUpEmail({ body: credentials })).rejects.toThrow();
+		await expect(
+			auth.api.requestPasswordReset({
+				body: { email: existingUser.email, redirectTo: '/reset-password' }
+			})
+		).rejects.toThrow();
+		await expect(
+			auth.api.sendVerificationEmail({ body: { email: credentials.email } })
+		).rejects.toThrow();
+
+		expect(database.user).toEqual([existingUser]);
+		expect(database.account).toHaveLength(0);
+		expect(database.verification).toHaveLength(0);
+		expect(database.session).toHaveLength(0);
+		expect(runMutation).not.toHaveBeenCalled();
+		expect(enqueue).not.toHaveBeenCalled();
+	});
+
+	it('keeps ready password reset responses enumeration-safe', async () => {
+		vi.stubEnv('SITE_URL', 'https://example.test');
+		vi.stubEnv('BETTER_AUTH_SECRET', 'test-secret-that-is-long-enough-for-signing');
+		vi.stubEnv('RESEND_API_KEY', 'configured-resend-key');
+		vi.stubEnv('AUTH_EMAIL', 'sender@example.com');
+		vi.stubEnv('EMAIL_ASSET_URL', 'https://assets.example.com');
+
+		const { createAuthOptions } = await import('../auth');
+		const runMutation = vi.fn().mockResolvedValue(null);
+		const options = createAuthOptions({ runMutation } as never);
+		const auth = betterAuth({
+			baseURL: 'https://example.test',
+			secret: 'test-secret-that-is-long-enough-for-signing',
+			database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+			emailAndPassword: options.emailAndPassword,
+			emailVerification: options.emailVerification,
+			hooks: options.hooks
+		});
+
+		const unknown = await auth.api.requestPasswordReset({
+			body: { email: 'unknown@example.test', redirectTo: '/reset-password' }
+		});
+		await auth.api.signUpEmail({ body: credentials });
+		const known = await auth.api.requestPasswordReset({
 			body: { email: credentials.email, redirectTo: '/reset-password' }
 		});
 
-		expect(resetResult.status).toBe(true);
-		await vi.waitFor(() => expect(errorLog).toHaveBeenCalled());
-		expect(enqueue).not.toHaveBeenCalled();
+		expect(unknown).toEqual(known);
+		expect(known.status).toBe(true);
 	});
 });

--- a/src/lib/convex/__tests__/authEmailCapabilities.test.ts
+++ b/src/lib/convex/__tests__/authEmailCapabilities.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment node
+
+import { betterAuth } from 'better-auth';
+import { memoryAdapter } from 'better-auth/adapters/memory';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../_generated/api', () => ({
+	components: {
+		betterAuth: { adapter: { findOne: 'components.betterAuth.adapter.findOne' } },
+		resend: {}
+	},
+	internal: {
+		auth: {},
+		emails: {
+			events: { handleEmailEvent: 'internal.emails.events.handleEmailEvent' },
+			send: {
+				sendVerificationEmail: 'internal.emails.send.sendVerificationEmail',
+				sendResetPasswordEmail: 'internal.emails.send.sendResetPasswordEmail'
+			}
+		}
+	}
+}));
+
+vi.mock('../_generated/server', () => ({
+	env: process.env,
+	query: (definition: unknown) => definition,
+	mutation: (definition: unknown) => definition,
+	internalMutation: (definition: { handler: unknown }) => ({
+		...definition,
+		_handler: definition.handler
+	})
+}));
+
+type RegisteredMutation = {
+	_handler: (ctx: unknown, args: Record<string, unknown>) => Promise<unknown>;
+};
+
+const credentials = {
+	name: 'Capability Probe',
+	email: 'capability@example.test',
+	password: 'correct-horse-battery-staple'
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+	vi.resetModules();
+});
+
+describe('authentication email capability failures', () => {
+	it('propagates real mutation failures through callbacks and Better Auth routes', async () => {
+		vi.stubEnv('SITE_URL', 'https://example.test');
+		vi.stubEnv('BETTER_AUTH_SECRET', 'test-secret-that-is-long-enough-for-signing');
+		vi.stubEnv('RESEND_API_KEY', 'configured-resend-key');
+		vi.stubEnv('AUTH_EMAIL', 'sender@example.com');
+		vi.stubEnv('EMAIL_ASSET_URL', 'https://assets.example.com');
+
+		const [{ createAuthOptions }, sendModule, resendModule, { CapabilityConfigurationError }] =
+			await Promise.all([
+				import('../auth'),
+				import('../emails/send'),
+				import('../emails/resend'),
+				import('../env')
+			]);
+		const sendVerificationEmail = sendModule.sendVerificationEmail as unknown as RegisteredMutation;
+		const sendResetPasswordEmail =
+			sendModule.sendResetPasswordEmail as unknown as RegisteredMutation;
+		const enqueue = vi
+			.spyOn(resendModule.resend, 'sendEmail')
+			.mockResolvedValue('email_1' as never);
+		const mutationCtx = {
+			runQuery: vi.fn().mockResolvedValue({ locale: 'en' })
+		};
+		const callbackCtx = {
+			runMutation: vi.fn(async (_reference: unknown, args: Record<string, unknown>) => {
+				if ('verificationUrl' in args) {
+					return await sendVerificationEmail._handler(mutationCtx, args);
+				}
+				return await sendResetPasswordEmail._handler(mutationCtx, args);
+			})
+		};
+		const options = createAuthOptions(callbackCtx as never);
+		const auth = betterAuth({
+			baseURL: 'https://example.test',
+			secret: 'test-secret-that-is-long-enough-for-signing',
+			database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+			emailAndPassword: options.emailAndPassword,
+			emailVerification: options.emailVerification
+		});
+
+		await auth.api.signUpEmail({ body: credentials });
+		enqueue.mockClear();
+		callbackCtx.runMutation.mockClear();
+		vi.stubEnv('AUTH_EMAIL', 'malformed-sender');
+
+		await expect(
+			sendVerificationEmail._handler(
+				{},
+				{
+					email: credentials.email,
+					verificationUrl: 'https://example.test/verify'
+				}
+			)
+		).rejects.toBeInstanceOf(CapabilityConfigurationError);
+		await expect(
+			sendResetPasswordEmail._handler(
+				{},
+				{
+					email: credentials.email,
+					resetUrl: 'https://example.test/reset',
+					userId: 'user_1'
+				}
+			)
+		).rejects.toBeInstanceOf(CapabilityConfigurationError);
+
+		const callbackUser = {
+			id: 'user_1',
+			email: credentials.email,
+			name: credentials.name
+		} as never;
+		await expect(
+			options.emailVerification.sendVerificationEmail({
+				user: callbackUser,
+				url: 'https://example.test/verify',
+				token: 'token'
+			})
+		).rejects.toBeInstanceOf(CapabilityConfigurationError);
+		await expect(
+			options.emailAndPassword.sendResetPassword({
+				user: callbackUser,
+				url: 'https://example.test/reset',
+				token: 'token'
+			})
+		).rejects.toBeInstanceOf(CapabilityConfigurationError);
+
+		const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+		await expect(
+			auth.api.sendVerificationEmail({ body: { email: credentials.email } })
+		).rejects.toThrow();
+		const resetResult = await auth.api.requestPasswordReset({
+			body: { email: credentials.email, redirectTo: '/reset-password' }
+		});
+
+		expect(resetResult.status).toBe(true);
+		await vi.waitFor(() => expect(errorLog).toHaveBeenCalled());
+		expect(enqueue).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/convex/__tests__/autumn.test.ts
+++ b/src/lib/convex/__tests__/autumn.test.ts
@@ -1,12 +1,35 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../env', () => ({
-	requireEnv: vi.fn(() => 'sk_test')
+const { PUBLISHED_ACTION_NAMES, autumnSdkConstruction, check, trackSdk } = vi.hoisted(() => ({
+	PUBLISHED_ACTION_NAMES: [
+		'track',
+		'cancel',
+		'query',
+		'attach',
+		'check',
+		'checkout',
+		'usage',
+		'setupPayment',
+		'createCustomer',
+		'listProducts',
+		'billingPortal',
+		'createReferralCode',
+		'redeemReferralCode',
+		'createEntity',
+		'getEntity'
+	] as const,
+	autumnSdkConstruction: vi.fn(),
+	check: vi.fn(),
+	trackSdk: vi.fn()
 }));
 
 vi.mock('../auth', () => ({
 	authComponent: {
-		getAuthUser: vi.fn()
+		getAuthUser: vi.fn().mockResolvedValue({
+			_id: 'user_1',
+			name: 'Test User',
+			email: 'user@example.com'
+		})
 	}
 }));
 
@@ -17,34 +40,109 @@ vi.mock('../_generated/api', () => ({
 
 vi.mock('@useautumn/convex', () => ({
 	Autumn: class {
+		options: { identify: (ctx: unknown) => unknown; secretKey: string; url?: string };
+
+		constructor(
+			_publicComponent: unknown,
+			options: { identify: (ctx: unknown) => unknown; secretKey: string; url?: string }
+		) {
+			this.options = options;
+		}
+
+		async getAuthParams(_args?: unknown) {
+			autumnSdkConstruction(this.options.secretKey);
+			return { autumn: {}, identifierOpts: {} };
+		}
+
 		api() {
-			return {};
+			return Object.fromEntries(
+				PUBLISHED_ACTION_NAMES.map((name) => [
+					name,
+					{
+						_handler: async (ctx: unknown) => {
+							await this.getAuthParams({ ctx });
+							return null;
+						}
+					}
+				])
+			);
 		}
 	}
 }));
 
-const check = vi.fn();
-const track = vi.fn();
-
-// The autumn-js factory only runs when getAutumnSdk() dynamically
-// imports it inside a test, so the mocks above are initialized by then
 vi.mock('autumn-js', () => ({
 	Autumn: class {
 		check = check;
-		track = track;
+		track = trackSdk;
+
+		constructor(options: { secretKey: string }) {
+			autumnSdkConstruction(options.secretKey);
+		}
 	}
 }));
 
-import { checkAndCountUsage, refundUsage } from '../autumn';
+import * as autumnModule from '../autumn';
+import { checkAndCountUsage, getAutumnSdk, refundUsage } from '../autumn';
 
-// checkAndCountUsage wraps Autumn's atomic check-with-send_event. The
-// outcome mapping is the single place that decides between counted,
-// denied, and fail-open behavior for every metered feature, so each
-// branch is pinned here. Call sites only branch on the outcome
-// (covered in messages.test.ts and createAIResponse.test.ts).
+function setReadyBilling() {
+	vi.stubEnv('AUTUMN_SECRET_KEY', 'configured-autumn-key');
+}
+
+function registeredAction(value: unknown) {
+	return value as { _handler: (ctx: unknown, args: unknown) => Promise<unknown> };
+}
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe('published Autumn actions', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('keeps the complete published action surface guarded', async () => {
+		vi.stubEnv('AUTUMN_SECRET_KEY', 'am_sk_local_e2e_dummy');
+
+		for (const name of PUBLISHED_ACTION_NAMES) {
+			await expect(registeredAction(autumnModule[name])._handler({}, {})).rejects.toThrow(
+				'[capability] billing is misconfigured'
+			);
+		}
+
+		expect(autumnSdkConstruction).not.toHaveBeenCalled();
+	});
+
+	it('constructs autumn-js only after a ready action reaches getAuthParams', async () => {
+		setReadyBilling();
+
+		await registeredAction(autumnModule.check)._handler({}, {});
+
+		expect(autumnSdkConstruction).toHaveBeenCalledTimes(1);
+		expect(autumnSdkConstruction).toHaveBeenCalledWith('configured-autumn-key');
+	});
+});
+
+describe('getAutumnSdk', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it.each([
+		{ state: 'disabled' as const },
+		{ state: 'misconfigured' as const, issue: 'missing' as const }
+	])('does not import or construct the SDK for $state configuration', async (configuration) => {
+		await expect(getAutumnSdk(configuration)).rejects.toThrow(
+			`[capability] billing is ${configuration.state}`
+		);
+		expect(autumnSdkConstruction).not.toHaveBeenCalled();
+	});
+});
+
 describe('checkAndCountUsage', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		setReadyBilling();
 	});
 
 	it('sends an atomic check and maps allowed to counted', async () => {
@@ -64,26 +162,38 @@ describe('checkAndCountUsage', () => {
 	it('maps a definitive not-allowed response to denied', async () => {
 		check.mockResolvedValue({ data: { allowed: false } });
 
-		const outcome = await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages' });
-
-		expect(outcome).toBe('denied');
+		expect(await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages' })).toBe(
+			'denied'
+		);
 	});
 
-	it('maps a missing data payload (non-2xx response) to unavailable', async () => {
+	it('fails closed without SDK construction when billing is misconfigured', async () => {
+		vi.stubEnv('AUTUMN_SECRET_KEY', 'am_sk_local_e2e_dummy');
+
+		expect(await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages' })).toBe(
+			'denied'
+		);
+		expect(autumnSdkConstruction).not.toHaveBeenCalled();
+		expect(check).not.toHaveBeenCalled();
+	});
+
+	it('maps a missing data payload after a ready attempt to unavailable', async () => {
 		check.mockResolvedValue({ data: null });
 
-		const outcome = await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages' });
-
-		expect(outcome).toBe('unavailable');
+		expect(await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages' })).toBe(
+			'unavailable'
+		);
+		expect(autumnSdkConstruction).toHaveBeenCalledTimes(1);
 	});
 
-	it('maps a thrown network error to unavailable', async () => {
+	it('maps a thrown provider error after a ready attempt to unavailable', async () => {
 		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		check.mockRejectedValue(new Error('network down'));
 
-		const outcome = await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages' });
-
-		expect(outcome).toBe('unavailable');
+		expect(await checkAndCountUsage({ customerId: 'user_1', featureId: 'messages' })).toBe(
+			'unavailable'
+		);
+		expect(autumnSdkConstruction).toHaveBeenCalledTimes(1);
 		warn.mockRestore();
 	});
 
@@ -99,29 +209,30 @@ describe('checkAndCountUsage', () => {
 describe('refundUsage', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		setReadyBilling();
 	});
 
 	it('credits the balance with a negative track value', async () => {
-		track.mockResolvedValue({ data: {} });
+		trackSdk.mockResolvedValue({ data: {} });
 
 		await refundUsage({ customerId: 'user_1', featureId: 'ai_chat_messages' });
 
-		expect(track).toHaveBeenCalledWith({
+		expect(trackSdk).toHaveBeenCalledWith({
 			customer_id: 'user_1',
 			feature_id: 'ai_chat_messages',
 			value: -1
 		});
 	});
 
-	it('never throws: a failed refund is logged, not propagated', async () => {
+	it('never throws when a refund fails', async () => {
 		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
-		track.mockRejectedValue(new Error('network down'));
+		trackSdk.mockRejectedValue(new Error('network down'));
 
 		await expect(
 			refundUsage({ customerId: 'user_1', featureId: 'ai_chat_messages', value: 2 })
 		).resolves.toBeUndefined();
 
-		expect(track).toHaveBeenCalledWith(expect.objectContaining({ value: -2 }));
+		expect(trackSdk).toHaveBeenCalledWith(expect.objectContaining({ value: -2 }));
 		error.mockRestore();
 	});
 });

--- a/src/lib/convex/__tests__/messages.test.ts
+++ b/src/lib/convex/__tests__/messages.test.ts
@@ -11,6 +11,10 @@ vi.mock('../autumn', () => ({
 	checkAndCountUsage: vi.fn()
 }));
 
+vi.mock('../env', () => ({
+	requireBillingConfiguration: vi.fn(() => ({ secretKey: 'configured' }))
+}));
+
 vi.mock('../rateLimit', () => ({
 	appRateLimiter: {
 		limit: vi.fn().mockResolvedValue({ ok: true, retryAfter: 0 })
@@ -30,11 +34,13 @@ vi.mock('../_generated/api', () => ({
 import { authComponent } from '../auth';
 import { checkAndCountUsage } from '../autumn';
 import { appRateLimiter } from '../rateLimit';
+import { requireBillingConfiguration } from '../env';
 import { enforceAndTrackMessageUsage, removeMessage, send } from '../messages';
 
 const getAuthUserMock = authComponent.getAuthUser as unknown as ReturnType<typeof vi.fn>;
 const checkAndCountUsageMock = checkAndCountUsage as unknown as ReturnType<typeof vi.fn>;
 const limitMock = appRateLimiter.limit as unknown as ReturnType<typeof vi.fn>;
+const requireBillingMock = requireBillingConfiguration as unknown as ReturnType<typeof vi.fn>;
 
 type RegisteredFunction<TArgs, TResult> = {
 	_handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
@@ -124,6 +130,22 @@ describe('send', () => {
 		vi.clearAllMocks();
 		getAuthUserMock.mockResolvedValue({ _id: 'user_1' });
 		limitMock.mockResolvedValue({ ok: true, retryAfter: 0 });
+	});
+
+	it('does not save or schedule a message without ready billing configuration', async () => {
+		requireBillingMock.mockImplementationOnce(() => {
+			throw new Error('[capability] billing is misconfigured');
+		});
+		const insert = vi.fn();
+		const runAfter = vi.fn();
+		const ctx = { db: { insert }, scheduler: { runAfter } };
+
+		await expect(sendHandler._handler(ctx, { body: 'hello' })).rejects.toThrow(
+			'[capability] billing is misconfigured'
+		);
+		expect(limitMock).not.toHaveBeenCalled();
+		expect(insert).not.toHaveBeenCalled();
+		expect(runAfter).not.toHaveBeenCalled();
 	});
 
 	it('rejects with a structured error when the rate limit is exhausted', async () => {

--- a/src/lib/convex/admin/support/__tests__/mutations.test.ts
+++ b/src/lib/convex/admin/support/__tests__/mutations.test.ts
@@ -71,22 +71,25 @@ function makeCtx({
 	hasUnreadAdminReply?: boolean;
 	unreadAdminReplyCount?: number;
 } = {}) {
+	const supportThread: Record<string, unknown> = {
+		_id: 'st_1',
+		threadId: 't1',
+		assignedTo: undefined,
+		notificationEmail,
+		notificationSentAt: undefined,
+		hasUnreadAdminReply,
+		unreadAdminReplyCount
+	};
 	return {
 		db: {
 			query: vi.fn(() => ({
 				withIndex: vi.fn(() => ({
-					first: vi.fn().mockResolvedValue({
-						_id: 'st_1',
-						threadId: 't1',
-						assignedTo: undefined,
-						notificationEmail,
-						notificationSentAt: undefined,
-						hasUnreadAdminReply,
-						unreadAdminReplyCount
-					})
+					first: vi.fn().mockResolvedValue(supportThread)
 				}))
 			})),
-			patch: vi.fn()
+			patch: vi.fn(async (_id: string, patch: Record<string, unknown>) => {
+				Object.assign(supportThread, patch);
+			})
 		},
 		scheduler: { runAfter: vi.fn() }
 	};
@@ -196,7 +199,28 @@ describe('sendAdminReply', () => {
 		expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(
 			0,
 			'internal.emails.send.sendAdminReplyNotification',
-			expect.objectContaining({ messagePreview: `${'a'.repeat(199)}…` })
+			expect.objectContaining({
+				supportThreadId: 'st_1',
+				messagePreview: `${'a'.repeat(199)}…`
+			})
 		);
+		expect(ctx.db.patch.mock.calls[0][1]).not.toHaveProperty('notificationSentAt');
+	});
+
+	it('does not suppress a later reply before a notification enqueue commits', async () => {
+		shouldSendNotificationMock.mockImplementation(
+			(email: string | undefined, sentAt: number | undefined) => Boolean(email) && !sentAt
+		);
+		const ctx = makeCtx({ notificationEmail: 'user@example.com' });
+
+		await replyHandler._handler(ctx, { threadId: 't1', prompt: 'first reply' });
+		await replyHandler._handler(ctx, { threadId: 't1', prompt: 'second reply' });
+
+		const emailSchedules = ctx.scheduler.runAfter.mock.calls.filter(
+			(call) => call[1] === 'internal.emails.send.sendAdminReplyNotification'
+		);
+		expect(emailSchedules).toHaveLength(2);
+		expect(ctx.db.patch.mock.calls[0][1]).not.toHaveProperty('notificationSentAt');
+		expect(ctx.db.patch.mock.calls[1][1]).not.toHaveProperty('notificationSentAt');
 	});
 });

--- a/src/lib/convex/admin/support/mutations.ts
+++ b/src/lib/convex/admin/support/mutations.ts
@@ -253,7 +253,8 @@ export const sendAdminReply = adminMutation({
 			? (supportThread.unreadAdminReplyCount ?? 1) + 1
 			: 1;
 
-		// Update thread: response status, assignment, and notification timestamp
+		// Update the reply state. The scheduled email mutation owns the cooldown
+		// timestamp so only a committed provider enqueue can consume it.
 		await ctx.db.patch(supportThread._id, {
 			awaitingAdminResponse: false, // Admin has responded, user is no longer waiting
 			lastAdminReplyAt: replyTimestamp,
@@ -261,13 +262,13 @@ export const sendAdminReply = adminMutation({
 			hasUnreadAdminReply: true,
 			unreadAdminReplyCount,
 			updatedAt: replyTimestamp,
-			...(shouldAutoAssign && { assignedTo: ctx.user._id }),
-			...(shouldNotify && { notificationSentAt: replyTimestamp })
+			...(shouldAutoAssign && { assignedTo: ctx.user._id })
 		});
 
 		// Schedule notification email (async - doesn't block response)
 		if (shouldNotify && supportThread.notificationEmail) {
 			await ctx.scheduler.runAfter(0, internal.emails.send.sendAdminReplyNotification, {
+				supportThreadId: supportThread._id,
 				email: supportThread.notificationEmail,
 				adminName,
 				messagePreview: emailReplyPreview(args.prompt),

--- a/src/lib/convex/admin/support/notifications.test.ts
+++ b/src/lib/convex/admin/support/notifications.test.ts
@@ -1,6 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 
-import { scheduleAdminNotification } from './notifications';
+vi.mock('../../emails/resend', () => ({
+	getEmailDeliveryConfiguration: vi.fn(() => ({
+		state: 'ready',
+		value: {
+			apiKey: 'configured',
+			sender: 'sender@example.com',
+			assetUrl: 'https://assets.example.com'
+		}
+	}))
+}));
+
+import { getEmailDeliveryConfiguration } from '../../emails/resend';
+import { scheduleAdminNotification, sendPendingAdminNotification } from './notifications';
 
 /**
  * Handler-level unit test (the codebase idiom): the Convex fn exposes its
@@ -23,6 +35,13 @@ const scheduleAdminNotificationH = scheduleAdminNotification as unknown as Fn<
 		notificationType: 'newTickets' | 'userReplies';
 	},
 	null
+>;
+const sendPendingAdminNotificationH = sendPendingAdminNotification as unknown as Fn<
+	{ notificationId: string },
+	null
+>;
+const getEmailConfigurationMock = getEmailDeliveryConfiguration as unknown as ReturnType<
+	typeof vi.fn
 >;
 
 function createCtx() {
@@ -65,6 +84,18 @@ function createCtx() {
 }
 
 describe('scheduleAdminNotification', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getEmailConfigurationMock.mockReturnValue({
+			state: 'ready',
+			value: {
+				apiKey: 'configured',
+				sender: 'sender@example.com',
+				assetUrl: 'https://assets.example.com'
+			}
+		});
+	});
+
 	it('creates a pending row and schedules the send with no messages (bare handoff)', async () => {
 		const { ctx, rows, runAfter } = createCtx();
 
@@ -90,4 +121,56 @@ describe('scheduleAdminNotification', () => {
 		// The scheduled send targets the row we just created.
 		expect(runAfter.mock.calls[0][2]).toEqual({ notificationId: rows[0]._id });
 	});
+
+	it.each(['disabled', 'misconfigured'] as const)(
+		'does not create pending work when email is %s',
+		async (state) => {
+			getEmailConfigurationMock.mockReturnValue(
+				state === 'disabled' ? { state } : { state, issue: 'missing' }
+			);
+			const { ctx, rows, runAfter } = createCtx();
+
+			await scheduleAdminNotificationH._handler(ctx, {
+				threadId: 'thread_1',
+				messageIds: ['message_1'],
+				isReopen: false,
+				notificationType: 'newTickets'
+			});
+
+			expect(rows).toHaveLength(0);
+			expect(runAfter).not.toHaveBeenCalled();
+		}
+	);
+});
+
+describe('sendPendingAdminNotification', () => {
+	it.each(['disabled', 'misconfigured'] as const)(
+		'deletes a claimed row without queries, sends, or retries when email is %s',
+		async (state) => {
+			getEmailConfigurationMock.mockReturnValue(
+				state === 'disabled' ? { state } : { state, issue: 'missing' }
+			);
+			const notification = {
+				threadId: 'thread_1',
+				messageIds: ['message_1'],
+				isReopen: false,
+				notificationType: 'newTickets',
+				retryCount: 0
+			};
+			const runMutation = vi.fn().mockResolvedValueOnce(notification).mockResolvedValueOnce(true);
+			const runQuery = vi.fn();
+
+			expect(
+				await sendPendingAdminNotificationH._handler(
+					{ runMutation, runQuery },
+					{ notificationId: 'notification_1' }
+				)
+			).toBeNull();
+			expect(runMutation).toHaveBeenCalledTimes(2);
+			expect(runMutation.mock.calls[1][1]).toEqual({
+				notificationId: 'notification_1'
+			});
+			expect(runQuery).not.toHaveBeenCalled();
+		}
+	);
 });

--- a/src/lib/convex/admin/support/notifications.ts
+++ b/src/lib/convex/admin/support/notifications.ts
@@ -22,6 +22,7 @@ import { internalMutation, internalAction, internalQuery } from '../../_generate
 import { internal, components } from '../../_generated/api';
 import { supportThreadFields } from '../../support/supportThreadFields';
 import { isPreviewAdminEmail } from '../notificationPreferences/helpers';
+import { getEmailDeliveryConfiguration } from '../../emails/resend';
 
 /** Delay before sending a notification after the latest message. */
 const NOTIFICATION_DELAY_MS = 4 * 60 * 1000;
@@ -54,6 +55,8 @@ export const scheduleAdminNotification = internalMutation({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
+		if (getEmailDeliveryConfiguration().state !== 'ready') return null;
+
 		// A handoff with no prior user messages (a bare "Talk to a human") still
 		// notifies admins. Downstream the email renders a no-messages fallback line
 		// instead of message excerpts.
@@ -168,6 +171,13 @@ export const sendPendingAdminNotification = internalAction({
 			return null;
 		}
 
+		if (getEmailDeliveryConfiguration().state !== 'ready') {
+			await ctx.runMutation(internal.admin.support.notifications.deletePendingNotification, {
+				notificationId: args.notificationId
+			});
+			return null;
+		}
+
 		// Get support thread data
 		const supportThread = await ctx.runQuery(
 			internal.admin.support.notifications.getSupportThread,
@@ -216,18 +226,21 @@ export const sendPendingAdminNotification = internalAction({
 		let sentCount = 0;
 		for (const email of targetEmails) {
 			try {
-				await ctx.runMutation(internal.emails.send.sendNewTicketAdminNotification, {
-					email,
-					isReopen: notification.isReopen,
-					// A handoff with no accumulated messages is a bare "Talk to a human",
-					// so the email's empty-state line names the handoff instead of the
-					// neutral "no messages" shared with reopen/reply notifications.
-					isBareHandoff: notification.messageIds.length === 0,
-					userName: supportThread.userName || 'Anonymous',
-					messages,
-					threadId: notification.threadId
-				});
-				sentCount++;
+				const enqueued = await ctx.runMutation(
+					internal.emails.send.sendNewTicketAdminNotification,
+					{
+						email,
+						isReopen: notification.isReopen,
+						// A handoff with no accumulated messages is a bare "Talk to a human",
+						// so the email's empty-state line names the handoff instead of the
+						// neutral "no messages" shared with reopen/reply notifications.
+						isBareHandoff: notification.messageIds.length === 0,
+						userName: supportThread.userName || 'Anonymous',
+						messages,
+						threadId: notification.threadId
+					}
+				);
+				if (enqueued) sentCount++;
 			} catch (error) {
 				// Log error but continue to other recipients
 				console.error(
@@ -235,6 +248,15 @@ export const sendPendingAdminNotification = internalAction({
 					error instanceof Error ? error.message : error
 				);
 			}
+		}
+
+		// If configuration changed while recipient sends were running, finish the
+		// claimed row instead of retrying work that cannot reach the provider.
+		if (sentCount === 0 && getEmailDeliveryConfiguration().state !== 'ready') {
+			await ctx.runMutation(internal.admin.support.notifications.deletePendingNotification, {
+				notificationId: args.notificationId
+			});
+			return null;
 		}
 
 		// If all sends failed, reschedule for retry (up to MAX_RETRY_COUNT attempts)

--- a/src/lib/convex/aiChat/__tests__/createAIResponse.test.ts
+++ b/src/lib/convex/aiChat/__tests__/createAIResponse.test.ts
@@ -12,8 +12,18 @@ vi.mock('../../autumn', () => ({
 	refundUsage: vi.fn().mockResolvedValue(undefined)
 }));
 
+vi.mock('../../env', () => {
+	class CapabilityConfigurationError extends Error {}
+	return {
+		CapabilityConfigurationError,
+		requireAiConfiguration: vi.fn(() => ({ apiKey: 'configured' })),
+		requireBillingConfiguration: vi.fn(() => ({ secretKey: 'configured' }))
+	};
+});
+
 vi.mock('../agent', () => ({
 	aiChatAgent: {
+		saveMessage: vi.fn(),
 		streamText: vi.fn()
 	}
 }));
@@ -57,14 +67,26 @@ vi.mock('../../_generated/api', () => ({
 }));
 
 import { checkAndCountUsage, refundUsage } from '../../autumn';
+import {
+	CapabilityConfigurationError,
+	requireAiConfiguration,
+	requireBillingConfiguration
+} from '../../env';
+import { authComponent } from '../../auth';
 import { saveMessage } from '@convex-dev/agent';
 import { aiChatAgent } from '../agent';
-import { createAIResponse } from '../messages';
+import { requireAiChatThreadRecord } from '../ownership';
+import { createAIResponse, sendMessage } from '../messages';
 
 const checkAndCountUsageMock = checkAndCountUsage as unknown as ReturnType<typeof vi.fn>;
 const refundUsageMock = refundUsage as unknown as ReturnType<typeof vi.fn>;
 const saveMessageMock = saveMessage as unknown as ReturnType<typeof vi.fn>;
 const streamTextMock = aiChatAgent.streamText as unknown as ReturnType<typeof vi.fn>;
+const agentSaveMessageMock = aiChatAgent.saveMessage as unknown as ReturnType<typeof vi.fn>;
+const requireAiMock = requireAiConfiguration as unknown as ReturnType<typeof vi.fn>;
+const requireBillingMock = requireBillingConfiguration as unknown as ReturnType<typeof vi.fn>;
+const requireThreadMock = requireAiChatThreadRecord as unknown as ReturnType<typeof vi.fn>;
+const getAuthUserMock = authComponent.getAuthUser as unknown as ReturnType<typeof vi.fn>;
 
 type RegisteredFunction<TArgs> = {
 	_handler: (ctx: unknown, args: TArgs) => Promise<unknown>;
@@ -88,6 +110,8 @@ describe('createAIResponse', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		requireAiMock.mockReturnValue({ apiKey: 'configured' });
+		requireBillingMock.mockReturnValue({ secretKey: 'configured' });
 		refundUsageMock.mockResolvedValue(undefined);
 		saveMessageMock.mockResolvedValue({ messageId: 'notice_1' });
 		runMutation = vi.fn().mockResolvedValue(null);
@@ -116,6 +140,41 @@ describe('createAIResponse', () => {
 			}
 		});
 		warn.mockRestore();
+	});
+
+	it('persists a terminal notice when queued work loses provider configuration', async () => {
+		requireAiMock.mockImplementationOnce(() => {
+			throw new CapabilityConfigurationError('ai', 'misconfigured');
+		});
+
+		await handler._handler(ctx, args);
+
+		expect(checkAndCountUsageMock).not.toHaveBeenCalled();
+		expect(streamTextMock).not.toHaveBeenCalled();
+		expect(saveMessageMock).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.objectContaining({
+				threadId: 'thread_1',
+				message: { role: 'assistant', content: expect.stringContaining('AI is unavailable') }
+			})
+		);
+	});
+
+	it('refunds and terminates if AI is lost after billing succeeds', async () => {
+		checkAndCountUsageMock.mockResolvedValue('counted');
+		requireAiMock.mockReturnValueOnce({ apiKey: 'configured' }).mockImplementationOnce(() => {
+			throw new CapabilityConfigurationError('ai', 'misconfigured');
+		});
+
+		await handler._handler(ctx, args);
+
+		expect(refundUsageMock).toHaveBeenCalledWith({
+			customerId: 'user_1',
+			featureId: 'ai_chat_messages'
+		});
+		expect(streamTextMock).not.toHaveBeenCalled();
+		expect(saveMessageMock).toHaveBeenCalled();
 	});
 
 	it('generates and keeps the counted unit on success', async () => {
@@ -167,10 +226,51 @@ describe('createAIResponse', () => {
 		expect(refundUsageMock).not.toHaveBeenCalled();
 	});
 
-	it('skips billing entirely without a userId', async () => {
+	it('skips entitlement lookup without a userId after static configuration passes', async () => {
 		await handler._handler(ctx, { threadId: 'thread_1', promptMessageId: 'prompt_1' });
 
+		expect(requireBillingMock).toHaveBeenCalled();
+		expect(requireAiMock).toHaveBeenCalled();
 		expect(checkAndCountUsageMock).not.toHaveBeenCalled();
 		expect(streamTextMock).toHaveBeenCalled();
 	});
+});
+
+describe('sendMessage provider preflight', () => {
+	const sendHandler = sendMessage as unknown as RegisteredFunction<{
+		threadId: string;
+		prompt: string;
+	}>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getAuthUserMock.mockResolvedValue({ _id: 'user_1' });
+		requireThreadMock.mockResolvedValue({
+			_id: 'record_1',
+			isWarm: false,
+			lastMessageAt: undefined
+		});
+		requireAiMock.mockReturnValue({ apiKey: 'configured' });
+		requireBillingMock.mockReturnValue({ secretKey: 'configured' });
+		agentSaveMessageMock.mockResolvedValue({ messageId: 'message_1' });
+	});
+
+	it.each([requireBillingMock, requireAiMock])(
+		'does not save or schedule when a required provider is not ready',
+		async (requireConfiguration) => {
+			requireConfiguration.mockImplementationOnce(() => {
+				throw new CapabilityConfigurationError('ai', 'misconfigured');
+			});
+			const patch = vi.fn();
+			const runAfter = vi.fn();
+			const ctx = { db: { patch }, scheduler: { runAfter } };
+
+			await expect(
+				sendHandler._handler(ctx, { threadId: 'thread_1', prompt: 'hello' })
+			).rejects.toThrow(CapabilityConfigurationError);
+			expect(agentSaveMessageMock).not.toHaveBeenCalled();
+			expect(patch).not.toHaveBeenCalled();
+			expect(runAfter).not.toHaveBeenCalled();
+		}
+	);
 });

--- a/src/lib/convex/aiChat/messages.ts
+++ b/src/lib/convex/aiChat/messages.ts
@@ -17,6 +17,11 @@ import { t } from '../i18n/translations';
 import { AI_CHAT_LIMIT_NOTICE, MAX_MESSAGE_LENGTH } from '../constants';
 import { makeAgentUsageSink } from '../aiUsage/agentUsage';
 import { recordAiUsage } from '../aiUsage/record';
+import {
+	CapabilityConfigurationError,
+	requireAiConfiguration,
+	requireBillingConfiguration
+} from '../env';
 
 const THREAD_PREVIEW_LENGTH = 100;
 
@@ -48,6 +53,9 @@ export const sendMessage = authedMutation({
 			threadId: args.threadId,
 			userId
 		});
+
+		requireBillingConfiguration();
+		requireAiConfiguration();
 
 		// First send in this thread → derive a descriptive title from it. Uses
 		// lastMessageAt (written on every send, never an empty string) rather than
@@ -145,6 +153,39 @@ export const createAIResponse = internalAction({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
+		const saveTerminalNotice = async ({
+			content,
+			notice
+		}: {
+			content: string;
+			notice?: typeof AI_CHAT_LIMIT_NOTICE;
+		}) => {
+			await saveMessage(ctx, components.agent, {
+				threadId: args.threadId,
+				userId: args.userId,
+				message: { role: 'assistant', content },
+				...(notice
+					? {
+							metadata: {
+								provider: 'system',
+								providerMetadata: { system: { notice } }
+							}
+						}
+					: {})
+			});
+		};
+
+		try {
+			requireBillingConfiguration();
+			requireAiConfiguration();
+		} catch (error) {
+			if (!(error instanceof CapabilityConfigurationError)) throw error;
+			await saveTerminalNotice({
+				content: "This reply couldn't be generated because AI is unavailable."
+			});
+			return null;
+		}
+
 		// Direct SDK path with explicit customer_id (no auth context in
 		// internalAction). See: https://github.com/useautumn/autumn-js/issues/51
 		let usageCounted = false;
@@ -158,25 +199,28 @@ export const createAIResponse = internalAction({
 				// Returning without an assistant message strands the client in its
 				// awaiting-stream state. Persist a terminal notice so the turn resolves;
 				// providerMetadata lets the UI replace this fallback with localized copy.
-				await saveMessage(ctx, components.agent, {
-					threadId: args.threadId,
-					userId: args.userId,
-					message: {
-						role: 'assistant',
-						content: "You've reached your message limit, so this reply couldn't be generated."
-					},
-					metadata: {
-						provider: 'system',
-						providerMetadata: {
-							system: { notice: AI_CHAT_LIMIT_NOTICE }
-						}
-					}
+				await saveTerminalNotice({
+					content: "You've reached your message limit, so this reply couldn't be generated.",
+					notice: AI_CHAT_LIMIT_NOTICE
 				});
 				return null;
 			}
 			// 'unavailable' fails open: generate uncounted rather than blocking
 			// a legitimate user on a billing outage
 			usageCounted = outcome === 'counted';
+		}
+
+		try {
+			requireAiConfiguration();
+		} catch (error) {
+			if (!(error instanceof CapabilityConfigurationError)) throw error;
+			if (args.userId && usageCounted) {
+				await refundUsage({ customerId: args.userId, featureId: 'ai_chat_messages' });
+			}
+			await saveTerminalNotice({
+				content: "This reply couldn't be generated because AI is unavailable."
+			});
+			return null;
 		}
 
 		const sink = makeAgentUsageSink();

--- a/src/lib/convex/aiChat/titles.test.ts
+++ b/src/lib/convex/aiChat/titles.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../env', () => {
+	class CapabilityConfigurationError extends Error {}
+	return {
+		CapabilityConfigurationError,
+		requireAiConfiguration: vi.fn(() => ({ apiKey: 'configured' })),
+		requireBillingConfiguration: vi.fn(() => ({ secretKey: 'configured' }))
+	};
+});
+
+const { autumnCheck, generateText, orModel } = vi.hoisted(() => ({
+	autumnCheck: vi.fn(),
+	generateText: vi.fn(),
+	orModel: vi.fn(() => 'model')
+}));
+
+vi.mock('../autumn', () => ({
+	getAutumnSdk: vi.fn(async () => ({ check: autumnCheck }))
+}));
+
+vi.mock('ai', () => ({ generateText }));
+
+vi.mock('../aiUsage/capture', () => ({
+	orModel,
+	captureDirect: vi.fn(() => ({ model: 'model' }))
+}));
+
+vi.mock('../aiUsage/record', () => ({ recordAiUsage: vi.fn() }));
+
+vi.mock('../_generated/api', () => ({
+	internal: {
+		aiChat: {
+			threads: { setThreadTitleIfEmpty: 'internal.aiChat.threads.setThreadTitleIfEmpty' }
+		}
+	}
+}));
+
+import { getAutumnSdk } from '../autumn';
+import {
+	CapabilityConfigurationError,
+	requireAiConfiguration,
+	requireBillingConfiguration
+} from '../env';
+import { generateThreadTitle } from './titles';
+
+const getAutumnSdkMock = getAutumnSdk as unknown as ReturnType<typeof vi.fn>;
+const requireAiMock = requireAiConfiguration as unknown as ReturnType<typeof vi.fn>;
+const requireBillingMock = requireBillingConfiguration as unknown as ReturnType<typeof vi.fn>;
+
+type RegisteredAction = {
+	_handler: (
+		ctx: { runMutation: ReturnType<typeof vi.fn> },
+		args: { threadId: string; prompt: string; userId?: string }
+	) => Promise<null>;
+};
+
+const handler = generateThreadTitle as unknown as RegisteredAction;
+const args = { threadId: 'thread_1', prompt: 'How do I configure billing?', userId: 'user_1' };
+
+describe('generateThreadTitle', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		requireAiMock.mockReturnValue({ apiKey: 'configured' });
+		requireBillingMock.mockReturnValue({ secretKey: 'configured' });
+		getAutumnSdkMock.mockResolvedValue({ check: autumnCheck });
+		autumnCheck.mockResolvedValue({ data: { allowed: true } });
+		generateText.mockResolvedValue({
+			text: 'Configure Billing',
+			usage: {},
+			providerMetadata: {}
+		});
+	});
+
+	it.each([requireBillingMock, requireAiMock])(
+		'skips queued work before SDK, model, or writes when configuration is not ready',
+		async (requireConfiguration) => {
+			requireConfiguration.mockImplementationOnce(() => {
+				throw new CapabilityConfigurationError('ai', 'misconfigured');
+			});
+			const runMutation = vi.fn();
+
+			expect(await handler._handler({ runMutation }, args)).toBeNull();
+			expect(getAutumnSdkMock).not.toHaveBeenCalled();
+			expect(orModel).not.toHaveBeenCalled();
+			expect(generateText).not.toHaveBeenCalled();
+			expect(runMutation).not.toHaveBeenCalled();
+		}
+	);
+
+	it('returns without transport or writes if billing is lost during revalidation', async () => {
+		getAutumnSdkMock.mockRejectedValue(
+			new CapabilityConfigurationError('billing', 'misconfigured')
+		);
+		const runMutation = vi.fn();
+
+		expect(await handler._handler({ runMutation }, args)).toBeNull();
+		expect(generateText).not.toHaveBeenCalled();
+		expect(runMutation).not.toHaveBeenCalled();
+	});
+
+	it('skips model transport if AI is lost after the entitlement check', async () => {
+		requireAiMock.mockReturnValueOnce({ apiKey: 'configured' }).mockImplementationOnce(() => {
+			throw new CapabilityConfigurationError('ai', 'misconfigured');
+		});
+		const runMutation = vi.fn();
+
+		expect(await handler._handler({ runMutation }, args)).toBeNull();
+		expect(autumnCheck).toHaveBeenCalledTimes(1);
+		expect(generateText).not.toHaveBeenCalled();
+		expect(runMutation).not.toHaveBeenCalled();
+	});
+
+	it('skips model transport on a definitive ready-provider entitlement denial', async () => {
+		autumnCheck.mockResolvedValue({ data: { allowed: false } });
+		const runMutation = vi.fn();
+
+		expect(await handler._handler({ runMutation }, args)).toBeNull();
+		expect(getAutumnSdkMock).toHaveBeenCalledTimes(1);
+		expect(generateText).not.toHaveBeenCalled();
+		expect(runMutation).not.toHaveBeenCalled();
+	});
+
+	it('preserves fail-open behavior for a ready-provider unavailable response', async () => {
+		autumnCheck.mockResolvedValue({ data: null });
+		const runMutation = vi.fn().mockResolvedValue(null);
+
+		expect(await handler._handler({ runMutation }, args)).toBeNull();
+		expect(generateText).toHaveBeenCalledTimes(1);
+		expect(runMutation).toHaveBeenCalledWith('internal.aiChat.threads.setThreadTitleIfEmpty', {
+			threadId: 'thread_1',
+			title: 'Configure Billing'
+		});
+	});
+});

--- a/src/lib/convex/aiChat/titles.ts
+++ b/src/lib/convex/aiChat/titles.ts
@@ -6,6 +6,11 @@ import { TITLE_MODEL_ID } from '../utils/chatModel';
 import { getAutumnSdk } from '../autumn';
 import { orModel, captureDirect } from '../aiUsage/capture';
 import { recordAiUsage } from '../aiUsage/record';
+import {
+	CapabilityConfigurationError,
+	requireAiConfiguration,
+	requireBillingConfiguration
+} from '../env';
 
 // Clamp the stored title; the sidebar span also CSS-truncates for display.
 const MAX_TITLE_LENGTH = 60;
@@ -38,15 +43,35 @@ export const generateThreadTitle = internalAction({
 		const source = args.prompt.trim().slice(0, MAX_PROMPT_CHARS);
 		if (!source) return null;
 
+		try {
+			requireBillingConfiguration();
+			requireAiConfiguration();
+		} catch (error) {
+			if (error instanceof CapabilityConfigurationError) return null;
+			throw error;
+		}
+
 		// Billing gate (check only): skip when the user is out of AI chat
-		// allowance, matching createAIResponse. Autumn fails open on 5xx/network.
+		// allowance, matching createAIResponse. A missing data response fails open.
 		if (args.userId) {
-			const sdk = await getAutumnSdk();
-			const checkResult = await sdk.check({
-				customer_id: args.userId,
-				feature_id: 'ai_chat_messages'
-			});
-			if (checkResult.data && !checkResult.data.allowed) return null;
+			try {
+				const sdk = await getAutumnSdk();
+				const checkResult = await sdk.check({
+					customer_id: args.userId,
+					feature_id: 'ai_chat_messages'
+				});
+				if (checkResult.data && !checkResult.data.allowed) return null;
+			} catch (error) {
+				if (error instanceof CapabilityConfigurationError) return null;
+				throw error;
+			}
+		}
+
+		try {
+			requireAiConfiguration();
+		} catch (error) {
+			if (error instanceof CapabilityConfigurationError) return null;
+			throw error;
 		}
 
 		let raw: string;

--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -12,7 +12,7 @@ import { betterAuth, type BetterAuthOptions } from 'better-auth';
 import { createAuthMiddleware } from 'better-auth/api';
 import authSchema from './betterAuth/schema';
 import authConfig from './auth.config';
-import { requireEnv, googleOAuth, githubOAuth } from './env';
+import { requireEmailConfiguration, requireEnv, googleOAuth, githubOAuth } from './env';
 import { getFounderWelcomeDelay } from './emails/helpers';
 import { incrementCounter } from './admin/counters';
 import { DISABLED_ADMIN_PATHS } from './admin/adminHttpPaths';
@@ -366,6 +366,11 @@ function buildTrustedOrigins(): string[] {
 // its own policy.
 const JWKS_PATH = '/convex/jwks';
 const JWKS_CACHE_CONTROL = 'public, max-age=60, must-revalidate';
+const EMAIL_CAPABILITY_PREFLIGHT_PATHS = new Set([
+	'/sign-up/email',
+	'/request-password-reset',
+	'/send-verification-email'
+]);
 
 // Creates Better Auth options object (used by adapter and betterAuth CLI).
 // Typed via `satisfies` (not a return annotation) so the concrete plugin
@@ -450,6 +455,13 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>) => {
 			}
 		},
 		hooks: {
+			// Better Auth runs some email callbacks in the background after committing
+			// user or verification state. Reject email-producing routes before their
+			// handlers can write when the complete delivery group is unavailable.
+			before: createAuthMiddleware(async (ctx) => {
+				if (!EMAIL_CAPABILITY_PREFLIGHT_PATHS.has(ctx.path)) return;
+				requireEmailConfiguration();
+			}),
 			// The key set is identical for every caller, so consumers may use their own
 			// HTTP cache instead of reloading before every verification. The 60-second
 			// value bounds normal copy freshness and is not a revocation deadline. A newly

--- a/src/lib/convex/autumn.ts
+++ b/src/lib/convex/autumn.ts
@@ -1,12 +1,19 @@
 import { Autumn } from '@useautumn/convex';
 import { components } from './_generated/api';
 import { authComponent } from './auth';
-import { requireEnv } from './env';
+import type { BillingConfiguration, CapabilityConfiguration } from '../dev/features';
+import { CapabilityConfigurationError, requireBillingConfiguration } from './env';
 
-const secretKey = requireEnv('AUTUMN_SECRET_KEY', { feature: 'billing & checkout' });
+class GuardedAutumn extends Autumn {
+	override async getAuthParams(args: Parameters<Autumn['getAuthParams']>[0]) {
+		this.options.secretKey = requireBillingConfiguration().secretKey;
+		return await super.getAuthParams(args);
+	}
+}
 
-export const autumn = new Autumn(components.autumn, {
-	secretKey,
+export const autumn = new GuardedAutumn(components.autumn, {
+	// The wrapper does not construct autumn-js until guarded getAuthParams runs.
+	secretKey: '',
 	identify: async (ctx: Parameters<typeof authComponent.getAuthUser>[0]) => {
 		// Get the authenticated user from Better Auth
 		const user = await authComponent.getAuthUser(ctx);
@@ -48,7 +55,8 @@ export const {
  * Pass explicit customer_id to check/track methods.
  * See: https://github.com/useautumn/autumn-js/issues/51
  */
-export async function getAutumnSdk() {
+export async function getAutumnSdk(configuration?: CapabilityConfiguration<BillingConfiguration>) {
+	const { secretKey } = requireBillingConfiguration(configuration);
 	const { Autumn: AutumnSDK } = await import('autumn-js');
 	return new AutumnSDK({ secretKey });
 }
@@ -71,11 +79,12 @@ export type UsageCheckOutcome = 'counted' | 'denied' | 'unavailable';
  * Outcomes:
  * - 'counted': access granted, `value` units were deducted. The usage
  *   is recorded; no separate track call must follow.
- * - 'denied': access denied, nothing was deducted.
- * - 'unavailable': Autumn errored (the SDK returns `data: null` on a
- *   non-2xx response and throws on network failures). Nothing was
- *   deducted. Callers fail open: grant access uncounted rather than
- *   punishing legitimate users for a billing outage.
+ * - 'denied': access denied or billing is not structurally ready;
+ *   nothing was deducted. Configuration failures fail closed.
+ * - 'unavailable': a structurally ready Autumn attempt errored (the SDK
+ *   returns `data: null` on a non-2xx response and throws on network
+ *   failures). Nothing was deducted. Callers fail open rather than
+ *   punishing legitimate users for a provider outage.
  *
  * Only valid for metered features with a usage amount known up front
  * (Autumn rejects `send_event` for boolean features and publishable
@@ -91,9 +100,9 @@ export async function checkAndCountUsage({
 	featureId: string;
 	value?: number;
 }): Promise<UsageCheckOutcome> {
-	const sdk = await getAutumnSdk();
 	let result;
 	try {
+		const sdk = await getAutumnSdk();
 		result = await sdk.check({
 			customer_id: customerId,
 			feature_id: featureId,
@@ -102,6 +111,7 @@ export async function checkAndCountUsage({
 			send_event: true
 		});
 	} catch (error) {
+		if (error instanceof CapabilityConfigurationError) return 'denied';
 		console.warn(`[checkAndCountUsage] Autumn unreachable for ${featureId}:`, error);
 		return 'unavailable';
 	}

--- a/src/lib/convex/emails/__tests__/passwordResetTemplate.test.ts
+++ b/src/lib/convex/emails/__tests__/passwordResetTemplate.test.ts
@@ -14,7 +14,7 @@ describe('renderPasswordResetEmail', () => {
 	beforeAll(() => {
 		vi.stubEnv('RESEND_API_KEY', 'configured-resend-key');
 		vi.stubEnv('AUTH_EMAIL', 'sender@example.com');
-		vi.stubEnv('EMAIL_ASSET_URL', '  https://assets.example.test/email  ');
+		vi.stubEnv('EMAIL_ASSET_URL', '  https://assets.example.com/email  ');
 	});
 	afterAll(() => {
 		vi.unstubAllEnvs();
@@ -30,8 +30,8 @@ describe('renderPasswordResetEmail', () => {
 
 	it('renders the trimmed validated asset URL', () => {
 		const { html } = renderPasswordResetEmail(url, undefined, 'en', true);
-		expect(html).toContain('https://assets.example.test/email');
-		expect(html).not.toContain('  https://assets.example.test/email  ');
+		expect(html).toContain('https://assets.example.com/email');
+		expect(html).not.toContain('  https://assets.example.com/email  ');
 	});
 
 	it('reports a reset for an account that has a password', () => {

--- a/src/lib/convex/emails/__tests__/passwordResetTemplate.test.ts
+++ b/src/lib/convex/emails/__tests__/passwordResetTemplate.test.ts
@@ -12,7 +12,9 @@ describe('renderPasswordResetEmail', () => {
 	// The renderer resolves asset URLs from the Convex environment, which a unit
 	// run does not have.
 	beforeAll(() => {
-		vi.stubEnv('EMAIL_ASSET_URL', 'https://assets.example.test');
+		vi.stubEnv('RESEND_API_KEY', 'configured-resend-key');
+		vi.stubEnv('AUTH_EMAIL', 'sender@example.com');
+		vi.stubEnv('EMAIL_ASSET_URL', '  https://assets.example.test/email  ');
 	});
 	afterAll(() => {
 		vi.unstubAllEnvs();
@@ -25,6 +27,12 @@ describe('renderPasswordResetEmail', () => {
 		rendered.replaceAll('&#39;', "'").replaceAll('&quot;', '"').replaceAll('&amp;', '&');
 	const reset = en.email.reset_password;
 	const set = en.email.set_password;
+
+	it('renders the trimmed validated asset URL', () => {
+		const { html } = renderPasswordResetEmail(url, undefined, 'en', true);
+		expect(html).toContain('https://assets.example.test/email');
+		expect(html).not.toContain('  https://assets.example.test/email  ');
+	});
 
 	it('reports a reset for an account that has a password', () => {
 		const { html, text } = renderPasswordResetEmail(url, undefined, 'en', true);

--- a/src/lib/convex/emails/founderIncidentCore.test.ts
+++ b/src/lib/convex/emails/founderIncidentCore.test.ts
@@ -90,6 +90,7 @@ describe('createFounderIncidentEmailMutation', () => {
 	it('queues one localized plain-text email and records the component enqueue', async () => {
 		vi.stubEnv('RESEND_API_KEY', 're_test');
 		vi.stubEnv('AUTH_EMAIL', 'founder@example.com');
+		vi.stubEnv('EMAIL_ASSET_URL', 'https://assets.example.com');
 		const sendEmail = vi.spyOn(resend, 'sendEmail').mockResolvedValue('email_1' as never);
 		const { ctx, handler, rows } = setup();
 		const args = { userId: 'user_1', incident: 'service_restored_2026_08_24' };
@@ -119,6 +120,21 @@ describe('createFounderIncidentEmailMutation', () => {
 				deliveryStatus: 'waiting'
 			})
 		]);
+	});
+
+	it('does not enqueue or commit a delivery row when email configuration is malformed', async () => {
+		vi.stubEnv('RESEND_API_KEY', 're_local_e2e_dummy');
+		vi.stubEnv('AUTH_EMAIL', 'founder@example.com');
+		vi.stubEnv('EMAIL_ASSET_URL', 'https://assets.example.com');
+		vi.stubEnv('AUTH_E2E_TEST_SECRET', 'test-selector-must-not-bypass');
+		const sendEmail = vi.spyOn(resend, 'sendEmail');
+		const { ctx, handler, rows } = setup();
+
+		await expect(
+			handler(ctx, { userId: 'user_1', incident: 'service_restored_2026_08_24' })
+		).rejects.toThrow('[capability] email is misconfigured');
+		expect(sendEmail).not.toHaveBeenCalled();
+		expect(rows).toHaveLength(0);
 	});
 
 	it.each([
@@ -169,6 +185,7 @@ describe('createFounderIncidentEmailMutation', () => {
 	it('falls back to the source locale before rendering', async () => {
 		vi.stubEnv('RESEND_API_KEY', 're_test');
 		vi.stubEnv('AUTH_EMAIL', 'founder@example.com');
+		vi.stubEnv('EMAIL_ASSET_URL', 'https://assets.example.com');
 		vi.spyOn(resend, 'sendEmail').mockResolvedValue('email_1' as never);
 		const render = vi.fn(() => ({ subject: 'Restored', text: 'Body' }));
 		const { ctx, handler } = setup({

--- a/src/lib/convex/emails/founderIncidentCore.ts
+++ b/src/lib/convex/emails/founderIncidentCore.ts
@@ -1,7 +1,6 @@
 import { ConvexError, v } from 'convex/values';
 import { components } from '../_generated/api';
 import { internalMutation, type MutationCtx } from '../_generated/server';
-import { requireEnv } from '../env';
 import { getValidLocale } from '../i18n/translations';
 import { isTestEmail } from './helpers';
 import { assertResendApiKey, resend } from './resend';
@@ -90,9 +89,9 @@ export function createFounderIncidentEmailMutation<Registry extends FounderIncid
 			});
 			const { subject, text } = validateRenderedEmail(rendered.subject, rendered.text);
 
-			assertResendApiKey();
+			const emailConfiguration = assertResendApiKey();
 			const emailId = await resend.sendEmail(ctx, {
-				from: `${contact.name} <${requireEnv('AUTH_EMAIL', { feature: 'email delivery' })}>`,
+				from: `${contact.name} <${emailConfiguration.sender}>`,
 				replyTo: contact.replyTo ? [contact.replyTo] : undefined,
 				to: email,
 				subject,

--- a/src/lib/convex/emails/founderIncidentSend.test.ts
+++ b/src/lib/convex/emails/founderIncidentSend.test.ts
@@ -115,6 +115,7 @@ describe('founder incident application binding', () => {
 		registerTestIncident();
 		vi.stubEnv('RESEND_API_KEY', 're_test');
 		vi.stubEnv('AUTH_EMAIL', 'founder@example.com');
+		vi.stubEnv('EMAIL_ASSET_URL', 'https://assets.example.com');
 		const sendEmail = vi.spyOn(resend, 'sendEmail').mockResolvedValue('email_1' as never);
 		const { ctx } = makeCtx({
 			enabled: true,

--- a/src/lib/convex/emails/resend.ts
+++ b/src/lib/convex/emails/resend.ts
@@ -1,6 +1,7 @@
 import { components, internal } from '../_generated/api';
 import { Resend } from '@convex-dev/resend';
-import { requireEnv } from '../env';
+import { getCapabilityConfigurations, requireEmailConfiguration } from '../env';
+import type { CapabilityConfiguration, EmailConfiguration } from '../../dev/features';
 import { devNotice } from '../../dev/notice';
 
 /**
@@ -42,22 +43,18 @@ export const resend: Resend = new Resend(components.resend, {
 	onEmailEvent: internal.emails.events.handleEmailEvent
 });
 
+/** Resolve the complete outbound email group at the enqueue boundary. */
+export function getEmailDeliveryConfiguration(): CapabilityConfiguration<EmailConfiguration> {
+	return getCapabilityConfigurations().email;
+}
+
 /**
- * Throws a loud, copy-paste-friendly error when RESEND_API_KEY is not set.
- *
- * Without this preflight, the Resend SDK accepts the send call and queues it,
- * but the actual API call fails inside the component's workpool. The Better
- * Auth verify-email flow then "succeeds" from the user's perspective while no
- * email ever arrives. Calling this at the top of every email-sending handler
- * converts that silent hang into an immediate, named failure in Convex logs.
- *
- * Delegates to `requireEnv` so the error format and docs path stay in one
- * place. AUTH_EMAIL presence is covered separately by `requireEnv('AUTH_EMAIL',
- * ...)` in each handler's `from` argument.
+ * Guard the component enqueue before it can accept work that will never send.
+ * The historical name remains stable for existing callers, but the guard now
+ * validates the API key, sender address, and public asset URL as one group.
  */
-export function assertResendApiKey(): void {
-	// E2E test runs propagate AUTH_E2E_TEST_SECRET into the Convex backend
-	// (vite.config.ts) and intentionally do not configure Resend. Stay quiet there.
-	if (process.env.AUTH_E2E_TEST_SECRET) return;
-	requireEnv('RESEND_API_KEY', { feature: 'email delivery' });
+export function assertResendApiKey(
+	configuration = getEmailDeliveryConfiguration()
+): EmailConfiguration {
+	return requireEmailConfiguration(configuration);
 }

--- a/src/lib/convex/emails/send.test.ts
+++ b/src/lib/convex/emails/send.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { sendEmail, getEmailDeliveryConfiguration } = vi.hoisted(() => ({
+	sendEmail: vi.fn(),
+	getEmailDeliveryConfiguration: vi.fn()
+}));
+
+vi.mock('./resend', () => ({
+	resend: { sendEmail },
+	getEmailDeliveryConfiguration,
+	assertResendApiKey: vi.fn((configuration) => configuration.value)
+}));
+
+vi.mock('./templates', () => ({
+	renderVerificationEmail: vi.fn(() => ({ html: 'html', text: 'text' })),
+	renderPasswordResetEmail: vi.fn(() => ({ html: 'html', text: 'text' })),
+	renderAdminReplyNotificationEmail: vi.fn(() => ({ html: 'html', text: 'text' })),
+	renderNewTicketAdminNotificationEmail: vi.fn(() => ({ html: 'html', text: 'text' })),
+	renderNewUserSignupNotificationEmail: vi.fn(() => ({ html: 'html', text: 'text' }))
+}));
+
+vi.mock('./helpers', () => ({
+	buildSupportDeepLink: vi.fn(() => 'https://app.example.com/support'),
+	shouldSkipTestEmail: vi.fn(() => false)
+}));
+
+vi.mock('../credentialAccounts', () => ({ hasUsablePassword: vi.fn(() => true) }));
+
+vi.mock('../env', () => ({ requireEnv: vi.fn(() => 'https://app.example.com') }));
+
+vi.mock('../i18n/translations', () => ({
+	t: vi.fn(() => 'subject'),
+	getValidLocale: vi.fn(() => 'en')
+}));
+
+vi.mock('../_generated/api', () => ({
+	components: {
+		betterAuth: { adapter: { findOne: 'components.betterAuth.adapter.findOne' } }
+	},
+	internal: {
+		admin: {
+			founderWelcome: {
+				queries: {
+					getFounderWelcomeConfigInternal:
+						'internal.admin.founderWelcome.queries.getFounderWelcomeConfigInternal'
+				}
+			},
+			notificationPreferences: {
+				queries: {
+					getRecipientsForNotificationType:
+						'internal.admin.notificationPreferences.queries.getRecipientsForNotificationType'
+				}
+			}
+		}
+	}
+}));
+
+import {
+	sendAdminReplyNotification,
+	sendFounderWelcomeEmail,
+	sendNewTicketAdminNotification,
+	sendNewUserSignupNotification,
+	sendResetPasswordEmail,
+	sendVerificationEmail
+} from './send';
+
+type RegisteredMutation = {
+	_handler: (ctx: unknown, args: Record<string, unknown>) => Promise<unknown>;
+};
+
+const immediateSendCases = [
+	[
+		'sendVerificationEmail',
+		sendVerificationEmail,
+		{ email: 'user@example.com', verificationUrl: 'https://app.example.com/verify' }
+	],
+	[
+		'sendResetPasswordEmail',
+		sendResetPasswordEmail,
+		{
+			email: 'user@example.com',
+			resetUrl: 'https://app.example.com/reset',
+			userId: 'user_1'
+		}
+	],
+	[
+		'sendAdminReplyNotification',
+		sendAdminReplyNotification,
+		{
+			email: 'user@example.com',
+			adminName: 'Admin',
+			messagePreview: 'Reply',
+			threadId: 'thread_1'
+		}
+	],
+	[
+		'sendNewTicketAdminNotification',
+		sendNewTicketAdminNotification,
+		{
+			email: 'admin@example.com',
+			isReopen: false,
+			isBareHandoff: false,
+			userName: 'User',
+			messages: [],
+			threadId: 'thread_1'
+		}
+	],
+	[
+		'sendNewUserSignupNotification',
+		sendNewUserSignupNotification,
+		{
+			userEmail: 'user@example.com',
+			signupMethod: 'Email',
+			signupTime: 'now'
+		}
+	]
+] as const;
+
+function readyEmailConfiguration() {
+	return {
+		state: 'ready' as const,
+		value: {
+			apiKey: 'configured',
+			sender: 'sender@example.com',
+			assetUrl: 'https://assets.example.com'
+		}
+	};
+}
+
+describe('email send provider preflights', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getEmailDeliveryConfiguration.mockReturnValue(readyEmailConfiguration());
+		sendEmail.mockResolvedValue('email_1');
+	});
+
+	it.each(immediateSendCases)(
+		'%s does not query, render, count, or enqueue when email is misconfigured',
+		async (_name, mutation, args) => {
+			getEmailDeliveryConfiguration.mockReturnValue({
+				state: 'misconfigured',
+				issue: 'sentinel'
+			});
+			const runQuery = vi.fn();
+			const ctx = { runQuery, db: { get: vi.fn(), patch: vi.fn() } };
+
+			const result = await (mutation as unknown as RegisteredMutation)._handler(ctx, args);
+
+			expect(result).toBe(mutation === sendNewTicketAdminNotification ? false : null);
+			expect(runQuery).not.toHaveBeenCalled();
+			expect(sendEmail).not.toHaveBeenCalled();
+		}
+	);
+
+	it.each(['disabled', 'misconfigured'] as const)(
+		'marks a scheduled founder welcome terminal when email is %s',
+		async (state) => {
+			getEmailDeliveryConfiguration.mockReturnValue(
+				state === 'disabled' ? { state } : { state, issue: 'missing' }
+			);
+			const patch = vi.fn().mockResolvedValue(undefined);
+			const runQuery = vi.fn();
+			const ctx = {
+				db: {
+					get: vi.fn().mockResolvedValue({
+						status: 'scheduled',
+						userId: 'user_1',
+						signupEmail: 'user@example.com'
+					}),
+					patch
+				},
+				runQuery
+			};
+
+			expect(
+				await (sendFounderWelcomeEmail as unknown as RegisteredMutation)._handler(ctx, {
+					founderWelcomeId: 'welcome_1'
+				})
+			).toBeNull();
+			expect(patch).toHaveBeenCalledWith('welcome_1', {
+				status: 'skipped',
+				skippedReason: 'email_unavailable'
+			});
+			expect(runQuery).not.toHaveBeenCalled();
+			expect(sendEmail).not.toHaveBeenCalled();
+		}
+	);
+
+	it('returns an enqueue result that pending notification work can count', async () => {
+		const ctx = { runQuery: vi.fn().mockResolvedValue({ locale: 'en' }) };
+
+		expect(
+			await (sendNewTicketAdminNotification as unknown as RegisteredMutation)._handler(ctx, {
+				email: 'admin@example.com',
+				isReopen: false,
+				isBareHandoff: false,
+				userName: 'User',
+				messages: [],
+				threadId: 'thread_1'
+			})
+		).toBe(true);
+		expect(sendEmail).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/lib/convex/emails/send.test.ts
+++ b/src/lib/convex/emails/send.test.ts
@@ -1,14 +1,25 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { sendEmail, getEmailDeliveryConfiguration } = vi.hoisted(() => ({
-	sendEmail: vi.fn(),
-	getEmailDeliveryConfiguration: vi.fn()
-}));
+const { sendEmail, getEmailDeliveryConfiguration, assertResendApiKey } = vi.hoisted(() => {
+	const getConfiguration = vi.fn();
+	return {
+		sendEmail: vi.fn(),
+		getEmailDeliveryConfiguration: getConfiguration,
+		assertResendApiKey: vi.fn((configuration = getConfiguration()) => {
+			if (configuration.state !== 'ready') {
+				const error = new Error(`[capability] email is ${configuration.state}`);
+				error.name = 'CapabilityConfigurationError';
+				throw error;
+			}
+			return configuration.value;
+		})
+	};
+});
 
 vi.mock('./resend', () => ({
 	resend: { sendEmail },
 	getEmailDeliveryConfiguration,
-	assertResendApiKey: vi.fn((configuration) => configuration.value)
+	assertResendApiKey
 }));
 
 vi.mock('./templates', () => ({
@@ -25,6 +36,10 @@ vi.mock('./helpers', () => ({
 }));
 
 vi.mock('../credentialAccounts', () => ({ hasUsablePassword: vi.fn(() => true) }));
+
+vi.mock('../support/notificationPreferences', () => ({
+	shouldSendNotification: vi.fn(() => true)
+}));
 
 vi.mock('../env', () => ({ requireEnv: vi.fn(() => 'https://app.example.com') }));
 
@@ -55,6 +70,7 @@ vi.mock('../_generated/api', () => ({
 	}
 }));
 
+import { shouldSendNotification } from '../support/notificationPreferences';
 import {
 	sendAdminReplyNotification,
 	sendFounderWelcomeEmail,
@@ -67,6 +83,8 @@ import {
 type RegisteredMutation = {
 	_handler: (ctx: unknown, args: Record<string, unknown>) => Promise<unknown>;
 };
+
+const shouldSendNotificationMock = shouldSendNotification as unknown as ReturnType<typeof vi.fn>;
 
 const immediateSendCases = [
 	[
@@ -87,6 +105,7 @@ const immediateSendCases = [
 		'sendAdminReplyNotification',
 		sendAdminReplyNotification,
 		{
+			supportThreadId: 'support_thread_1',
 			email: 'user@example.com',
 			adminName: 'Admin',
 			messagePreview: 'Reply',
@@ -131,23 +150,32 @@ describe('email send provider preflights', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		getEmailDeliveryConfiguration.mockReturnValue(readyEmailConfiguration());
+		shouldSendNotificationMock.mockReturnValue(true);
 		sendEmail.mockResolvedValue('email_1');
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	it.each(immediateSendCases)(
 		'%s does not query, render, count, or enqueue when email is misconfigured',
-		async (_name, mutation, args) => {
+		async (name, mutation, args) => {
 			getEmailDeliveryConfiguration.mockReturnValue({
 				state: 'misconfigured',
 				issue: 'sentinel'
 			});
 			const runQuery = vi.fn();
 			const ctx = { runQuery, db: { get: vi.fn(), patch: vi.fn() } };
+			const invocation = (mutation as unknown as RegisteredMutation)._handler(ctx, args);
 
-			const result = await (mutation as unknown as RegisteredMutation)._handler(ctx, args);
-
-			expect(result).toBe(mutation === sendNewTicketAdminNotification ? false : null);
+			if (name === 'sendVerificationEmail' || name === 'sendResetPasswordEmail') {
+				await expect(invocation).rejects.toThrow('[capability] email is misconfigured');
+			} else {
+				expect(await invocation).toBe(mutation === sendNewTicketAdminNotification ? false : null);
+			}
 			expect(runQuery).not.toHaveBeenCalled();
+			expect(ctx.db.patch).not.toHaveBeenCalled();
 			expect(sendEmail).not.toHaveBeenCalled();
 		}
 	);
@@ -185,6 +213,114 @@ describe('email send provider preflights', () => {
 			expect(sendEmail).not.toHaveBeenCalled();
 		}
 	);
+
+	it('rechecks the admin reply cooldown before enqueueing', async () => {
+		shouldSendNotificationMock.mockReturnValue(false);
+		const patch = vi.fn();
+		const runQuery = vi.fn();
+		const ctx = {
+			db: {
+				get: vi.fn().mockResolvedValue({ notificationSentAt: Date.now() }),
+				patch
+			},
+			runQuery
+		};
+
+		expect(
+			await (sendAdminReplyNotification as unknown as RegisteredMutation)._handler(ctx, {
+				supportThreadId: 'support_thread_1',
+				email: 'user@example.com',
+				adminName: 'Admin',
+				messagePreview: 'Reply',
+				threadId: 'thread_1'
+			})
+		).toBeNull();
+		expect(sendEmail).not.toHaveBeenCalled();
+		expect(patch).not.toHaveBeenCalled();
+		expect(runQuery).not.toHaveBeenCalled();
+	});
+
+	it('writes the admin reply cooldown only after the component enqueue returns', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-09-09T00:00:00.000Z'));
+		const patch = vi.fn().mockResolvedValue(undefined);
+		const ctx = {
+			db: {
+				get: vi.fn().mockResolvedValue({ notificationSentAt: undefined }),
+				patch
+			},
+			runQuery: vi.fn().mockResolvedValue({ locale: 'en' })
+		};
+
+		expect(
+			await (sendAdminReplyNotification as unknown as RegisteredMutation)._handler(ctx, {
+				supportThreadId: 'support_thread_1',
+				email: 'user@example.com',
+				adminName: 'Admin',
+				messagePreview: 'Reply',
+				threadId: 'thread_1'
+			})
+		).toBeNull();
+		expect(sendEmail).toHaveBeenCalledTimes(1);
+		expect(patch).toHaveBeenCalledWith('support_thread_1', {
+			notificationSentAt: Date.now()
+		});
+		expect(sendEmail.mock.invocationCallOrder[0]).toBeLessThan(patch.mock.invocationCallOrder[0]);
+		vi.useRealTimers();
+	});
+
+	it('does not write the admin reply cooldown when the component enqueue fails', async () => {
+		sendEmail.mockRejectedValueOnce(new Error('enqueue failed'));
+		const patch = vi.fn();
+		const ctx = {
+			db: {
+				get: vi.fn().mockResolvedValue({ notificationSentAt: undefined }),
+				patch
+			},
+			runQuery: vi.fn().mockResolvedValue({ locale: 'en' })
+		};
+
+		await expect(
+			(sendAdminReplyNotification as unknown as RegisteredMutation)._handler(ctx, {
+				supportThreadId: 'support_thread_1',
+				email: 'user@example.com',
+				adminName: 'Admin',
+				messagePreview: 'Reply',
+				threadId: 'thread_1'
+			})
+		).rejects.toThrow('enqueue failed');
+		expect(patch).not.toHaveBeenCalled();
+	});
+
+	it('lets only the successful admin reply enqueue consume the cooldown', async () => {
+		shouldSendNotificationMock.mockImplementation(
+			(email: string | undefined, sentAt: number | undefined) => Boolean(email) && !sentAt
+		);
+		const supportThread: Record<string, unknown> = { notificationSentAt: undefined };
+		const patch = vi.fn(async (_id: string, update: Record<string, unknown>) => {
+			Object.assign(supportThread, update);
+		});
+		const ctx = {
+			db: {
+				get: vi.fn().mockResolvedValue(supportThread),
+				patch
+			},
+			runQuery: vi.fn().mockResolvedValue({ locale: 'en' })
+		};
+		const args = {
+			supportThreadId: 'support_thread_1',
+			email: 'user@example.com',
+			adminName: 'Admin',
+			messagePreview: 'Reply',
+			threadId: 'thread_1'
+		};
+
+		await (sendAdminReplyNotification as unknown as RegisteredMutation)._handler(ctx, args);
+		await (sendAdminReplyNotification as unknown as RegisteredMutation)._handler(ctx, args);
+
+		expect(sendEmail).toHaveBeenCalledTimes(1);
+		expect(patch).toHaveBeenCalledTimes(1);
+	});
 
 	it('returns an enqueue result that pending notification work can count', async () => {
 		const ctx = { runQuery: vi.fn().mockResolvedValue({ locale: 'en' }) };

--- a/src/lib/convex/emails/send.ts
+++ b/src/lib/convex/emails/send.ts
@@ -1,7 +1,7 @@
 import { internalMutation } from '../_generated/server';
 import { v } from 'convex/values';
 import { components, internal } from '../_generated/api';
-import { resend, assertResendApiKey } from './resend';
+import { resend, assertResendApiKey, getEmailDeliveryConfiguration } from './resend';
 import {
 	renderVerificationEmail,
 	renderPasswordResetEmail,
@@ -19,6 +19,11 @@ import { hasUsablePassword } from '../credentialAccounts';
 
 /** Type for user result from Better Auth adapter with optional locale field */
 type UserWithLocale = { locale?: string | null } | null;
+
+function getReadyEmailConfiguration() {
+	const configuration = getEmailDeliveryConfiguration();
+	return configuration.state === 'ready' ? assertResendApiKey(configuration) : null;
+}
 
 /**
  * Look up a user's locale preference by email address.
@@ -52,13 +57,15 @@ export const sendVerificationEmail = internalMutation({
 		const { email, verificationUrl, expiryMinutes = 20 } = args;
 
 		if (shouldSkipTestEmail('sendVerificationEmail', email)) return null;
-		assertResendApiKey();
+		if (!getReadyEmailConfiguration()) return null;
 
 		const locale = await getLocaleForEmail(ctx, email);
 		const { html, text } = renderVerificationEmail(verificationUrl, expiryMinutes, locale);
+		const emailConfiguration = getReadyEmailConfiguration();
+		if (!emailConfiguration) return null;
 
 		await resend.sendEmail(ctx, {
-			from: requireEnv('AUTH_EMAIL', { feature: 'email delivery' }),
+			from: emailConfiguration.sender,
 			to: email,
 			subject: t(locale, 'email.subject.verify'),
 			html,
@@ -91,7 +98,7 @@ export const sendResetPasswordEmail = internalMutation({
 		const { email, resetUrl, userName } = args;
 
 		if (shouldSkipTestEmail('sendResetPasswordEmail', email)) return null;
-		assertResendApiKey();
+		if (!getReadyEmailConfiguration()) return null;
 
 		// Resolved here rather than in the caller: the reset hook awaits that
 		// caller, so the lookup would sit on the response path as its own round
@@ -99,9 +106,11 @@ export const sendResetPasswordEmail = internalMutation({
 		const hasPassword = await hasUsablePassword(ctx, args.userId);
 		const locale = await getLocaleForEmail(ctx, email);
 		const { html, text } = renderPasswordResetEmail(resetUrl, userName, locale, hasPassword);
+		const emailConfiguration = getReadyEmailConfiguration();
+		if (!emailConfiguration) return null;
 
 		await resend.sendEmail(ctx, {
-			from: requireEnv('AUTH_EMAIL', { feature: 'email delivery' }),
+			from: emailConfiguration.sender,
 			to: email,
 			subject: t(
 				locale,
@@ -139,7 +148,7 @@ export const sendAdminReplyNotification = internalMutation({
 		const { email, adminName, messagePreview, threadId, pageUrl } = args;
 
 		if (shouldSkipTestEmail('sendAdminReplyNotification', email)) return null;
-		assertResendApiKey();
+		if (!getReadyEmailConfiguration()) return null;
 
 		const locale = await getLocaleForEmail(ctx, email);
 		const siteUrl = requireEnv('SITE_URL', { feature: 'email deep links' });
@@ -152,9 +161,11 @@ export const sendAdminReplyNotification = internalMutation({
 			deepLink,
 			locale
 		);
+		const emailConfiguration = getReadyEmailConfiguration();
+		if (!emailConfiguration) return null;
 
 		await resend.sendEmail(ctx, {
-			from: requireEnv('AUTH_EMAIL', { feature: 'email delivery' }),
+			from: emailConfiguration.sender,
 			to: email,
 			subject: t(locale, 'email.subject.support_reply'),
 			html,
@@ -193,10 +204,10 @@ export const sendNewTicketAdminNotification = internalMutation({
 		),
 		threadId: v.string()
 	},
-	returns: v.null(),
+	returns: v.boolean(),
 	handler: async (ctx, args) => {
 		const { email, isReopen, isBareHandoff, userName, messages, threadId } = args;
-		assertResendApiKey();
+		if (!getReadyEmailConfiguration()) return false;
 		const siteUrl = requireEnv('SITE_URL', { feature: 'email deep links' });
 		const locale = await getLocaleForEmail(ctx, email);
 
@@ -217,9 +228,11 @@ export const sendNewTicketAdminNotification = internalMutation({
 		const subject = isReopen
 			? t(locale, 'email.subject.ticket_reopened', { userName })
 			: t(locale, 'email.subject.ticket_new', { userName });
+		const emailConfiguration = getReadyEmailConfiguration();
+		if (!emailConfiguration) return false;
 
 		await resend.sendEmail(ctx, {
-			from: requireEnv('AUTH_EMAIL', { feature: 'email delivery' }),
+			from: emailConfiguration.sender,
 			to: email,
 			subject,
 			html,
@@ -231,7 +244,7 @@ export const sendNewTicketAdminNotification = internalMutation({
 				{ name: 'X-Thread-ID', value: threadId }
 			]
 		});
-		return null;
+		return true;
 	}
 });
 
@@ -256,6 +269,7 @@ export const sendNewUserSignupNotification = internalMutation({
 		const { userName, userEmail, signupMethod, signupTime } = args;
 
 		if (shouldSkipTestEmail('sendNewUserSignupNotification', userEmail)) return null;
+		if (!getReadyEmailConfiguration()) return null;
 
 		// Get recipients who have new signup notifications enabled
 		const recipients = await ctx.runQuery(
@@ -267,11 +281,6 @@ export const sendNewUserSignupNotification = internalMutation({
 			console.log('[sendNewUserSignupNotification] No recipients configured, skipping');
 			return null;
 		}
-
-		// Only require Resend once we know we'll actually send; with no recipients
-		// configured (common in fresh local-dev installs) the function short-circuits
-		// above and must not demand the API key.
-		assertResendApiKey();
 
 		const siteUrl = requireEnv('SITE_URL', { feature: 'email deep links' });
 
@@ -285,6 +294,7 @@ export const sendNewUserSignupNotification = internalMutation({
 		// across re-runs of this loop comes from Convex's exactly-once scheduled-mutation
 		// execution (scheduled from the auth onCreate/onUpdate triggers, auth.ts).
 		let sentCount = 0;
+		let emailUnavailable = false;
 		for (const email of recipients) {
 			try {
 				// Per-recipient locale lookup and render: recipient list is small
@@ -300,8 +310,13 @@ export const sendNewUserSignupNotification = internalMutation({
 					},
 					locale
 				);
+				const emailConfiguration = getReadyEmailConfiguration();
+				if (!emailConfiguration) {
+					emailUnavailable = true;
+					break;
+				}
 				await resend.sendEmail(ctx, {
-					from: requireEnv('AUTH_EMAIL', { feature: 'email delivery' }),
+					from: emailConfiguration.sender,
 					to: email,
 					subject: t(locale, 'email.subject.new_signup', { userEmail }),
 					html,
@@ -321,6 +336,8 @@ export const sendNewUserSignupNotification = internalMutation({
 				);
 			}
 		}
+
+		if (emailUnavailable && sentCount === 0) return null;
 
 		if (sentCount > 0) {
 			console.log(
@@ -348,6 +365,13 @@ export const sendFounderWelcomeEmail = internalMutation({
 	handler: async (ctx, { founderWelcomeId }) => {
 		const row = await ctx.db.get(founderWelcomeId);
 		if (!row || row.status !== 'scheduled') return null;
+		if (!getReadyEmailConfiguration()) {
+			await ctx.db.patch(founderWelcomeId, {
+				status: 'skipped',
+				skippedReason: 'email_unavailable'
+			});
+			return null;
+		}
 
 		// Read config at send time
 		const config = await ctx.runQuery(
@@ -413,8 +437,6 @@ export const sendFounderWelcomeEmail = internalMutation({
 			return null;
 		}
 
-		assertResendApiKey();
-
 		// Render plain text with {{placeholder}} interpolation
 		const parts = (name?.trim() || 'there').split(/\s+/);
 		const templateVars: Record<string, string> = {
@@ -429,9 +451,17 @@ export const sendFounderWelcomeEmail = internalMutation({
 
 		const text = renderTemplate(config.body);
 		const subject = renderTemplate(config.subject);
+		const emailConfiguration = getReadyEmailConfiguration();
+		if (!emailConfiguration) {
+			await ctx.db.patch(founderWelcomeId, {
+				status: 'skipped',
+				skippedReason: 'email_unavailable'
+			});
+			return null;
+		}
 
 		await resend.sendEmail(ctx, {
-			from: `${config.name} <${requireEnv('AUTH_EMAIL', { feature: 'email delivery' })}>`,
+			from: `${config.name} <${emailConfiguration.sender}>`,
 			replyTo: config.replyTo ? [config.replyTo] : undefined,
 			to: email,
 			subject,

--- a/src/lib/convex/emails/send.ts
+++ b/src/lib/convex/emails/send.ts
@@ -16,6 +16,7 @@ import type { GenericMutationCtx } from 'convex/server';
 import type { DataModel } from '../_generated/dataModel';
 import { buildSupportDeepLink, shouldSkipTestEmail } from './helpers';
 import { hasUsablePassword } from '../credentialAccounts';
+import { shouldSendNotification } from '../support/notificationPreferences';
 
 /** Type for user result from Better Auth adapter with optional locale field */
 type UserWithLocale = { locale?: string | null } | null;
@@ -57,12 +58,11 @@ export const sendVerificationEmail = internalMutation({
 		const { email, verificationUrl, expiryMinutes = 20 } = args;
 
 		if (shouldSkipTestEmail('sendVerificationEmail', email)) return null;
-		if (!getReadyEmailConfiguration()) return null;
+		assertResendApiKey();
 
 		const locale = await getLocaleForEmail(ctx, email);
 		const { html, text } = renderVerificationEmail(verificationUrl, expiryMinutes, locale);
-		const emailConfiguration = getReadyEmailConfiguration();
-		if (!emailConfiguration) return null;
+		const emailConfiguration = assertResendApiKey();
 
 		await resend.sendEmail(ctx, {
 			from: emailConfiguration.sender,
@@ -98,7 +98,7 @@ export const sendResetPasswordEmail = internalMutation({
 		const { email, resetUrl, userName } = args;
 
 		if (shouldSkipTestEmail('sendResetPasswordEmail', email)) return null;
-		if (!getReadyEmailConfiguration()) return null;
+		assertResendApiKey();
 
 		// Resolved here rather than in the caller: the reset hook awaits that
 		// caller, so the lookup would sit on the response path as its own round
@@ -106,8 +106,7 @@ export const sendResetPasswordEmail = internalMutation({
 		const hasPassword = await hasUsablePassword(ctx, args.userId);
 		const locale = await getLocaleForEmail(ctx, email);
 		const { html, text } = renderPasswordResetEmail(resetUrl, userName, locale, hasPassword);
-		const emailConfiguration = getReadyEmailConfiguration();
-		if (!emailConfiguration) return null;
+		const emailConfiguration = assertResendApiKey();
 
 		await resend.sendEmail(ctx, {
 			from: emailConfiguration.sender,
@@ -137,6 +136,7 @@ export const sendResetPasswordEmail = internalMutation({
  */
 export const sendAdminReplyNotification = internalMutation({
 	args: {
+		supportThreadId: v.id('supportThreads'),
 		email: v.string(),
 		adminName: v.string(),
 		messagePreview: v.string(),
@@ -145,10 +145,15 @@ export const sendAdminReplyNotification = internalMutation({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		const { email, adminName, messagePreview, threadId, pageUrl } = args;
+		const { supportThreadId, email, adminName, messagePreview, threadId, pageUrl } = args;
 
 		if (shouldSkipTestEmail('sendAdminReplyNotification', email)) return null;
 		if (!getReadyEmailConfiguration()) return null;
+
+		const supportThread = await ctx.db.get(supportThreadId);
+		if (!supportThread || !shouldSendNotification(email, supportThread.notificationSentAt)) {
+			return null;
+		}
 
 		const locale = await getLocaleForEmail(ctx, email);
 		const siteUrl = requireEnv('SITE_URL', { feature: 'email deep links' });
@@ -177,6 +182,7 @@ export const sendAdminReplyNotification = internalMutation({
 				{ name: 'X-Thread-ID', value: threadId }
 			]
 		});
+		await ctx.db.patch(supportThreadId, { notificationSentAt: Date.now() });
 		return null;
 	}
 });

--- a/src/lib/convex/emails/templates.ts
+++ b/src/lib/convex/emails/templates.ts
@@ -28,7 +28,7 @@ import {
 	NEWUSERSIGNUPNOTIFICATION_HTML,
 	NEWUSERSIGNUPNOTIFICATION_TEXT
 } from '../../emails/generated/index.js';
-import { requireEnv } from '../env';
+import { requireEmailConfiguration } from '../env';
 import { t, DEFAULT_LOCALE, getValidLocale } from '../i18n/translations';
 
 /**
@@ -59,12 +59,9 @@ function escapeHtml(str: string): string {
 	);
 }
 
-/**
- * Get base URL for email assets (images, footer links)
- * Uses EMAIL_ASSET_URL env var - should point to publicly accessible URL
- */
+/** Get the validated base URL for email assets and footer links. */
 function getBaseUrl(): string {
-	return requireEnv('EMAIL_ASSET_URL', { feature: 'email asset URLs (logo, etc.)' });
+	return requireEmailConfiguration().assetUrl;
 }
 
 /**

--- a/src/lib/convex/env.test.ts
+++ b/src/lib/convex/env.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { requireEnv } from './env';
+import { CapabilityConfigurationError, requireCapabilityConfiguration, requireEnv } from './env';
 
 const env = process.env as Record<string, string | undefined>;
 
@@ -41,14 +41,18 @@ describe('requireEnv', () => {
 		expect(requireEnv('BETTER_AUTH_SECRET')).toBe('placeholder-secret-for-analysis');
 	});
 
-	it('throws a structured error when no value and no placeholder', () => {
-		// AUTH_EMAIL has no ANALYSIS_PLACEHOLDER entry, so an unset value must throw.
-		withMissing('AUTH_EMAIL', () => {
-			expect(() => requireEnv('AUTH_EMAIL')).toThrowError(
-				/\[env\] Missing AUTH_EMAIL\n {2}Fix: bunx convex env set AUTH_EMAIL <value>\n {2}See: \.env\.convex\.example/
-			);
-		});
-	});
+	it.each(['AUTH_EMAIL', 'AUTUMN_SECRET_KEY'] as const)(
+		'throws a structured error for %s when no value and no placeholder exists',
+		(key) => {
+			withMissing(key, () => {
+				expect(() => requireEnv(key)).toThrowError(
+					new RegExp(
+						`\\[env\\] Missing ${key}\\n {2}Fix: bunx convex env set ${key} <value>\\n {2}See: \\.env\\.convex\\.example`
+					)
+				);
+			});
+		}
+	);
 
 	it('includes the feature name in the error message when provided', () => {
 		withMissing('AUTH_EMAIL', () => {
@@ -64,5 +68,28 @@ describe('requireEnv', () => {
 				requireEnv('AUTH_EMAIL', { feature: 'email delivery', docs: 'docs/email.md' })
 			).toThrowError(/See: docs\/email\.md/);
 		});
+	});
+});
+
+describe('requireCapabilityConfiguration', () => {
+	it.each(['disabled', 'misconfigured'] as const)(
+		'rejects %s configuration without exposing provider details',
+		(state) => {
+			expect(() =>
+				requireCapabilityConfiguration(
+					'billing',
+					state === 'disabled' ? { state } : { state, issue: 'missing' }
+				)
+			).toThrowError(CapabilityConfigurationError);
+		}
+	);
+
+	it('returns only the normalized ready value', () => {
+		expect(
+			requireCapabilityConfiguration('ai', {
+				state: 'ready',
+				value: { apiKey: 'configured' }
+			})
+		).toEqual({ apiKey: 'configured' });
 	});
 });

--- a/src/lib/convex/env.ts
+++ b/src/lib/convex/env.ts
@@ -19,6 +19,14 @@
  * redacts values it loaded itself.
  */
 
+import {
+	resolveCapabilityConfigurations,
+	type AiConfiguration,
+	type BillingConfiguration,
+	type CapabilityConfiguration,
+	type CapabilityConfigurations,
+	type EmailConfiguration
+} from '../dev/features';
 import { env } from './_generated/server';
 
 // Required keys type as `string`; optional keys as `string | undefined`.
@@ -32,15 +40,14 @@ type RequiredKeys = {
  * Convex bundles and statically analyzes modules before env vars are available,
  * and `env` is just `process.env`, so a top-level read returns `undefined`
  * during that pass. `createApi()` in adapter.ts calls `createAuthOptions()` at
- * load time to extract the Better Auth schema, and `new Autumn()` in autumn.ts
- * runs at top level, so these vars must return something during analysis.
- * Placeholders are never used at runtime -- the declared `env` block makes
- * Convex reject a deploy that is missing the real values.
+ * load time to extract the Better Auth schema, so these vars must return
+ * something during analysis. Placeholders are never used at runtime -- the
+ * declared `env` block makes Convex reject a deploy that is missing the real
+ * values.
  */
 const ANALYSIS_PLACEHOLDERS: Partial<Record<string, string>> = {
 	BETTER_AUTH_SECRET: 'placeholder-secret-for-analysis',
-	SITE_URL: 'https://placeholder.invalid',
-	AUTUMN_SECRET_KEY: 'placeholder-key-for-analysis'
+	SITE_URL: 'https://placeholder.invalid'
 };
 
 export type RequireEnvOptions = {
@@ -75,6 +82,49 @@ export function requireEnv<K extends RequiredKeys>(name: K, opts?: RequireEnvOpt
 			`  Fix: bunx convex env set ${name} <value>\n` +
 			`  See: ${docs}`
 	);
+}
+
+export class CapabilityConfigurationError extends Error {
+	constructor(
+		readonly capability: keyof CapabilityConfigurations,
+		readonly state: Exclude<CapabilityConfiguration<unknown>['state'], 'ready'>
+	) {
+		super(`[capability] ${capability} is ${state}`);
+		this.name = 'CapabilityConfigurationError';
+	}
+}
+
+/** Resolve provider configuration from the current Convex environment. */
+export function getCapabilityConfigurations(): CapabilityConfigurations {
+	return resolveCapabilityConfigurations(env);
+}
+
+export function requireCapabilityConfiguration<Value>(
+	capability: keyof CapabilityConfigurations,
+	configuration: CapabilityConfiguration<Value>
+): Value {
+	if (configuration.state !== 'ready') {
+		throw new CapabilityConfigurationError(capability, configuration.state);
+	}
+	return configuration.value;
+}
+
+export function requireBillingConfiguration(
+	configuration = getCapabilityConfigurations().billing
+): BillingConfiguration {
+	return requireCapabilityConfiguration('billing', configuration);
+}
+
+export function requireEmailConfiguration(
+	configuration = getCapabilityConfigurations().email
+): EmailConfiguration {
+	return requireCapabilityConfiguration('email', configuration);
+}
+
+export function requireAiConfiguration(
+	configuration = getCapabilityConfigurations().ai
+): AiConfiguration {
+	return requireCapabilityConfiguration('ai', configuration);
 }
 
 // =============================================================================

--- a/src/lib/convex/messages.ts
+++ b/src/lib/convex/messages.ts
@@ -7,6 +7,7 @@ import { appRateLimiter } from './rateLimit';
 import { createRateLimitError } from './support/types';
 import { t } from './i18n/translations';
 import { MAX_MESSAGE_LENGTH } from './constants';
+import { requireBillingConfiguration } from './env';
 
 export const list = authedQuery({
 	args: {},
@@ -79,6 +80,8 @@ export const send = authedMutation({
 				t(undefined, 'backend.community.message_too_long', { max: MAX_MESSAGE_LENGTH })
 			);
 		}
+
+		requireBillingConfiguration();
 
 		const status = await appRateLimiter.limit(ctx, 'communityMessage', { key: ctx.user._id });
 		if (!status.ok) {

--- a/src/lib/convex/support/__tests__/messages.test.ts
+++ b/src/lib/convex/support/__tests__/messages.test.ts
@@ -53,6 +53,26 @@ vi.mock('../../constants', () => ({ MAX_MESSAGE_LENGTH: 4000 }));
 
 vi.mock('../../../config/support', () => ({ isSupportAiEnabled: vi.fn(() => true) }));
 
+vi.mock('../../env', () => {
+	class CapabilityConfigurationError extends Error {}
+	return {
+		CapabilityConfigurationError,
+		getCapabilityConfigurations: vi.fn(() => ({
+			billing: { state: 'ready', value: { secretKey: 'configured' } },
+			email: {
+				state: 'ready',
+				value: {
+					apiKey: 'configured',
+					sender: 'sender@example.com',
+					assetUrl: 'https://assets.example.com'
+				}
+			},
+			ai: { state: 'ready', value: { apiKey: 'configured' } }
+		})),
+		requireAiConfiguration: vi.fn(() => ({ apiKey: 'configured' }))
+	};
+});
+
 vi.mock('@convex-dev/agent', () => ({ getFile: vi.fn() }));
 
 vi.mock('@convex-dev/agent/validators', async () => {
@@ -91,10 +111,17 @@ import { requireSupportThreadAccess } from '../ownership';
 import { createAIResponse, sendMessage } from '../messages';
 import { syncSupportLastMessage } from '../threads';
 import { isSupportAiEnabled } from '../../../config/support';
+import {
+	CapabilityConfigurationError,
+	getCapabilityConfigurations,
+	requireAiConfiguration
+} from '../../env';
 
 const syncMock = syncSupportLastMessage as unknown as ReturnType<typeof vi.fn>;
 
 const aiEnabledMock = isSupportAiEnabled as unknown as ReturnType<typeof vi.fn>;
+const getCapabilitiesMock = getCapabilityConfigurations as unknown as ReturnType<typeof vi.fn>;
+const requireAiMock = requireAiConfiguration as unknown as ReturnType<typeof vi.fn>;
 
 const streamTextMock = supportAgent.streamText as unknown as ReturnType<typeof vi.fn>;
 
@@ -137,6 +164,38 @@ describe('createAIResponse prompt override wiring', () => {
 		expect(ctx.runQuery).not.toHaveBeenCalled();
 		// acknowledge, because no model speaks in this turn: without it the visitor
 		// gets no reply at all, and an anonymous one gets no email prompt either.
+		expect(ctx.runMutation).toHaveBeenCalledWith('internal.support.handoff.internalSetHandoff', {
+			threadId: 'thread_1',
+			acknowledge: true
+		});
+	});
+
+	it('hands queued work to the team when AI configuration is lost', async () => {
+		requireAiMock.mockImplementationOnce(() => {
+			throw new CapabilityConfigurationError('ai', 'misconfigured');
+		});
+		const ctx = { runQuery: vi.fn(), runMutation: vi.fn().mockResolvedValue(null) };
+
+		await handler._handler(ctx, args);
+
+		expect(streamTextMock).not.toHaveBeenCalled();
+		expect(ctx.runQuery).not.toHaveBeenCalled();
+		expect(ctx.runMutation).toHaveBeenCalledWith('internal.support.handoff.internalSetHandoff', {
+			threadId: 'thread_1',
+			acknowledge: true
+		});
+	});
+
+	it('hands off if AI is lost immediately before model transport', async () => {
+		requireAiMock.mockReturnValueOnce({ apiKey: 'configured' }).mockImplementationOnce(() => {
+			throw new CapabilityConfigurationError('ai', 'misconfigured');
+		});
+		const ctx = makeCtx('stored override prompt');
+
+		await handler._handler(ctx, args);
+
+		expect(ctx.runQuery).toHaveBeenCalledWith(GET_ACTIVE_REF, {});
+		expect(streamTextMock).not.toHaveBeenCalled();
 		expect(ctx.runMutation).toHaveBeenCalledWith('internal.support.handoff.internalSetHandoff', {
 			threadId: 'thread_1',
 			acknowledge: true
@@ -322,6 +381,32 @@ describe('sendMessage routing between the agent and the team', () => {
 		expect(ctx.scheduler.runAfter.mock.calls[0][2]).toEqual(
 			expect.objectContaining({ messageIds: ['m1'] })
 		);
+	});
+
+	it('persists the human handoff when configured AI is unavailable before scheduling', async () => {
+		getCapabilitiesMock.mockReturnValueOnce({
+			billing: { state: 'ready', value: { secretKey: 'configured' } },
+			email: {
+				state: 'ready',
+				value: {
+					apiKey: 'configured',
+					sender: 'sender@example.com',
+					assetUrl: 'https://assets.example.com'
+				}
+			},
+			ai: { state: 'misconfigured', issue: 'missing' }
+		});
+		givenThread({ isWarm: true, isHandedOff: false });
+		const ctx = makeCtx();
+
+		await sendHandler._handler(ctx, { threadId: 't1', prompt: 'the map is blank' });
+
+		expect(scheduledRefs(ctx)).toEqual([SCHEDULE_NOTIFICATION_REF]);
+		expect(ctx.db.patch).toHaveBeenCalledWith(
+			'st_1',
+			expect.objectContaining({ isHandedOff: true })
+		);
+		expect(saveMessageMock).toHaveBeenCalledTimes(2);
 	});
 
 	// The history query keeps the newest 50 entries of any role and filters to

--- a/src/lib/convex/support/messages.ts
+++ b/src/lib/convex/support/messages.ts
@@ -18,6 +18,11 @@ import { syncSupportLastMessage } from './threads';
 import { getFileMetadataByUrls } from '../files/metadata';
 import { makeAgentUsageSink } from '../aiUsage/agentUsage';
 import { recordAiUsage } from '../aiUsage/record';
+import {
+	CapabilityConfigurationError,
+	getCapabilityConfigurations,
+	requireAiConfiguration
+} from '../env';
 
 /**
  * Send a user message and get AI response with streaming
@@ -53,7 +58,7 @@ export const sendMessage = mutation({
 		// false, so the mode has to be re-read per message: otherwise disabling
 		// the agent would leave those threads waiting for a reply nobody sends.
 		const wasHandedOff = supportThread.isHandedOff === true;
-		const aiEnabled = isSupportAiEnabled();
+		const aiEnabled = isSupportAiEnabled() && getCapabilityConfigurations().ai.state === 'ready';
 		const isHumanOnly = wasHandedOff || !aiEnabled;
 
 		// Rate limit check - stricter limits for anonymous users
@@ -231,12 +236,19 @@ export const createAIResponse = internalAction({
 	},
 	returns: v.null(),
 	handler: async (ctx, args) => {
-		// sendMessage decides the mode, but the agent can be switched off while a
-		// job it scheduled is still queued. Dropping that job would strand the
-		// message: nothing answers, and the thread is not handed off, so it is
-		// absent from the admin lists too. Hand it to the team instead, which is
-		// what switching the agent off asks for.
-		if (!isSupportAiEnabled()) {
+		// sendMessage decides the mode, but the agent can be switched off or lose
+		// provider configuration while a scheduled job is still queued. Dropping
+		// that job would strand the message, so hand it to the team instead.
+		let aiReady = isSupportAiEnabled();
+		if (aiReady) {
+			try {
+				requireAiConfiguration();
+			} catch (error) {
+				if (!(error instanceof CapabilityConfigurationError)) throw error;
+				aiReady = false;
+			}
+		}
+		if (!aiReady) {
 			await ctx.runMutation(internal.support.handoff.internalSetHandoff, {
 				threadId: args.threadId,
 				// No model is going to speak in this turn, so the acknowledgement has
@@ -278,6 +290,17 @@ export const createAIResponse = internalAction({
 			// agent's built-in SUPPORT_AGENT_INSTRUCTIONS (agent.ts). The seam already
 			// accepts a locale; we pass none here and serve the global default.
 			const systemOverride = await ctx.runQuery(internal.support.promptStore.getActive, {});
+
+			try {
+				requireAiConfiguration();
+			} catch (error) {
+				if (!(error instanceof CapabilityConfigurationError)) throw error;
+				await ctx.runMutation(internal.support.handoff.internalSetHandoff, {
+					threadId: args.threadId,
+					acknowledge: true
+				});
+				return null;
+			}
 
 			// Stream the AI response with tool execution support
 			// maxSteps is configured at the agent level (agent.ts) for multi-step tool execution

--- a/src/lib/dev/features.test.ts
+++ b/src/lib/dev/features.test.ts
@@ -72,60 +72,125 @@ describe('resolveCapabilityConfigurations', () => {
 	});
 
 	it.each([
-		'https://features.example.com',
-		'https://fcatalog.example.com',
-		'https://february.example.com',
-		'https://assets.example.com.',
-		'https://8.8.8.8',
-		'https://192.0.0.9',
-		'https://192.0.0.10',
-		'https://192.88.99.2',
-		'https://[2001:4860:4860::8888]',
-		'https://[::ffff:8.8.8.8]'
-	])('accepts the syntactically public asset URL %s', (assetUrl) => {
+		['public DNS', 'https://features.example.com'],
+		['hex-looking DNS label', 'https://fcatalog.example.com'],
+		['trailing-dot public DNS', 'https://assets.example.com.'],
+		['public IPv4', 'https://8.8.8.8'],
+		['PCP anycast exception', 'https://192.0.0.9'],
+		['TURN anycast exception', 'https://192.0.0.10'],
+		['address beside the 6a44 anycast address', 'https://192.88.99.1'],
+		['public IPv6', 'https://[2001:4860:4860::8888]'],
+		['IPv4-IPv6 translation prefix', 'https://[64:ff9b::808:808]'],
+		['mapped public IPv4', 'https://[::ffff:8.8.8.8]'],
+		['IPv6 PCP anycast exception', 'https://[2001:1::1]'],
+		['IPv6 TURN anycast exception', 'https://[2001:1::2]'],
+		['IPv6 DNS-SD anycast exception', 'https://[2001:1::3]'],
+		['AMT exception', 'https://[2001:3::1]'],
+		['AS112-v6 exception', 'https://[2001:4:112::1]'],
+		['ORCHIDv2 exception', 'https://[2001:20::1]'],
+		['DETs exception', 'https://[2001:30::1]']
+	])('accepts the syntactically public %s asset URL', (_description, assetUrl) => {
 		expect(
 			resolveCapabilityConfigurations({ ...READY_ENVIRONMENT, EMAIL_ASSET_URL: assetUrl }).email
 		).toMatchObject({ state: 'ready' });
 	});
 
 	it.each([
-		'https://localhost.',
-		'https://assets.localhost',
-		'https://assets.localhost.',
-		'https://assets.local',
-		'https://0.0.0.1',
-		'https://10.0.0.1',
-		'https://100.64.0.1',
-		'https://127.0.0.1',
-		'https://169.254.0.1',
-		'https://172.16.0.1',
-		'https://192.0.0.1',
-		'https://192.0.2.1',
-		'https://192.88.99.1',
-		'https://192.168.0.1',
-		'https://198.18.0.1',
-		'https://198.51.100.1',
-		'https://203.0.113.1',
-		'https://224.0.0.1',
-		'https://240.0.0.1',
-		'https://[fc00::1]',
-		'https://[fd12::1]',
-		'https://[fe80::1]',
-		'https://[fec0::1]',
-		'https://[ff02::1]',
-		'https://[2001:db8::1]',
-		'https://[3fff:0::1]',
-		'https://[::1]',
-		'https://[::]',
-		'https://[::8.8.8.8]',
-		'https://[::ffff:10.0.0.1]',
-		'https://[::ffff:192.0.2.1]',
-		'https://[::ffff:224.0.0.1]'
-	])('rejects the syntactically non-public asset URL %s', (assetUrl) => {
+		['0.0.0.0/8', 'https://0.0.0.1'],
+		['10.0.0.0/8', 'https://10.0.0.1'],
+		['100.64.0.0/10', 'https://100.64.0.1'],
+		['127.0.0.0/8', 'https://127.0.0.1'],
+		['169.254.0.0/16', 'https://169.254.0.1'],
+		['172.16.0.0/12', 'https://172.16.0.1'],
+		['192.0.0.0/24', 'https://192.0.0.1'],
+		['192.0.2.0/24', 'https://192.0.2.1'],
+		['192.88.99.2/32', 'https://192.88.99.2'],
+		['192.168.0.0/16', 'https://192.168.0.1'],
+		['198.18.0.0/15', 'https://198.18.0.1'],
+		['198.51.100.0/24', 'https://198.51.100.1'],
+		['203.0.113.0/24', 'https://203.0.113.1'],
+		['224.0.0.0/4', 'https://224.0.0.1'],
+		['240.0.0.0/4', 'https://240.0.0.1'],
+		['::/128', 'https://[::]'],
+		['::1/128', 'https://[::1]'],
+		['::/96', 'https://[::808:808]'],
+		['::ffff:0:0/96 with private IPv4', 'https://[::ffff:10.0.0.1]'],
+		['64:ff9b:1::/48', 'https://[64:ff9b:1::1]'],
+		['100::/64', 'https://[100::1]'],
+		['100:0:0:1::/64', 'https://[100:0:0:1::1]'],
+		['2001::/23', 'https://[2001:10::1]'],
+		['2001:2::/48', 'https://[2001:2::1]'],
+		['2001:db8::/32', 'https://[2001:db8::1]'],
+		['3fff::/20', 'https://[3fff::1]'],
+		['5f00::/16', 'https://[5f00::1]'],
+		['fc00::/7', 'https://[fd12::1]'],
+		['fe80::/10', 'https://[fe80::1]'],
+		['fec0::/10', 'https://[fec0::1]'],
+		['ff00::/8', 'https://[ff02::1]']
+	])('rejects the syntactically non-public %s literal', (_cidr, assetUrl) => {
 		expect(
 			resolveCapabilityConfigurations({ ...READY_ENVIRONMENT, EMAIL_ASSET_URL: assetUrl }).email
 		).toEqual({ state: 'misconfigured', issue: 'invalid' });
 	});
+
+	it.each([
+		'alt',
+		'6tisch.arpa',
+		'eap.arpa',
+		'eap-noob.arpa',
+		'home.arpa',
+		'10.in-addr.arpa',
+		'254.169.in-addr.arpa',
+		'16.172.in-addr.arpa',
+		'17.172.in-addr.arpa',
+		'18.172.in-addr.arpa',
+		'19.172.in-addr.arpa',
+		'20.172.in-addr.arpa',
+		'21.172.in-addr.arpa',
+		'22.172.in-addr.arpa',
+		'23.172.in-addr.arpa',
+		'24.172.in-addr.arpa',
+		'25.172.in-addr.arpa',
+		'26.172.in-addr.arpa',
+		'27.172.in-addr.arpa',
+		'28.172.in-addr.arpa',
+		'29.172.in-addr.arpa',
+		'30.172.in-addr.arpa',
+		'31.172.in-addr.arpa',
+		'170.0.0.192.in-addr.arpa',
+		'171.0.0.192.in-addr.arpa',
+		'168.192.in-addr.arpa',
+		'8.e.f.ip6.arpa',
+		'9.e.f.ip6.arpa',
+		'a.e.f.ip6.arpa',
+		'b.e.f.ip6.arpa',
+		'ipv4only.arpa',
+		'resolver.arpa',
+		'service.arpa',
+		'example',
+		'invalid',
+		'local',
+		'localhost',
+		'onion',
+		'test'
+	])('rejects the registered non-public DNS suffix %s', (suffix) => {
+		const assetUrl = `https://assets.${suffix}.`;
+		expect(
+			resolveCapabilityConfigurations({ ...READY_ENVIRONMENT, EMAIL_ASSET_URL: assetUrl }).email
+		).toEqual({ state: 'misconfigured', issue: 'invalid' });
+	});
+
+	it.each(['example.com', 'example.net', 'example.org'])(
+		'keeps the public documentation host assets.%s usable',
+		(suffix) => {
+			expect(
+				resolveCapabilityConfigurations({
+					...READY_ENVIRONMENT,
+					EMAIL_ASSET_URL: `https://assets.${suffix}`
+				}).email
+			).toMatchObject({ state: 'ready' });
+		}
+	);
 
 	it.each([
 		['RESEND_API_KEY', 're_your_api_key_here', 'email'],

--- a/src/lib/dev/features.test.ts
+++ b/src/lib/dev/features.test.ts
@@ -72,6 +72,30 @@ describe('resolveCapabilityConfigurations', () => {
 	});
 
 	it.each([
+		'https://features.example.com',
+		'https://fcatalog.example.com',
+		'https://february.example.com',
+		'https://[2001:4860:4860::8888]'
+	])('accepts the public asset URL %s', (assetUrl) => {
+		expect(
+			resolveCapabilityConfigurations({ ...READY_ENVIRONMENT, EMAIL_ASSET_URL: assetUrl }).email
+		).toMatchObject({ state: 'ready' });
+	});
+
+	it.each([
+		'https://[fc00::1]',
+		'https://[fd12::1]',
+		'https://[fe80::1]',
+		'https://[febf::1]',
+		'https://[::1]',
+		'https://[::]'
+	])('rejects the non-public IPv6 asset URL %s', (assetUrl) => {
+		expect(
+			resolveCapabilityConfigurations({ ...READY_ENVIRONMENT, EMAIL_ASSET_URL: assetUrl }).email
+		).toEqual({ state: 'misconfigured', issue: 'invalid' });
+	});
+
+	it.each([
 		['RESEND_API_KEY', 're_your_api_key_here', 'email'],
 		['RESEND_API_KEY', 're_local_e2e_dummy', 'email'],
 		['AUTH_EMAIL', 'noreply@yourdomain.com', 'email'],

--- a/src/lib/dev/features.test.ts
+++ b/src/lib/dev/features.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+	resolveCapabilityConfigurations,
+	type CapabilityEnvironment,
+	type CapabilityRequirements
+} from './features';
+
+const OPTIONAL_REQUIREMENTS: CapabilityRequirements = {
+	billing: 'optional',
+	email: 'optional',
+	ai: 'optional'
+};
+
+const READY_ENVIRONMENT: CapabilityEnvironment = {
+	RESEND_API_KEY: 'resend-key',
+	AUTH_EMAIL: 'noreply@example.com',
+	EMAIL_ASSET_URL: 'https://assets.example.com',
+	AUTUMN_SECRET_KEY: 'autumn-key',
+	OPENROUTER_API_KEY: 'openrouter-key'
+};
+
+describe('resolveCapabilityConfigurations', () => {
+	it('keeps absent optional providers distinct from required misconfiguration', () => {
+		expect(resolveCapabilityConfigurations({}, OPTIONAL_REQUIREMENTS)).toEqual({
+			billing: { state: 'disabled' },
+			email: { state: 'disabled' },
+			ai: { state: 'disabled' }
+		});
+		expect(resolveCapabilityConfigurations({})).toEqual({
+			billing: { state: 'misconfigured', issue: 'missing' },
+			email: { state: 'misconfigured', issue: 'missing' },
+			ai: { state: 'misconfigured', issue: 'missing' }
+		});
+	});
+
+	it('normalizes structurally ready provider values without provider-specific key rules', () => {
+		expect(
+			resolveCapabilityConfigurations({
+				RESEND_API_KEY: ' r ',
+				AUTH_EMAIL: ' sender@example.com ',
+				EMAIL_ASSET_URL: ' https://assets.example.com/email ',
+				AUTUMN_SECRET_KEY: ' a ',
+				OPENROUTER_API_KEY: ' o '
+			})
+		).toEqual({
+			billing: { state: 'ready', value: { secretKey: 'a' } },
+			email: {
+				state: 'ready',
+				value: {
+					apiKey: 'r',
+					sender: 'sender@example.com',
+					assetUrl: 'https://assets.example.com/email'
+				}
+			},
+			ai: { state: 'ready', value: { apiKey: 'o' } }
+		});
+	});
+
+	it.each([
+		[{ ...READY_ENVIRONMENT, AUTUMN_SECRET_KEY: '   ' }, 'billing', 'blank'],
+		[{ ...READY_ENVIRONMENT, OPENROUTER_API_KEY: '\t' }, 'ai', 'blank'],
+		[{ ...READY_ENVIRONMENT, AUTH_EMAIL: undefined }, 'email', 'incomplete'],
+		[{ ...READY_ENVIRONMENT, AUTH_EMAIL: 'not-an-email' }, 'email', 'invalid'],
+		[{ ...READY_ENVIRONMENT, EMAIL_ASSET_URL: 'http://assets.example.com' }, 'email', 'invalid'],
+		[{ ...READY_ENVIRONMENT, EMAIL_ASSET_URL: 'https://localhost/assets' }, 'email', 'invalid'],
+		[{ ...READY_ENVIRONMENT, EMAIL_ASSET_URL: 'https://192.168.1.2/assets' }, 'email', 'invalid']
+	] as const)('marks narrow structural failures as misconfigured', (input, capability, issue) => {
+		expect(resolveCapabilityConfigurations(input)[capability]).toEqual({
+			state: 'misconfigured',
+			issue
+		});
+	});
+
+	it.each([
+		['RESEND_API_KEY', 're_your_api_key_here', 'email'],
+		['RESEND_API_KEY', 're_local_e2e_dummy', 'email'],
+		['AUTH_EMAIL', 'noreply@yourdomain.com', 'email'],
+		['AUTH_EMAIL', 'noreply@e2e.example.com', 'email'],
+		['EMAIL_ASSET_URL', 'https://yourdomain.com', 'email'],
+		['EMAIL_ASSET_URL', 'http://localhost', 'email'],
+		['AUTUMN_SECRET_KEY', 'am_sk_your_secret_key_here', 'billing'],
+		['AUTUMN_SECRET_KEY', 'am_sk_local_e2e_dummy', 'billing'],
+		['AUTUMN_SECRET_KEY', 'placeholder-key-for-analysis', 'billing'],
+		['OPENROUTER_API_KEY', 'sk-or-v1-your_openrouter_api_key_here', 'ai'],
+		['OPENROUTER_API_KEY', 'sk-or-local-e2e-dummy', 'ai']
+	] as const)('rejects the exact known sentinel in %s', (key, value, capability) => {
+		const resolved = resolveCapabilityConfigurations({ ...READY_ENVIRONMENT, [key]: value });
+		expect(resolved[capability]).toEqual({ state: 'misconfigured', issue: 'sentinel' });
+	});
+});

--- a/src/lib/dev/features.test.ts
+++ b/src/lib/dev/features.test.ts
@@ -75,21 +75,53 @@ describe('resolveCapabilityConfigurations', () => {
 		'https://features.example.com',
 		'https://fcatalog.example.com',
 		'https://february.example.com',
-		'https://[2001:4860:4860::8888]'
-	])('accepts the public asset URL %s', (assetUrl) => {
+		'https://assets.example.com.',
+		'https://8.8.8.8',
+		'https://192.0.0.9',
+		'https://192.0.0.10',
+		'https://192.88.99.2',
+		'https://[2001:4860:4860::8888]',
+		'https://[::ffff:8.8.8.8]'
+	])('accepts the syntactically public asset URL %s', (assetUrl) => {
 		expect(
 			resolveCapabilityConfigurations({ ...READY_ENVIRONMENT, EMAIL_ASSET_URL: assetUrl }).email
 		).toMatchObject({ state: 'ready' });
 	});
 
 	it.each([
+		'https://localhost.',
+		'https://assets.localhost',
+		'https://assets.localhost.',
+		'https://assets.local',
+		'https://0.0.0.1',
+		'https://10.0.0.1',
+		'https://100.64.0.1',
+		'https://127.0.0.1',
+		'https://169.254.0.1',
+		'https://172.16.0.1',
+		'https://192.0.0.1',
+		'https://192.0.2.1',
+		'https://192.88.99.1',
+		'https://192.168.0.1',
+		'https://198.18.0.1',
+		'https://198.51.100.1',
+		'https://203.0.113.1',
+		'https://224.0.0.1',
+		'https://240.0.0.1',
 		'https://[fc00::1]',
 		'https://[fd12::1]',
 		'https://[fe80::1]',
-		'https://[febf::1]',
+		'https://[fec0::1]',
+		'https://[ff02::1]',
+		'https://[2001:db8::1]',
+		'https://[3fff:0::1]',
 		'https://[::1]',
-		'https://[::]'
-	])('rejects the non-public IPv6 asset URL %s', (assetUrl) => {
+		'https://[::]',
+		'https://[::8.8.8.8]',
+		'https://[::ffff:10.0.0.1]',
+		'https://[::ffff:192.0.2.1]',
+		'https://[::ffff:224.0.0.1]'
+	])('rejects the syntactically non-public asset URL %s', (assetUrl) => {
 		expect(
 			resolveCapabilityConfigurations({ ...READY_ENVIRONMENT, EMAIL_ASSET_URL: assetUrl }).email
 		).toEqual({ state: 'misconfigured', issue: 'invalid' });

--- a/src/lib/dev/features.ts
+++ b/src/lib/dev/features.ts
@@ -103,37 +103,104 @@ function isValidSenderEmail(value: string): boolean {
 	return /^[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+$/.test(value);
 }
 
-function isPrivateIpv4(hostname: string): boolean {
+function parseIpv4(hostname: string): number[] | null {
 	const parts = hostname.split('.');
-	if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part))) return false;
+	if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part))) return null;
 	const octets = parts.map(Number);
-	if (octets.some((octet) => octet < 0 || octet > 255)) return true;
-	const [first, second] = octets;
+	return octets.some((octet) => octet < 0 || octet > 255) ? null : octets;
+}
+
+function isNonGlobalIpv4(octets: readonly number[]): boolean {
+	const [first, second, third, fourth] = octets;
 	return (
 		first === 0 ||
 		first === 10 ||
+		(first === 100 && second !== undefined && second >= 64 && second <= 127) ||
 		first === 127 ||
 		(first === 169 && second === 254) ||
 		(first === 172 && second !== undefined && second >= 16 && second <= 31) ||
-		(first === 192 && second === 168)
+		(first === 192 &&
+			second === 0 &&
+			((third === 0 && fourth !== 9 && fourth !== 10) || third === 2)) ||
+		(first === 192 && second === 88 && third === 99 && fourth !== 2) ||
+		(first === 192 && second === 168) ||
+		(first === 198 && (second === 18 || second === 19)) ||
+		(first === 198 && second === 51 && third === 100) ||
+		(first === 203 && second === 0 && third === 113) ||
+		(first !== undefined && first >= 224)
 	);
 }
 
+function parseIpv6(hostname: string): number[] | null {
+	if (!hostname.includes(':')) return null;
+	const halves = hostname.split('::');
+	if (halves.length > 2) return null;
+	const left = halves[0] ? halves[0].split(':') : [];
+	const right = halves[1] ? halves[1].split(':') : [];
+	const missing = 8 - left.length - right.length;
+	if ((halves.length === 1 && missing !== 0) || (halves.length === 2 && missing < 1)) return null;
+
+	const segments = [...left, ...Array.from({ length: missing }, () => '0'), ...right];
+	if (segments.length !== 8 || segments.some((segment) => !/^[\da-f]{1,4}$/i.test(segment))) {
+		return null;
+	}
+	return segments.map((segment) => Number.parseInt(segment, 16));
+}
+
+function isNonGlobalIpv6(words: readonly number[]): boolean {
+	const [first, second] = words;
+	const unspecified = words.every((word) => word === 0);
+	const loopback = words.slice(0, 7).every((word) => word === 0) && words[7] === 1;
+	const uniqueLocal = first !== undefined && (first & 0xfe00) === 0xfc00;
+	const localPrefix = first === undefined ? undefined : first & 0xffc0;
+	const linkOrSiteLocal = localPrefix === 0xfe80 || localPrefix === 0xfec0;
+	const multicast = first !== undefined && (first & 0xff00) === 0xff00;
+	const documentation =
+		(first === 0x2001 && second === 0x0db8) ||
+		(first === 0x3fff && second !== undefined && (second & 0xf000) === 0);
+	const mappedIpv4 =
+		words.slice(0, 5).every((word) => word === 0) && words[5] === 0xffff
+			? [words[6]! >> 8, words[6]! & 0xff, words[7]! >> 8, words[7]! & 0xff]
+			: null;
+	const compatibleIpv4 = words.slice(0, 6).every((word) => word === 0);
+
+	return (
+		unspecified ||
+		loopback ||
+		compatibleIpv4 ||
+		uniqueLocal ||
+		linkOrSiteLocal ||
+		multicast ||
+		documentation ||
+		(mappedIpv4 !== null && isNonGlobalIpv4(mappedIpv4))
+	);
+}
+
+// Syntactic screening only: DNS names are never resolved here.
 function isPublicAssetUrl(value: string): boolean {
 	try {
 		const url = new URL(value);
 		if (url.protocol !== 'https:' || url.username || url.password) return false;
 
-		const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
-		if (!hostname || hostname === 'localhost' || hostname.endsWith('.local')) return false;
-		if (isPrivateIpv4(hostname)) return false;
+		const hostname = url.hostname
+			.toLowerCase()
+			.replace(/^\[|\]$/g, '')
+			.replace(/\.+$/, '');
 		if (
-			hostname.includes(':') &&
-			(hostname === '::' || hostname === '::1' || /^(?:fc|fd|fe[89ab])/i.test(hostname))
+			!hostname ||
+			hostname === 'localhost' ||
+			hostname.endsWith('.localhost') ||
+			hostname === 'local' ||
+			hostname.endsWith('.local')
 		) {
 			return false;
 		}
-		return hostname.includes('.') || hostname.includes(':');
+
+		const ipv4 = parseIpv4(hostname);
+		if (ipv4) return !isNonGlobalIpv4(ipv4);
+		const ipv6 = parseIpv6(hostname);
+		if (ipv6) return !isNonGlobalIpv6(ipv6);
+		return hostname.includes('.');
 	} catch {
 		return false;
 	}

--- a/src/lib/dev/features.ts
+++ b/src/lib/dev/features.ts
@@ -127,7 +127,10 @@ function isPublicAssetUrl(value: string): boolean {
 		const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
 		if (!hostname || hostname === 'localhost' || hostname.endsWith('.local')) return false;
 		if (isPrivateIpv4(hostname)) return false;
-		if (hostname === '::' || hostname === '::1' || /^(?:fc|fd|fe[89ab])/i.test(hostname)) {
+		if (
+			hostname.includes(':') &&
+			(hostname === '::' || hostname === '::1' || /^(?:fc|fd|fe[89ab])/i.test(hostname))
+		) {
 			return false;
 		}
 		return hostname.includes('.') || hostname.includes(':');

--- a/src/lib/dev/features.ts
+++ b/src/lib/dev/features.ts
@@ -103,32 +103,108 @@ function isValidSenderEmail(value: string): boolean {
 	return /^[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+$/.test(value);
 }
 
+type AddressParser = (address: string) => number[] | null;
+
+// IANA IPv4 and IPv6 Special-Purpose Address Registries, updated 2025-10-09.
+// Multicast and deprecated compatible/site-local ranges remain non-public too.
+const NON_GLOBAL_IPV4_CIDRS = [
+	'0.0.0.0/8',
+	'10.0.0.0/8',
+	'100.64.0.0/10',
+	'127.0.0.0/8',
+	'169.254.0.0/16',
+	'172.16.0.0/12',
+	'192.0.0.0/24',
+	'192.0.2.0/24',
+	'192.88.99.2/32',
+	'192.168.0.0/16',
+	'198.18.0.0/15',
+	'198.51.100.0/24',
+	'203.0.113.0/24',
+	'224.0.0.0/4',
+	'240.0.0.0/4'
+] as const;
+
+const GLOBAL_IPV4_EXCEPTIONS = ['192.0.0.9/32', '192.0.0.10/32'] as const;
+
+const NON_GLOBAL_IPV6_CIDRS = [
+	'::/128',
+	'::1/128',
+	'::/96',
+	'::ffff:0:0/96',
+	'64:ff9b:1::/48',
+	'100::/64',
+	'100:0:0:1::/64',
+	'2001::/23',
+	'2001:2::/48',
+	'2001:db8::/32',
+	'3fff::/20',
+	'5f00::/16',
+	'fc00::/7',
+	'fe80::/10',
+	'fec0::/10',
+	'ff00::/8'
+] as const;
+
+const GLOBAL_IPV6_EXCEPTIONS = [
+	'2001:1::1/128',
+	'2001:1::2/128',
+	'2001:1::3/128',
+	'2001:3::/32',
+	'2001:4:112::/48',
+	'2001:20::/28',
+	'2001:30::/28'
+] as const;
+
+// IANA Special-Use Domain Names registry, updated 2026-05-22. The public
+// documentation hosts example.com/.net/.org intentionally remain usable.
+const NON_PUBLIC_DOMAIN_SUFFIXES = [
+	'alt',
+	'6tisch.arpa',
+	'eap.arpa',
+	'eap-noob.arpa',
+	'home.arpa',
+	'10.in-addr.arpa',
+	'254.169.in-addr.arpa',
+	'16.172.in-addr.arpa',
+	'17.172.in-addr.arpa',
+	'18.172.in-addr.arpa',
+	'19.172.in-addr.arpa',
+	'20.172.in-addr.arpa',
+	'21.172.in-addr.arpa',
+	'22.172.in-addr.arpa',
+	'23.172.in-addr.arpa',
+	'24.172.in-addr.arpa',
+	'25.172.in-addr.arpa',
+	'26.172.in-addr.arpa',
+	'27.172.in-addr.arpa',
+	'28.172.in-addr.arpa',
+	'29.172.in-addr.arpa',
+	'30.172.in-addr.arpa',
+	'31.172.in-addr.arpa',
+	'170.0.0.192.in-addr.arpa',
+	'171.0.0.192.in-addr.arpa',
+	'168.192.in-addr.arpa',
+	'8.e.f.ip6.arpa',
+	'9.e.f.ip6.arpa',
+	'a.e.f.ip6.arpa',
+	'b.e.f.ip6.arpa',
+	'ipv4only.arpa',
+	'resolver.arpa',
+	'service.arpa',
+	'example',
+	'invalid',
+	'local',
+	'localhost',
+	'onion',
+	'test'
+] as const;
+
 function parseIpv4(hostname: string): number[] | null {
 	const parts = hostname.split('.');
 	if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part))) return null;
 	const octets = parts.map(Number);
 	return octets.some((octet) => octet < 0 || octet > 255) ? null : octets;
-}
-
-function isNonGlobalIpv4(octets: readonly number[]): boolean {
-	const [first, second, third, fourth] = octets;
-	return (
-		first === 0 ||
-		first === 10 ||
-		(first === 100 && second !== undefined && second >= 64 && second <= 127) ||
-		first === 127 ||
-		(first === 169 && second === 254) ||
-		(first === 172 && second !== undefined && second >= 16 && second <= 31) ||
-		(first === 192 &&
-			second === 0 &&
-			((third === 0 && fourth !== 9 && fourth !== 10) || third === 2)) ||
-		(first === 192 && second === 88 && third === 99 && fourth !== 2) ||
-		(first === 192 && second === 168) ||
-		(first === 198 && (second === 18 || second === 19)) ||
-		(first === 198 && second === 51 && third === 100) ||
-		(first === 203 && second === 0 && third === 113) ||
-		(first !== undefined && first >= 224)
-	);
 }
 
 function parseIpv6(hostname: string): number[] | null {
@@ -147,33 +223,57 @@ function parseIpv6(hostname: string): number[] | null {
 	return segments.map((segment) => Number.parseInt(segment, 16));
 }
 
+function matchesCidr(
+	address: readonly number[],
+	cidr: string,
+	parseAddress: AddressParser,
+	bitsPerPart: number
+): boolean {
+	const [networkAddress, prefixLengthText] = cidr.split('/');
+	const network = networkAddress ? parseAddress(networkAddress) : null;
+	const prefixLength = Number(prefixLengthText);
+	if (!network || address.length !== network.length || !Number.isInteger(prefixLength))
+		return false;
+	if (prefixLength < 0 || prefixLength > address.length * bitsPerPart) return false;
+
+	const fullParts = Math.floor(prefixLength / bitsPerPart);
+	for (let index = 0; index < fullParts; index += 1) {
+		if (address[index] !== network[index]) return false;
+	}
+
+	const remainingBits = prefixLength % bitsPerPart;
+	if (remainingBits === 0) return true;
+	const mask = 2 ** bitsPerPart - 2 ** (bitsPerPart - remainingBits);
+	return (address[fullParts]! & mask) === (network[fullParts]! & mask);
+}
+
+function matchesAnyCidr(
+	address: readonly number[],
+	cidrs: readonly string[],
+	parseAddress: AddressParser,
+	bitsPerPart: number
+): boolean {
+	return cidrs.some((cidr) => matchesCidr(address, cidr, parseAddress, bitsPerPart));
+}
+
+function isNonGlobalIpv4(octets: readonly number[]): boolean {
+	if (matchesAnyCidr(octets, GLOBAL_IPV4_EXCEPTIONS, parseIpv4, 8)) return false;
+	return matchesAnyCidr(octets, NON_GLOBAL_IPV4_CIDRS, parseIpv4, 8);
+}
+
 function isNonGlobalIpv6(words: readonly number[]): boolean {
-	const [first, second] = words;
-	const unspecified = words.every((word) => word === 0);
-	const loopback = words.slice(0, 7).every((word) => word === 0) && words[7] === 1;
-	const uniqueLocal = first !== undefined && (first & 0xfe00) === 0xfc00;
-	const localPrefix = first === undefined ? undefined : first & 0xffc0;
-	const linkOrSiteLocal = localPrefix === 0xfe80 || localPrefix === 0xfec0;
-	const multicast = first !== undefined && (first & 0xff00) === 0xff00;
-	const documentation =
-		(first === 0x2001 && second === 0x0db8) ||
-		(first === 0x3fff && second !== undefined && (second & 0xf000) === 0);
 	const mappedIpv4 =
 		words.slice(0, 5).every((word) => word === 0) && words[5] === 0xffff
 			? [words[6]! >> 8, words[6]! & 0xff, words[7]! >> 8, words[7]! & 0xff]
 			: null;
-	const compatibleIpv4 = words.slice(0, 6).every((word) => word === 0);
+	// Mapped literals inherit the reachability of their embedded IPv4 address.
+	if (mappedIpv4) return isNonGlobalIpv4(mappedIpv4);
+	if (matchesAnyCidr(words, GLOBAL_IPV6_EXCEPTIONS, parseIpv6, 16)) return false;
+	return matchesAnyCidr(words, NON_GLOBAL_IPV6_CIDRS, parseIpv6, 16);
+}
 
-	return (
-		unspecified ||
-		loopback ||
-		compatibleIpv4 ||
-		uniqueLocal ||
-		linkOrSiteLocal ||
-		multicast ||
-		documentation ||
-		(mappedIpv4 !== null && isNonGlobalIpv4(mappedIpv4))
-	);
+function hasDomainSuffix(hostname: string, suffix: string): boolean {
+	return hostname === suffix || hostname.endsWith(`.${suffix}`);
 }
 
 // Syntactic screening only: DNS names are never resolved here.
@@ -188,10 +288,7 @@ function isPublicAssetUrl(value: string): boolean {
 			.replace(/\.+$/, '');
 		if (
 			!hostname ||
-			hostname === 'localhost' ||
-			hostname.endsWith('.localhost') ||
-			hostname === 'local' ||
-			hostname.endsWith('.local')
+			NON_PUBLIC_DOMAIN_SUFFIXES.some((suffix) => hasDomainSuffix(hostname, suffix))
 		) {
 			return false;
 		}

--- a/src/lib/dev/features.ts
+++ b/src/lib/dev/features.ts
@@ -25,11 +25,172 @@ export type DevFeature = {
 	docs?: string;
 };
 
+export type CapabilityRequirement = 'optional' | 'required';
+
+type ConfigurationIssue = 'blank' | 'incomplete' | 'invalid' | 'missing' | 'sentinel';
+
+export type CapabilityConfiguration<Value> =
+	| { state: 'disabled' }
+	| { state: 'misconfigured'; issue: ConfigurationIssue }
+	| { state: 'ready'; value: Value };
+
+export type CapabilityEnvironment = {
+	RESEND_API_KEY?: string | null;
+	AUTH_EMAIL?: string | null;
+	EMAIL_ASSET_URL?: string | null;
+	AUTUMN_SECRET_KEY?: string | null;
+	OPENROUTER_API_KEY?: string | null;
+};
+
+export type CapabilityRequirements = {
+	billing: CapabilityRequirement;
+	email: CapabilityRequirement;
+	ai: CapabilityRequirement;
+};
+
+export type EmailConfiguration = {
+	apiKey: string;
+	sender: string;
+	assetUrl: string;
+};
+
+export type BillingConfiguration = { secretKey: string };
+export type AiConfiguration = { apiKey: string };
+
+export type CapabilityConfigurations = {
+	billing: CapabilityConfiguration<BillingConfiguration>;
+	email: CapabilityConfiguration<EmailConfiguration>;
+	ai: CapabilityConfiguration<AiConfiguration>;
+};
+
+export const STRICT_CAPABILITY_REQUIREMENTS: CapabilityRequirements = {
+	billing: 'required',
+	email: 'required',
+	ai: 'required'
+};
+
+const BILLING_SENTINELS = new Set([
+	'am_sk_your_secret_key_here',
+	'am_sk_local_e2e_dummy',
+	'placeholder-key-for-analysis'
+]);
+const AI_SENTINELS = new Set(['sk-or-v1-your_openrouter_api_key_here', 'sk-or-local-e2e-dummy']);
+const EMAIL_SENTINELS = {
+	apiKey: new Set(['re_your_api_key_here', 're_local_e2e_dummy']),
+	sender: new Set(['noreply@yourdomain.com', 'noreply@e2e.example.com']),
+	assetUrl: new Set(['https://yourdomain.com', 'http://localhost'])
+};
+
+function resolveSingle<Value>(
+	value: string | null | undefined,
+	requirement: CapabilityRequirement,
+	sentinels: ReadonlySet<string>,
+	map: (value: string) => Value
+): CapabilityConfiguration<Value> {
+	if (value === undefined || value === null) {
+		return requirement === 'optional'
+			? { state: 'disabled' }
+			: { state: 'misconfigured', issue: 'missing' };
+	}
+
+	const normalized = value.trim();
+	if (!normalized) return { state: 'misconfigured', issue: 'blank' };
+	if (sentinels.has(normalized)) return { state: 'misconfigured', issue: 'sentinel' };
+	return { state: 'ready', value: map(normalized) };
+}
+
+function isValidSenderEmail(value: string): boolean {
+	return /^[^\s<>@]+@[^\s<>@]+\.[^\s<>@]+$/.test(value);
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+	const parts = hostname.split('.');
+	if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part))) return false;
+	const octets = parts.map(Number);
+	if (octets.some((octet) => octet < 0 || octet > 255)) return true;
+	const [first, second] = octets;
+	return (
+		first === 0 ||
+		first === 10 ||
+		first === 127 ||
+		(first === 169 && second === 254) ||
+		(first === 172 && second !== undefined && second >= 16 && second <= 31) ||
+		(first === 192 && second === 168)
+	);
+}
+
+function isPublicAssetUrl(value: string): boolean {
+	try {
+		const url = new URL(value);
+		if (url.protocol !== 'https:' || url.username || url.password) return false;
+
+		const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+		if (!hostname || hostname === 'localhost' || hostname.endsWith('.local')) return false;
+		if (isPrivateIpv4(hostname)) return false;
+		if (hostname === '::' || hostname === '::1' || /^(?:fc|fd|fe[89ab])/i.test(hostname)) {
+			return false;
+		}
+		return hostname.includes('.') || hostname.includes(':');
+	} catch {
+		return false;
+	}
+}
+
+function resolveEmailConfiguration(
+	input: CapabilityEnvironment,
+	requirement: CapabilityRequirement
+): CapabilityConfiguration<EmailConfiguration> {
+	const rawValues = [input.RESEND_API_KEY, input.AUTH_EMAIL, input.EMAIL_ASSET_URL];
+	if (rawValues.every((value) => value === undefined || value === null)) {
+		return requirement === 'optional'
+			? { state: 'disabled' }
+			: { state: 'misconfigured', issue: 'missing' };
+	}
+	if (rawValues.some((value) => value === undefined || value === null)) {
+		return { state: 'misconfigured', issue: 'incomplete' };
+	}
+
+	const [apiKey, sender, assetUrl] = rawValues.map((value) => value!.trim());
+	if (!apiKey || !sender || !assetUrl) return { state: 'misconfigured', issue: 'blank' };
+	if (
+		EMAIL_SENTINELS.apiKey.has(apiKey) ||
+		EMAIL_SENTINELS.sender.has(sender) ||
+		EMAIL_SENTINELS.assetUrl.has(assetUrl)
+	) {
+		return { state: 'misconfigured', issue: 'sentinel' };
+	}
+	if (!isValidSenderEmail(sender) || !isPublicAssetUrl(assetUrl)) {
+		return { state: 'misconfigured', issue: 'invalid' };
+	}
+
+	return { state: 'ready', value: { apiKey, sender, assetUrl } };
+}
+
+export function resolveCapabilityConfigurations(
+	input: CapabilityEnvironment,
+	requirements: CapabilityRequirements = STRICT_CAPABILITY_REQUIREMENTS
+): CapabilityConfigurations {
+	return {
+		billing: resolveSingle(
+			input.AUTUMN_SECRET_KEY,
+			requirements.billing,
+			BILLING_SENTINELS,
+			(secretKey) => ({
+				secretKey
+			})
+		),
+		email: resolveEmailConfiguration(input, requirements.email),
+		ai: resolveSingle(input.OPENROUTER_API_KEY, requirements.ai, AI_SENTINELS, (apiKey) => ({
+			apiKey
+		}))
+	};
+}
+
 export const DEV_FEATURES = [
 	{
 		name: 'Email delivery (Resend)',
 		scope: 'convex',
-		missing: ['RESEND_API_KEY', 'AUTH_EMAIL'],
+		missing: ['RESEND_API_KEY', 'AUTH_EMAIL', 'EMAIL_ASSET_URL'],
 		docs: '.env.convex.example'
 	},
 	{

--- a/src/lib/emails/__tests__/email-rendering.test.ts
+++ b/src/lib/emails/__tests__/email-rendering.test.ts
@@ -1,16 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// Mock the env module before importing templates
+// Mock the validated email capability before importing templates.
 vi.mock('$lib/convex/env', () => ({
-	requireEnv: (name: string) => {
-		const vars: Record<string, string> = {
-			EMAIL_ASSET_URL: 'https://test.example.com',
-			SITE_URL: 'https://test.example.com',
-			AUTH_EMAIL: 'test@example.com'
-		};
-		if (name in vars) return vars[name];
-		throw new Error(`Unexpected env var requested in test: ${name}`);
-	}
+	requireEmailConfiguration: () => ({
+		apiKey: 'configured',
+		sender: 'test@example.com',
+		assetUrl: 'https://test.example.com'
+	})
 }));
 
 import { sanitizeEmailCss } from '../email-css';


### PR DESCRIPTION
Regression guard: covered by provider-boundary and lifecycle tests

Provider-backed paths could construct SDK requests or leave queued work inconsistent when billing, email, or AI configuration was malformed. Better Auth could commit signup or reset state without enqueueing mail, and support cooldowns could start before the durable email component accepted a job.

This change adds one runtime configuration resolver and guards every Autumn, Resend, OpenRouter, AI-chat, community-message, and support boundary. Better Auth now rejects email-producing routes before writes when delivery is unavailable. Email assets use the validated normalized URL, with IANA-based screening for non-public addresses and special-use domains. Queued work reaches explicit terminal states, provider outages remain distinct from configuration denial, and support cooldown starts only after a committed Resend enqueue.

Verified with 206 focused regressions, 2,901 unit tests, changed-file static checks, full type and Convex checks, production build, and independent full-diff review.
