### PR TITLE
fix(billing): Report failed usage refunds

### DIFF
--- a/src/lib/convex/__tests__/autumn.test.ts
+++ b/src/lib/convex/__tests__/autumn.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { PUBLISHED_ACTION_NAMES, autumnSdkConstruction, check, trackSdk } = vi.hoisted(() => ({
+const { PUBLISHED_ACTION_NAMES, autumnSdkConstruction, check } = vi.hoisted(() => ({
 	PUBLISHED_ACTION_NAMES: [
 		'track',
 		'cancel',
@@ -19,8 +19,7 @@ const { PUBLISHED_ACTION_NAMES, autumnSdkConstruction, check, trackSdk } = vi.ho
 		'getEntity'
 	] as const,
 	autumnSdkConstruction: vi.fn(),
-	check: vi.fn(),
-	trackSdk: vi.fn()
+	check: vi.fn()
 }));
 
 vi.mock('../auth', () => ({
@@ -73,7 +72,6 @@ vi.mock('@useautumn/convex', () => ({
 vi.mock('autumn-js', () => ({
 	Autumn: class {
 		check = check;
-		track = trackSdk;
 
 		constructor(options: { secretKey: string }) {
 			autumnSdkConstruction(options.secretKey);
@@ -94,6 +92,7 @@ function registeredAction(value: unknown) {
 
 afterEach(() => {
 	vi.unstubAllEnvs();
+	vi.unstubAllGlobals();
 });
 
 describe('published Autumn actions', () => {
@@ -212,17 +211,10 @@ describe('refundUsage', () => {
 		setReadyBilling();
 	});
 
-	it('credits the balance with a negative track value', async () => {
-		trackSdk.mockResolvedValue({
-			data: {
-				id: 'event_1',
-				code: 'event_received',
-				customer_id: 'user_1',
-				feature_id: 'ai_chat_messages'
-			},
-			error: null,
-			statusCode: 200
-		});
+	it('posts a negative usage event with the Autumn API contract', async () => {
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+		vi.stubGlobal('fetch', fetchMock);
 
 		const outcome = await refundUsage({
 			customerId: 'user_1',
@@ -230,20 +222,31 @@ describe('refundUsage', () => {
 		});
 
 		expect(outcome).toEqual({ status: 'refunded' });
-		expect(trackSdk).toHaveBeenCalledWith({
-			customer_id: 'user_1',
-			feature_id: 'ai_chat_messages',
-			value: -1
+		expect(autumnSdkConstruction).not.toHaveBeenCalled();
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(fetchMock).toHaveBeenCalledWith('https://api.useautumn.com/v1/track', {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer configured-autumn-key',
+				'Content-Type': 'application/json',
+				'x-api-version': '1.2'
+			},
+			body: JSON.stringify({
+				customer_id: 'user_1',
+				feature_id: 'ai_chat_messages',
+				value: -1
+			})
 		});
+		expect(error).not.toHaveBeenCalled();
+		error.mockRestore();
 	});
 
-	it('reports a non-2xx result without provider or request details', async () => {
+	it('does not read or log a provider-controlled non-2xx body', async () => {
+		const providerMessage = 'provider rejected refund for user_1';
+		const response = new Response(providerMessage, { status: 503 });
+		const fetchMock = vi.fn().mockResolvedValue(response);
 		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
-		trackSdk.mockResolvedValue({
-			data: null,
-			error: new Error('provider rejected the refund'),
-			statusCode: 503
-		});
+		vi.stubGlobal('fetch', fetchMock);
 
 		const outcome = await refundUsage({
 			customerId: 'user_1',
@@ -252,26 +255,32 @@ describe('refundUsage', () => {
 		});
 
 		expect(outcome).toEqual({ status: 'failed', reason: 'non_2xx', statusCode: 503 });
-		expect(trackSdk).toHaveBeenCalledWith(expect.objectContaining({ value: -2 }));
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(response.bodyUsed).toBe(false);
 		expect(error).toHaveBeenCalledOnce();
 		expect(error).toHaveBeenCalledWith('[refundUsage] Autumn refund failed', outcome);
+		expect(error.mock.calls.flat().map(String).join(' ')).not.toContain(providerMessage);
 		error.mockRestore();
 	});
 
-	it('reports a thrown exception without masking the caller failure', async () => {
+	it('does not log a raw thrown fetch failure or mask the caller failure', async () => {
+		const providerError = new Error('raw transport failure for user_1');
+		const fetchMock = vi.fn().mockRejectedValue(providerError);
 		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
-		trackSdk.mockRejectedValue(new Error('network down'));
+		vi.stubGlobal('fetch', fetchMock);
 
 		await expect(
 			refundUsage({ customerId: 'user_1', featureId: 'ai_chat_messages', value: 2 })
 		).resolves.toEqual({ status: 'failed', reason: 'exception' });
 
-		expect(trackSdk).toHaveBeenCalledWith(expect.objectContaining({ value: -2 }));
+		expect(fetchMock).toHaveBeenCalledOnce();
 		expect(error).toHaveBeenCalledOnce();
 		expect(error).toHaveBeenCalledWith('[refundUsage] Autumn refund failed', {
 			status: 'failed',
 			reason: 'exception'
 		});
+		expect(error.mock.calls.flat()).not.toContain(providerError);
+		expect(error.mock.calls.flat().map(String).join(' ')).not.toContain(providerError.message);
 		error.mockRestore();
 	});
 });

--- a/src/lib/convex/__tests__/autumn.test.ts
+++ b/src/lib/convex/__tests__/autumn.test.ts
@@ -213,10 +213,23 @@ describe('refundUsage', () => {
 	});
 
 	it('credits the balance with a negative track value', async () => {
-		trackSdk.mockResolvedValue({ data: {} });
+		trackSdk.mockResolvedValue({
+			data: {
+				id: 'event_1',
+				code: 'event_received',
+				customer_id: 'user_1',
+				feature_id: 'ai_chat_messages'
+			},
+			error: null,
+			statusCode: 200
+		});
 
-		await refundUsage({ customerId: 'user_1', featureId: 'ai_chat_messages' });
+		const outcome = await refundUsage({
+			customerId: 'user_1',
+			featureId: 'ai_chat_messages'
+		});
 
+		expect(outcome).toEqual({ status: 'refunded' });
 		expect(trackSdk).toHaveBeenCalledWith({
 			customer_id: 'user_1',
 			feature_id: 'ai_chat_messages',
@@ -224,15 +237,41 @@ describe('refundUsage', () => {
 		});
 	});
 
-	it('never throws when a refund fails', async () => {
+	it('reports a non-2xx result without provider or request details', async () => {
+		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+		trackSdk.mockResolvedValue({
+			data: null,
+			error: new Error('provider rejected the refund'),
+			statusCode: 503
+		});
+
+		const outcome = await refundUsage({
+			customerId: 'user_1',
+			featureId: 'ai_chat_messages',
+			value: 2
+		});
+
+		expect(outcome).toEqual({ status: 'failed', reason: 'non_2xx', statusCode: 503 });
+		expect(trackSdk).toHaveBeenCalledWith(expect.objectContaining({ value: -2 }));
+		expect(error).toHaveBeenCalledOnce();
+		expect(error).toHaveBeenCalledWith('[refundUsage] Autumn refund failed', outcome);
+		error.mockRestore();
+	});
+
+	it('reports a thrown exception without masking the caller failure', async () => {
 		const error = vi.spyOn(console, 'error').mockImplementation(() => {});
 		trackSdk.mockRejectedValue(new Error('network down'));
 
 		await expect(
 			refundUsage({ customerId: 'user_1', featureId: 'ai_chat_messages', value: 2 })
-		).resolves.toBeUndefined();
+		).resolves.toEqual({ status: 'failed', reason: 'exception' });
 
 		expect(trackSdk).toHaveBeenCalledWith(expect.objectContaining({ value: -2 }));
+		expect(error).toHaveBeenCalledOnce();
+		expect(error).toHaveBeenCalledWith('[refundUsage] Autumn refund failed', {
+			status: 'failed',
+			reason: 'exception'
+		});
 		error.mockRestore();
 	});
 });

--- a/src/lib/convex/autumn.ts
+++ b/src/lib/convex/autumn.ts
@@ -121,14 +121,20 @@ export async function checkAndCountUsage({
 	return result.data.allowed ? 'counted' : 'denied';
 }
 
+/** Outcome of a best-effort usage refund. */
+export type RefundUsageOutcome =
+	| { status: 'refunded' }
+	| { status: 'failed'; reason: 'non_2xx'; statusCode?: number }
+	| { status: 'failed'; reason: 'exception' };
+
 /**
  * Credit back usage previously counted by `checkAndCountUsage`, for
  * when the operation the usage paid for failed afterwards. Negative
  * track values credit the balance (documented Autumn behavior).
  *
- * Best effort: a failed refund is logged, never thrown, so it cannot
- * mask the original failure. The cost of a lost refund is one unit on
- * a double fault (operation AND refund both failed).
+ * Best effort: failures return a structured outcome and are logged
+ * without request or provider details. They are never thrown, so a
+ * refund failure cannot mask the original failure.
  */
 export async function refundUsage({
 	customerId,
@@ -138,11 +144,28 @@ export async function refundUsage({
 	customerId: string;
 	featureId: string;
 	value?: number;
-}): Promise<void> {
+}): Promise<RefundUsageOutcome> {
+	let result;
 	try {
 		const sdk = await getAutumnSdk();
-		await sdk.track({ customer_id: customerId, feature_id: featureId, value: -value });
-	} catch (error) {
-		console.error(`[refundUsage] Failed to refund ${value} ${featureId} for ${customerId}:`, error);
+		result = await sdk.track({
+			customer_id: customerId,
+			feature_id: featureId,
+			value: -value
+		});
+	} catch {
+		const failure = { status: 'failed', reason: 'exception' } as const;
+		console.error('[refundUsage] Autumn refund failed', failure);
+		return failure;
 	}
+	if (result.data === null) {
+		const failure = {
+			status: 'failed',
+			reason: 'non_2xx',
+			...(typeof result.statusCode === 'number' ? { statusCode: result.statusCode } : {})
+		} as const;
+		console.error('[refundUsage] Autumn refund failed', failure);
+		return failure;
+	}
+	return { status: 'refunded' };
 }

--- a/src/lib/convex/autumn.ts
+++ b/src/lib/convex/autumn.ts
@@ -124,7 +124,7 @@ export async function checkAndCountUsage({
 /** Outcome of a best-effort usage refund. */
 export type RefundUsageOutcome =
 	| { status: 'refunded' }
-	| { status: 'failed'; reason: 'non_2xx'; statusCode?: number }
+	| { status: 'failed'; reason: 'non_2xx'; statusCode: number }
 	| { status: 'failed'; reason: 'exception' };
 
 /**
@@ -145,24 +145,32 @@ export async function refundUsage({
 	featureId: string;
 	value?: number;
 }): Promise<RefundUsageOutcome> {
-	let result;
+	let response: Response;
 	try {
-		const sdk = await getAutumnSdk();
-		result = await sdk.track({
-			customer_id: customerId,
-			feature_id: featureId,
-			value: -value
+		const { secretKey } = requireBillingConfiguration();
+		response = await fetch('https://api.useautumn.com/v1/track', {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${secretKey}`,
+				'Content-Type': 'application/json',
+				'x-api-version': '1.2'
+			},
+			body: JSON.stringify({
+				customer_id: customerId,
+				feature_id: featureId,
+				value: -value
+			})
 		});
 	} catch {
 		const failure = { status: 'failed', reason: 'exception' } as const;
 		console.error('[refundUsage] Autumn refund failed', failure);
 		return failure;
 	}
-	if (result.data === null) {
+	if (!response.ok) {
 		const failure = {
 			status: 'failed',
 			reason: 'non_2xx',
-			...(typeof result.statusCode === 'number' ? { statusCode: result.statusCode } : {})
+			statusCode: response.status
 		} as const;
 		console.error('[refundUsage] Autumn refund failed', failure);
 		return failure;


### PR DESCRIPTION
Closes #938
Regression guard: added refund transport tests

## Problem

The pinned Autumn SDK can return a failed usage refund without throwing and can log raw provider or transport errors before callers sanitize them.

## Solution

Send the compensating Track request through a narrow direct transport. Return a controlled outcome, never read response bodies, and log only the failure class and numeric HTTP status. Existing callers keep their original outcome. No retry or reconciliation is added.

## Verification

- 23 focused Vitest tests
- Convex typecheck
- Full static checks for both changed files
- Independent review plus targeted follow-up: blocker closed
