### PR TITLE
fix(chat): Make example executable

### DIFF
--- a/src/lib/chat/examples/SimpleChat.svelte
+++ b/src/lib/chat/examples/SimpleChat.svelte
@@ -5,8 +5,11 @@
   Copy and customize this for your own chat implementations.
 -->
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import { ChatDraftManager } from '$lib/chat';
+	import SimpleChatSessionObserver from './SimpleChatSessionObserver.svelte';
 	import SimpleChatThread from './SimpleChatThread.svelte';
+	import { SimpleChatSessionRegistry } from './simple-chat-session.svelte.ts';
 
 	let {
 		threadId,
@@ -22,8 +25,14 @@
 	} = $props();
 
 	const draftManager = new ChatDraftManager('simple-chat');
+	const sessionRegistry = new SimpleChatSessionRegistry(draftManager);
+	onDestroy(() => sessionRegistry.dispose());
 </script>
 
+{#each sessionRegistry.retainedSessions as session (session.threadId)}
+	<SimpleChatSessionObserver {session} />
+{/each}
+
 {#key threadId}
-	<SimpleChatThread {threadId} {title} {greeting} {draftManager} />
+	<SimpleChatThread {threadId} {title} {greeting} registry={sessionRegistry} />
 {/key}

--- a/src/lib/chat/examples/SimpleChat.svelte
+++ b/src/lib/chat/examples/SimpleChat.svelte
@@ -7,6 +7,7 @@
 <script lang="ts">
 	import { onDestroy } from 'svelte';
 	import { useConvexClient } from 'convex-svelte';
+	import { registerPersistedChatHolder } from '../core/chat-persisted-state.ts';
 	import SimpleChatSessionObserver from './SimpleChatSessionObserver.svelte';
 	import SimpleChatThread from './SimpleChatThread.svelte';
 	import { acquireSimpleChatSessionRegistry } from './simple-chat-session.svelte.ts';
@@ -25,14 +26,27 @@
 	} = $props();
 
 	const client = useConvexClient();
-	const sessionRegistry = acquireSimpleChatSessionRegistry(client);
-	onDestroy(() => sessionRegistry.releaseOwner());
+	let registryLease = $state.raw(acquireSimpleChatSessionRegistry(client));
+	const unregisterSessionHolder = registerPersistedChatHolder({
+		forgetPersistedState() {
+			const previousLease = registryLease;
+			registryLease = acquireSimpleChatSessionRegistry(client);
+			previousLease.registry.releaseOwner(previousLease.owner);
+		}
+	});
+
+	onDestroy(() => {
+		unregisterSessionHolder();
+		registryLease.registry.releaseOwner(registryLease.owner);
+	});
 </script>
 
-{#each sessionRegistry.retainedSessions as session (session.threadId)}
+{#each registryLease.registry.retainedSessionsFor(registryLease.owner) as session (session.threadId)}
 	<SimpleChatSessionObserver {session} />
 {/each}
 
-{#key threadId}
-	<SimpleChatThread {threadId} {title} {greeting} registry={sessionRegistry} />
+{#key registryLease.owner}
+	{#key threadId}
+		<SimpleChatThread {threadId} {title} {greeting} registry={registryLease.registry} />
+	{/key}
 {/key}

--- a/src/lib/chat/examples/SimpleChat.svelte
+++ b/src/lib/chat/examples/SimpleChat.svelte
@@ -5,14 +5,14 @@
   Copy and customize this for your own chat implementations.
 -->
 <script lang="ts">
-	import { ChatRoot, ChatMessages, ChatInput } from '$lib/chat';
+	import { ChatCore, ChatRoot, ChatMessages, ChatInput } from '$lib/chat';
 	import { Avatar, AvatarImage } from '$lib/components/ui/avatar';
 	import memberFour from '$blocks/team/avatars/member-four.webp';
 	import memberTwo from '$blocks/team/avatars/member-two.webp';
 	import memberFive from '$blocks/team/avatars/member-five.webp';
 
 	import type { ChatCoreAPI } from '$lib/chat';
-	import type { useQuery } from 'convex-svelte';
+	import { useConvexClient, type useQuery } from 'convex-svelte';
 
 	type ChatAPI = ChatCoreAPI & {
 		listMessages: Parameters<typeof useQuery>[0];
@@ -24,8 +24,8 @@
 		title = 'Chat',
 		greeting = 'How can we help?'
 	}: {
-		/** Thread ID for the conversation */
-		threadId: string | null;
+		/** Existing thread ID for the conversation */
+		threadId: string;
 		/** Convex API endpoints */
 		api: ChatAPI;
 		/** Chat title */
@@ -33,6 +33,19 @@
 		/** Greeting message */
 		greeting?: string;
 	} = $props();
+
+	const client = useConvexClient();
+	// API references are fixed for this mounted example; threadId is synchronized below.
+	// svelte-ignore state_referenced_locally
+	const core = new ChatCore({ threadId, api });
+
+	$effect(() => {
+		if (core.threadId !== threadId) core.setThread(threadId);
+	});
+
+	async function handleSend(prompt: string) {
+		await core.sendMessage(client, prompt);
+	}
 
 	// Intentionally English-only: this is a copy-and-customize example, not shipped UI.
 	const suggestions = [
@@ -49,7 +62,7 @@
 	</div>
 
 	<!-- Chat area -->
-	<ChatRoot {threadId} {api}>
+	<ChatRoot {threadId} {api} externalCore={core}>
 		<div class="relative flex-1 overflow-hidden">
 			<ChatMessages>
 				{#snippet emptyState()}
@@ -83,7 +96,8 @@
 		<ChatInput
 			{suggestions}
 			placeholder="Type a message..."
-			showFileButton={true}
+			showFileButton={false}
+			onSend={handleSend}
 			class="mx-4 mb-4"
 		/>
 	</ChatRoot>

--- a/src/lib/chat/examples/SimpleChat.svelte
+++ b/src/lib/chat/examples/SimpleChat.svelte
@@ -5,100 +5,25 @@
   Copy and customize this for your own chat implementations.
 -->
 <script lang="ts">
-	import { ChatCore, ChatRoot, ChatMessages, ChatInput } from '$lib/chat';
-	import { Avatar, AvatarImage } from '$lib/components/ui/avatar';
-	import memberFour from '$blocks/team/avatars/member-four.webp';
-	import memberTwo from '$blocks/team/avatars/member-two.webp';
-	import memberFive from '$blocks/team/avatars/member-five.webp';
-
-	import type { ChatCoreAPI } from '$lib/chat';
-	import { useConvexClient, type useQuery } from 'convex-svelte';
-
-	type ChatAPI = ChatCoreAPI & {
-		listMessages: Parameters<typeof useQuery>[0];
-	};
+	import { ChatDraftManager } from '$lib/chat';
+	import SimpleChatThread from './SimpleChatThread.svelte';
 
 	let {
 		threadId,
-		api,
 		title = 'Chat',
 		greeting = 'How can we help?'
 	}: {
 		/** Existing thread ID for the conversation */
 		threadId: string;
-		/** Convex API endpoints */
-		api: ChatAPI;
 		/** Chat title */
 		title?: string;
 		/** Greeting message */
 		greeting?: string;
 	} = $props();
 
-	const client = useConvexClient();
-	// API references are fixed for this mounted example; threadId is synchronized below.
-	// svelte-ignore state_referenced_locally
-	const core = new ChatCore({ threadId, api });
-
-	$effect(() => {
-		if (core.threadId !== threadId) core.setThread(threadId);
-	});
-
-	async function handleSend(prompt: string) {
-		await core.sendMessage(client, prompt);
-	}
-
-	// Intentionally English-only: this is a copy-and-customize example, not shipped UI.
-	const suggestions = [
-		{ text: 'I have a question about...', label: 'Ask a question' },
-		{ text: 'I found an issue with...', label: 'Report an issue' },
-		{ text: 'Can you help me with...', label: 'Get help' }
-	];
+	const draftManager = new ChatDraftManager('simple-chat');
 </script>
 
-<div class="flex h-full w-full flex-col overflow-hidden rounded-lg border bg-background shadow-lg">
-	<!-- Header -->
-	<div class="border-b px-4 py-3">
-		<h2 class="font-semibold">{title}</h2>
-	</div>
-
-	<!-- Chat area -->
-	<ChatRoot {threadId} {api} externalCore={core}>
-		<div class="relative flex-1 overflow-hidden">
-			<ChatMessages>
-				{#snippet emptyState()}
-					<div class="flex !h-full flex-col justify-start">
-						<div class="m-10 flex flex-col items-start">
-							<!-- Avatar stack -->
-							<div class="mb-6 flex -space-x-3">
-								<Avatar class="size-12 outline outline-4 outline-background">
-									<AvatarImage src={memberFour} alt="Team member" class="object-cover" />
-								</Avatar>
-								<Avatar class="size-12 outline outline-4 outline-background">
-									<AvatarImage src={memberTwo} alt="Team member" class="object-cover" />
-								</Avatar>
-								<Avatar class="size-12 outline outline-4 outline-background">
-									<AvatarImage src={memberFive} alt="Team member" class="object-cover" />
-								</Avatar>
-							</div>
-
-							<!-- Greeting -->
-							<h2 class="mb-4 text-5xl font-semibold text-muted-foreground">Hi</h2>
-
-							<!-- Main heading -->
-							<h3 class="text-3xl font-bold">{greeting}</h3>
-						</div>
-					</div>
-				{/snippet}
-			</ChatMessages>
-		</div>
-
-		<!-- Input -->
-		<ChatInput
-			{suggestions}
-			placeholder="Type a message..."
-			showFileButton={false}
-			onSend={handleSend}
-			class="mx-4 mb-4"
-		/>
-	</ChatRoot>
-</div>
+{#key threadId}
+	<SimpleChatThread {threadId} {title} {greeting} {draftManager} />
+{/key}

--- a/src/lib/chat/examples/SimpleChat.svelte
+++ b/src/lib/chat/examples/SimpleChat.svelte
@@ -6,10 +6,10 @@
 -->
 <script lang="ts">
 	import { onDestroy } from 'svelte';
-	import { ChatDraftManager } from '$lib/chat';
+	import { useConvexClient } from 'convex-svelte';
 	import SimpleChatSessionObserver from './SimpleChatSessionObserver.svelte';
 	import SimpleChatThread from './SimpleChatThread.svelte';
-	import { SimpleChatSessionRegistry } from './simple-chat-session.svelte.ts';
+	import { acquireSimpleChatSessionRegistry } from './simple-chat-session.svelte.ts';
 
 	let {
 		threadId,
@@ -24,9 +24,9 @@
 		greeting?: string;
 	} = $props();
 
-	const draftManager = new ChatDraftManager('simple-chat');
-	const sessionRegistry = new SimpleChatSessionRegistry(draftManager);
-	onDestroy(() => sessionRegistry.dispose());
+	const client = useConvexClient();
+	const sessionRegistry = acquireSimpleChatSessionRegistry(client);
+	onDestroy(() => sessionRegistry.releaseOwner());
 </script>
 
 {#each sessionRegistry.retainedSessions as session (session.threadId)}

--- a/src/lib/chat/examples/SimpleChat.test.ts
+++ b/src/lib/chat/examples/SimpleChat.test.ts
@@ -51,14 +51,19 @@ function mountChat(threadId: string, provideTolgee = true) {
 	return provider;
 }
 
-async function enterMessage(value: string) {
+async function setComposerValue(value: string) {
 	const input = document.querySelector<HTMLTextAreaElement>('[data-testid="chat-input-textarea"]')!;
 	input.value = value;
 	input.dispatchEvent(new Event('input', { bubbles: true }));
 	await tick();
 	const button = document.querySelector<HTMLButtonElement>('[data-testid="chat-input-send"]')!;
-	expect(button.disabled).toBe(false);
 	return { input, button };
+}
+
+async function enterMessage(value: string) {
+	const composer = await setComposerValue(value);
+	expect(composer.button.disabled).toBe(false);
+	return composer;
 }
 
 function pasteItems(input: HTMLTextAreaElement, items: DataTransferItem[]) {
@@ -275,12 +280,13 @@ describe('SimpleChat', () => {
 		expect(mutation).toHaveBeenCalledTimes(1);
 	});
 
-	it('preserves a genuine edit made after returning to a pending origin', async () => {
+	it('preserves a same-text new edit through locked remounts and success', async () => {
 		const pending = Promise.withResolvers<Record<string, never>>();
-		vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		const mutation = vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
 		const provider = mountChat('thread-a');
 		await tick();
-		const { button: originButton } = await enterMessage('Original A draft');
+		const sentDraft = 'Original A draft';
+		const { button: originButton } = await enterMessage(sentDraft);
 		originButton.click();
 		await tick();
 
@@ -288,20 +294,73 @@ describe('SimpleChat', () => {
 		await tick();
 		provider.setContentProps({ threadId: 'thread-a' });
 		await tick();
-		const newerDraft = 'A newer draft while pending';
+		const newerDraft = sentDraft;
+		const { button: lockedButton } = await setComposerValue(newerDraft);
+		expect(lockedButton.disabled).toBe(true);
+		expect(storedDrafts()).toEqual({ 'thread-a': newerDraft });
+
+		provider.setContentProps({ threadId: 'thread-b' });
+		await tick();
+		provider.setContentProps({ threadId: 'thread-a' });
+		await tick();
 		const input = document.querySelector<HTMLTextAreaElement>(
 			'[data-testid="chat-input-textarea"]'
 		)!;
-		input.value = newerDraft;
-		input.dispatchEvent(new Event('input', { bubbles: true }));
-		await tick();
-		expect(storedDrafts()).toEqual({ 'thread-a': newerDraft });
+		expect(input.value).toBe(newerDraft);
+		expect(
+			document.querySelector<HTMLButtonElement>('[data-testid="chat-input-send"]')!.disabled
+		).toBe(true);
+		expect(mutation).toHaveBeenCalledTimes(1);
 
 		pending.resolve({});
 		await vi.waitFor(() => expect(capturedChatMessages.context?.core.isSending).toBe(false));
 		expect(storedDrafts()).toEqual({ 'thread-a': newerDraft });
 		expect(input.value).toBe(newerDraft);
 		expect(capturedChatMessages.context?.core.isAwaitingStream).toBe(true);
+		capturedChatMessages.context?.core.setAwaitingStream(false);
+		await tick();
+		expect(storedDrafts()).toEqual({ 'thread-a': newerDraft });
+		expect(input.value).toBe(newerDraft);
+		expect(
+			document.querySelector<HTMLButtonElement>('[data-testid="chat-input-send"]')!.disabled
+		).toBe(false);
+	});
+
+	it('preserves a genuine edit through repeated locked remounts and rejection', async () => {
+		const pending = Promise.withResolvers<never>();
+		const mutation = vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		const provider = mountChat('thread-a');
+		await tick();
+		const { button: originButton } = await enterMessage('Rejected A draft');
+		originButton.click();
+		await tick();
+
+		provider.setContentProps({ threadId: 'thread-b' });
+		await tick();
+		provider.setContentProps({ threadId: 'thread-a' });
+		await tick();
+		const newerDraft = 'Keep this newer A draft';
+		const { button: lockedButton } = await setComposerValue(newerDraft);
+		expect(lockedButton.disabled).toBe(true);
+
+		provider.setContentProps({ threadId: 'thread-b' });
+		await tick();
+		provider.setContentProps({ threadId: 'thread-a' });
+		await tick();
+		const input = document.querySelector<HTMLTextAreaElement>(
+			'[data-testid="chat-input-textarea"]'
+		)!;
+		expect(input.value).toBe(newerDraft);
+		expect(mutation).toHaveBeenCalledTimes(1);
+
+		pending.reject(new Error('Send rejected'));
+		await vi.waitFor(() => expect(capturedChatMessages.context?.core.isSending).toBe(false));
+		expect(input.value).toBe(newerDraft);
+		expect(storedDrafts()).toEqual({ 'thread-a': newerDraft });
+		expect(
+			document.querySelector<HTMLButtonElement>('[data-testid="chat-input-send"]')!.disabled
+		).toBe(false);
+		expect(mutation).toHaveBeenCalledTimes(1);
 	});
 
 	it('releases an inactive retained session after its stream lock ends', async () => {
@@ -324,6 +383,121 @@ describe('SimpleChat', () => {
 		await tick();
 
 		expect(capturedChatMessages.context?.core).not.toBe(originCore);
+		expect(capturedChatMessages.context?.core.isAwaitingStream).toBe(false);
+	});
+
+	it('retains an in-flight rejection across a full provider remount', async () => {
+		const pending = Promise.withResolvers<never>();
+		const error = new Error('Send rejected');
+		const mutation = vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		mountChat('thread-a');
+		await tick();
+		const originCore = capturedChatMessages.context!.core;
+		const exactText = '  Retry after a full remount  ';
+		const { button: originButton } = await enterMessage(exactText);
+		originButton.click();
+		await tick();
+
+		await unmount(component!);
+		component = undefined;
+		mountChat('thread-a');
+		await tick();
+		const input = document.querySelector<HTMLTextAreaElement>(
+			'[data-testid="chat-input-textarea"]'
+		)!;
+		const button = document.querySelector<HTMLButtonElement>('[data-testid="chat-input-send"]')!;
+		expect(capturedChatMessages.context?.core).toBe(originCore);
+		expect(input.value).toBe('');
+		expect(button.disabled).toBe(true);
+		expect(mutation).toHaveBeenCalledTimes(1);
+
+		pending.reject(error);
+		await vi.waitFor(() => expect(input.value).toBe(exactText));
+		expect(button.disabled).toBe(false);
+		expect(storedDrafts()).toEqual({ 'thread-a': exactText });
+		expect(mutation).toHaveBeenCalledTimes(1);
+	});
+
+	it('retains an in-flight success across a full provider remount', async () => {
+		const pending = Promise.withResolvers<Record<string, never>>();
+		const mutation = vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		mountChat('thread-a');
+		await tick();
+		const originCore = capturedChatMessages.context!.core;
+		const { button: originButton } = await enterMessage('Send across a full remount');
+		originButton.click();
+		await tick();
+
+		await unmount(component!);
+		component = undefined;
+		mountChat('thread-a');
+		await tick();
+		const input = document.querySelector<HTMLTextAreaElement>(
+			'[data-testid="chat-input-textarea"]'
+		)!;
+		const button = document.querySelector<HTMLButtonElement>('[data-testid="chat-input-send"]')!;
+		expect(capturedChatMessages.context?.core).toBe(originCore);
+		expect(input.value).toBe('');
+		expect(button.disabled).toBe(true);
+
+		pending.resolve({});
+		await vi.waitFor(() => expect(originCore.isSending).toBe(false));
+		expect(originCore.isAwaitingStream).toBe(true);
+		expect(input.value).toBe('');
+		expect(storedDrafts()).toEqual({});
+		button.click();
+		expect(mutation).toHaveBeenCalledTimes(1);
+
+		originCore.setAwaitingStream(false);
+		await tick();
+		await unmount(component!);
+		component = undefined;
+		mountChat('thread-a');
+		await tick();
+		expect(capturedChatMessages.context?.core).not.toBe(originCore);
+		expect(capturedChatMessages.context?.core.isAwaitingStream).toBe(false);
+		expect(
+			document.querySelector<HTMLTextAreaElement>('[data-testid="chat-input-textarea"]')!.value
+		).toBe('');
+	});
+
+	it('cleans up an ownerless rejection before a later mount', async () => {
+		const pending = Promise.withResolvers<never>();
+		vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		mountChat('thread-a');
+		await tick();
+		const originCore = capturedChatMessages.context!.core;
+		const exactText = '  Restore after ownerless rejection  ';
+		const { button } = await enterMessage(exactText);
+		button.click();
+		await tick();
+		await unmount(component!);
+		component = undefined;
+
+		pending.reject(new Error('Send rejected'));
+		await vi.waitFor(() => expect(originCore.isSending).toBe(false));
+		mountChat('thread-a');
+		await tick();
+		expect(capturedChatMessages.context?.core).not.toBe(originCore);
+		expect(capturedChatMessages.context?.core.isSending).toBe(false);
+		expect(
+			document.querySelector<HTMLTextAreaElement>('[data-testid="chat-input-textarea"]')!.value
+		).toBe(exactText);
+	});
+
+	it('does not retain idle core state across sequential mounts', async () => {
+		mountChat('thread-a');
+		await tick();
+		const originCore = capturedChatMessages.context!.core;
+		originCore.setError('stale error');
+		await unmount(component!);
+		component = undefined;
+
+		mountChat('thread-a');
+		await tick();
+		expect(capturedChatMessages.context?.core).not.toBe(originCore);
+		expect(capturedChatMessages.context?.core.error).toBeNull();
+		expect(capturedChatMessages.context?.core.isSending).toBe(false);
 		expect(capturedChatMessages.context?.core.isAwaitingStream).toBe(false);
 	});
 

--- a/src/lib/chat/examples/SimpleChat.test.ts
+++ b/src/lib/chat/examples/SimpleChat.test.ts
@@ -5,6 +5,7 @@ import { ConvexClient } from 'convex/browser';
 import { getFunctionName } from 'convex/server';
 import en from '../../../i18n/en.json';
 import { ChatUIContext } from '../ui/chat-context.svelte.ts';
+import { capturedChatMessages } from '../ui/test-fixtures/CapturedChatMessages.svelte';
 import ChatTestProvider from '../ui/test-fixtures/ChatTestProvider.svelte';
 import SimpleChat from './SimpleChat.svelte';
 
@@ -13,7 +14,9 @@ vi.mock('svelte', () =>
 	vi.importActual<typeof Svelte>('../../../../node_modules/svelte/src/index-client.js')
 );
 vi.mock('esm-env', () => ({ BROWSER: true, DEV: true }));
-vi.mock('$lib/chat/ui/ChatMessages.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/chat/ui/ChatMessages.svelte', async () => ({
+	default: (await import('../ui/test-fixtures/CapturedChatMessages.svelte')).default
+}));
 vi.mock('$lib/chat/ui/ChatAttachments.svelte', () => ({ default: () => {} }));
 vi.mock('$lib/hooks/use-haptic.svelte.ts', () => ({ haptic: { trigger: vi.fn() } }));
 
@@ -25,6 +28,7 @@ let client: ConvexClient;
 
 beforeEach(() => {
 	localStorage.clear();
+	delete capturedChatMessages.context;
 	client = new ConvexClient('https://chat-test.convex.cloud', { disabled: true });
 	vi.spyOn(console, 'error').mockImplementation(() => {});
 });
@@ -208,6 +212,119 @@ describe('SimpleChat', () => {
 			userId: undefined,
 			fileIds: undefined
 		});
+	});
+
+	it('keeps an origin send locked when returning before rejection', async () => {
+		const pending = Promise.withResolvers<never>();
+		const error = new Error('Send rejected');
+		const mutation = vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		const provider = mountChat('thread-a');
+		await tick();
+		const exactText = '  Retry after returning to A  ';
+		const { button: originButton } = await enterMessage(exactText);
+		originButton.click();
+		await tick();
+
+		provider.setContentProps({ threadId: 'thread-b' });
+		await tick();
+		provider.setContentProps({ threadId: 'thread-a' });
+		await tick();
+		const input = document.querySelector<HTMLTextAreaElement>(
+			'[data-testid="chat-input-textarea"]'
+		)!;
+		const button = document.querySelector<HTMLButtonElement>('[data-testid="chat-input-send"]')!;
+		expect(input.value).toBe('');
+		expect(button.disabled).toBe(true);
+		expect(capturedChatMessages.context?.core.isSending).toBe(true);
+		button.click();
+		expect(mutation).toHaveBeenCalledTimes(1);
+
+		pending.reject(error);
+		await vi.waitFor(() => expect(input.value).toBe(exactText));
+		expect(button.disabled).toBe(false);
+		expect(capturedChatMessages.context?.core.isSending).toBe(false);
+		expect(mutation).toHaveBeenCalledTimes(1);
+	});
+
+	it('clears an unchanged origin after returning before success and keeps awaiting locked', async () => {
+		const pending = Promise.withResolvers<Record<string, never>>();
+		const mutation = vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		const provider = mountChat('thread-a');
+		await tick();
+		const { button: originButton } = await enterMessage('Send once from A');
+		originButton.click();
+		await tick();
+
+		provider.setContentProps({ threadId: 'thread-b' });
+		await tick();
+		provider.setContentProps({ threadId: 'thread-a' });
+		await tick();
+		const input = document.querySelector<HTMLTextAreaElement>(
+			'[data-testid="chat-input-textarea"]'
+		)!;
+		const button = document.querySelector<HTMLButtonElement>('[data-testid="chat-input-send"]')!;
+		expect(input.value).toBe('');
+		expect(capturedChatMessages.context?.core.isSending).toBe(true);
+
+		pending.resolve({});
+		await vi.waitFor(() => expect(capturedChatMessages.context?.core.isSending).toBe(false));
+		expect(storedDrafts()).toEqual({});
+		expect(input.value).toBe('');
+		expect(capturedChatMessages.context?.core.isAwaitingStream).toBe(true);
+		button.click();
+		expect(mutation).toHaveBeenCalledTimes(1);
+	});
+
+	it('preserves a genuine edit made after returning to a pending origin', async () => {
+		const pending = Promise.withResolvers<Record<string, never>>();
+		vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		const provider = mountChat('thread-a');
+		await tick();
+		const { button: originButton } = await enterMessage('Original A draft');
+		originButton.click();
+		await tick();
+
+		provider.setContentProps({ threadId: 'thread-b' });
+		await tick();
+		provider.setContentProps({ threadId: 'thread-a' });
+		await tick();
+		const newerDraft = 'A newer draft while pending';
+		const input = document.querySelector<HTMLTextAreaElement>(
+			'[data-testid="chat-input-textarea"]'
+		)!;
+		input.value = newerDraft;
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+		await tick();
+		expect(storedDrafts()).toEqual({ 'thread-a': newerDraft });
+
+		pending.resolve({});
+		await vi.waitFor(() => expect(capturedChatMessages.context?.core.isSending).toBe(false));
+		expect(storedDrafts()).toEqual({ 'thread-a': newerDraft });
+		expect(input.value).toBe(newerDraft);
+		expect(capturedChatMessages.context?.core.isAwaitingStream).toBe(true);
+	});
+
+	it('releases an inactive retained session after its stream lock ends', async () => {
+		const pending = Promise.withResolvers<Record<string, never>>();
+		vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		const provider = mountChat('thread-a');
+		await tick();
+		const originCore = capturedChatMessages.context!.core;
+		const { button } = await enterMessage('Observe the stream lifecycle');
+		button.click();
+		await tick();
+
+		provider.setContentProps({ threadId: 'thread-b' });
+		await tick();
+		pending.resolve({});
+		await vi.waitFor(() => expect(originCore.isAwaitingStream).toBe(true));
+		originCore.setAwaitingStream(false);
+		await tick();
+		provider.setContentProps({ threadId: 'thread-a' });
+		await tick();
+
+		expect(capturedChatMessages.context?.core).not.toBe(originCore);
+		expect(capturedChatMessages.context?.core.isAwaitingStream).toBe(false);
 	});
 
 	it.each([

--- a/src/lib/chat/examples/SimpleChat.test.ts
+++ b/src/lib/chat/examples/SimpleChat.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mount, tick, unmount } from 'svelte';
+import { mount, tick, unmount, type ComponentProps } from 'svelte';
 import type * as Svelte from 'svelte';
 import { ConvexClient } from 'convex/browser';
 import { getFunctionName } from 'convex/server';
-import { api } from '$lib/convex/_generated/api';
 import en from '../../../i18n/en.json';
+import { ChatUIContext } from '../ui/chat-context.svelte.ts';
 import ChatTestProvider from '../ui/test-fixtures/ChatTestProvider.svelte';
 import SimpleChat from './SimpleChat.svelte';
 
@@ -17,15 +17,8 @@ vi.mock('$lib/chat/ui/ChatMessages.svelte', () => ({ default: () => {} }));
 vi.mock('$lib/chat/ui/ChatAttachments.svelte', () => ({ default: () => {} }));
 vi.mock('$lib/hooks/use-haptic.svelte.ts', () => ({ haptic: { trigger: vi.fn() } }));
 
-const chatApi = {
-	sendMessage: api.aiChat.messages.sendMessage,
-	listMessages: api.aiChat.messages.listMessages
-};
-
-type ContentProps = {
-	threadId: string;
-	api: typeof chatApi;
-};
+type ContentProps = ComponentProps<typeof SimpleChat>;
+type RejectsApiOverride = 'api' extends keyof ContentProps ? false : true;
 
 let component: ReturnType<typeof mount> | undefined;
 let client: ConvexClient;
@@ -44,11 +37,11 @@ afterEach(async () => {
 	vi.restoreAllMocks();
 });
 
-function mountChat(threadId: string) {
-	const contentProps: ContentProps = { threadId, api: chatApi };
+function mountChat(threadId: string, provideTolgee = true) {
+	const contentProps: ContentProps = { threadId };
 	const provider = mount(ChatTestProvider<ContentProps>, {
 		target: document.body,
-		props: { client, content: SimpleChat, contentProps }
+		props: { client, content: SimpleChat, contentProps, provideTolgee }
 	});
 	component = provider;
 	return provider;
@@ -62,6 +55,20 @@ async function enterMessage(value: string) {
 	const button = document.querySelector<HTMLButtonElement>('[data-testid="chat-input-send"]')!;
 	expect(button.disabled).toBe(false);
 	return { input, button };
+}
+
+function pasteItems(input: HTMLTextAreaElement, items: DataTransferItem[]) {
+	const event = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+	Object.defineProperty(event, 'clipboardData', {
+		value: { items },
+		configurable: true
+	});
+	input.dispatchEvent(event);
+	return event;
+}
+
+function storedDrafts(): Record<string, string> {
+	return JSON.parse(localStorage.getItem('drafts:simple-chat') ?? '{}');
 }
 
 describe('SimpleChat', () => {
@@ -125,7 +132,7 @@ describe('SimpleChat', () => {
 		const provider = mountChat('thread-before');
 		await tick();
 
-		provider.setContentProps({ threadId: 'thread-after', api: chatApi });
+		provider.setContentProps({ threadId: 'thread-after' });
 		await tick();
 		const { button } = await enterMessage('Use the current thread');
 		button.click();
@@ -139,5 +146,104 @@ describe('SimpleChat', () => {
 			userId: undefined,
 			fileIds: undefined
 		});
+	});
+
+	it('restores the exact origin draft after switching away from a rejected send', async () => {
+		const pending = Promise.withResolvers<never>();
+		const error = new Error('Send rejected');
+		vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		const provider = mountChat('thread-a');
+		await tick();
+		const exactText = '  Retry in thread A  ';
+		const { button } = await enterMessage(exactText);
+		button.click();
+		await tick();
+
+		provider.setContentProps({ threadId: 'thread-b' });
+		await tick();
+		expect(
+			document.querySelector<HTMLTextAreaElement>('[data-testid="chat-input-textarea"]')!.value
+		).toBe('');
+		expect(storedDrafts()).toEqual({ 'thread-a': exactText });
+		pending.reject(error);
+		await vi.waitFor(() =>
+			expect(console.error).toHaveBeenCalledWith('[ChatInput] onSend failed:', error)
+		);
+		const { button: selectedButton } = await enterMessage('Thread B stays independent');
+		expect(selectedButton.disabled).toBe(false);
+
+		provider.setContentProps({ threadId: 'thread-a' });
+		await tick();
+		expect(
+			document.querySelector<HTMLTextAreaElement>('[data-testid="chat-input-textarea"]')!.value
+		).toBe(exactText);
+	});
+
+	it('keeps the selected thread sendable when an origin send succeeds', async () => {
+		const pending = Promise.withResolvers<Record<string, never>>();
+		const mutation = vi.spyOn(client, 'mutation').mockImplementation((_reference, args) => {
+			return (args as { threadId?: string }).threadId === 'thread-a'
+				? pending.promise
+				: Promise.resolve({});
+		});
+		const provider = mountChat('thread-a');
+		await tick();
+		const { button: originButton } = await enterMessage('Send from A');
+		originButton.click();
+		await tick();
+
+		provider.setContentProps({ threadId: 'thread-b' });
+		await tick();
+		const { button: selectedButton } = await enterMessage('Send from B');
+		expect(selectedButton.disabled).toBe(false);
+		pending.resolve({});
+		await vi.waitFor(() => expect(storedDrafts()).toEqual({ 'thread-b': 'Send from B' }));
+		expect(selectedButton.disabled).toBe(false);
+
+		selectedButton.click();
+		await vi.waitFor(() => expect(mutation).toHaveBeenCalledTimes(2));
+		expect(mutation.mock.calls[1]?.[1]).toEqual({
+			threadId: 'thread-b',
+			prompt: 'Send from B',
+			userId: undefined,
+			fileIds: undefined
+		});
+	});
+
+	it.each([
+		{ name: 'file-only', includeText: false },
+		{ name: 'mixed', includeText: true }
+	])('ignores $name clipboard files when uploads are hidden', async ({ includeText }) => {
+		mountChat('thread-paste');
+		await tick();
+		const uploadFile = vi.spyOn(ChatUIContext.prototype, 'uploadFile');
+		const input = document.querySelector<HTMLTextAreaElement>(
+			'[data-testid="chat-input-textarea"]'
+		)!;
+		const file = new File(['notes'], 'notes.txt', { type: 'text/plain' });
+		const fileItem = {
+			kind: 'file',
+			type: file.type,
+			getAsFile: () => file
+		} as DataTransferItem;
+		const textItem = {
+			kind: 'string',
+			type: 'text/plain',
+			getAsFile: () => null
+		} as DataTransferItem;
+		const event = pasteItems(input, includeText ? [textItem, fileItem] : [fileItem]);
+		await tick();
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(uploadFile).not.toHaveBeenCalled();
+	});
+
+	it('does not accept an API override prop', () => {
+		const rejectsApiOverride: RejectsApiOverride = true;
+		expect(rejectsApiOverride).toBe(true);
+	});
+
+	it('requires the documented TolgeeProvider context', () => {
+		expect(() => mountChat('thread-without-tolgee', false)).toThrow(/TolgeeProvider/);
 	});
 });

--- a/src/lib/chat/examples/SimpleChat.test.ts
+++ b/src/lib/chat/examples/SimpleChat.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, tick, unmount } from 'svelte';
+import type * as Svelte from 'svelte';
+import { ConvexClient } from 'convex/browser';
+import { getFunctionName } from 'convex/server';
+import { api } from '$lib/convex/_generated/api';
+import en from '../../../i18n/en.json';
+import ChatTestProvider from '../ui/test-fixtures/ChatTestProvider.svelte';
+import SimpleChat from './SimpleChat.svelte';
+
+// Vitest resolves Svelte's server entry by default; use its real client runtime for mounting.
+vi.mock('svelte', () =>
+	vi.importActual<typeof Svelte>('../../../../node_modules/svelte/src/index-client.js')
+);
+vi.mock('esm-env', () => ({ BROWSER: true, DEV: true }));
+vi.mock('$lib/chat/ui/ChatMessages.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/chat/ui/ChatAttachments.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/hooks/use-haptic.svelte.ts', () => ({ haptic: { trigger: vi.fn() } }));
+
+const chatApi = {
+	sendMessage: api.aiChat.messages.sendMessage,
+	listMessages: api.aiChat.messages.listMessages
+};
+
+type ContentProps = {
+	threadId: string;
+	api: typeof chatApi;
+};
+
+let component: ReturnType<typeof mount> | undefined;
+let client: ConvexClient;
+
+beforeEach(() => {
+	localStorage.clear();
+	client = new ConvexClient('https://chat-test.convex.cloud', { disabled: true });
+	vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(async () => {
+	if (component) await unmount(component);
+	component = undefined;
+	await client.close();
+	localStorage.clear();
+	vi.restoreAllMocks();
+});
+
+function mountChat(threadId: string) {
+	const contentProps: ContentProps = { threadId, api: chatApi };
+	const provider = mount(ChatTestProvider<ContentProps>, {
+		target: document.body,
+		props: { client, content: SimpleChat, contentProps }
+	});
+	component = provider;
+	return provider;
+}
+
+async function enterMessage(value: string) {
+	const input = document.querySelector<HTMLTextAreaElement>('[data-testid="chat-input-textarea"]')!;
+	input.value = value;
+	input.dispatchEvent(new Event('input', { bubbles: true }));
+	await tick();
+	const button = document.querySelector<HTMLButtonElement>('[data-testid="chat-input-send"]')!;
+	expect(button.disabled).toBe(false);
+	return { input, button };
+}
+
+describe('SimpleChat', () => {
+	it('sends trimmed text with optimistic state and no attachment controls', async () => {
+		const pending = Promise.withResolvers<Record<string, never>>();
+		const mutation = vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		mountChat('thread-selected');
+		await tick();
+		const { input, button } = await enterMessage('  Send this once  ');
+
+		button.click();
+		await tick();
+
+		expect(mutation).toHaveBeenCalledTimes(1);
+		const [reference, args, options] = mutation.mock.calls[0]!;
+		expect(getFunctionName(reference)).toBe('aiChat/messages:sendMessage');
+		expect(args).toEqual({
+			threadId: 'thread-selected',
+			prompt: 'Send this once',
+			userId: undefined,
+			fileIds: undefined
+		});
+		expect(options?.optimisticUpdate).toBeTypeOf('function');
+		expect(input.value).toBe('');
+		expect(button.disabled).toBe(true);
+		expect(
+			document.querySelector(`button[aria-label="${en.chat.tooltip.attach_files}"]`)
+		).toBeNull();
+		expect(document.querySelector('input[type="file"]')).toBeNull();
+
+		pending.resolve({});
+		await tick();
+	});
+
+	it('lets ChatInput restore exact text when the mutation rejects', async () => {
+		const pending = Promise.withResolvers<never>();
+		const error = new Error('Send rejected');
+		vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		mountChat('thread-retry');
+		await tick();
+		const exactText = '  Retry this exactly  ';
+		const { input, button } = await enterMessage(exactText);
+
+		button.click();
+		await tick();
+		expect(input.value).toBe('');
+		expect(button.disabled).toBe(true);
+		pending.reject(error);
+
+		await vi.waitFor(() => expect(input.value).toBe(exactText));
+		expect(button.disabled).toBe(false);
+		expect(console.error).toHaveBeenCalledWith(
+			'[ChatCore.sendMessage] Failed to send message:',
+			error
+		);
+		expect(console.error).toHaveBeenCalledWith('[ChatInput] onSend failed:', error);
+	});
+
+	it('uses a changed thread ID for the next send', async () => {
+		const mutation = vi.spyOn(client, 'mutation').mockResolvedValue({});
+		const provider = mountChat('thread-before');
+		await tick();
+
+		provider.setContentProps({ threadId: 'thread-after', api: chatApi });
+		await tick();
+		const { button } = await enterMessage('Use the current thread');
+		button.click();
+
+		await vi.waitFor(() => expect(mutation).toHaveBeenCalledTimes(1));
+		const [reference, args] = mutation.mock.calls[0]!;
+		expect(getFunctionName(reference)).toBe('aiChat/messages:sendMessage');
+		expect(args).toEqual({
+			threadId: 'thread-after',
+			prompt: 'Use the current thread',
+			userId: undefined,
+			fileIds: undefined
+		});
+	});
+});

--- a/src/lib/chat/examples/SimpleChat.test.ts
+++ b/src/lib/chat/examples/SimpleChat.test.ts
@@ -4,9 +4,13 @@ import type * as Svelte from 'svelte';
 import { ConvexClient } from 'convex/browser';
 import { getFunctionName } from 'convex/server';
 import en from '../../../i18n/en.json';
+import { clearPersistedChatState } from '../core/chat-persisted-state.ts';
 import { ChatUIContext } from '../ui/chat-context.svelte.ts';
 import { capturedChatMessages } from '../ui/test-fixtures/CapturedChatMessages.svelte';
 import ChatTestProvider from '../ui/test-fixtures/ChatTestProvider.svelte';
+import SimpleChatOwnersHarness, {
+	simpleChatOwnersHarness
+} from '../ui/test-fixtures/SimpleChatOwnersHarness.svelte';
 import SimpleChat from './SimpleChat.svelte';
 
 // Vitest resolves Svelte's server entry by default; use its real client runtime for mounting.
@@ -29,6 +33,10 @@ let client: ConvexClient;
 beforeEach(() => {
 	localStorage.clear();
 	delete capturedChatMessages.context;
+	delete simpleChatOwnersHarness.setFirstThreadId;
+	delete simpleChatOwnersHarness.setSecondThreadId;
+	delete simpleChatOwnersHarness.hideFirst;
+	delete simpleChatOwnersHarness.hideSecond;
 	client = new ConvexClient('https://chat-test.convex.cloud', { disabled: true });
 	vi.spyOn(console, 'error').mockImplementation(() => {});
 });
@@ -49,6 +57,30 @@ function mountChat(threadId: string, provideTolgee = true) {
 	});
 	component = provider;
 	return provider;
+}
+
+function mountOwners(firstThreadId: string, secondThreadId: string) {
+	const contentProps = { firstThreadId, secondThreadId };
+	component = mount(ChatTestProvider<typeof contentProps>, {
+		target: document.body,
+		props: { client, content: SimpleChatOwnersHarness, contentProps }
+	});
+}
+
+function ownerComposer(owner: 'first' | 'second') {
+	const surface = document.querySelector<HTMLElement>(`[data-simple-chat-owner="${owner}"]`)!;
+	return {
+		input: surface.querySelector<HTMLTextAreaElement>('[data-testid="chat-input-textarea"]')!,
+		button: surface.querySelector<HTMLButtonElement>('[data-testid="chat-input-send"]')!
+	};
+}
+
+async function setOwnerComposerValue(owner: 'first' | 'second', value: string) {
+	const composer = ownerComposer(owner);
+	composer.input.value = value;
+	composer.input.dispatchEvent(new Event('input', { bubbles: true }));
+	await tick();
+	return ownerComposer(owner);
 }
 
 async function setComposerValue(value: string) {
@@ -499,6 +531,134 @@ describe('SimpleChat', () => {
 		expect(capturedChatMessages.context?.core.error).toBeNull();
 		expect(capturedChatMessages.context?.core.isSending).toBe(false);
 		expect(capturedChatMessages.context?.core.isAwaitingStream).toBe(false);
+	});
+
+	it('discards an ownerless awaiting session after the chat epoch changes', async () => {
+		const pending = Promise.withResolvers<Record<string, never>>();
+		vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		const onUpdate = vi.spyOn(client, 'onUpdate');
+		mountChat('thread-before-logout');
+		await tick();
+		const originCore = capturedChatMessages.context!.core;
+		const { button } = await enterMessage('Do not retain this session');
+		button.click();
+		await tick();
+		await unmount(component!);
+		component = undefined;
+		pending.resolve({});
+		await vi.waitFor(() => expect(originCore.isAwaitingStream).toBe(true));
+
+		clearPersistedChatState();
+		onUpdate.mockClear();
+		mountChat('thread-after-logout');
+		await tick();
+		const subscribedThreads = onUpdate.mock.calls.map(([, args]) =>
+			'threadId' in args ? args.threadId : undefined
+		);
+
+		expect(subscribedThreads).not.toContain('thread-before-logout');
+		expect(
+			document.querySelector(
+				'[data-testid="simple-chat-session-observer"][data-thread-id="thread-before-logout"]'
+			)
+		).toBeNull();
+		expect(capturedChatMessages.context?.core).not.toBe(originCore);
+		expect(capturedChatMessages.context?.core.isSending).toBe(false);
+		expect(capturedChatMessages.context?.core.isAwaitingStream).toBe(false);
+		expect(
+			document.querySelector<HTMLTextAreaElement>('[data-testid="chat-input-textarea"]')!.value
+		).toBe('');
+		expect(storedDrafts()).toEqual({});
+	});
+
+	it('keeps stale async callbacks out of the replacement epoch registry', async () => {
+		const pending = Promise.withResolvers<never>();
+		const mutation = vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		mountChat('thread-a');
+		await tick();
+		const oldCore = capturedChatMessages.context!.core;
+		const { button } = await enterMessage('Old session draft');
+		button.click();
+		await tick();
+		await unmount(component!);
+		component = undefined;
+
+		clearPersistedChatState();
+		mountChat('thread-a');
+		await tick();
+		const newCore = capturedChatMessages.context!.core;
+		const newDraft = 'New session draft';
+		const { input } = await enterMessage(newDraft);
+		pending.reject(new Error('Old session rejected'));
+		await tick();
+		await Promise.resolve();
+
+		expect(newCore).not.toBe(oldCore);
+		expect(capturedChatMessages.context?.core).toBe(newCore);
+		expect(input.value).toBe(newDraft);
+		expect(storedDrafts()).toEqual({ 'thread-a': newDraft });
+		expect(mutation).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		{ hidden: 'first' as const, remaining: 'second' as const },
+		{ hidden: 'second' as const, remaining: 'first' as const }
+	])('shares one thread context when the $hidden owner unmounts', async ({ hidden, remaining }) => {
+		const pending = Promise.withResolvers<never>();
+		const mutation = vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		mountOwners('thread-shared', 'thread-shared');
+		await tick();
+
+		await setOwnerComposerValue('first', 'Draft from first');
+		expect(ownerComposer('second').input.value).toBe('Draft from first');
+		const sharedDraft = 'Draft from second';
+		await setOwnerComposerValue('second', sharedDraft);
+		expect(ownerComposer('first').input.value).toBe(sharedDraft);
+
+		ownerComposer('first').button.click();
+		await tick();
+		expect(ownerComposer('first').input.value).toBe('');
+		expect(ownerComposer('second').input.value).toBe('');
+		expect(ownerComposer('first').button.disabled).toBe(true);
+		expect(ownerComposer('second').button.disabled).toBe(true);
+		ownerComposer('second').button.click();
+		expect(mutation).toHaveBeenCalledTimes(1);
+
+		if (hidden === 'first') simpleChatOwnersHarness.hideFirst?.();
+		else simpleChatOwnersHarness.hideSecond?.();
+		await tick();
+		pending.reject(new Error('Send rejected'));
+		await vi.waitFor(() => expect(ownerComposer(remaining).input.value).toBe(sharedDraft));
+		expect(ownerComposer(remaining).button.disabled).toBe(false);
+		expect(storedDrafts()).toEqual({ 'thread-shared': sharedDraft });
+		expect(mutation).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders one retained observer and transfers primary ownership', async () => {
+		const pending = Promise.withResolvers<never>();
+		vi.spyOn(client, 'mutation').mockReturnValue(pending.promise);
+		const observersFor = (threadId: string) =>
+			Array.from(
+				document.querySelectorAll<HTMLElement>(
+					`[data-testid="simple-chat-session-observer"][data-thread-id="${threadId}"]`
+				)
+			);
+		mountOwners('thread-a', 'thread-c');
+		await tick();
+		await setOwnerComposerValue('first', 'Retain A while hidden');
+		ownerComposer('first').button.click();
+		await tick();
+
+		simpleChatOwnersHarness.setFirstThreadId?.('thread-b');
+		await vi.waitFor(() => expect(observersFor('thread-a')).toHaveLength(1));
+		const firstObserver = observersFor('thread-a')[0];
+
+		simpleChatOwnersHarness.hideFirst?.();
+		await vi.waitFor(() => expect(observersFor('thread-a')).toHaveLength(1));
+		expect(observersFor('thread-a')[0]).not.toBe(firstObserver);
+
+		pending.reject(new Error('Send rejected'));
+		await vi.waitFor(() => expect(observersFor('thread-a')).toHaveLength(0));
 	});
 
 	it.each([

--- a/src/lib/chat/examples/SimpleChatSessionObserver.svelte
+++ b/src/lib/chat/examples/SimpleChatSessionObserver.svelte
@@ -6,5 +6,10 @@
 </script>
 
 <ChatRoot threadId={session.threadId} api={session.api} externalCore={session.core}>
-	<span hidden aria-hidden="true"></span>
+	<span
+		hidden
+		aria-hidden="true"
+		data-testid="simple-chat-session-observer"
+		data-thread-id={session.threadId}
+	></span>
 </ChatRoot>

--- a/src/lib/chat/examples/SimpleChatSessionObserver.svelte
+++ b/src/lib/chat/examples/SimpleChatSessionObserver.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import ChatRoot from '../ui/ChatRoot.svelte';
+	import type { SimpleChatSession } from './simple-chat-session.svelte.ts';
+
+	let { session }: { session: SimpleChatSession } = $props();
+</script>
+
+<ChatRoot threadId={session.threadId} api={session.api} externalCore={session.core}>
+	<span hidden aria-hidden="true"></span>
+</ChatRoot>

--- a/src/lib/chat/examples/SimpleChatThread.svelte
+++ b/src/lib/chat/examples/SimpleChatThread.svelte
@@ -40,7 +40,7 @@
 	});
 
 	async function handleSend(prompt: string) {
-		await session.send(client, prompt);
+		await session.send(client, prompt, uiContext);
 	}
 
 	// Intentionally English-only: this is a copy-and-customize example, not shipped UI.

--- a/src/lib/chat/examples/SimpleChatThread.svelte
+++ b/src/lib/chat/examples/SimpleChatThread.svelte
@@ -2,15 +2,8 @@
 	import { onDestroy } from 'svelte';
 	import { useConvexClient } from 'convex-svelte';
 	import { watch } from 'runed';
-	import { api } from '$lib/convex/_generated/api';
-	import {
-		ChatCore,
-		ChatRoot,
-		ChatMessages,
-		ChatInput,
-		ChatUIContext,
-		type ChatDraftManager
-	} from '$lib/chat';
+	import { ChatRoot, ChatMessages, ChatInput, ChatUIContext } from '$lib/chat';
+	import type { SimpleChatSessionRegistry } from './simple-chat-session.svelte.ts';
 	import { Avatar, AvatarImage } from '$lib/components/ui/avatar';
 	import memberFour from '$blocks/team/avatars/member-four.webp';
 	import memberTwo from '$blocks/team/avatars/member-two.webp';
@@ -20,53 +13,34 @@
 		threadId,
 		title,
 		greeting,
-		draftManager
+		registry
 	}: {
 		threadId: string;
 		title: string;
 		greeting: string;
-		draftManager: ChatDraftManager;
+		registry: SimpleChatSessionRegistry;
 	} = $props();
 
 	const client = useConvexClient();
-	const chatApi = {
-		sendMessage: api.aiChat.messages.sendMessage,
-		listMessages: api.aiChat.messages.listMessages
-	};
-	// The parent keys this child by threadId, so the core and context belong to one thread lifetime.
+	// The parent keys this child by threadId, so this mount acquires exactly one thread session.
 	// svelte-ignore state_referenced_locally
-	const core = new ChatCore({ threadId, api: chatApi });
-	const uiContext = new ChatUIContext(core, client);
-	// Restore this thread before ChatInput mounts and reads the context.
-	// svelte-ignore state_referenced_locally
-	uiContext.setInputValue(draftManager.getDraft(threadId));
-	let sending = $state(false);
+	const session = registry.acquire(threadId);
+	const uiContext = new ChatUIContext(session.core, client);
+	session.attach(uiContext);
 
 	watch(
-		() => [uiContext.inputValue, sending] as const,
-		([value, isSending]) => {
-			// ChatInput clears before calling onSend. Keep the origin draft while its send is pending.
-			if (isSending && value === '') return;
-			draftManager.setDraft(threadId, value);
-		}
+		() => uiContext.inputValue,
+		(value) => session.recordInput(uiContext, value),
+		{ lazy: true }
 	);
 
 	onDestroy(() => {
-		if (!sending || uiContext.inputValue !== '') {
-			draftManager.setDraft(threadId, uiContext.inputValue);
-		}
+		session.detach(uiContext);
 		uiContext.dispose();
 	});
 
 	async function handleSend(prompt: string) {
-		const checkpoint = draftManager.captureCheckpoint(threadId);
-		sending = true;
-		try {
-			await core.sendMessage(client, prompt);
-			draftManager.clearDraftIfUnchanged(checkpoint);
-		} finally {
-			sending = false;
-		}
+		await session.send(client, prompt);
 	}
 
 	// Intentionally English-only: this is a copy-and-customize example, not shipped UI.
@@ -84,7 +58,7 @@
 	</div>
 
 	<!-- Chat area -->
-	<ChatRoot {threadId} api={chatApi} externalCore={core} externalUIContext={uiContext}>
+	<ChatRoot {threadId} api={session.api} externalCore={session.core} externalUIContext={uiContext}>
 		<div class="relative flex-1 overflow-hidden">
 			<ChatMessages>
 				{#snippet emptyState()}

--- a/src/lib/chat/examples/SimpleChatThread.svelte
+++ b/src/lib/chat/examples/SimpleChatThread.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { useConvexClient } from 'convex-svelte';
+	import { watch } from 'runed';
+	import { api } from '$lib/convex/_generated/api';
+	import {
+		ChatCore,
+		ChatRoot,
+		ChatMessages,
+		ChatInput,
+		ChatUIContext,
+		type ChatDraftManager
+	} from '$lib/chat';
+	import { Avatar, AvatarImage } from '$lib/components/ui/avatar';
+	import memberFour from '$blocks/team/avatars/member-four.webp';
+	import memberTwo from '$blocks/team/avatars/member-two.webp';
+	import memberFive from '$blocks/team/avatars/member-five.webp';
+
+	let {
+		threadId,
+		title,
+		greeting,
+		draftManager
+	}: {
+		threadId: string;
+		title: string;
+		greeting: string;
+		draftManager: ChatDraftManager;
+	} = $props();
+
+	const client = useConvexClient();
+	const chatApi = {
+		sendMessage: api.aiChat.messages.sendMessage,
+		listMessages: api.aiChat.messages.listMessages
+	};
+	// The parent keys this child by threadId, so the core and context belong to one thread lifetime.
+	// svelte-ignore state_referenced_locally
+	const core = new ChatCore({ threadId, api: chatApi });
+	const uiContext = new ChatUIContext(core, client);
+	// Restore this thread before ChatInput mounts and reads the context.
+	// svelte-ignore state_referenced_locally
+	uiContext.setInputValue(draftManager.getDraft(threadId));
+	let sending = $state(false);
+
+	watch(
+		() => [uiContext.inputValue, sending] as const,
+		([value, isSending]) => {
+			// ChatInput clears before calling onSend. Keep the origin draft while its send is pending.
+			if (isSending && value === '') return;
+			draftManager.setDraft(threadId, value);
+		}
+	);
+
+	onDestroy(() => {
+		if (!sending || uiContext.inputValue !== '') {
+			draftManager.setDraft(threadId, uiContext.inputValue);
+		}
+		uiContext.dispose();
+	});
+
+	async function handleSend(prompt: string) {
+		const checkpoint = draftManager.captureCheckpoint(threadId);
+		sending = true;
+		try {
+			await core.sendMessage(client, prompt);
+			draftManager.clearDraftIfUnchanged(checkpoint);
+		} finally {
+			sending = false;
+		}
+	}
+
+	// Intentionally English-only: this is a copy-and-customize example, not shipped UI.
+	const suggestions = [
+		{ text: 'I have a question about...', label: 'Ask a question' },
+		{ text: 'I found an issue with...', label: 'Report an issue' },
+		{ text: 'Can you help me with...', label: 'Get help' }
+	];
+</script>
+
+<div class="flex h-full w-full flex-col overflow-hidden rounded-lg border bg-background shadow-lg">
+	<!-- Header -->
+	<div class="border-b px-4 py-3">
+		<h2 class="font-semibold">{title}</h2>
+	</div>
+
+	<!-- Chat area -->
+	<ChatRoot {threadId} api={chatApi} externalCore={core} externalUIContext={uiContext}>
+		<div class="relative flex-1 overflow-hidden">
+			<ChatMessages>
+				{#snippet emptyState()}
+					<div class="flex !h-full flex-col justify-start">
+						<div class="m-10 flex flex-col items-start">
+							<!-- Avatar stack -->
+							<div class="mb-6 flex -space-x-3">
+								<Avatar class="size-12 outline outline-4 outline-background">
+									<AvatarImage src={memberFour} alt="Team member" class="object-cover" />
+								</Avatar>
+								<Avatar class="size-12 outline outline-4 outline-background">
+									<AvatarImage src={memberTwo} alt="Team member" class="object-cover" />
+								</Avatar>
+								<Avatar class="size-12 outline outline-4 outline-background">
+									<AvatarImage src={memberFive} alt="Team member" class="object-cover" />
+								</Avatar>
+							</div>
+
+							<!-- Greeting -->
+							<h2 class="mb-4 text-5xl font-semibold text-muted-foreground">Hi</h2>
+
+							<!-- Main heading -->
+							<h3 class="text-3xl font-bold">{greeting}</h3>
+						</div>
+					</div>
+				{/snippet}
+			</ChatMessages>
+		</div>
+
+		<!-- Input -->
+		<ChatInput
+			{suggestions}
+			placeholder="Type a message..."
+			showFileButton={false}
+			onSend={handleSend}
+			class="mx-4 mb-4"
+		/>
+	</ChatRoot>
+</div>

--- a/src/lib/chat/examples/simple-chat-session.svelte.ts
+++ b/src/lib/chat/examples/simple-chat-session.svelte.ts
@@ -1,0 +1,149 @@
+import type { ConvexClient } from 'convex/browser';
+import { api } from '$lib/convex/_generated/api';
+import { ChatCore, type ChatCoreOptions } from '../core/chat-core.svelte.ts';
+import type { ChatDraftManager } from '../core/chat-draft-manager.svelte.ts';
+import type { ChatUIContext } from '../ui/chat-context.svelte.ts';
+
+const SIMPLE_CHAT_API = {
+	sendMessage: api.aiChat.messages.sendMessage,
+	listMessages: api.aiChat.messages.listMessages
+};
+
+type IgnoredInput = {
+	context: ChatUIContext;
+	value: string;
+};
+
+class SimpleChatCore extends ChatCore {
+	constructor(
+		options: ChatCoreOptions,
+		private readonly releaseAfterStream: () => void
+	) {
+		super(options);
+	}
+
+	override setAwaitingStream(awaiting: boolean): void {
+		super.setAwaitingStream(awaiting);
+		if (!awaiting) this.releaseAfterStream();
+	}
+}
+
+export class SimpleChatSession {
+	readonly api = SIMPLE_CHAT_API;
+	readonly core: ChatCore;
+	activeMounts = $state(0);
+
+	private context: ChatUIContext | null = null;
+	private ignoredInput: IgnoredInput | null = null;
+	private inputRevision = 0;
+
+	constructor(
+		readonly threadId: string,
+		private readonly draftManager: ChatDraftManager,
+		private readonly releaseIfIdle: (session: SimpleChatSession) => void
+	) {
+		this.core = new SimpleChatCore({ threadId, api: this.api }, () => this.releaseIfIdle(this));
+	}
+
+	get isLocked(): boolean {
+		return this.core.isSending || this.core.isAwaitingStream;
+	}
+
+	attach(context: ChatUIContext): void {
+		this.activeMounts += 1;
+		this.context = context;
+		this.setContextInput(context, this.isLocked ? '' : this.draftManager.getDraft(this.threadId));
+	}
+
+	recordInput(context: ChatUIContext, value: string): void {
+		if (this.context !== context) return;
+		if (this.ignoredInput?.context === context && this.ignoredInput.value === value) {
+			this.ignoredInput = null;
+			return;
+		}
+		this.ignoredInput = null;
+		this.inputRevision += 1;
+		this.draftManager.setDraft(this.threadId, value);
+	}
+
+	detach(context: ChatUIContext): void {
+		if (this.context === context) {
+			const value = context.inputValue;
+			if (!(this.isLocked && value === '') && this.draftManager.getDraft(this.threadId) !== value) {
+				this.inputRevision += 1;
+				this.draftManager.setDraft(this.threadId, value);
+			}
+			this.context = null;
+			this.ignoredInput = null;
+		}
+		this.activeMounts = Math.max(0, this.activeMounts - 1);
+		this.releaseIfIdle(this);
+	}
+
+	async send(client: ConvexClient, prompt: string): Promise<void> {
+		const checkpoint = this.draftManager.captureCheckpoint(this.threadId);
+		const inputRevision = this.inputRevision;
+		if (this.context?.inputValue === '') this.ignoreContextInput(this.context, '');
+
+		try {
+			await this.core.sendMessage(client, prompt);
+			if (this.draftManager.clearDraftIfUnchanged(checkpoint)) {
+				const context = this.context;
+				if (context && this.inputRevision === inputRevision) this.setContextInput(context, '');
+			}
+		} catch (error) {
+			const context = this.context;
+			if (
+				context &&
+				this.inputRevision === inputRevision &&
+				context.inputValue === '' &&
+				this.draftManager.getDraft(this.threadId) === checkpoint.value
+			) {
+				this.setContextInput(context, checkpoint.value);
+			}
+			throw error;
+		} finally {
+			this.releaseIfIdle(this);
+		}
+	}
+
+	private setContextInput(context: ChatUIContext, value: string): void {
+		this.ignoreContextInput(context, value);
+		context.setInputValue(value);
+	}
+
+	private ignoreContextInput(context: ChatUIContext, value: string): void {
+		this.ignoredInput = { context, value };
+	}
+}
+
+export class SimpleChatSessionRegistry {
+	sessions = $state.raw<SimpleChatSession[]>([]);
+
+	constructor(private readonly draftManager: ChatDraftManager) {}
+
+	acquire(threadId: string): SimpleChatSession {
+		let session = this.sessions.find((candidate) => candidate.threadId === threadId);
+		if (!session) {
+			session = new SimpleChatSession(threadId, this.draftManager, (candidate) =>
+				this.releaseIfIdle(candidate)
+			);
+			this.sessions = [...this.sessions, session];
+		}
+		return session;
+	}
+
+	get retainedSessions(): SimpleChatSession[] {
+		return this.sessions.filter((session) => session.activeMounts === 0 && session.isLocked);
+	}
+
+	releaseIfIdle(session: SimpleChatSession): void {
+		if (session.activeMounts > 0 || session.isLocked) return;
+		if (!this.sessions.includes(session)) return;
+		this.sessions = this.sessions.filter((candidate) => candidate !== session);
+	}
+
+	dispose(): void {
+		this.sessions = [];
+	}
+}

--- a/src/lib/chat/examples/simple-chat-session.svelte.ts
+++ b/src/lib/chat/examples/simple-chat-session.svelte.ts
@@ -1,7 +1,7 @@
 import type { ConvexClient } from 'convex/browser';
 import { api } from '$lib/convex/_generated/api';
 import { ChatCore, type ChatCoreOptions } from '../core/chat-core.svelte.ts';
-import type { ChatDraftManager } from '../core/chat-draft-manager.svelte.ts';
+import { ChatDraftManager, type ChatDraftCheckpoint } from '../core/chat-draft-manager.svelte.ts';
 import type { ChatUIContext } from '../ui/chat-context.svelte.ts';
 
 const SIMPLE_CHAT_API = {
@@ -9,22 +9,30 @@ const SIMPLE_CHAT_API = {
 	listMessages: api.aiChat.messages.listMessages
 };
 
+const clientRegistries = new WeakMap<ConvexClient, SimpleChatSessionRegistry>();
+
 type IgnoredInput = {
 	context: ChatUIContext;
 	value: string;
 };
 
+type ActiveSend = {
+	checkpoint: ChatDraftCheckpoint;
+	inputRevision: number;
+	succeeded: boolean;
+};
+
 class SimpleChatCore extends ChatCore {
 	constructor(
 		options: ChatCoreOptions,
-		private readonly releaseAfterStream: () => void
+		private readonly awaitingChanged: (awaiting: boolean) => void
 	) {
 		super(options);
 	}
 
 	override setAwaitingStream(awaiting: boolean): void {
 		super.setAwaitingStream(awaiting);
-		if (!awaiting) this.releaseAfterStream();
+		this.awaitingChanged(awaiting);
 	}
 }
 
@@ -36,13 +44,16 @@ export class SimpleChatSession {
 	private context: ChatUIContext | null = null;
 	private ignoredInput: IgnoredInput | null = null;
 	private inputRevision = 0;
+	private activeSend: ActiveSend | null = null;
 
 	constructor(
 		readonly threadId: string,
 		private readonly draftManager: ChatDraftManager,
 		private readonly releaseIfIdle: (session: SimpleChatSession) => void
 	) {
-		this.core = new SimpleChatCore({ threadId, api: this.api }, () => this.releaseIfIdle(this));
+		this.core = new SimpleChatCore({ threadId, api: this.api }, (awaiting) =>
+			this.handleAwaitingChange(awaiting)
+		);
 	}
 
 	get isLocked(): boolean {
@@ -52,7 +63,8 @@ export class SimpleChatSession {
 	attach(context: ChatUIContext): void {
 		this.activeMounts += 1;
 		this.context = context;
-		this.setContextInput(context, this.isLocked ? '' : this.draftManager.getDraft(this.threadId));
+		const hideSentDraft = this.isLocked && this.activeSend?.inputRevision === this.inputRevision;
+		this.setContextInput(context, hideSentDraft ? '' : this.draftManager.getDraft(this.threadId));
 	}
 
 	recordInput(context: ChatUIContext, value: string): void {
@@ -69,7 +81,9 @@ export class SimpleChatSession {
 	detach(context: ChatUIContext): void {
 		if (this.context === context) {
 			const value = context.inputValue;
-			if (!(this.isLocked && value === '') && this.draftManager.getDraft(this.threadId) !== value) {
+			const hideSentDraft =
+				this.isLocked && this.activeSend?.inputRevision === this.inputRevision && value === '';
+			if (!hideSentDraft && this.draftManager.getDraft(this.threadId) !== value) {
 				this.inputRevision += 1;
 				this.draftManager.setDraft(this.threadId, value);
 			}
@@ -81,30 +95,46 @@ export class SimpleChatSession {
 	}
 
 	async send(client: ConvexClient, prompt: string): Promise<void> {
-		const checkpoint = this.draftManager.captureCheckpoint(this.threadId);
-		const inputRevision = this.inputRevision;
+		const activeSend: ActiveSend = {
+			checkpoint: this.draftManager.captureCheckpoint(this.threadId),
+			inputRevision: this.inputRevision,
+			succeeded: false
+		};
+		this.activeSend = activeSend;
 		if (this.context?.inputValue === '') this.ignoreContextInput(this.context, '');
 
 		try {
 			await this.core.sendMessage(client, prompt);
-			if (this.draftManager.clearDraftIfUnchanged(checkpoint)) {
+			activeSend.succeeded = true;
+			if (this.draftManager.clearDraftIfUnchanged(activeSend.checkpoint)) {
 				const context = this.context;
-				if (context && this.inputRevision === inputRevision) this.setContextInput(context, '');
+				if (context && this.inputRevision === activeSend.inputRevision) {
+					this.setContextInput(context, '');
+				}
+			}
+			if (!this.core.isAwaitingStream && this.activeSend === activeSend) {
+				this.activeSend = null;
 			}
 		} catch (error) {
 			const context = this.context;
 			if (
 				context &&
-				this.inputRevision === inputRevision &&
+				this.inputRevision === activeSend.inputRevision &&
 				context.inputValue === '' &&
-				this.draftManager.getDraft(this.threadId) === checkpoint.value
+				this.draftManager.getDraft(this.threadId) === activeSend.checkpoint.value
 			) {
-				this.setContextInput(context, checkpoint.value);
+				this.setContextInput(context, activeSend.checkpoint.value);
 			}
+			if (this.activeSend === activeSend) this.activeSend = null;
 			throw error;
 		} finally {
 			this.releaseIfIdle(this);
 		}
+	}
+
+	private handleAwaitingChange(awaiting: boolean): void {
+		if (!awaiting && this.activeSend?.succeeded) this.activeSend = null;
+		this.releaseIfIdle(this);
 	}
 
 	private setContextInput(context: ChatUIContext, value: string): void {
@@ -119,8 +149,24 @@ export class SimpleChatSession {
 
 export class SimpleChatSessionRegistry {
 	sessions = $state.raw<SimpleChatSession[]>([]);
+	private ownerCount = 0;
+	private readonly draftManager = new ChatDraftManager('simple-chat');
 
-	constructor(private readonly draftManager: ChatDraftManager) {}
+	constructor(private readonly removeIfUnused: () => void) {}
+
+	retainOwner(): void {
+		this.ownerCount += 1;
+	}
+
+	releaseOwner(): void {
+		this.ownerCount = Math.max(0, this.ownerCount - 1);
+		if (this.ownerCount === 0) {
+			this.sessions = this.sessions.filter(
+				(session) => session.activeMounts > 0 || session.isLocked
+			);
+		}
+		this.cleanupIfUnused();
+	}
 
 	acquire(threadId: string): SimpleChatSession {
 		let session = this.sessions.find((candidate) => candidate.threadId === threadId);
@@ -139,11 +185,26 @@ export class SimpleChatSessionRegistry {
 
 	releaseIfIdle(session: SimpleChatSession): void {
 		if (session.activeMounts > 0 || session.isLocked) return;
-		if (!this.sessions.includes(session)) return;
-		this.sessions = this.sessions.filter((candidate) => candidate !== session);
+		if (this.sessions.includes(session)) {
+			this.sessions = this.sessions.filter((candidate) => candidate !== session);
+		}
+		this.cleanupIfUnused();
 	}
 
-	dispose(): void {
-		this.sessions = [];
+	private cleanupIfUnused(): void {
+		if (this.ownerCount === 0 && this.sessions.length === 0) this.removeIfUnused();
 	}
+}
+
+export function acquireSimpleChatSessionRegistry(client: ConvexClient): SimpleChatSessionRegistry {
+	let registry = clientRegistries.get(client);
+	if (!registry) {
+		const created = new SimpleChatSessionRegistry(() => {
+			if (clientRegistries.get(client) === created) clientRegistries.delete(client);
+		});
+		registry = created;
+		clientRegistries.set(client, registry);
+	}
+	registry.retainOwner();
+	return registry;
 }

--- a/src/lib/chat/examples/simple-chat-session.svelte.ts
+++ b/src/lib/chat/examples/simple-chat-session.svelte.ts
@@ -2,6 +2,7 @@ import type { ConvexClient } from 'convex/browser';
 import { api } from '$lib/convex/_generated/api';
 import { ChatCore, type ChatCoreOptions } from '../core/chat-core.svelte.ts';
 import { ChatDraftManager, type ChatDraftCheckpoint } from '../core/chat-draft-manager.svelte.ts';
+import { getChatSessionEpoch, isChatSessionCurrent } from '../core/chat-persisted-state.ts';
 import type { ChatUIContext } from '../ui/chat-context.svelte.ts';
 
 const SIMPLE_CHAT_API = {
@@ -11,9 +12,11 @@ const SIMPLE_CHAT_API = {
 
 const clientRegistries = new WeakMap<ConvexClient, SimpleChatSessionRegistry>();
 
-type IgnoredInput = {
-	context: ChatUIContext;
-	value: string;
+export type SimpleChatOwner = object;
+
+export type SimpleChatRegistryLease = {
+	registry: SimpleChatSessionRegistry;
+	owner: SimpleChatOwner;
 };
 
 type ActiveSend = {
@@ -41,13 +44,16 @@ export class SimpleChatSession {
 	readonly core: ChatCore;
 	activeMounts = $state(0);
 
-	private context: ChatUIContext | null = null;
-	private ignoredInput: IgnoredInput | null = null;
+	// Component-local contexts. Their count is mirrored through activeMounts for registry rendering.
+	// eslint-disable-next-line svelte/prefer-svelte-reactivity
+	private readonly contexts = new Set<ChatUIContext>();
+	private readonly ignoredInputs = new WeakMap<ChatUIContext, string>();
 	private inputRevision = 0;
 	private activeSend: ActiveSend | null = null;
 
 	constructor(
 		readonly threadId: string,
+		readonly sessionEpoch: number,
 		private readonly draftManager: ChatDraftManager,
 		private readonly releaseIfIdle: (session: SimpleChatSession) => void
 	) {
@@ -61,69 +67,76 @@ export class SimpleChatSession {
 	}
 
 	attach(context: ChatUIContext): void {
-		this.activeMounts += 1;
-		this.context = context;
+		this.contexts.add(context);
+		this.activeMounts = this.contexts.size;
+		if (!isChatSessionCurrent(this.sessionEpoch)) {
+			this.core.forgetChatSession();
+			this.setContextInput(context, '');
+			return;
+		}
 		const hideSentDraft = this.isLocked && this.activeSend?.inputRevision === this.inputRevision;
 		this.setContextInput(context, hideSentDraft ? '' : this.draftManager.getDraft(this.threadId));
 	}
 
 	recordInput(context: ChatUIContext, value: string): void {
-		if (this.context !== context) return;
-		if (this.ignoredInput?.context === context && this.ignoredInput.value === value) {
-			this.ignoredInput = null;
+		if (!this.contexts.has(context) || !isChatSessionCurrent(this.sessionEpoch)) return;
+		if (this.ignoredInputs.get(context) === value) {
+			this.ignoredInputs.delete(context);
 			return;
 		}
-		this.ignoredInput = null;
+		this.ignoredInputs.delete(context);
 		this.inputRevision += 1;
 		this.draftManager.setDraft(this.threadId, value);
+		this.setOtherContextInputs(context, value);
 	}
 
 	detach(context: ChatUIContext): void {
-		if (this.context === context) {
+		if (!this.contexts.delete(context)) return;
+		if (isChatSessionCurrent(this.sessionEpoch)) {
 			const value = context.inputValue;
 			const hideSentDraft =
 				this.isLocked && this.activeSend?.inputRevision === this.inputRevision && value === '';
 			if (!hideSentDraft && this.draftManager.getDraft(this.threadId) !== value) {
 				this.inputRevision += 1;
 				this.draftManager.setDraft(this.threadId, value);
+				this.setAllContextInputs(value);
 			}
-			this.context = null;
-			this.ignoredInput = null;
 		}
-		this.activeMounts = Math.max(0, this.activeMounts - 1);
+		this.ignoredInputs.delete(context);
+		this.activeMounts = this.contexts.size;
 		this.releaseIfIdle(this);
 	}
 
-	async send(client: ConvexClient, prompt: string): Promise<void> {
+	async send(client: ConvexClient, prompt: string, context: ChatUIContext): Promise<void> {
+		if (!isChatSessionCurrent(this.sessionEpoch)) throw new Error('Chat session ended');
+		if (!this.contexts.has(context)) throw new Error('Chat composer is no longer mounted');
+		if (this.core.isSending) throw new Error('A message is already being sent');
+
 		const activeSend: ActiveSend = {
 			checkpoint: this.draftManager.captureCheckpoint(this.threadId),
 			inputRevision: this.inputRevision,
 			succeeded: false
 		};
 		this.activeSend = activeSend;
-		if (this.context?.inputValue === '') this.ignoreContextInput(this.context, '');
+		this.setAllContextInputs('');
 
 		try {
 			await this.core.sendMessage(client, prompt);
+			if (!isChatSessionCurrent(this.sessionEpoch)) return;
 			activeSend.succeeded = true;
 			if (this.draftManager.clearDraftIfUnchanged(activeSend.checkpoint)) {
-				const context = this.context;
-				if (context && this.inputRevision === activeSend.inputRevision) {
-					this.setContextInput(context, '');
-				}
+				if (this.inputRevision === activeSend.inputRevision) this.setAllContextInputs('');
 			}
 			if (!this.core.isAwaitingStream && this.activeSend === activeSend) {
 				this.activeSend = null;
 			}
 		} catch (error) {
-			const context = this.context;
 			if (
-				context &&
+				isChatSessionCurrent(this.sessionEpoch) &&
 				this.inputRevision === activeSend.inputRevision &&
-				context.inputValue === '' &&
 				this.draftManager.getDraft(this.threadId) === activeSend.checkpoint.value
 			) {
-				this.setContextInput(context, activeSend.checkpoint.value);
+				this.setAllContextInputs(activeSend.checkpoint.value);
 			}
 			if (this.activeSend === activeSend) this.activeSend = null;
 			throw error;
@@ -137,30 +150,50 @@ export class SimpleChatSession {
 		this.releaseIfIdle(this);
 	}
 
-	private setContextInput(context: ChatUIContext, value: string): void {
-		this.ignoreContextInput(context, value);
-		context.setInputValue(value);
+	private setOtherContextInputs(source: ChatUIContext, value: string): void {
+		for (const context of this.contexts) {
+			if (context !== source) this.setContextInput(context, value);
+		}
 	}
 
-	private ignoreContextInput(context: ChatUIContext, value: string): void {
-		this.ignoredInput = { context, value };
+	private setAllContextInputs(value: string): void {
+		for (const context of this.contexts) this.setContextInput(context, value);
+	}
+
+	private setContextInput(context: ChatUIContext, value: string): void {
+		this.ignoredInputs.set(context, value);
+		context.setInputValue(value);
 	}
 }
 
 export class SimpleChatSessionRegistry {
 	sessions = $state.raw<SimpleChatSession[]>([]);
-	private ownerCount = 0;
+	owners = $state.raw<SimpleChatOwner[]>([]);
+	readonly sessionEpoch = getChatSessionEpoch();
+
+	private invalidated = false;
 	private readonly draftManager = new ChatDraftManager('simple-chat');
 
-	constructor(private readonly removeIfUnused: () => void) {}
-
-	retainOwner(): void {
-		this.ownerCount += 1;
+	constructor(
+		private readonly removeIfUnused: () => void,
+		resetDrafts: boolean
+	) {
+		if (resetDrafts) this.draftManager.drafts.current = {};
 	}
 
-	releaseOwner(): void {
-		this.ownerCount = Math.max(0, this.ownerCount - 1);
-		if (this.ownerCount === 0) {
+	get isCurrent(): boolean {
+		return !this.invalidated && isChatSessionCurrent(this.sessionEpoch);
+	}
+
+	retainOwner(): SimpleChatOwner {
+		const owner = {};
+		this.owners = [...this.owners, owner];
+		return owner;
+	}
+
+	releaseOwner(owner: SimpleChatOwner): void {
+		this.owners = this.owners.filter((candidate) => candidate !== owner);
+		if (this.owners.length === 0) {
 			this.sessions = this.sessions.filter(
 				(session) => session.activeMounts > 0 || session.isLocked
 			);
@@ -169,9 +202,13 @@ export class SimpleChatSessionRegistry {
 	}
 
 	acquire(threadId: string): SimpleChatSession {
+		if (!this.isCurrent) {
+			this.invalidate();
+			throw new Error('SimpleChat registry belongs to an expired chat session');
+		}
 		let session = this.sessions.find((candidate) => candidate.threadId === threadId);
 		if (!session) {
-			session = new SimpleChatSession(threadId, this.draftManager, (candidate) =>
+			session = new SimpleChatSession(threadId, this.sessionEpoch, this.draftManager, (candidate) =>
 				this.releaseIfIdle(candidate)
 			);
 			this.sessions = [...this.sessions, session];
@@ -179,11 +216,17 @@ export class SimpleChatSessionRegistry {
 		return session;
 	}
 
-	get retainedSessions(): SimpleChatSession[] {
+	retainedSessionsFor(owner: SimpleChatOwner): SimpleChatSession[] {
+		if (!this.isCurrent) {
+			this.invalidate();
+			return [];
+		}
+		if (this.owners[0] !== owner) return [];
 		return this.sessions.filter((session) => session.activeMounts === 0 && session.isLocked);
 	}
 
 	releaseIfIdle(session: SimpleChatSession): void {
+		if (this.invalidated || session.sessionEpoch !== this.sessionEpoch) return;
 		if (session.activeMounts > 0 || session.isLocked) return;
 		if (this.sessions.includes(session)) {
 			this.sessions = this.sessions.filter((candidate) => candidate !== session);
@@ -191,20 +234,34 @@ export class SimpleChatSessionRegistry {
 		this.cleanupIfUnused();
 	}
 
+	invalidate(): void {
+		if (this.invalidated) return;
+		this.invalidated = true;
+		this.sessions = [];
+		this.owners = [];
+		this.removeIfUnused();
+	}
+
 	private cleanupIfUnused(): void {
-		if (this.ownerCount === 0 && this.sessions.length === 0) this.removeIfUnused();
+		if (this.owners.length === 0 && this.sessions.length === 0) this.removeIfUnused();
 	}
 }
 
-export function acquireSimpleChatSessionRegistry(client: ConvexClient): SimpleChatSessionRegistry {
+export function acquireSimpleChatSessionRegistry(client: ConvexClient): SimpleChatRegistryLease {
+	const sessionEpoch = getChatSessionEpoch();
 	let registry = clientRegistries.get(client);
+	let resetDrafts = false;
+	if (registry && registry.sessionEpoch !== sessionEpoch) {
+		registry.invalidate();
+		registry = undefined;
+		resetDrafts = true;
+	}
 	if (!registry) {
 		const created = new SimpleChatSessionRegistry(() => {
 			if (clientRegistries.get(client) === created) clientRegistries.delete(client);
-		});
+		}, resetDrafts);
 		registry = created;
 		clientRegistries.set(client, registry);
 	}
-	registry.retainOwner();
-	return registry;
+	return { registry, owner: registry.retainOwner() };
 }

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -5,21 +5,14 @@
  * Provides both headless core functionality and UI components.
  *
  * @example Executable text-only chat
- * Render this inside the existing Convex and authentication providers. The signed-in user must
- * already own the supplied thread.
+ * Mount below a Convex client provider, an authentication provider such as `AppAuthProvider`, and
+ * `TolgeeProvider`. The signed-in user must already own the supplied AI chat thread.
  * ```svelte
  * <script lang="ts">
  *   import SimpleChat from '$lib/chat/examples/SimpleChat.svelte';
- *   import { api } from '$lib/convex/_generated/api';
  *   let { ownedThreadId }: { ownedThreadId: string } = $props();
  * </script>
- * <SimpleChat
- *   threadId={ownedThreadId}
- *   api={{
- *     sendMessage: api.aiChat.messages.sendMessage,
- *     listMessages: api.aiChat.messages.listMessages
- *   }}
- * />
+ * <SimpleChat threadId={ownedThreadId} />
  * ```
  *
  * @example Using core without UI

--- a/src/lib/chat/index.ts
+++ b/src/lib/chat/index.ts
@@ -4,23 +4,22 @@
  * A reusable AI chat library built on top of Convex Agent.
  * Provides both headless core functionality and UI components.
  *
- * @example Basic usage with UI components
+ * @example Executable text-only chat
+ * Render this inside the existing Convex and authentication providers. The signed-in user must
+ * already own the supplied thread.
  * ```svelte
- * <script>
- *   import { ChatRoot, ChatMessages, ChatInput } from '$lib/chat';
+ * <script lang="ts">
+ *   import SimpleChat from '$lib/chat/examples/SimpleChat.svelte';
  *   import { api } from '$lib/convex/_generated/api';
+ *   let { ownedThreadId }: { ownedThreadId: string } = $props();
  * </script>
- *
- * <ChatRoot
- *   threadId="thread_123"
+ * <SimpleChat
+ *   threadId={ownedThreadId}
  *   api={{
- *     sendMessage: api.support.messages.sendMessage,
- *     listMessages: api.support.messages.listMessages
+ *     sendMessage: api.aiChat.messages.sendMessage,
+ *     listMessages: api.aiChat.messages.listMessages
  *   }}
- * >
- *   <ChatMessages />
- *   <ChatInput />
- * </ChatRoot>
+ * />
  * ```
  *
  * @example Using core without UI

--- a/src/lib/chat/ui/ChatInput.svelte
+++ b/src/lib/chat/ui/ChatInput.svelte
@@ -498,6 +498,7 @@
 	}
 
 	function handlePaste(event: ClipboardEvent) {
+		if (!showFileButton) return;
 		const items = event.clipboardData?.items;
 		if (!items) return;
 

--- a/src/lib/chat/ui/test-fixtures/CapturedChatMessages.svelte
+++ b/src/lib/chat/ui/test-fixtures/CapturedChatMessages.svelte
@@ -1,0 +1,11 @@
+<script module lang="ts">
+	import type { ChatUIContext } from '../chat-context.svelte.ts';
+
+	export const capturedChatMessages: { context?: ChatUIContext } = {};
+</script>
+
+<script lang="ts">
+	import { getChatUIContext } from '../chat-context.svelte.ts';
+
+	capturedChatMessages.context = getChatUIContext();
+</script>

--- a/src/lib/chat/ui/test-fixtures/ChatTestProvider.svelte
+++ b/src/lib/chat/ui/test-fixtures/ChatTestProvider.svelte
@@ -17,12 +17,14 @@
 		client,
 		content: Content,
 		contentProps,
-		supportThread
+		supportThread,
+		provideTolgee = true
 	}: {
 		client: ConvexClient;
 		content: Component<Props>;
 		contentProps: Props;
 		supportThread?: SupportThreadContext;
+		provideTolgee?: boolean;
 	} = $props();
 
 	// The provider is fixed for the mounted test instance.
@@ -42,6 +44,10 @@
 	}
 </script>
 
-<TolgeeProvider {tolgee}>
+{#if provideTolgee}
+	<TolgeeProvider {tolgee}>
+		<Content {...renderedContentProps} />
+	</TolgeeProvider>
+{:else}
 	<Content {...renderedContentProps} />
-</TolgeeProvider>
+{/if}

--- a/src/lib/chat/ui/test-fixtures/ChatTestProvider.svelte
+++ b/src/lib/chat/ui/test-fixtures/ChatTestProvider.svelte
@@ -33,8 +33,15 @@
 	// svelte-ignore state_referenced_locally
 	if (supportThread) supportThreadContext.set(supportThread);
 	const tolgee = Tolgee().use(FormatSimple()).init({ language: 'en', staticData: { en } });
+	// Tests may replace the child props without remounting its providers.
+	// svelte-ignore state_referenced_locally
+	let renderedContentProps = $state.raw(contentProps);
+
+	export function setContentProps(next: Props) {
+		renderedContentProps = next;
+	}
 </script>
 
 <TolgeeProvider {tolgee}>
-	<Content {...contentProps} />
+	<Content {...renderedContentProps} />
 </TolgeeProvider>

--- a/src/lib/chat/ui/test-fixtures/SimpleChatOwnersHarness.svelte
+++ b/src/lib/chat/ui/test-fixtures/SimpleChatOwnersHarness.svelte
@@ -1,0 +1,60 @@
+<script module lang="ts">
+	export const simpleChatOwnersHarness: {
+		setFirstThreadId?: (threadId: string) => void;
+		setSecondThreadId?: (threadId: string) => void;
+		hideFirst?: () => void;
+		hideSecond?: () => void;
+	} = {};
+</script>
+
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import SimpleChat from '../../examples/SimpleChat.svelte';
+
+	let {
+		firstThreadId,
+		secondThreadId
+	}: {
+		firstThreadId: string;
+		secondThreadId: string;
+	} = $props();
+
+	let firstVisible = $state(true);
+	let secondVisible = $state(true);
+	// Harness setters own later updates after these initial prop values.
+	// svelte-ignore state_referenced_locally
+	let currentFirstThreadId = $state(firstThreadId);
+	// svelte-ignore state_referenced_locally
+	let currentSecondThreadId = $state(secondThreadId);
+
+	simpleChatOwnersHarness.setFirstThreadId = (threadId) => {
+		currentFirstThreadId = threadId;
+	};
+	simpleChatOwnersHarness.setSecondThreadId = (threadId) => {
+		currentSecondThreadId = threadId;
+	};
+	simpleChatOwnersHarness.hideFirst = () => {
+		firstVisible = false;
+	};
+	simpleChatOwnersHarness.hideSecond = () => {
+		secondVisible = false;
+	};
+
+	onDestroy(() => {
+		delete simpleChatOwnersHarness.setFirstThreadId;
+		delete simpleChatOwnersHarness.setSecondThreadId;
+		delete simpleChatOwnersHarness.hideFirst;
+		delete simpleChatOwnersHarness.hideSecond;
+	});
+</script>
+
+<div data-simple-chat-owner="first">
+	{#if firstVisible}
+		<SimpleChat threadId={currentFirstThreadId} />
+	{/if}
+</div>
+<div data-simple-chat-owner="second">
+	{#if secondVisible}
+		<SimpleChat threadId={currentSecondThreadId} />
+	{/if}
+</div>


### PR DESCRIPTION
Regression guard: covered by the SimpleChat component and lifecycle tests

The public chat example rendered a send button without a send operation and exposed upload paths without upload configuration. Its loose endpoint types also allowed unrelated query and mutation references to be combined.

`SimpleChat` now sends through one coherent AI-chat endpoint pair and is explicitly text-only. Thread and full-component remounts retain the authoritative send lock, exact draft revision, and stream ownership without crossing Convex clients or authentication epochs. Multiple mounted examples synchronize same-thread drafts safely, while only one owner observes an inactive pending session. Clipboard files are ignored when uploads are hidden, and the executable JSDoc names its Convex, authentication, and Tolgee prerequisites.

Verified with 397 chat tests, 2,924 unit tests, changed-file static checks, full type checks, Knip, package generation, production build, the official Svelte autofixer, and independent full-diff review.
