### PR TITLE
fix(chat): Truncate attachment preview title

### DIFF
--- a/e2e/ai-chat-attachment-preview.spec.ts
+++ b/e2e/ai-chat-attachment-preview.spec.ts
@@ -46,4 +46,88 @@ test.describe('AI Chat - attachment text preview', () => {
 		// The hardened renderer blocks images entirely (no <img> is loaded).
 		await expect(content.locator('img')).toHaveCount(0);
 	});
+
+	// Cheaper layers rejected because truncation and tooltip hover/focus behavior
+	// require browser layout; a request-only check cannot render the dialog DOM.
+	test('preview titles reveal only visually truncated filenames', async ({ page }) => {
+		await page.goto('/app/ai-chat');
+		await waitForAuthenticated(page);
+		await page.waitForURL(/\/app\/ai-chat\?thread=/, { timeout: 15000 });
+		await expect(page.locator('textarea')).toBeVisible({ timeout: 10000 });
+
+		const fileInput = page.locator('input[type="file"]').first();
+		const longName = `quarterly-strategy-${'very-long-'.repeat(18)}notes.md`;
+		await fileInput.setInputFiles({
+			name: longName,
+			mimeType: 'text/markdown',
+			buffer: Buffer.from('# Long title\nPreview title geometry.', 'utf8')
+		});
+
+		const longChip = page.getByTestId('attachment-chip').filter({ hasText: longName });
+		await expect(longChip).toHaveAttribute('role', 'button', { timeout: 20000 });
+
+		const shortName = 'brief.md';
+		await fileInput.setInputFiles({
+			name: shortName,
+			mimeType: 'text/markdown',
+			buffer: Buffer.from('# Brief\nNo hidden title text.', 'utf8')
+		});
+		const shortChip = page.getByTestId('attachment-chip').filter({ hasText: shortName });
+		await expect(shortChip).toHaveAttribute('role', 'button', { timeout: 20000 });
+		await longChip.click();
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+		await expect(dialog).toHaveAccessibleName(longName);
+		const close = dialog.locator('[data-slot="dialog-close"]');
+		const tooltip = page.locator('[data-slot="tooltip-content"]');
+		await expect(close).toBeFocused();
+		await expect(tooltip).toHaveCount(0);
+
+		const title = dialog.locator('[data-slot="attachment-preview-title"]');
+		await expect(title).toHaveText(longName);
+		await expect(title).toHaveCSS('white-space', 'nowrap');
+		await expect(title).toHaveCSS('text-overflow', 'ellipsis');
+		const titleGeometry = await title.evaluate((element) => {
+			const style = getComputedStyle(element);
+			const rect = element.getBoundingClientRect();
+			return {
+				clientWidth: element.clientWidth,
+				scrollWidth: element.scrollWidth,
+				visibleTextRight: rect.right - Number.parseFloat(style.paddingRight)
+			};
+		});
+		expect(titleGeometry.scrollWidth).toBeGreaterThan(titleGeometry.clientWidth);
+		const closeBox = await close.boundingBox();
+		expect(closeBox).not.toBeNull();
+		expect(titleGeometry.visibleTextRight).toBeLessThanOrEqual(closeBox!.x);
+
+		await title.hover();
+		await expect(tooltip).toHaveText(longName);
+		await page.mouse.move(0, 0);
+		await close.focus();
+		await expect(tooltip).toHaveCount(0);
+		await title.focus();
+		await expect(tooltip).toHaveText(longName);
+
+		await close.click();
+		await shortChip.evaluate((element) => (element as HTMLElement).click());
+		await expect(dialog).toBeVisible();
+		await expect(dialog).toHaveAccessibleName(shortName);
+
+		const shortTitle = dialog.locator('[data-slot="attachment-preview-title"]');
+		await expect(shortTitle).toHaveText(shortName);
+		await expect(close).toBeFocused();
+		await expect(shortTitle).not.toHaveAttribute('tabindex');
+		await expect(tooltip).toHaveCount(0);
+		const shortTitleGeometry = await shortTitle.evaluate((element) => ({
+			clientWidth: element.clientWidth,
+			scrollWidth: element.scrollWidth
+		}));
+		expect(shortTitleGeometry.scrollWidth).toBeLessThanOrEqual(shortTitleGeometry.clientWidth);
+		await shortTitle.hover();
+		await expect(tooltip).toHaveCount(0);
+		await shortTitle.focus();
+		await expect(tooltip).toHaveCount(0);
+	});
 });

--- a/e2e/ai-chat-attachment-preview.spec.ts
+++ b/e2e/ai-chat-attachment-preview.spec.ts
@@ -88,6 +88,7 @@ test.describe('AI Chat - attachment text preview', () => {
 		await expect(title).toHaveText(longName);
 		await expect(title).toHaveCSS('white-space', 'nowrap');
 		await expect(title).toHaveCSS('text-overflow', 'ellipsis');
+		await expect(title).toHaveCSS('overflow', 'hidden');
 		const titleGeometry = await title.evaluate((element) => {
 			const style = getComputedStyle(element);
 			const rect = element.getBoundingClientRect();
@@ -107,11 +108,36 @@ test.describe('AI Chat - attachment text preview', () => {
 		await page.mouse.move(0, 0);
 		await close.focus();
 		await expect(tooltip).toHaveCount(0);
-		await title.focus();
+		await page.keyboard.press('Tab');
+		await expect(title).toBeFocused();
 		await expect(tooltip).toHaveText(longName);
 
-		await close.click();
-		await shortChip.evaluate((element) => (element as HTMLElement).click());
+		const reopenedBeforeUnmount = await page.evaluate((filename) => {
+			return new Promise<boolean>((resolve) => {
+				const content = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
+				const closeButton = content?.querySelector<HTMLElement>('[data-slot="dialog-close"]');
+				const shortAttachment = [
+					...document.querySelectorAll<HTMLElement>('[data-testid="attachment-chip"]')
+				].find((element) => element.textContent?.includes(filename));
+				if (!content || !closeButton || !shortAttachment) {
+					resolve(false);
+					return;
+				}
+
+				const reopen = () => {
+					if (content.dataset.state !== 'closed') return;
+					const remainedConnected = content.isConnected;
+					observer.disconnect();
+					shortAttachment.click();
+					resolve(remainedConnected);
+				};
+				const observer = new MutationObserver(reopen);
+				observer.observe(content, { attributes: true, attributeFilter: ['data-state'] });
+				closeButton.click();
+				reopen();
+			});
+		}, shortName);
+		expect(reopenedBeforeUnmount).toBe(true);
 		await expect(dialog).toBeVisible();
 		await expect(dialog).toHaveAccessibleName(shortName);
 

--- a/src/lib/chat/ui/ChatAttachments.svelte
+++ b/src/lib/chat/ui/ChatAttachments.svelte
@@ -8,6 +8,7 @@
 	import { haptic } from '$lib/hooks/use-haptic.svelte.ts';
 	import Progress from '$lib/components/ui/progress/progress.svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import AttachmentTextPreview from './AttachmentTextPreview.svelte';
 	import { isTextPreviewable } from '../core/attachmentPreview.js';
 	import type { Attachment, UploadState } from '../core/types.js';
@@ -72,6 +73,30 @@
 	let isDialogOpen = $state(false);
 	let selectedAttachment = $state<Attachment | null>(null);
 	let displayDimensions = $state<{ width: number; height: number } | null>(null);
+	let dialogContent = $state<HTMLElement | null>(null);
+	let titleTruncated = $state(false);
+	const dialogTitle = $derived(
+		selectedAttachment ? getFilename(selectedAttachment) : $t('chat.attachment.dialog_title')
+	);
+
+	function measureTitle(_filename: string) {
+		return (element: HTMLElement) => {
+			function update() {
+				titleTruncated = element.scrollWidth > element.clientWidth;
+			}
+
+			update();
+			const observer = new ResizeObserver(update);
+			observer.observe(element);
+
+			return () => observer.disconnect();
+		};
+	}
+
+	function focusDialogClose(event: Event) {
+		event.preventDefault();
+		dialogContent?.querySelector<HTMLElement>('[data-slot="dialog-close"]')?.focus();
+	}
 
 	/**
 	 * Get filename from attachment
@@ -226,17 +251,29 @@
 
 <Dialog.Root bind:open={isDialogOpen}>
 	<Dialog.Content
+		bind:ref={dialogContent}
 		class={displayDimensions ? '!max-w-none' : 'sm:max-w-4xl'}
 		style={displayDimensions
 			? `width: calc(${displayDimensions.width}px + var(--dialog-inset) * 2);`
 			: ''}
+		onOpenAutoFocus={focusDialogClose}
 	>
-		<Dialog.Header>
-			<Dialog.Title
-				>{selectedAttachment
-					? getFilename(selectedAttachment)
-					: $t('chat.attachment.dialog_title')}</Dialog.Title
-			>
+		<Dialog.Header class="min-w-0">
+			<Tooltip.Root disabled={!titleTruncated}>
+				<Tooltip.Trigger disabled={!titleTruncated}>
+					{#snippet child({ props })}
+						<Dialog.Title
+							{...props}
+							class="min-w-0 truncate pr-10"
+							data-slot="attachment-preview-title"
+							{@attach measureTitle(dialogTitle)}
+						>
+							{dialogTitle}
+						</Dialog.Title>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content class="wrap-anywhere">{dialogTitle}</Tooltip.Content>
+			</Tooltip.Root>
 		</Dialog.Header>
 		{#if selectedAttachment}
 			{@const openUrl = getOpenUrl(selectedAttachment)}


### PR DESCRIPTION
Regression guard: added browser coverage for clipped title geometry, pointer and keyboard disclosure, and same-instance reopen

Long attachment filenames wrapped into the preview content and collided with the absolutely positioned close button.

The dialog now keeps the title to one ellipsized line, reserves the close-button area, and exposes the complete filename through a tooltip only when layout measurement confirms truncation. The close button receives initial focus, while the title remains reachable by keyboard when hidden text exists. Filename changes during the dialog exit/reopen lifecycle trigger a fresh measurement.

| Viewport | Before | After |
| --- | --- | --- |
| 390 px | ![Long title overflowing at 390 px](https://github.com/user-attachments/assets/4c89cd71-8680-4dea-9c1b-4536878efab7) | ![Truncated title at 390 px](https://github.com/user-attachments/assets/49d03335-68e3-47ae-a9e4-089834017e74) |
| 1280 px | ![Long title wrapping at 1280 px](https://github.com/user-attachments/assets/ba80fa5f-d86d-4432-b7df-2d302a10e732) | ![Truncated title at 1280 px](https://github.com/user-attachments/assets/4e93665b-7d54-4856-96e1-21424285ab38) |

![Full title shown on hover](https://github.com/user-attachments/assets/09268440-92e5-4003-a450-33fe0105eb99)

Verification: 111 E2E tests passed with 1 skipped; focused Playwright coverage, changed-file static checks, full type checks, Svelte autofix, and independent review.
