### PR TITLE
test(support): Guard owned notification retries

### DIFF
--- a/src/lib/convex/admin/support/notifications.test.ts
+++ b/src/lib/convex/admin/support/notifications.test.ts
@@ -361,4 +361,27 @@ describe('pending notification ownership', () => {
 		expect(rows[0].retryCount).toBeUndefined();
 		expect(runAfter).toHaveBeenCalledTimes(2);
 	});
+
+	it('reschedules an owned row after failed sends', async () => {
+		const { ctx, rows, runAfter } = createCtx();
+
+		await scheduleAdminNotificationH._handler(ctx, {
+			threadId: 'thread_retry',
+			messageIds: ['message_1'],
+			isReopen: false,
+			notificationType: 'newTickets'
+		});
+		const notificationId = rows[0]._id as string;
+		const armedFnId = rows[0].scheduledFnId;
+
+		const failingSend = createActionCtx(ctx, { sendThrows: true });
+		await sendPendingAdminNotificationH._handler(failingSend, { notificationId });
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0].retryCount).toBe(1);
+		expect(rows[0].scheduledFnId).toBeDefined();
+		expect(rows[0].scheduledFnId).not.toBe(armedFnId);
+		expect(runAfter).toHaveBeenCalledTimes(2);
+		expect(runAfter.mock.calls[1][0]).toBe(60_000);
+	});
 });

--- a/src/lib/convex/admin/support/notifications.ts
+++ b/src/lib/convex/admin/support/notifications.ts
@@ -30,9 +30,9 @@ const NOTIFICATION_DELAY_MS = 4 * 60 * 1000;
 /** Maximum number of retry attempts before giving up */
 const MAX_RETRY_COUNT = 5;
 
-/** Logged when a re-armed row revoked the running send's ownership. */
+/** Logged when the running send no longer owns its row and skips cleanup. */
 const OWNERSHIP_MOVED_LOG =
-	'[sendPendingAdminNotification] Pending notification re-armed by a newer send, leaving it to the new owner:';
+	'[sendPendingAdminNotification] Pending notification no longer owned by this send; row was re-armed or cancelled, skipping cleanup:';
 
 /**
  * Schedule or update an admin notification for a support thread


### PR DESCRIPTION
Regression guard: added `reschedules an owned row after failed sends`

The independent review of #942 (see #945) found the ownership retry test
one-sided. It proves that a re-armed row is left alone, but it stays green even
if `sendPendingAdminNotification` stops calling `reschedulePendingNotification`
altogether: the row then keeps the re-armed id, `retryCount` stays undefined,
and `runAfter` was still called twice. Nothing covered the owned path, so a
missing retry could leave a claimed row unscheduled forever.

The new test drives a failing send on a row nobody re-armed and asserts that a
retry is scheduled with the 60 s delay and that `retryCount` advances.

`OWNERSHIP_MOVED_LOG` also claimed the row was re-armed, but the `false` result
equally means `cancelPendingNotification` deleted it when the ticket was closed
or assigned. It now states only what that result establishes.

Verification: the new test fails on a tree with the reschedule call removed
(`expected undefined to be 1`), 8/8 green once restored; static checks over both
files and `--scope types`; `check:convex`.

See also: #945
