### PR TITLE
fix(upstream-report): Skip prunable worktrees

### DIFF
--- a/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.integration.test.ts
@@ -1167,8 +1167,50 @@ describe('upstream-relevance (integration)', { timeout: 30_000 }, () => {
 		expect(r.stderr).toMatch(/shared Git storage/);
 	});
 
-	it('refuses a temporary directory inside a sibling linked worktree', () => {
-		const sibling = join(tmp, 'sibling-worktree');
+	it('ignores a prunable linked worktree whose directory is missing', () => {
+		const linked = join(tmp, 'stale-worktree');
+		git(fork, ['worktree', 'add', '-q', '-b', 'stale-test', linked, 'HEAD']);
+		rmSync(linked, { recursive: true, force: true });
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status, r.stderr).toBe(0);
+	});
+
+	it('fences an existing checkout that Git marks prunable', () => {
+		const linked = join(tmp, 'prunable-worktree');
+		git(fork, ['worktree', 'add', '-q', '-b', 'prunable-test', linked, 'HEAD']);
+		const linkedCanonical = realpathSync(linked);
+		rmSync(join(linked, '.git'));
+		const worktrees = git(fork, ['worktree', 'list', '--porcelain', '-z']);
+		expect(worktrees).toContain(`worktree ${linkedCanonical}\0`);
+		expect(worktrees.split('\0').some((field) => field.startsWith('prunable '))).toBe(true);
+		const insideLinked = join(linked, 'detector-temp');
+		mkdirSync(insideLinked);
+		const sentinel = join(insideLinked, 'keep');
+		writeFileSync(sentinel, 'unrelated');
+
+		const r = run(fork, ['--json'], { TMPDIR: insideLinked });
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toMatch(/temporary directory resolves inside this repository/);
+		expect(readFileSync(sentinel, 'utf8')).toBe('unrelated');
+	});
+
+	it('names a locked linked worktree whose directory is missing', () => {
+		const linked = join(tmp, 'locked-worktree');
+		git(fork, ['worktree', 'add', '-q', '-b', 'locked-test', linked, 'HEAD']);
+		git(fork, ['worktree', 'lock', linked]);
+		rmSync(linked, { recursive: true, force: true });
+
+		const r = run(fork, ['--json']);
+
+		expect(r.status).not.toBe(0);
+		expect(r.stderr).toContain(linked);
+	});
+
+	itWithPosixPaths('preserves a newline in a sibling linked-worktree path', () => {
+		const sibling = join(tmp, 'sibling\nworktree');
 		git(fork, ['worktree', 'add', '-q', '-b', 'sibling-test', sibling, 'HEAD']);
 		const insideSibling = join(sibling, 'detector-temp');
 		mkdirSync(insideSibling);

--- a/.agents/skills/upstream-report/scripts/upstream-relevance.ts
+++ b/.agents/skills/upstream-report/scripts/upstream-relevance.ts
@@ -958,19 +958,33 @@ function useScratchIndex(root: string): void {
 		fail('The system temporary directory or Git storage is not readable.');
 	}
 	const ownedRoots = new Set([rootPath, commonPath, gitPath]);
-	const worktreeFields = decodeZRecords(gitBytes(['worktree', 'list', '--porcelain', '-z'])).filter(
-		(field) => field.startsWith('worktree ')
-	);
-	if (worktreeFields.length === 0) {
+	const worktreeRecords: string[][] = [];
+	let currentWorktree: string[] | undefined;
+	for (const field of decodeZRecords(gitBytes(['worktree', 'list', '--porcelain', '-z']))) {
+		if (field.startsWith('worktree ')) {
+			currentWorktree = [field];
+			worktreeRecords.push(currentWorktree);
+		} else {
+			currentWorktree?.push(field);
+		}
+	}
+	if (worktreeRecords.length === 0) {
 		fail('Git did not identify any checkout for this repository.');
 	}
-	for (const field of worktreeFields) {
+	for (const [worktreeField, ...fields] of worktreeRecords) {
+		const listedPath = worktreeField!.slice('worktree '.length);
+		const prunable = fields.some((field) => field.startsWith('prunable '));
 		let worktreePath: string;
 		try {
-			worktreePath = realpathSync(field.slice('worktree '.length));
+			worktreePath = realpathSync(listedPath);
 		} catch {
+			// Prunable can mean only the checkout's .git file is missing. Skip the record
+			// only when its checkout directory no longer resolves; remain read-only rather
+			// than pruning shared Git metadata.
+			if (prunable) continue;
 			fail(
-				'Git listed a checkout whose path is not readable. Prune stale worktrees, then try again.'
+				`Git listed a checkout whose path is not readable: ${terminalSafe(listedPath)}. ` +
+					'Repair or prune that worktree, then try again.'
 			);
 		}
 		if (worktreePath === commonPath) {
@@ -986,6 +1000,8 @@ function useScratchIndex(root: string): void {
 			);
 		}
 		ownedRoots.add(worktreePath);
+		// commonPath already fences this checkout's broken Git administration.
+		if (prunable) continue;
 		try {
 			ownedRoots.add(
 				realpathSync(git(['-C', worktreePath, 'rev-parse', '--path-format=absolute', '--git-dir']))


### PR DESCRIPTION
Regression guard: added Git-emitted stale and locked worktree cases

The upstream relevance report resolved every path returned by `git worktree list`. Git retains metadata after a linked checkout directory disappears, so one stale entry stopped every report until someone modified shared repository state with `git worktree prune`.

The report now groups the NUL-delimited fields Git emits and fences every checkout directory that still resolves. It ignores a missing path only when Git marks that record `prunable`; missing locked or otherwise unreadable checkouts still fail and name their path. Skipping is safe because a checkout without a directory cannot contain the temporary root or a cleanup target, and the report remains read-only.

The integration tests exercise Git's actual porcelain output for missing, surviving-prunable, locked, and newline-containing worktree paths.

Verification: upstream-report suite, changed-file static checks, type checks, and independent review.
